### PR TITLE
chore: update CORS_ORIGINS in .env.example for local development

### DIFF
--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -2,7 +2,7 @@
 
 # Environment: local, test, staging, production
 ENVIRONMENT="local"
-CORS_ORIGINS=["http://localhost:8000", "https://localhost:8000", "http://localhost", "https://localhost"]
+CORS_ORIGINS=["http://localhost:3000"]
 SERVER_HOST="https://new_project_name.dev"
 
 #--- DB ---#


### PR DESCRIPTION
At minimum, we only need `http://localhost:3000` 