### PR TITLE
fix: Fix duplicate detection query to match database constraint

### DIFF
--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -52,7 +52,7 @@ class EventRecordRepository(
                 .filter(
                     self.model.external_device_mapping_id == mapping.id,
                     self.model.start_datetime == creation.start_datetime,
-                    self.model.category == creation.category,
+                    self.model.end_datetime == creation.end_datetime,
                 )
                 .one_or_none()
             )


### PR DESCRIPTION
## Problem
- The duplicate detection code in `EventRecordRepository.create()` was checking for `category` instead of `end_datetime` when handling `IntegrityError` exceptions.
- However, the database unique constraint `uq_event_record_datetime` uses `(external_device_mapping_id, start_datetime, end_datetime)`, not `category`.
- This mismatch prevented the system from finding existing records when duplicate constraint violations occurred, causing unnecessary errors which I faced while working on https://github.com/the-momentum/open-wearables/pull/237

## Solution
Changed duplicate detection query to use `end_datetime` instead of `category`, matching actual database constraint fields.

## Impact
- Duplicate event records are now correctly detected and the existing record is returned instead of raising an error.