### PR TITLE
fix(event_record_repository): Correct filter conditions to use end_datetime for sleep records

### DIFF
--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -202,7 +202,7 @@ class EventRecordRepository(
         # Then cast back to UUID
         subquery = (
             db_session.query(
-                cast(EventRecord.start_datetime, Date).label("sleep_date"),
+                cast(EventRecord.end_datetime, Date).label("sleep_date"),
                 func.min(EventRecord.start_datetime).label("min_start_time"),
                 func.max(EventRecord.end_datetime).label("max_end_time"),
                 func.sum(EventRecord.duration_seconds).label("total_duration"),
@@ -214,11 +214,11 @@ class EventRecordRepository(
             .filter(
                 ExternalDeviceMapping.user_id == user_id,
                 EventRecord.category == "sleep",
-                EventRecord.start_datetime >= start_date,
-                cast(EventRecord.start_datetime, Date) <= cast(end_date, Date),
+                EventRecord.end_datetime >= start_date,
+                cast(EventRecord.end_datetime, Date) <= cast(end_date, Date),
             )
             .group_by(
-                cast(EventRecord.start_datetime, Date),
+                cast(EventRecord.end_datetime, Date),
                 ExternalDeviceMapping.provider_name,
                 ExternalDeviceMapping.device_id,
             )

--- a/backend/tests/api/v1/test_summaries.py
+++ b/backend/tests/api/v1/test_summaries.py
@@ -34,7 +34,7 @@ class TestSleepSummaryEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert len(data["data"]) == 1
-        assert data["data"][0]["date"] == "2025-12-25"
+        assert data["data"][0]["date"] == "2025-12-26"
         assert data["data"][0]["start_time"] == "2025-12-25T22:00:00Z"
         assert data["data"][0]["end_time"] == "2025-12-26T05:00:00Z"
         assert data["data"][0]["duration_seconds"] == 25200


### PR DESCRIPTION
## Description

- Use end_datetime (wake-up time) instead of start_datetime for daily sleep statistics aggregation
- Prevents duplicate daily entries when sleep spans midnight
- Aligns with user expectations of "last night's sleep" being attributed to the wake-up date


### Related Issue

Closes: https://github.com/the-momentum/open-wearables/issues/234

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] New and existing tests pass locally

### Backend Changes

- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run ty check` passes
