### PR TITLE
feat: Not found exception for get endpoints

### DIFF
--- a/backend/app/services/services.py
+++ b/backend/app/services/services.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from app.database import BaseDbModel, DbSession
 from app.repositories.repositories import CrudRepository
 from app.schemas import FilterParams
-from app.utils.exceptions import ResourceNotFoundError
+from app.utils.exceptions import ResourceNotFoundError, handle_exceptions
 
 type OptRequest = Request | None
 
@@ -37,6 +37,7 @@ class AppService[
         self.logger.debug(f"Created {self.name} with ID: {creation.id}.")  # type: ignore[union-attr]
         return creation  # type: ignore[return-value]
 
+    @handle_exceptions
     def get(
         self,
         db_session: DbSession,
@@ -63,6 +64,7 @@ class AppService[
 
         return fetched
 
+    @handle_exceptions
     def get_all(
         self,
         db_session: DbSession,

--- a/backend/tests/api/v1/test_api_keys.py
+++ b/backend/tests/api/v1/test_api_keys.py
@@ -9,7 +9,6 @@ Tests cover:
 - POST /api/v1/developer/api-keys/{key_id}/rotate - rotate API key
 """
 
-import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -243,16 +242,17 @@ class TestDeleteApiKey:
 
     def test_delete_api_key_not_found(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test deleting non-existent API key raises ResourceNotFoundError."""
-        from app.utils.exceptions import ResourceNotFoundError
 
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         headers = developer_auth_headers(developer.id)
         fake_key_id = "sk-nonexistent1234567890"
 
-        # Act & Assert
-        with pytest.raises(ResourceNotFoundError):
-            client.delete(f"{api_v1_prefix}/developer/api-keys/{fake_key_id}", headers=headers)
+        # Act
+        response = client.delete(f"{api_v1_prefix}/developer/api-keys/{fake_key_id}", headers=headers)
+
+        # Assert
+        assert response.status_code == 404
 
     def test_delete_api_key_unauthorized(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test deleting API key fails without authentication."""
@@ -332,7 +332,6 @@ class TestUpdateApiKey:
 
     def test_update_api_key_not_found(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test updating non-existent API key raises ResourceNotFoundError."""
-        from app.utils.exceptions import ResourceNotFoundError
 
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
@@ -340,13 +339,15 @@ class TestUpdateApiKey:
         fake_key_id = "sk-nonexistent1234567890"
         payload = {"name": "New Name"}
 
-        # Act & Assert
-        with pytest.raises(ResourceNotFoundError):
-            client.patch(
-                f"{api_v1_prefix}/developer/api-keys/{fake_key_id}",
-                json=payload,
-                headers=headers,
-            )
+        # Act
+        response = client.patch(
+            f"{api_v1_prefix}/developer/api-keys/{fake_key_id}",
+            json=payload,
+            headers=headers,
+        )
+
+        # Assert
+        assert response.status_code == 404
 
     def test_update_api_key_unauthorized(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test updating API key fails without authentication."""
@@ -403,19 +404,20 @@ class TestRotateApiKey:
 
     def test_rotate_api_key_not_found(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test rotating non-existent API key raises ResourceNotFoundError."""
-        from app.utils.exceptions import ResourceNotFoundError
 
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         headers = developer_auth_headers(developer.id)
         fake_key_id = "sk-nonexistent1234567890"
 
-        # Act & Assert
-        with pytest.raises(ResourceNotFoundError):
-            client.post(
-                f"{api_v1_prefix}/developer/api-keys/{fake_key_id}/rotate",
-                headers=headers,
-            )
+        # Act
+        response = client.post(
+            f"{api_v1_prefix}/developer/api-keys/{fake_key_id}/rotate",
+            headers=headers,
+        )
+
+        # Assert
+        assert response.status_code == 404
 
     def test_rotate_api_key_unauthorized(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test rotating API key fails without authentication."""

--- a/backend/tests/api/v1/test_auth.py
+++ b/backend/tests/api/v1/test_auth.py
@@ -11,7 +11,6 @@ Tests cover:
 - DELETE /api/v1/developers/{developer_id} - delete developer
 """
 
-import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -319,16 +318,17 @@ class TestGetDeveloperById:
 
     def test_get_developer_by_id_not_found(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test getting non-existent developer raises ResourceNotFoundError."""
-        from app.utils.exceptions import ResourceNotFoundError
 
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         headers = developer_auth_headers(developer.id)
         fake_id = "00000000-0000-0000-0000-000000000000"
 
-        # Act & Assert
-        with pytest.raises(ResourceNotFoundError):
-            client.get(f"{api_v1_prefix}/developers/{fake_id}", headers=headers)
+        # Act
+        response = client.get(f"{api_v1_prefix}/developers/{fake_id}", headers=headers)
+
+        # Assert
+        assert response.status_code == 404
 
     def test_get_developer_by_id_invalid_uuid(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test getting developer with invalid UUID format."""
@@ -383,7 +383,6 @@ class TestUpdateDeveloperById:
 
     def test_update_developer_by_id_not_found(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test updating non-existent developer raises ResourceNotFoundError."""
-        from app.utils.exceptions import ResourceNotFoundError
 
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
@@ -391,9 +390,11 @@ class TestUpdateDeveloperById:
         fake_id = "00000000-0000-0000-0000-000000000000"
         payload = {"email": "updated@example.com"}
 
-        # Act & Assert
-        with pytest.raises(ResourceNotFoundError):
-            client.patch(f"{api_v1_prefix}/developers/{fake_id}", json=payload, headers=headers)
+        # Act
+        response = client.patch(f"{api_v1_prefix}/developers/{fake_id}", json=payload, headers=headers)
+
+        # Assert
+        assert response.status_code == 404
 
     def test_update_developer_by_id_unauthorized(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test updating developer by ID fails without authentication."""
@@ -454,16 +455,17 @@ class TestDeleteDeveloperById:
 
     def test_delete_developer_by_id_not_found(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test deleting non-existent developer raises ResourceNotFoundError."""
-        from app.utils.exceptions import ResourceNotFoundError
 
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         headers = developer_auth_headers(developer.id)
         fake_id = "00000000-0000-0000-0000-000000000000"
 
-        # Act & Assert
-        with pytest.raises(ResourceNotFoundError):
-            client.delete(f"{api_v1_prefix}/developers/{fake_id}", headers=headers)
+        # Act
+        response = client.delete(f"{api_v1_prefix}/developers/{fake_id}", headers=headers)
+
+        # Assert
+        assert response.status_code == 404
 
     def test_delete_developer_by_id_unauthorized(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test deleting developer fails without authentication."""

--- a/backend/tests/api/v1/test_users.py
+++ b/backend/tests/api/v1/test_users.py
@@ -109,9 +109,6 @@ class TestGetUser:
 
     def test_get_user_not_found(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test getting non-existent user raises ResourceNotFoundError."""
-        import pytest
-
-        from app.utils.exceptions import ResourceNotFoundError
 
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
@@ -119,9 +116,11 @@ class TestGetUser:
         headers = api_key_headers(api_key.id)
         fake_id = "00000000-0000-0000-0000-000000000000"
 
-        # Act & Assert
-        with pytest.raises(ResourceNotFoundError):
-            client.get(f"{api_v1_prefix}/users/{fake_id}", headers=headers)
+        # Act
+        response = client.get(f"{api_v1_prefix}/users/{fake_id}", headers=headers)
+
+        # Assert
+        assert response.status_code == 404
 
     def test_get_user_invalid_uuid(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test getting user with invalid UUID format."""
@@ -347,9 +346,6 @@ class TestUpdateUser:
 
     def test_update_user_not_found(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test updating non-existent user raises ResourceNotFoundError."""
-        import pytest
-
-        from app.utils.exceptions import ResourceNotFoundError
 
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
@@ -357,9 +353,11 @@ class TestUpdateUser:
         fake_id = "00000000-0000-0000-0000-000000000000"
         payload = {"email": "new@example.com"}
 
-        # Act & Assert
-        with pytest.raises(ResourceNotFoundError):
-            client.patch(f"{api_v1_prefix}/users/{fake_id}", json=payload, headers=headers)
+        # Act
+        response = client.patch(f"{api_v1_prefix}/users/{fake_id}", json=payload, headers=headers)
+
+        # Assert
+        assert response.status_code == 404
 
     def test_update_user_invalid_email(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test updating user with invalid email."""
@@ -431,18 +429,17 @@ class TestDeleteUser:
 
     def test_delete_user_not_found(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test deleting non-existent user raises ResourceNotFoundError."""
-        import pytest
-
-        from app.utils.exceptions import ResourceNotFoundError
 
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         headers = developer_auth_headers(developer.id)
         fake_id = "00000000-0000-0000-0000-000000000000"
 
-        # Act & Assert
-        with pytest.raises(ResourceNotFoundError):
-            client.delete(f"{api_v1_prefix}/users/{fake_id}", headers=headers)
+        # Act
+        response = client.delete(f"{api_v1_prefix}/users/{fake_id}", headers=headers)
+
+        # Assert
+        assert response.status_code == 404
 
     def test_delete_user_invalid_uuid(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test deleting user with invalid UUID format."""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -161,10 +161,13 @@ def mock_celery_tasks(monkeypatch: pytest.MonkeyPatch) -> Generator[MagicMock, N
         patch("celery.current_app") as mock_celery,
         patch("app.integrations.celery.tasks.poll_sqs_task.poll_sqs_task", mock_task),
         patch("app.api.routes.v1.import_data.poll_sqs_task", mock_task),
+        patch("app.api.routes.v1.import_xml.poll_sqs_task", mock_task),
     ):
         mock_celery.conf = {
             "task_always_eager": True,
             "task_eager_propagates": True,
+            "broker_url": "memory://",
+            "result_backend": "cache+memory://",
         }
         yield mock_task
 

--- a/backend/tests/services/test_api_key_service.py
+++ b/backend/tests/services/test_api_key_service.py
@@ -208,16 +208,18 @@ class TestApiKeyServiceRotateApiKey:
         assert new_key.created_by is None
 
     def test_rotate_nonexistent_key_raises_404(self, db: Session) -> None:
-        """Should raise ResourceNotFoundError when rotating non-existent key."""
+        """Should raise HTTPException(404) when rotating non-existent key."""
         # Arrange
-        from app.utils.exceptions import ResourceNotFoundError
+        from fastapi import HTTPException
 
         fake_key = "sk-nonexistent"
         developer = DeveloperFactory()
 
         # Act & Assert
-        with pytest.raises(ResourceNotFoundError):
+        with pytest.raises(HTTPException) as exc_info:
             api_key_service.rotate_api_key(db, fake_key, developer.id)
+
+        assert exc_info.value.status_code == 404
 
 
 class TestApiKeyServiceValidateApiKey:

--- a/backend/tests/services/test_developer_service.py
+++ b/backend/tests/services/test_developer_service.py
@@ -181,16 +181,18 @@ class TestDeveloperServiceUpdateDeveloperInfo:
         assert result is None
 
     def test_update_developer_with_raise_404(self, db: Session) -> None:
-        """Should raise ResourceNotFoundError when updating non-existent developer with raise_404=True."""
+        """Should raise HTTPException(404) when updating non-existent developer with raise_404=True."""
         # Arrange
-        from app.utils.exceptions import ResourceNotFoundError
+        from fastapi import HTTPException
 
         fake_id = uuid4()
         update_payload = DeveloperUpdate(email="new@example.com")
 
         # Act & Assert
-        with pytest.raises(ResourceNotFoundError):
+        with pytest.raises(HTTPException) as exc_info:
             developer_service.update_developer_info(db, fake_id, update_payload, raise_404=True)
+
+        assert exc_info.value.status_code == 404
 
     def test_update_developer_empty_update(self, db: Session) -> None:
         """Should handle empty update gracefully."""

--- a/backend/tests/services/test_user_service.py
+++ b/backend/tests/services/test_user_service.py
@@ -136,16 +136,18 @@ class TestUserServiceUpdate:
         assert result is None
 
     def test_update_user_with_raise_404(self, db: Session) -> None:
-        """Should raise ResourceNotFoundError when updating non-existent user with raise_404=True."""
+        """Should raise HTTPException(404) when updating non-existent user with raise_404=True."""
         # Arrange
-        from app.utils.exceptions import ResourceNotFoundError
+        from fastapi import HTTPException
 
         fake_id = uuid4()
         update_payload = UserUpdate(email="new@example.com")
 
         # Act & Assert
-        with pytest.raises(ResourceNotFoundError):
+        with pytest.raises(HTTPException) as exc_info:
             user_service.update(db, fake_id, update_payload, raise_404=True)
+
+        assert exc_info.value.status_code == 404
 
 
 class TestUserServiceGet:


### PR DESCRIPTION
Example based on user tag:

```
curl -X 'GET' \
  'http://localhost:8000/api/v1/users/b84099c7-b613-4afd-b543-cc05a0b89d62'
```

```
{
  "detail": "User with ID: b84099c7-b613-4afd-b543-cc05a0b89d62 not found."
}
```

It will work for all services which inherited base methods from generic base service.