### PR TITLE
Added Compose Watch startup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,8 +13,9 @@ FROM python:3.13-slim AS builder
     COPY uv.lock pyproject.toml ./
     COPY . .
 
-    RUN uv venv /root_project/.venv
-    ENV PATH="/root_project/.venv/bin:$PATH"
+    ENV VIRTUAL_ENV=/opt/venv
+    RUN uv venv $VIRTUAL_ENV
+    ENV PATH="$VIRTUAL_ENV/bin:$PATH"
     RUN uv sync --locked --no-dev
 
 FROM python:3.13-slim
@@ -28,6 +29,10 @@ FROM python:3.13-slim
 
     COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
+    COPY --from=builder /opt/venv /opt/venv
     COPY --from=builder /root_project /root_project
+    ENV VIRTUAL_ENV=/opt/venv
+    ENV PATH="/opt/venv/bin:$PATH"
+    ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 
     EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,48 +35,66 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-    volumes:
-      - ./backend/app:/root_project/app
-      - type: bind
-        source: ./backend/config/.env
-        target: /root_project/config/.env
-        bind:
-          create_host_path: false
+    develop:
+      watch:
+        - action: sync
+          path: ./backend/app
+          target: /root_project/app
+        - action: rebuild
+          path: ./backend/uv.lock
     restart: on-failure
 
   celery-worker:
+    build:
+        context: ./backend
+        dockerfile: Dockerfile
     container_name: celery-worker__open-wearables
     image: open-wearables-platform:latest
     command: scripts/start/worker.sh
-    volumes:
-      - ./backend:/root_project
-      - /root_project/.venv
     env_file:
       - ./backend/config/.env
     depends_on:
       - redis
       - db
+    develop:
+      watch:
+        - action: sync
+          path: ./backend
+          target: /root_project
+          ignore:
+            - .venv/
+        - action: rebuild
+          path: ./backend/uv.lock
 
   celery-beat:
+    build:
+        context: ./backend
+        dockerfile: Dockerfile
     container_name: celery-beat__open-wearables
     image: open-wearables-platform:latest
     command: scripts/start/beat.sh
-    volumes:
-      - ./backend:/root_project
-      - /root_project/.venv
     env_file:
       - ./backend/config/.env
     depends_on:
       - redis
       - db
+    develop:
+      watch:
+        - action: sync
+          path: ./backend
+          target: /root_project
+          ignore:
+            - .venv/
+        - action: rebuild
+          path: ./backend/uv.lock
 
   flower:
+    build:
+        context: ./backend
+        dockerfile: Dockerfile
     container_name: flower__open-wearables
     image: open-wearables-platform:latest
     command: scripts/start/flower.sh
-    volumes:
-      - ./backend:/root_project
-      - /root_project/.venv
     env_file:
       - ./backend/config/.env
     ports:
@@ -84,6 +102,15 @@ services:
     depends_on:
       - redis
       - db
+    develop:
+      watch:
+        - action: sync
+          path: ./backend
+          target: /root_project
+          ignore:
+            - .venv/
+        - action: rebuild
+          path: ./backend/uv.lock
 
   redis:
     container_name: redis__open-wearables


### PR DESCRIPTION
### Summary
Move Python virtual environment outside project directory and replace Docker volumes with Compose Watch for development.

## Changes
### Dockerfile
- Moved venv from /root_project/.venv to /opt/venv
- Added UV_PROJECT_ENVIRONMENT env var to ensure uv uses the correct venv location
- This prevents conflicts when syncing files to /root_project during development

### docker-compose.yml
- Replaced volumes with develop.watch configuration for all backend services (app, celery-worker, celery-beat, flower)
- Added build context to Celery services (required for action: rebuild)
- Watch configuration:
  - action: sync – syncs code changes (ignores .venv/ for Celery services)
  - action: rebuild – rebuilds image when uv.lock changes

## Why
Previously, bind-mounting ./backend:/root_project caused conflicts with the container's .venv directory. The local macOS venv would overwrite the Linux venv in the container, breaking package execution.
With venv in /opt/venv, file sync cannot affect it. This provides:
- Stable hot-reload for development (docker compose watch)
- Clean production builds (docker compose up)
- No more "Failed to spawn" errors from binary incompatibility