### PR TITLE
Ensure non-negative sleep stage values in seed script

### DIFF
--- a/backend/scripts/init/seed_activity_data.py
+++ b/backend/scripts/init/seed_activity_data.py
@@ -154,7 +154,7 @@ def generate_sleep(
     deep_minutes = fake_instance.random_int(min=60, max=min(180, sleep_duration_minutes // 3))
     rem_minutes = fake_instance.random_int(min=60, max=min(150, sleep_duration_minutes // 3))
     awake_minutes = fake_instance.random_int(min=10, max=min(30, sleep_duration_minutes // 10))
-    
+
     # Light sleep is the remainder, ensuring it's non-negative
     remaining_for_light = sleep_duration_minutes - deep_minutes - rem_minutes - awake_minutes
     light_minutes = max(0, remaining_for_light)


### PR DESCRIPTION

## Description
Got some negative values in `sleep_light_minutes` from the seed script.
```sql
open-wearables=# SELECT * FROM sleep_details LIMIT 5;
              record_id               | sleep_total_duration_minutes | sleep_time_in_bed_minutes | sleep_efficiency_score | sleep_deep_minutes | sleep_rem_minutes | sleep_light_minutes | sleep_awake_minutes | is_nap 
--------------------------------------+------------------------------+---------------------------+------------------------+--------------------+-------------------+---------------------+---------------------+--------
 e9b70ec6-d54c-4ebc-81d1-e645c579bbde |                          454 |                       514 |                  88.33 |                149 |               119 |                 165 |                  21 | f
 7832918d-98a6-4318-a05b-1d9c7d51de39 |                          300 |                       322 |                  93.17 |                179 |               147 |                 -51 |                  25 | f
 52f4ad10-042a-4f5d-94f2-421fca90c01a |                          532 |                       575 |                  92.52 |                166 |               141 |                 197 |                  28 | f
 89a06fe2-6f14-423a-a050-ac0b7f558fe9 |                          498 |                       541 |                  92.05 |                159 |               132 |                 182 |                  25 | f
 bcb607ca-2f52-42ef-b748-2b668b82fd0f |                          485 |                       515 |                  94.17 |                 84 |               118 |                 261 |                  22 | f
(5 rows)
```

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): Data seeding

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] New and existing tests pass locally

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->

- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [ ] `uv run ty check` passes

## Testing Instructions

**Steps to test:**
1. Run `make init`
2. Check if negative values get seeded into `sleep_light_minutes` column in `sleep_details`

**Expected behavior:**
Post this check, negative values should not be seen for `sleep_light_minutes`.
