### PR TITLE
fix: handle Nitro and Vite build output directories in Docker

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -21,11 +21,25 @@ COPY . .
 # Build the application
 RUN pnpm run build
 
+# Determine build output directory and prepare it for copying
+# Nitro outputs to .output/public, Vite outputs to dist
+RUN if [ -d /app/.output/public ]; then \
+      echo "Using Nitro output: .output/public"; \
+      cp -r /app/.output/public /app/build-output; \
+    elif [ -d /app/dist ]; then \
+      echo "Using Vite output: dist"; \
+      cp -r /app/dist /app/build-output; \
+    else \
+      echo "ERROR: No build output found!"; \
+      ls -la /app/; \
+      exit 1; \
+    fi
+
 # Production stage
 FROM nginx:alpine
 
 # Copy built assets from builder
-COPY --from=builder /app/dist /usr/share/nginx/html
+COPY --from=builder /app/build-output /usr/share/nginx/html
 
 # Copy nginx configuration
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,6 +7,9 @@ import tailwindcss from '@tailwindcss/vite';
 import { nitro } from 'nitro/vite';
 
 const config = defineConfig({
+  build: {
+    outDir: 'dist',
+  },
   plugins: [
     devtools(),
     nitro(),


### PR DESCRIPTION
# Fix: Handle Nitro and Vite build output directories in Docker

## Problem

The Docker build for the frontend service was failing with the following error:
```
ERROR [frontend stage-1 2/3] COPY --from=builder /app/dist /usr/share/nginx/html
failed to solve: failed to compute cache key: failed to calculate checksum of ref ...: "/app/dist": not found
```

The issue occurred because the project uses both **TanStack Start** with **Nitro** plugin, which outputs build artifacts to `.output/public`, while the Dockerfile was only looking for the standard Vite output directory `dist`.

## Solution

This PR fixes the Docker build by:

1. **Explicitly configuring Vite output directory** in `vite.config.ts`:
   - Added `build.outDir: 'dist'` to ensure consistent output location

2. **Updating Dockerfile to handle both output locations**:
   - Added logic to detect which build output directory exists (`.output/public` for Nitro or `dist` for Vite)
   - Standardizes the output to `/app/build-output` before copying to the nginx stage
   - Includes error handling to fail fast if no build output is found

## Changes

- `frontend/vite.config.ts`: Added explicit `outDir` configuration
- `frontend/Dockerfile`: Added build output detection and standardization logic

## Testing

To test this fix:
1. Rebuild the Docker image: `docker-compose build frontend`
2. Verify the build completes successfully
3. Check that the frontend service starts correctly

## Notes

The fix is backward compatible and will work whether the build outputs to:
- `.output/public` (Nitro default)
- `dist` (Vite default)

If neither directory exists after the build, the Docker build will fail with a clear error message.
