### PR TITLE
Fix Celery task registration for dummy_task

### DIFF
--- a/backend/app/integrations/celery/core.py
+++ b/backend/app/integrations/celery/core.py
@@ -4,6 +4,9 @@ from celery.schedules import crontab
 
 from app.config import settings
 
+# Import tasks to ensure they're registered
+from app.integrations.celery.tasks import dummy_task  # noqa: F401
+
 
 def create_celery() -> Celery:
     celery_app: Celery = current_celery_app  # type: ignore[assignment]
@@ -20,7 +23,8 @@ def create_celery() -> Celery:
         result_expires=3 * 24 * 3600,
     )
 
-    celery_app.autodiscover_tasks(["app.integrations.celery.tasks.dummy_task"])
+    # Autodiscover tasks from the tasks package
+    celery_app.autodiscover_tasks(["app.integrations.celery.tasks"])
 
     celery_app.conf.beat_schedule = {
         "dummy-task": {

--- a/backend/app/integrations/celery/tasks/dummy_task.py
+++ b/backend/app/integrations/celery/tasks/dummy_task.py
@@ -5,6 +5,6 @@ from celery import shared_task
 log = logging.getLogger(__name__)
 
 
-@shared_task
+@shared_task(name="app.integrations.celery.tasks.dummy_task")
 def dummy_task() -> None:
     log.info("Task performed")


### PR DESCRIPTION
## Summary
Fixes Celery task registration so dummy_task is discoverable and registered. Resolves Sentry issue `OPEN-WEARABLES-BACKEND-1` where Celery workers received unregistered task errors.

## Changes
- Fixed autodiscovery path: changed from task path `app.integrations.celery.tasks.dummy_task` to package path `app.integrations.celery.tasks` in `autodiscover_tasks()`
- Added explicit task import: imported dummy_task in core.py to ensure registration at module load
- Set explicit task name: added name="app.integrations.celery.tasks.dummy_task" to the @shared_task decorator to match the beat schedule configuration

## Why
`autodiscover_tasks()` was given a task path instead of a package path, so tasks weren't discovered. The task name wasn't explicitly set, causing a mismatch with the beat schedule. These changes ensure the task is registered with the correct name and discoverable by Celery workers.

## Impact
- Eliminates unregistered task errors in Celery workers
- Ensures scheduled tasks execute correctly
- Improves reliability of the Celery task system