### PR TITLE
fix(api): Return 400 Bad Request for invalid datetime query parameters

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from app.integrations.celery import create_celery
 from app.integrations.sentry import init_sentry
 from app.integrations.sqladmin import add_admin_views
 from app.middlewares import add_cors_middleware
-from app.utils.exceptions import handle_exception
+from app.utils.exceptions import DatetimeParseError, handle_exception
 
 basicConfig(level=INFO, format="[%(asctime)s - %(name)s] (%(levelname)s) %(message)s")
 
@@ -38,6 +38,11 @@ async def root() -> dict[str, str]:
 
 @api.exception_handler(RequestValidationError)
 async def request_validation_exception_handler(_: Request, exc: RequestValidationError) -> None:
+    raise handle_exception(exc, "")
+
+
+@api.exception_handler(DatetimeParseError)
+async def datetime_parse_exception_handler(_: Request, exc: DatetimeParseError) -> None:
     raise handle_exception(exc, "")
 
 

--- a/backend/app/utils/dates.py
+++ b/backend/app/utils/dates.py
@@ -1,12 +1,21 @@
 from datetime import datetime, timezone
 
+from app.utils.exceptions import DatetimeParseError
+
 
 def parse_query_datetime(dt_str: str) -> datetime:
-    """Parse datetime from ISO string or Unix timestamp (seconds)."""
+    """Parse datetime from ISO string or Unix timestamp (seconds).
+
+    Raises:
+        DatetimeParseError: If the string is not a valid ISO 8601 datetime or Unix timestamp.
+    """
     try:
-        # Try parsing as Unix timestamp
         timestamp = float(dt_str)
         return datetime.fromtimestamp(timestamp, tz=timezone.utc)
     except ValueError:
-        # Fallback to ISO format
+        pass
+
+    try:
         return datetime.fromisoformat(dt_str)
+    except ValueError:
+        raise DatetimeParseError(dt_str)

--- a/backend/app/utils/exceptions.py
+++ b/backend/app/utils/exceptions.py
@@ -26,6 +26,12 @@ class InvalidCursorError(Exception):
         self.detail = f"Invalid cursor format: '{cursor}'. Expected 'timestamp|id'."
 
 
+class DatetimeParseError(ValueError):
+    def __init__(self, value: str):
+        self.detail = f"Invalid datetime format: '{value}'. Expected ISO 8601 format or Unix timestamp."
+        super().__init__(self.detail)
+
+
 @singledispatch
 def handle_exception(exc: Exception, _: str) -> HTTPException:
     raise exc
@@ -46,6 +52,11 @@ def _(exc: ResourceNotFoundError, _: str) -> HTTPException:
 
 @handle_exception.register
 def _(exc: InvalidCursorError, _: str) -> HTTPException:
+    return HTTPException(status_code=400, detail=exc.detail)
+
+
+@handle_exception.register
+def _(exc: DatetimeParseError, _: str) -> HTTPException:
     return HTTPException(status_code=400, detail=exc.detail)
 
 

--- a/backend/tests/utils_tests/test_dates.py
+++ b/backend/tests/utils_tests/test_dates.py
@@ -1,0 +1,25 @@
+"""Tests for date utility functions."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.utils.dates import parse_query_datetime
+from app.utils.exceptions import DatetimeParseError
+
+
+class TestParseQueryDatetime:
+    """Test suite for parse_query_datetime."""
+
+    def test_parse_unix_timestamp(self) -> None:
+        result = parse_query_datetime("1704067200")
+        assert result == datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    def test_parse_iso_format(self) -> None:
+        result = parse_query_datetime("2024-01-01T00:00:00+00:00")
+        assert result == datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    def test_invalid_format_raises_error(self) -> None:
+        with pytest.raises(DatetimeParseError) as exc_info:
+            parse_query_datetime("invalid")
+        assert "Invalid datetime format" in exc_info.value.detail


### PR DESCRIPTION
## Description

API endpoints accepting date parameters return **500 Internal Server Error** when given invalid values.

Solution
- Add `DatetimeParseError` exception extending `ValueError`
- Raise from `parse_query_datetime()` on invalid input
- Add global exception handler to convert to HTTP 400

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run ty check` passes

## Testing Instructions

**Steps to test:**

```bash
docker compose exec -e TEST_DATABASE_URL="postgresql+psycopg://open-wearables:open-wearables@db:5432/open_wearables_test" app uv run pytest tests/utils_tests/test_dates.py -v
================================================================================ test session starts =================================================================================
platform linux -- Python 3.13.11, pytest-9.0.1, pluggy-1.6.0 -- /opt/venv/bin/python3
cachedir: .pytest_cache
rootdir: /root_project
configfile: pyproject.toml
plugins: anyio-4.12.0, asyncio-1.3.0, Faker-38.2.0, cov-7.0.0, freezegun-0.4.2
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 3 items                                                                                                                                                                    

tests/utils_tests/test_dates.py::TestParseQueryDatetime::test_parse_unix_timestamp PASSED                                                                                      [ 33%]
tests/utils_tests/test_dates.py::TestParseQueryDatetime::test_parse_iso_format PASSED                                                                                          [ 66%]
tests/utils_tests/test_dates.py::TestParseQueryDatetime::test_invalid_format_raises_error PASSED                                                                               [100%]

================================================================================= 3 passed in 0.14s ==================================================================================
```