### PR TITLE
Clean up .env.example and remove auth0 from settings

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -50,12 +50,6 @@ class Settings(BaseSettings):
     SENTRY_SAMPLES_RATE: float = 0.5
     SENTRY_ENV: str | None = None
 
-    # AUTH0 SETTINGS (deprecated, will be removed)
-    auth0_domain: str = ""
-    auth0_audience: str = ""
-    auth0_issuer: str = ""
-    auth0_algorithms: list[str] = ["RS256"]
-
     # AUTH SETTINGS
     secret_key: str
     algorithm: str = "HS256"
@@ -136,10 +130,6 @@ class Settings(BaseSettings):
             f"{self.db_user}:{self.db_password.get_secret_value()}"
             f"@{self.db_host}:{self.db_port}/{self.db_name}"
         )
-
-    @property
-    def auth0_issuer_url(self) -> str:
-        return f"https://{self.auth0_domain}/"
 
     # 0. pytest ini_options
     # 1. environment variables

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -22,19 +22,9 @@ SENTRY_DSN=""
 SENTRY_ENV=production
 SENTRY_SAMPLES_RATE=0.5
 
-#--- AUTH0 ---#
-AUTH0_DOMAIN=dev-*****.eu.auth0.com
-AUTH0_AUDIENCE=healthion-api
-AUTH0_ISSUER=https://dev-*****.eu.auth0.com
-
 #--- AUTH ---#
 # python3 -c "import secrets; print(secrets.token_urlsafe(64))"
 SECRET_KEY=secret-key-str
-
-#--- Suunto ---#
-SUUNTO_CLIENT_ID=public-client-id
-SUUNTO_CLIENT_SECRET=private-secret-id
-SUUNTO_SUBSCRIPTION_KEY=private-subscription-id
 
 #--- AWS ---#
 AWS_BUCKET_NAME=open-wearables
@@ -42,6 +32,13 @@ AWS_ACCESS_KEY_ID=your-access-id
 AWS_SECRET_ACCESS_KEY=your-access-key
 AWS_REGION=eu-north-1
 SQS_QUEUE_URL=https://sqs.eu-north-1.amazonaws.com/12345678/xyz-queue
+
+#--- Providers ---#
+
+#--- Suunto ---#
+SUUNTO_CLIENT_ID=public-client-id
+SUUNTO_CLIENT_SECRET=private-secret-id
+SUUNTO_SUBSCRIPTION_KEY=private-subscription-id
 
 #--- Polar ---#
 POLAR_CLIENT_ID=public-client-id


### PR DESCRIPTION
Cleans up the .env.example a bit and removes Auth0 references from the config.