### PR TITLE
feat: Invalidate dashboard stats on user creation and deletion

### DIFF
--- a/frontend/src/hooks/api/use-users.ts
+++ b/frontend/src/hooks/api/use-users.ts
@@ -33,6 +33,11 @@ export function useCreateUser() {
     onSuccess: () => {
       // Invalidate users list
       queryClient.invalidateQueries({ queryKey: queryKeys.users.lists() });
+      // Invalidate dashboard stats - only refetches if dashboard is currently open
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.dashboard.stats(),
+        refetchType: 'active',
+      });
       toast.success('User created successfully');
     },
     onError: (error: unknown) => {
@@ -110,6 +115,11 @@ export function useDeleteUser() {
     mutationFn: (id: string) => usersService.delete(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.users.lists() });
+      // Invalidate dashboard stats - only refetches if dashboard is currently open
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.dashboard.stats(),
+        refetchType: 'active',
+      });
       toast.success('User deleted successfully');
     },
     onError: (error: unknown) => {


### PR DESCRIPTION
## Description

When a new user was created or an existing user deleted, the `Total Users` count on the dashboard wasn't updated for `2 minutes` leading to doubts if the user create / delete worked as expected. 

### Related Issue

Could not find any open issues on this.

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] New and existing tests pass locally

### Backend Changes

- [ ] `uv run ruff check` passes
- [ ] `uv run ruff format --check` passes
- [ ] `uv run ty check` passes

### Frontend Changes

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

## Testing Instructions

**Steps to test:**
1. `docker compose up -d`
2. Open http://localhost:3000/ to access the developer portal.
3. Make a note of, `Total Users` on the `Dashboard`
4. Create new user or Delete an existing user from the `Users` tab.
5. Visit the `Dashboard` again and check if `Total Users` has been updated.

**Expected behavior:**

Instead of staying the same for 2 minutes, the `Total Users` count should change based on Add / Delete user.


## Screenshots

<img width="1440" height="814" alt="Screenshot 2025-12-21 at 3 44 57 PM" src="https://github.com/user-attachments/assets/cf95faed-63f0-4852-bc8a-c78727bc231c" />

