### PR TITLE
Make suunto_subscription_key optional

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -69,7 +69,7 @@ class Settings(BaseSettings):
     suunto_client_id: str | None = None
     suunto_client_secret: SecretStr | None = None
     suunto_redirect_uri: str = "http://localhost:8000/api/v1/oauth/suunto/callback"
-    suunto_subscription_key: SecretStr
+    suunto_subscription_key: SecretStr | None = None
     suunto_authorize_url: str = "https://cloudapi-oauth.suunto.com/oauth/authorize"
     suunto_token_url: str = "https://cloudapi-oauth.suunto.com/oauth/token"
     suunto_api_base_url: str = "https://cloudapi.suunto.com"


### PR DESCRIPTION
Make `suunto_subscription_key` optional to allow the application to run without it when Suunto subscription key is not required or configured.