### PR TITLE
fix(whoop): Add offline scope to enable automatic token refresh

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -82,7 +82,7 @@ class Settings(BaseSettings):
     whoop_client_id: str | None = None
     whoop_client_secret: SecretStr | None = None
     whoop_redirect_uri: str = "http://localhost:8000/api/v1/oauth/whoop/callback"
-    whoop_default_scope: str = "read:cycles read:sleep read:recovery"
+    whoop_default_scope: str = "offline read:cycles read:sleep read:recovery"
 
     # EMAIL SETTINGS (Resend)
     resend_api_key: SecretStr | None = None

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -55,4 +55,4 @@ GARMIN_CLIENT_SECRET=your-garmin-client-secret
 WHOOP_CLIENT_ID=public-client-id
 WHOOP_CLIENT_SECRET=private-secret-id
 WHOOP_REDIRECT_URI=http://localhost:8000/api/v1/oauth/whoop/callback
-WHOOP_DEFAULT_SCOPE=read:cycles read:sleep read:recovery
+WHOOP_DEFAULT_SCOPE=offline read:cycles read:sleep read:recovery


### PR DESCRIPTION
## Description

### Problem
Whoop OAuth tokens expire after 1 hour. Without a refresh token, users must manually re-authorize when tokens expire.

### Root Cause
Whoop only returns a `refresh_token` if the `offline` scope is requested during OAuth authorization.

### Solution
Add `offline` to `WHOOP_DEFAULT_SCOPE` so refresh tokens are returned and stored, enabling automatic token refresh.

### References
- https://developer.whoop.com/docs/developing/oauth/
- https://developer.whoop.com/docs/tutorials/refresh-token-postman/

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Testing Instructions

```sql
# Force Token Expiry (to test refresh). Manually set the token as expired:
UPDATE user_connection 
SET token_expires_at = NOW() - INTERVAL '1 hour'
WHERE user_id = '7b50b5db-03e8-44f6-8bef-21d5c3a8b30a' AND provider = 'whoop';"
```

**Expected behavior:**

Before this PR:

```bash
backend__open-wearables        | [2026-01-07 03:23:57,528 - Whoop247Data] (ERROR) Error fetching Whoop sleep data: 401: Token expired and no refresh token available for whoop
backend__open-wearables        | [2026-01-07 03:23:57,679 - Whoop247Data] (ERROR) Failed to sync sleep data: 401: Token expired and no refresh token available for whoop
backend__open-wearables        | Making API request to /v2/activity/sleep with params: {'start': '2025-12-08T03:23:57Z', 'end': '2026-01-07T03:23:57Z', 'limit': 25}
backend__open-wearables        |       INFO   192.168.65.1:24981 - "POST                                         
backend__open-wearables        |              /api/v1/providers/whoop/users/7b50b5db-03e8-44f6-8bef-21d5c3a8b30a/
backend__open-wearables        |              sync?data_type=247 HTTP/1.1" 200
```

With changes in this PR:

```bash
backend__open-wearables        | Making API request to /v2/activity/sleep with params: {'start': '2025-12-08T03:38:40Z', 'end': '2026-01-07T03:38:40Z', 'limit': 25}
backend__open-wearables        |       INFO   192.168.65.1:45633 - "POST                                         
backend__open-wearables        |              /api/v1/providers/whoop/users/7b50b5db-03e8-44f6-8bef-21d5c3a8b30a/
backend__open-wearables        |              sync?data_type=247 HTTP/1.1" 200
```
