### PR TITLE
chore: add default timeframe to garmin

### DIFF
--- a/backend/app/services/providers/garmin/workouts.py
+++ b/backend/app/services/providers/garmin/workouts.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Any, Iterable
 from uuid import UUID, uuid4
@@ -50,11 +50,17 @@ class GarminWorkouts(BaseWorkoutsTemplate):
         start_ts = self._parse_timestamp(summary_start_time)
         end_ts = self._parse_timestamp(summary_end_time)
 
-        params = {}
-        if start_ts:
-            params["uploadStartTimeInSeconds"] = start_ts
-        if end_ts:
-            params["uploadEndTimeInSeconds"] = end_ts
+        # Default to last 24 hours if no time range provided
+        # Garmin API requires these parameters and has a max range of 86400 seconds (24 hours)
+        if not start_ts:
+            start_ts = int((datetime.now() - timedelta(hours=24)).timestamp())
+        if not end_ts:
+            end_ts = int(datetime.now().timestamp())
+
+        params = {
+            "uploadStartTimeInSeconds": start_ts,
+            "uploadEndTimeInSeconds": end_ts,
+        }
 
         return self._make_api_request(
             db,


### PR DESCRIPTION
## Description

Adds a default 24-hour timeframe to Garmin workout API requests when no time range is provided. The Garmin API requires these parameters and has a max range of 86400 seconds (24 hours).

### Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Other (please describe): Minor improvement to ensure Garmin API calls always have required time parameters

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run ty check` passes

### Frontend Changes

N/A - Backend only change

## Testing Instructions

**Steps to test:**
1. Trigger a Garmin workout sync without providing start/end timestamps
2. Verify the API request includes default time parameters (last 24 hours)
3. Confirm workouts are fetched successfully

**Expected behavior:**

Garmin API requests should always include `uploadStartTimeInSeconds` and `uploadEndTimeInSeconds` parameters, defaulting to the last 24 hours if not explicitly provided.

## Screenshots

N/A

## Additional Notes

This change ensures compatibility with the Garmin API requirements while maintaining backward compatibility with existing code that does provide time ranges.