### PR TITLE
feat(frontend): implement API keys CRUD on credentials page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.66.1(react@19.2.0))
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -792,6 +795,19 @@ packages:
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
@@ -3562,6 +3578,20 @@ snapshots:
   '@radix-ui/number@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.6)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.6)(react@19.2.0)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.6)(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.6
+      '@types/react-dom': 19.2.3(@types/react@19.2.6)
 
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.6))(@types/react@19.2.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,139 @@
+import * as React from 'react';
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+
+import { cn } from '@/lib/utils';
+import { buttonVariants } from '@/components/ui/button';
+
+const AlertDialog = AlertDialogPrimitive.Root;
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col space-y-2 text-center sm:text-left',
+      className
+    )}
+    {...props}
+  />
+);
+AlertDialogHeader.displayName = 'AlertDialogHeader';
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className
+    )}
+    {...props}
+  />
+);
+AlertDialogFooter.displayName = 'AlertDialogFooter';
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold', className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName;
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: 'outline' }),
+      'mt-2 sm:mt-0',
+      className
+    )}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/frontend/src/hooks/api/use-credentials.ts
+++ b/frontend/src/hooks/api/use-credentials.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { credentialsService } from '@/lib/api/services/credentials.service';
-import type { ApiKeyCreate } from '@/lib/api/types';
+import type { ApiKeyCreate, ApiKeyUpdate } from '@/lib/api/types';
 import { queryKeys } from '@/lib/query/keys';
 import { toast } from 'sonner';
 import { getErrorMessage } from '@/lib/errors/handler';
@@ -38,18 +38,19 @@ export function useCreateApiKey() {
   });
 }
 
-// Revoke API key
-export function useRevokeApiKey() {
+// Update API key
+export function useUpdateApiKey() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (id: string) => credentialsService.revokeApiKey(id),
+    mutationFn: ({ id, data }: { id: string; data: ApiKeyUpdate }) =>
+      credentialsService.updateApiKey(id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.credentials.list() });
-      toast.success('API key revoked successfully');
+      toast.success('API key updated successfully');
     },
     onError: (error) => {
-      toast.error(`Failed to revoke API key: ${getErrorMessage(error)}`);
+      toast.error(`Failed to update API key: ${getErrorMessage(error)}`);
     },
   });
 }
@@ -70,10 +71,18 @@ export function useDeleteApiKey() {
   });
 }
 
-// Get widget embed code (not a query, just a utility)
-export function useWidgetEmbedCode() {
-  return {
-    getEmbedCode: (apiKey: string, userId?: string) =>
-      credentialsService.getWidgetEmbedCode(apiKey, userId),
-  };
+// Rotate API key
+export function useRotateApiKey() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => credentialsService.rotateApiKey(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.credentials.list() });
+      toast.success('API key rotated successfully');
+    },
+    onError: (error) => {
+      toast.error(`Failed to rotate API key: ${getErrorMessage(error)}`);
+    },
+  });
 }

--- a/frontend/src/lib/api/config.ts
+++ b/frontend/src/lib/api/config.ts
@@ -24,6 +24,7 @@ export const API_ENDPOINTS = {
 
   apiKeys: '/api/v1/developer/api-keys',
   apiKeyDetail: (id: string) => `/api/v1/developer/api-keys/${id}`,
+  apiKeyRotate: (id: string) => `/api/v1/developer/api-keys/${id}/rotate`,
 
   automations: '/api/v1/automations',
   automationDetail: (id: string) => `/api/v1/automations/${id}`,

--- a/frontend/src/lib/api/services/credentials.service.ts
+++ b/frontend/src/lib/api/services/credentials.service.ts
@@ -1,6 +1,6 @@
 import { apiClient } from '../client';
 import { API_ENDPOINTS } from '../config';
-import type { ApiKey, ApiKeyCreate } from '../types';
+import type { ApiKey, ApiKeyCreate, ApiKeyUpdate } from '../types';
 
 export const credentialsService = {
   async getApiKeys(): Promise<ApiKey[]> {
@@ -15,72 +15,15 @@ export const credentialsService = {
     return apiClient.post<ApiKey>(API_ENDPOINTS.apiKeys, data);
   },
 
-  async revokeApiKey(id: string): Promise<void> {
-    return apiClient.delete<void>(API_ENDPOINTS.apiKeyDetail(id));
+  async updateApiKey(id: string, data: ApiKeyUpdate): Promise<ApiKey> {
+    return apiClient.patch<ApiKey>(API_ENDPOINTS.apiKeyDetail(id), data);
   },
 
-  async deleteApiKey(id: string): Promise<void> {
-    return apiClient.delete<void>(API_ENDPOINTS.apiKeyDetail(id));
+  async deleteApiKey(id: string): Promise<ApiKey> {
+    return apiClient.delete<ApiKey>(API_ENDPOINTS.apiKeyDetail(id));
   },
 
-  getWidgetEmbedCode(
-    apiKey: string,
-    userId?: string
-  ): { html: string; react: string } {
-    const userParam = userId ? `&user_id=${userId}` : '';
-    const baseUrl = import.meta.env.VITE_API_URL || 'http://localhost:8000';
-
-    const html = `<!-- Open Wearables Connect Widget -->
-<iframe
-  src="${baseUrl}/widget/connect?api_key=${apiKey}${userParam}"
-  width="600"
-  height="400"
-  frameborder="0"
-  allow="clipboard-write"
-  style="border-radius: 8px; box-shadow: 0 2px 8px rgba(0,0,0,0.1);"
-></iframe>
-
-<script>
-  // Listen for connection success
-  window.addEventListener('message', (event) => {
-    if (event.data.type === 'wearable_connected') {
-      console.log('Device connected:', event.data.provider)
-      // Handle successful connection
-    }
-  })
-</script>`;
-
-    const react = `import { useEffect } from 'react'
-
-function WearablesWidget() {
-  useEffect(() => {
-    // Listen for connection success
-    const handleMessage = (event: MessageEvent) => {
-      if (event.data.type === 'wearable_connected') {
-        console.log('Device connected:', event.data.provider)
-        // Handle successful connection
-      }
-    }
-
-    window.addEventListener('message', handleMessage)
-    return () => window.removeEventListener('message', handleMessage)
-  }, [])
-
-  return (
-    <iframe
-      src="${baseUrl}/widget/connect?api_key=${apiKey}${userParam}"
-      width={600}
-      height={400}
-      frameBorder={0}
-      allow="clipboard-write"
-      style={{
-        borderRadius: '8px',
-        boxShadow: '0 2px 8px rgba(0,0,0,0.1)'
-      }}
-    />
-  )
-}`;
-
-    return { html, react };
+  async rotateApiKey(id: string): Promise<ApiKey> {
+    return apiClient.post<ApiKey>(API_ENDPOINTS.apiKeyRotate(id));
   },
 };

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -204,27 +204,16 @@ export interface ActivitySummary {
 export interface ApiKey {
   id: string;
   name: string;
-  key: string;
-  type: 'live' | 'test' | 'widget';
-  status: 'active' | 'revoked';
-  lastUsed: string | null;
-  createdAt: string;
-  expiresAt: string | null;
-}
-
-export interface ApiKeyRead {
-  id: string;
-  name: string;
-  key: string;
-  type: 'developer' | 'widget';
-  status: 'active' | 'revoked';
-  lastUsed?: string;
-  createdAt: string;
+  created_by: string | null;
+  created_at: string;
 }
 
 export interface ApiKeyCreate {
   name: string;
-  type: 'live' | 'test' | 'widget';
+}
+
+export interface ApiKeyUpdate {
+  name?: string;
 }
 
 export interface Automation {

--- a/frontend/src/routes/_authenticated/credentials.tsx
+++ b/frontend/src/routes/_authenticated/credentials.tsx
@@ -6,18 +6,29 @@ import {
   EyeOff,
   Copy,
   Trash2,
-  Code,
   Key,
-  ChevronDown,
+  Pencil,
+  RefreshCw,
 } from 'lucide-react';
 import {
   useApiKeys,
   useCreateApiKey,
+  useUpdateApiKey,
   useDeleteApiKey,
+  useRotateApiKey,
 } from '@/hooks/api/use-credentials';
-import { credentialsService } from '@/lib/api/services/credentials.service';
-import type { ApiKeyCreate } from '@/lib/api/types';
+import type { ApiKeyCreate, ApiKeyUpdate, ApiKey } from '@/lib/api/types';
 import { toast } from 'sonner';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 
 export const Route = createFileRoute('/_authenticated/credentials')({
   component: CredentialsPage,
@@ -25,17 +36,24 @@ export const Route = createFileRoute('/_authenticated/credentials')({
 
 function CredentialsPage() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
-  const [isEmbedDialogOpen, setIsEmbedDialogOpen] = useState(false);
-  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isRotateDialogOpen, setIsRotateDialogOpen] = useState(false);
+  const [selectedKeyId, setSelectedKeyId] = useState<string | null>(null);
+  const [editingKey, setEditingKey] = useState<ApiKey | null>(null);
   const [visibleKeys, setVisibleKeys] = useState<Set<string>>(new Set());
   const [formData, setFormData] = useState<ApiKeyCreate>({
     name: '',
-    type: 'live',
+  });
+  const [editFormData, setEditFormData] = useState<ApiKeyUpdate>({
+    name: '',
   });
 
   const { data: apiKeys, isLoading, error, refetch } = useApiKeys();
   const createMutation = useCreateApiKey();
+  const updateMutation = useUpdateApiKey();
   const deleteMutation = useDeleteApiKey();
+  const rotateMutation = useRotateApiKey();
 
   const handleCreate = async () => {
     if (!formData.name) {
@@ -45,20 +63,54 @@ function CredentialsPage() {
 
     const newKey = await createMutation.mutateAsync(formData);
     setIsCreateDialogOpen(false);
-    setFormData({ name: '', type: 'live' });
-
-    toast.success('API key created successfully');
+    setFormData({ name: '' });
     setVisibleKeys((prev) => new Set(prev).add(newKey.id));
   };
 
-  const handleDelete = async (id: string) => {
-    if (
-      confirm(
-        'Are you sure you want to delete this API key? This action cannot be undone.'
-      )
-    ) {
-      await deleteMutation.mutateAsync(id);
+  const handleEdit = (key: ApiKey) => {
+    setEditingKey(key);
+    setEditFormData({ name: key.name });
+    setIsEditDialogOpen(true);
+  };
+
+  const handleUpdate = async () => {
+    if (!editingKey || !editFormData.name) {
+      toast.error('Please enter a key name');
+      return;
     }
+
+    await updateMutation.mutateAsync({
+      id: editingKey.id,
+      data: editFormData,
+    });
+    setIsEditDialogOpen(false);
+    setEditingKey(null);
+    setEditFormData({ name: '' });
+  };
+
+  const openDeleteDialog = (id: string) => {
+    setSelectedKeyId(id);
+    setIsDeleteDialogOpen(true);
+  };
+
+  const handleDelete = async () => {
+    if (!selectedKeyId) return;
+    await deleteMutation.mutateAsync(selectedKeyId);
+    setIsDeleteDialogOpen(false);
+    setSelectedKeyId(null);
+  };
+
+  const openRotateDialog = (id: string) => {
+    setSelectedKeyId(id);
+    setIsRotateDialogOpen(true);
+  };
+
+  const handleRotate = async () => {
+    if (!selectedKeyId) return;
+    const newKey = await rotateMutation.mutateAsync(selectedKeyId);
+    setVisibleKeys((prev) => new Set(prev).add(newKey.id));
+    setIsRotateDialogOpen(false);
+    setSelectedKeyId(null);
   };
 
   const toggleKeyVisibility = (id: string) => {
@@ -83,13 +135,8 @@ function CredentialsPage() {
     return key.substring(0, 10) + '****' + key.substring(key.length - 4);
   };
 
-  const formatDate = (dateString: string | null) => {
-    if (!dateString) return 'Never';
+  const formatDate = (dateString: string) => {
     return new Date(dateString).toLocaleString();
-  };
-
-  const getEmbedCode = (apiKey: string) => {
-    return credentialsService.getWidgetEmbedCode(apiKey);
   };
 
   if (isLoading) {
@@ -98,7 +145,7 @@ function CredentialsPage() {
         <div className="mb-6">
           <h1 className="text-2xl font-medium text-white">API Credentials</h1>
           <p className="text-sm text-zinc-500 mt-1">
-            Manage your API keys and widget embed codes
+            Manage your API keys for authentication
           </p>
         </div>
         <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-6">
@@ -133,12 +180,11 @@ function CredentialsPage() {
 
   return (
     <div className="p-8 space-y-6">
-      {/* Header */}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-medium text-white">API Credentials</h1>
           <p className="text-sm text-zinc-500 mt-1">
-            Manage your API keys and widget embed codes
+            Manage your API keys for authentication
           </p>
         </div>
         <button
@@ -150,12 +196,11 @@ function CredentialsPage() {
         </button>
       </div>
 
-      {/* API Keys Table */}
       <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl overflow-hidden">
         <div className="px-6 py-4 border-b border-zinc-800">
           <h2 className="text-sm font-medium text-white">API Keys</h2>
           <p className="text-xs text-zinc-500 mt-1">
-            Use these keys to authenticate API requests and embed widgets
+            Use these keys to authenticate API requests
           </p>
         </div>
 
@@ -171,13 +216,7 @@ function CredentialsPage() {
                     Key
                   </th>
                   <th className="px-6 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wider">
-                    Type
-                  </th>
-                  <th className="px-6 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wider">
-                    Status
-                  </th>
-                  <th className="px-6 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wider">
-                    Last Used
+                    Created At
                   </th>
                   <th className="px-6 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wider text-right">
                     Actions
@@ -196,11 +235,14 @@ function CredentialsPage() {
                     <td className="px-6 py-4">
                       <div className="flex items-center gap-2">
                         <code className="font-mono text-xs bg-zinc-800 text-zinc-300 px-2 py-1 rounded">
-                          {visibleKeys.has(key.id) ? key.key : maskKey(key.key)}
+                          {visibleKeys.has(key.id) ? key.id : maskKey(key.id)}
                         </code>
                         <button
                           onClick={() => toggleKeyVisibility(key.id)}
                           className="p-1 text-zinc-500 hover:text-zinc-300 transition-colors"
+                          title={
+                            visibleKeys.has(key.id) ? 'Hide key' : 'Show key'
+                          }
                         >
                           {visibleKeys.has(key.id) ? (
                             <EyeOff className="h-4 w-4" />
@@ -209,55 +251,39 @@ function CredentialsPage() {
                           )}
                         </button>
                         <button
-                          onClick={() => copyToClipboard(key.key, 'API key')}
+                          onClick={() => copyToClipboard(key.id, 'API key')}
                           className="p-1 text-zinc-500 hover:text-zinc-300 transition-colors"
+                          title="Copy key"
                         >
                           <Copy className="h-4 w-4" />
                         </button>
                       </div>
                     </td>
-                    <td className="px-6 py-4">
-                      <span className="px-2 py-0.5 text-xs rounded-full border border-zinc-700 text-zinc-400">
-                        {key.type === 'live'
-                          ? 'Live'
-                          : key.type === 'test'
-                            ? 'Test'
-                            : 'Widget'}
-                      </span>
-                    </td>
-                    <td className="px-6 py-4">
-                      <span
-                        className={`px-2 py-0.5 text-xs rounded-full ${
-                          key.status === 'active'
-                            ? 'bg-emerald-500/20 text-emerald-400'
-                            : 'bg-zinc-700 text-zinc-400'
-                        }`}
-                      >
-                        {key.status}
-                      </span>
-                    </td>
                     <td className="px-6 py-4 text-xs text-zinc-500">
-                      {formatDate(key.lastUsed)}
+                      {formatDate(key.created_at)}
                     </td>
                     <td className="px-6 py-4">
                       <div className="flex justify-end gap-1">
-                        {key.type === 'widget' && (
-                          <button
-                            onClick={() => {
-                              setSelectedKey(key.key);
-                              setIsEmbedDialogOpen(true);
-                            }}
-                            className="p-2 text-zinc-500 hover:text-white hover:bg-zinc-800 rounded-md transition-colors"
-                          >
-                            <Code className="h-4 w-4" />
-                          </button>
-                        )}
                         <button
-                          onClick={() => handleDelete(key.id)}
-                          disabled={
-                            deleteMutation.isPending || key.status === 'revoked'
-                          }
+                          onClick={() => handleEdit(key)}
+                          className="p-2 text-zinc-500 hover:text-white hover:bg-zinc-800 rounded-md transition-colors"
+                          title="Edit name"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </button>
+                        <button
+                          onClick={() => openRotateDialog(key.id)}
+                          disabled={rotateMutation.isPending}
+                          className="p-2 text-zinc-500 hover:text-amber-400 hover:bg-zinc-800 rounded-md transition-colors disabled:opacity-50"
+                          title="Rotate key"
+                        >
+                          <RefreshCw className="h-4 w-4" />
+                        </button>
+                        <button
+                          onClick={() => openDeleteDialog(key.id)}
+                          disabled={deleteMutation.isPending}
                           className="p-2 text-zinc-500 hover:text-red-400 hover:bg-zinc-800 rounded-md transition-colors disabled:opacity-50"
+                          title="Delete key"
                         >
                           <Trash2 className="h-4 w-4" />
                         </button>
@@ -286,7 +312,6 @@ function CredentialsPage() {
         )}
       </div>
 
-      {/* Create Dialog */}
       {isCreateDialogOpen && (
         <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4">
           <div className="bg-zinc-900 border border-zinc-800 rounded-xl w-full max-w-md shadow-2xl">
@@ -316,38 +341,6 @@ function CredentialsPage() {
                   A descriptive name to identify this key
                 </p>
               </div>
-
-              <div className="space-y-1.5">
-                <label className="text-xs font-medium text-zinc-300">
-                  Key Type
-                </label>
-                <div className="relative">
-                  <select
-                    value={formData.type}
-                    onChange={(e) =>
-                      setFormData((prev) => ({
-                        ...prev,
-                        type: e.target.value as 'live' | 'test' | 'widget',
-                      }))
-                    }
-                    className="appearance-none w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 pr-8 text-sm text-white focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all cursor-pointer"
-                  >
-                    <option value="live">Live - Production API access</option>
-                    <option value="test">Test - Development and testing</option>
-                    <option value="widget">
-                      Widget - For embedded connect widget
-                    </option>
-                  </select>
-                  <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-500 pointer-events-none" />
-                </div>
-                <p className="text-[10px] text-zinc-600">
-                  {formData.type === 'widget'
-                    ? 'Use this key for the embeddable wearables connection widget'
-                    : formData.type === 'test'
-                      ? 'Test keys work with test mode only'
-                      : 'Live keys have full access to production data'}
-                </p>
-              </div>
             </div>
             <div className="p-6 border-t border-zinc-800 flex justify-end gap-3">
               <button
@@ -369,83 +362,126 @@ function CredentialsPage() {
         </div>
       )}
 
-      {/* Embed Code Dialog */}
-      {isEmbedDialogOpen && selectedKey && (
+      {isEditDialogOpen && editingKey && (
         <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4">
-          <div className="bg-zinc-900 border border-zinc-800 rounded-xl w-full max-w-3xl max-h-[80vh] overflow-y-auto shadow-2xl">
+          <div className="bg-zinc-900 border border-zinc-800 rounded-xl w-full max-w-md shadow-2xl">
             <div className="p-6 border-b border-zinc-800">
-              <h2 className="text-lg font-medium text-white">
-                Widget Embed Code
-              </h2>
+              <h2 className="text-lg font-medium text-white">Edit API Key</h2>
               <p className="text-sm text-zinc-500 mt-1">
-                Copy and paste these code snippets to embed the wearables
-                connection widget
+                Update the name of your API key
               </p>
             </div>
-            <div className="p-6 space-y-6">
-              <div className="space-y-2">
-                <div className="flex justify-between items-center">
-                  <span className="text-xs font-medium text-zinc-300">
-                    HTML
-                  </span>
-                  <button
-                    onClick={() =>
-                      copyToClipboard(
-                        getEmbedCode(selectedKey).html,
-                        'HTML code'
-                      )
-                    }
-                    className="flex items-center gap-2 px-3 py-1.5 text-xs text-zinc-400 border border-zinc-700 rounded-md hover:text-white hover:border-zinc-600 transition-colors"
-                  >
-                    <Copy className="h-3 w-3" />
-                    Copy
-                  </button>
-                </div>
-                <textarea
-                  readOnly
-                  value={getEmbedCode(selectedKey).html}
-                  rows={12}
-                  className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-xs font-mono text-zinc-300 focus:outline-none resize-none"
+            <div className="p-6 space-y-4">
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium text-zinc-300">
+                  Key Name
+                </label>
+                <input
+                  type="text"
+                  placeholder="e.g., Production API Key"
+                  value={editFormData.name || ''}
+                  onChange={(e) =>
+                    setEditFormData((prev) => ({
+                      ...prev,
+                      name: e.target.value,
+                    }))
+                  }
+                  className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
                 />
-              </div>
-
-              <div className="space-y-2">
-                <div className="flex justify-between items-center">
-                  <span className="text-xs font-medium text-zinc-300">
-                    React / TypeScript
-                  </span>
-                  <button
-                    onClick={() =>
-                      copyToClipboard(
-                        getEmbedCode(selectedKey).react,
-                        'React code'
-                      )
-                    }
-                    className="flex items-center gap-2 px-3 py-1.5 text-xs text-zinc-400 border border-zinc-700 rounded-md hover:text-white hover:border-zinc-600 transition-colors"
-                  >
-                    <Copy className="h-3 w-3" />
-                    Copy
-                  </button>
-                </div>
-                <textarea
-                  readOnly
-                  value={getEmbedCode(selectedKey).react}
-                  rows={18}
-                  className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-xs font-mono text-zinc-300 focus:outline-none resize-none"
-                />
+                <p className="text-[10px] text-zinc-600">
+                  A descriptive name to identify this key
+                </p>
               </div>
             </div>
-            <div className="p-6 border-t border-zinc-800 flex justify-end">
+            <div className="p-6 border-t border-zinc-800 flex justify-end gap-3">
               <button
-                onClick={() => setIsEmbedDialogOpen(false)}
-                className="px-4 py-2 bg-white text-black rounded-md text-sm font-medium hover:bg-zinc-200 transition-colors"
+                onClick={() => {
+                  setIsEditDialogOpen(false);
+                  setEditingKey(null);
+                  setEditFormData({ name: '' });
+                }}
+                disabled={updateMutation.isPending}
+                className="px-4 py-2 text-sm text-zinc-400 hover:text-white transition-colors"
               >
-                Close
+                Cancel
+              </button>
+              <button
+                onClick={handleUpdate}
+                disabled={updateMutation.isPending}
+                className="px-4 py-2 bg-white text-black rounded-md text-sm font-medium hover:bg-zinc-200 transition-colors disabled:opacity-50"
+              >
+                {updateMutation.isPending ? 'Saving...' : 'Save Changes'}
               </button>
             </div>
           </div>
         </div>
       )}
+
+      <AlertDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+      >
+        <AlertDialogContent className="bg-zinc-900 border-zinc-800">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-white">
+              Delete API Key
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-zinc-400">
+              Are you sure you want to delete this API key? This action cannot
+              be undone and any applications using this key will no longer be
+              able to authenticate.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              className="bg-transparent border-zinc-700 text-zinc-300 hover:bg-zinc-800 hover:text-white"
+              onClick={() => setSelectedKeyId(null)}
+            >
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-red-600 text-white hover:bg-red-700"
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? 'Deleting...' : 'Delete Key'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={isRotateDialogOpen}
+        onOpenChange={setIsRotateDialogOpen}
+      >
+        <AlertDialogContent className="bg-zinc-900 border-zinc-800">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-white">
+              Rotate API Key
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-zinc-400">
+              Are you sure you want to rotate this API key? The old key will be
+              invalidated immediately and a new key will be generated. Any
+              applications using the old key will need to be updated.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              className="bg-transparent border-zinc-700 text-zinc-300 hover:bg-zinc-800 hover:text-white"
+              onClick={() => setSelectedKeyId(null)}
+            >
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-amber-600 text-white hover:bg-amber-700"
+              onClick={handleRotate}
+              disabled={rotateMutation.isPending}
+            >
+              {rotateMutation.isPending ? 'Rotating...' : 'Rotate Key'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/frontend/src/routes/_authenticated/users/$userId.tsx
+++ b/frontend/src/routes/_authenticated/users/$userId.tsx
@@ -148,17 +148,11 @@ function UserDetailPage() {
               </div>
             </div>
           ) : (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
               <div>
                 <p className="text-xs text-zinc-500 mb-1">User ID</p>
                 <code className="font-mono text-sm text-zinc-300 bg-zinc-800 px-2 py-1 rounded">
                   {user?.id.slice(0, 8)}...
-                </code>
-              </div>
-              <div>
-                <p className="text-xs text-zinc-500 mb-1">Client User ID</p>
-                <code className="font-mono text-sm text-zinc-300 bg-zinc-800 px-2 py-1 rounded">
-                  {user?.client_user_id}
                 </code>
               </div>
               <div>
@@ -387,14 +381,9 @@ function UserDetailPage() {
           <h2 className="text-sm font-medium text-white">
             Health Data Visualizations
           </h2>
-          <p className="text-xs text-zinc-500 mt-1">
-            Charts will be implemented in Phase 3 with Recharts
-          </p>
         </div>
         <div className="h-64 flex items-center justify-center text-zinc-500">
-          <p className="text-sm">
-            Heart Rate, Sleep, and Activity charts coming soon...
-          </p>
+          <p className="text-sm">Charts coming soon...</p>
         </div>
       </div>
 
@@ -404,12 +393,9 @@ function UserDetailPage() {
           <h2 className="text-sm font-medium text-white">
             AI Health Assistant
           </h2>
-          <p className="text-xs text-zinc-500 mt-1">
-            Chat interface will be implemented in Phase 3
-          </p>
         </div>
         <div className="h-64 flex items-center justify-center text-zinc-500">
-          <p className="text-sm">AI-powered health insights coming soon...</p>
+          <p className="text-sm">Coming soon...</p>
         </div>
       </div>
     </div>

--- a/frontend/src/routes/_authenticated/users/index.tsx
+++ b/frontend/src/routes/_authenticated/users/index.tsx
@@ -138,7 +138,8 @@ function UsersPage() {
     }
   };
 
-  const truncateId = (id: string) => {
+  const truncateId = (id: string | null | undefined) => {
+    if (!id) return '—';
     if (id.length <= 12) return id;
     return `${id.slice(0, 8)}...${id.slice(-4)}`;
   };
@@ -267,9 +268,6 @@ function UsersPage() {
                     User ID
                   </th>
                   <th className="px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wider">
-                    Client User ID
-                  </th>
-                  <th className="px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wider">
                     Name
                   </th>
                   <th className="px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wider">
@@ -305,11 +303,6 @@ function UsersPage() {
                           )}
                         </button>
                       </div>
-                    </td>
-                    <td className="px-4 py-3">
-                      <code className="font-mono text-xs bg-zinc-800 text-zinc-300 px-2 py-1 rounded">
-                        {truncateId(user.client_user_id)}
-                      </code>
                     </td>
                     <td className="px-4 py-3 text-sm text-zinc-300">
                       {user.first_name || user.last_name ? (


### PR DESCRIPTION
## Summary
- Align frontend types with backend `ApiKey` schema (`id`, `name`, `created_by`, `created_at`)
- Add Update (PATCH) and Rotate operations for API keys
- Replace native `confirm()` dialogs with Shadcn AlertDialog components
- Add `apiKeyRotate` endpoint configuration
- Remove unused widget embed code functionality
- Update users page to handle nullable `client_user_id`
