### PR TITLE
Restrict CI push trigger to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,14 @@
 name: CI
 
 on:
-  push: &paths
-    paths:
+  push:
+    branches:
+      - main
+    paths: &paths
       - "backend/**"
       - "frontend/**"
-  pull_request: *paths
+  pull_request:
+    paths: *paths
 
 jobs:
   # Detect which parts of the codebase changed


### PR DESCRIPTION
## Summary
- limit the CI workflow push trigger to the main branch to avoid duplicate runs alongside pull_request events
- retain shared path filters for backend and frontend changes

## Testing
- Not run (workflow change)
