### PR TITLE
feat(api): implement daily activity summary with metrics calculation

### DIFF
--- a/backend/app/api/routes/v1/summaries.py
+++ b/backend/app/api/routes/v1/summaries.py
@@ -28,8 +28,13 @@ async def get_activity_summary(
     cursor: str | None = None,
     limit: Annotated[int, Query(ge=1, le=100)] = 50,
 ) -> PaginatedResponse[ActivitySummary]:
-    """Returns daily aggregated activity metrics."""
-    raise HTTPException(status_code=501, detail="Not implemented")
+    """Returns daily aggregated activity metrics.
+
+    Aggregates time-series data (steps, energy, heart rate, etc.) by day.
+    """
+    start_datetime = parse_query_datetime(start_date)
+    end_datetime = parse_query_datetime(end_date)
+    return await summaries_service.get_activity_summaries(db, user_id, start_datetime, end_datetime, cursor, limit)
 
 
 @router.get("/users/{user_id}/summaries/sleep")

--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Query
 
 from app.database import DbSession
 from app.models import EventRecord, ExternalDeviceMapping, SleepDetails
+from app.models.workout_details import WorkoutDetails
 from app.repositories.external_mapping_repository import ExternalMappingRepository
 from app.repositories.repositories import CrudRepository
 from app.schemas import EventRecordCreate, EventRecordQueryParams, EventRecordUpdate
@@ -338,3 +339,61 @@ class EventRecordRepository(
                 }
             )
         return summaries
+
+    def get_daily_workout_aggregates(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[dict]:
+        """Get daily workout aggregates including elevation, distance, and energy.
+
+        Aggregates WorkoutDetails data by date for activity summaries.
+
+        Returns list of dicts with keys:
+        - workout_date, provider_name, device_id
+        - elevation_meters, distance_meters, energy_burned_kcal
+        """
+        results = (
+            db_session.query(
+                cast(self.model.end_datetime, Date).label("workout_date"),
+                ExternalDeviceMapping.provider_name,
+                ExternalDeviceMapping.device_id,
+                # Sum elevation gain for all workouts on that day
+                func.sum(WorkoutDetails.total_elevation_gain).label("elevation_sum"),
+                # Sum distance for all workouts
+                func.sum(WorkoutDetails.distance).label("distance_sum"),
+                # Sum energy burned
+                func.sum(WorkoutDetails.energy_burned).label("energy_sum"),
+            )
+            .join(ExternalDeviceMapping, self.model.external_device_mapping_id == ExternalDeviceMapping.id)
+            .join(WorkoutDetails, self.model.id == WorkoutDetails.record_id)
+            .filter(
+                ExternalDeviceMapping.user_id == user_id,
+                self.model.category == "workout",
+                self.model.end_datetime >= start_date,
+                cast(self.model.end_datetime, Date) <= cast(end_date, Date),
+            )
+            .group_by(
+                cast(self.model.end_datetime, Date),
+                ExternalDeviceMapping.provider_name,
+                ExternalDeviceMapping.device_id,
+            )
+            .order_by(asc(cast(self.model.end_datetime, Date)))
+            .all()
+        )
+
+        aggregates = []
+        for row in results:
+            aggregates.append(
+                {
+                    "workout_date": row.workout_date,
+                    "provider_name": row.provider_name,
+                    "device_id": row.device_id,
+                    "elevation_meters": float(row.elevation_sum) if row.elevation_sum is not None else None,
+                    "distance_meters": float(row.distance_sum) if row.distance_sum is not None else None,
+                    "energy_burned_kcal": float(row.energy_sum) if row.energy_sum is not None else None,
+                }
+            )
+        return aggregates

--- a/backend/app/schemas/summaries.py
+++ b/backend/app/schemas/summaries.py
@@ -11,17 +11,33 @@ class IntensityMinutes(BaseModel):
     vigorous: int | None = None
 
 
+class HeartRateStats(BaseModel):
+    """Heart rate statistics for a period."""
+
+    avg_bpm: int | None = None
+    max_bpm: int | None = None
+    min_bpm: int | None = None
+
+
 class ActivitySummary(BaseModel):
     date: date
     source: DataSource
+    # Step and movement metrics
     steps: int | None = Field(None, description="Total step count", example=8432)
     distance_meters: float | None = Field(None, example=6240.5)
-    floors_climbed: int | None = Field(None, example=12)
-    active_calories_kcal: float | None = Field(None, example=342.5)
-    total_calories_kcal: float | None = Field(None, example=2150.0)
-    active_duration_seconds: int | None = Field(None, description="Total active time", example=3600)
-    sedentary_duration_seconds: int | None = Field(None, example=28800)
+    # Elevation metrics
+    floors_climbed: int | None = Field(None, description="Calculated from elevation (1 floor ≈ 3m)", example=12)
+    elevation_meters: float | None = Field(None, description="Raw total elevation gain", example=36.0)
+    # Energy metrics
+    active_calories_kcal: float | None = Field(None, description="Active energy burned", example=342.5)
+    total_calories_kcal: float | None = Field(None, description="Active + basal energy", example=2150.0)
+    # Duration metrics (based on step threshold)
+    active_minutes: int | None = Field(None, description="Minutes with activity above threshold", example=60)
+    sedentary_minutes: int | None = Field(None, description="Minutes with minimal activity", example=480)
+    # Intensity metrics (based on HR zones)
     intensity_minutes: IntensityMinutes | None = None
+    # Heart rate aggregates
+    heart_rate: HeartRateStats | None = None
 
 
 class SleepStagesSummary(BaseModel):

--- a/backend/app/services/summaries_service.py
+++ b/backend/app/services/summaries_service.py
@@ -5,12 +5,17 @@ from logging import Logger, getLogger
 from uuid import UUID
 
 from app.database import DbSession
-from app.models import DataPointSeries, EventRecord
+from app.models import DataPointSeries, EventRecord, User
 from app.repositories import EventRecordRepository
-from app.repositories.data_point_series_repository import DataPointSeriesRepository
+from app.repositories.data_point_series_repository import (
+    ActiveMinutesResult,
+    DataPointSeriesRepository,
+    IntensityMinutesResult,
+)
+from app.repositories.user_repository import UserRepository
 from app.schemas.common_types import DataSource, PaginatedResponse, Pagination, TimeseriesMetadata
 from app.schemas.series_types import SeriesType
-from app.schemas.summaries import SleepStagesSummary, SleepSummary
+from app.schemas.summaries import ActivitySummary, HeartRateStats, IntensityMinutes, SleepStagesSummary, SleepSummary
 from app.utils.exceptions import handle_exceptions
 from app.utils.pagination import encode_cursor
 
@@ -20,6 +25,16 @@ SLEEP_PHYSIO_SERIES_TYPES = [
     SeriesType.heart_rate,
 ]
 
+# Activity summary constants
+DEFAULT_MAX_HR = 190  # Assumes ~30 years old when birth_date unavailable
+ACTIVE_STEPS_THRESHOLD = 30  # Steps per minute to be considered "active"
+METERS_PER_FLOOR = 3.0  # Standard floor height for floors_climbed calculation
+
+# HR zone percentages (as fraction of max HR)
+HR_ZONE_LIGHT = (0.50, 0.63)  # 50-63% of max HR
+HR_ZONE_MODERATE = (0.64, 0.76)  # 64-76% of max HR
+HR_ZONE_VIGOROUS = (0.77, 0.93)  # 77-93% of max HR
+
 
 class SummariesService:
     """Service for aggregating daily health summaries."""
@@ -28,6 +43,39 @@ class SummariesService:
         self.logger = log
         self.event_record_repo = EventRecordRepository(EventRecord)
         self.data_point_repo = DataPointSeriesRepository(DataPointSeries)
+        self.user_repo = UserRepository(User)
+
+    def _get_user_max_hr(self, db_session: DbSession, user_id: UUID, reference_date: datetime) -> int:
+        """Calculate user's max HR based on age.
+
+        Uses formula: max_hr = 220 - age
+        Falls back to DEFAULT_MAX_HR if birth_date is not available.
+        """
+        user = self.user_repo.get(db_session, user_id)
+        if not user or not user.personal_record or not user.personal_record.birth_date:
+            return DEFAULT_MAX_HR
+
+        # Calculate age as of the reference date
+        birth_date = user.personal_record.birth_date
+        age = reference_date.year - birth_date.year
+        # Adjust if birthday hasn't occurred yet this year
+        if (reference_date.month, reference_date.day) < (birth_date.month, birth_date.day):
+            age -= 1
+
+        max_hr = 220 - age
+        return max(max_hr, 100)  # Ensure reasonable minimum
+
+    def _get_hr_zone_thresholds(self, max_hr: int) -> dict[str, int]:
+        """Calculate HR zone thresholds as percentages of max HR.
+
+        Returns dict with keys: light_min, light_max, moderate_max, vigorous_max
+        """
+        return {
+            "light_min": int(max_hr * HR_ZONE_LIGHT[0]),
+            "light_max": int(max_hr * HR_ZONE_LIGHT[1]),
+            "moderate_max": int(max_hr * HR_ZONE_MODERATE[1]),
+            "vigorous_max": int(max_hr * HR_ZONE_VIGOROUS[1]),
+        }
 
     @handle_exceptions
     async def get_sleep_summaries(
@@ -123,6 +171,179 @@ class SummariesService:
                 avg_hrv_rmssd_ms=None,
                 avg_respiratory_rate=None,
                 avg_spo2_percent=None,
+            )
+            data.append(summary)
+
+        return PaginatedResponse(
+            data=data,
+            pagination=Pagination(
+                has_more=has_more,
+                next_cursor=next_cursor,
+                previous_cursor=previous_cursor,
+            ),
+            metadata=TimeseriesMetadata(
+                sample_count=len(data),
+                start_time=start_date,
+                end_time=end_date,
+            ),
+        )
+
+    @handle_exceptions
+    async def get_activity_summaries(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        start_date: datetime,
+        end_date: datetime,
+        cursor: str | None,
+        limit: int,
+    ) -> PaginatedResponse[ActivitySummary]:
+        """Get daily activity summaries aggregated by date, provider, and device.
+
+        Aggregates include:
+        - Steps (sum from time-series)
+        - Distance (sum from time-series)
+        - Calories (active + basal from time-series)
+        - Elevation (from workouts total_elevation_gain)
+        - Floors (from flights_climbed time-series OR elevation)
+        - Heart rate stats (avg, max, min)
+        - Active/sedentary minutes (based on step threshold)
+        - Intensity minutes (HR zones using max HR = 220 - age):
+          light 50-63%, moderate 64-76%, vigorous 77-93%
+        """
+        self.logger.debug(f"Fetching activity summaries for user {user_id} from {start_date} to {end_date}")
+
+        # Get aggregated data from time-series repository
+        results = self.data_point_repo.get_daily_activity_aggregates(db_session, user_id, start_date, end_date)
+
+        # Get workout aggregates (elevation, distance, energy from workouts)
+        workout_aggregates = self.event_record_repo.get_daily_workout_aggregates(
+            db_session, user_id, start_date, end_date
+        )
+
+        # Build lookup dict for workout data by (date, provider, device)
+        workout_lookup: dict[tuple, dict] = {}
+        for wa in workout_aggregates:
+            key = (wa["workout_date"], wa["provider_name"], wa.get("device_id"))
+            workout_lookup[key] = wa
+
+        # Get active/sedentary minutes from step data
+        activity_minutes = self.data_point_repo.get_daily_active_minutes(
+            db_session, user_id, start_date, end_date, active_threshold=ACTIVE_STEPS_THRESHOLD
+        )
+
+        # Build lookup for activity minutes
+        activity_lookup: dict[tuple, ActiveMinutesResult] = {}
+        for am in activity_minutes:
+            key = (am["activity_date"], am["provider_name"], am.get("device_id"))
+            activity_lookup[key] = am
+
+        # Get intensity minutes from HR data
+        # Calculate HR zone thresholds based on user's max HR (220 - age)
+        max_hr = self._get_user_max_hr(db_session, user_id, start_date)
+        hr_zones = self._get_hr_zone_thresholds(max_hr)
+        intensity_minutes_data = self.data_point_repo.get_daily_intensity_minutes(
+            db_session,
+            user_id,
+            start_date,
+            end_date,
+            light_min=hr_zones["light_min"],
+            light_max=hr_zones["light_max"],
+            moderate_max=hr_zones["moderate_max"],
+            vigorous_max=hr_zones["vigorous_max"],
+        )
+
+        # Build lookup for intensity minutes
+        intensity_lookup: dict[tuple, IntensityMinutesResult] = {}
+        for im in intensity_minutes_data:
+            key = (im["activity_date"], im["provider_name"], im.get("device_id"))
+            intensity_lookup[key] = im
+
+        # Apply pagination (simple offset-based for now, cursor-based can be added later)
+        # TODO: Implement proper cursor pagination like sleep summaries
+        has_more = len(results) > limit
+        if has_more:
+            results = results[:limit]
+
+        # Generate cursors (simplified for now)
+        next_cursor: str | None = None
+        previous_cursor: str | None = None
+
+        # Transform to schema
+        data = []
+        for result in results:
+            # Look up workout data for this day/provider/device
+            result_key = (result["activity_date"], result["provider_name"], result.get("device_id"))
+            workout_data = workout_lookup.get(result_key, {})
+            activity_data = activity_lookup.get(result_key, {})
+            intensity_data = intensity_lookup.get(result_key, {})
+
+            # Get elevation from workouts
+            elevation_meters = workout_data.get("elevation_meters")
+
+            # Calculate floors: prefer flights_climbed from time-series, fallback to elevation
+            flights_climbed = result.get("flights_climbed_sum")
+            if flights_climbed is not None:
+                floors_climbed = flights_climbed
+            elif elevation_meters is not None and elevation_meters > 0:
+                floors_climbed = int(elevation_meters / METERS_PER_FLOOR)
+            else:
+                floors_climbed = None
+
+            # Distance from time-series only
+            # Note: workout distance (from WorkoutDetails) is typically a subset of daily distance,
+            # not additive - providers report daily totals that include workout distance
+            ts_distance = result.get("distance_sum")
+            total_distance = float(ts_distance) if ts_distance is not None else None
+
+            # Build heart rate stats if available
+            hr_stats = None
+            if result.get("hr_avg") is not None:
+                hr_stats = HeartRateStats(
+                    avg_bpm=result.get("hr_avg"),
+                    max_bpm=result.get("hr_max"),
+                    min_bpm=result.get("hr_min"),
+                )
+
+            # Calculate total calories from time-series data
+            # Note: workout energy (from WorkoutDetails) is typically a subset of active_energy,
+            # not additive - providers report daily totals that include workout calories
+            active_cal = result.get("active_energy_sum")
+            basal_cal = result.get("basal_energy_sum")
+            total_cal = None
+            if active_cal is not None or basal_cal is not None:
+                total_cal = (active_cal or 0.0) + (basal_cal or 0.0)
+
+            # Get active/sedentary minutes
+            active_mins = activity_data.get("active_minutes")
+            sedentary_mins = activity_data.get("sedentary_minutes")
+
+            # Get intensity minutes from HR data
+            intensity_mins = None
+            if intensity_data:
+                light = intensity_data.get("light_minutes", 0)
+                moderate = intensity_data.get("moderate_minutes", 0)
+                vigorous = intensity_data.get("vigorous_minutes", 0)
+                intensity_mins = IntensityMinutes(
+                    light=light,
+                    moderate=moderate,
+                    vigorous=vigorous,
+                )
+
+            steps = result.get("steps_sum")
+            summary = ActivitySummary(
+                date=result["activity_date"],
+                source=DataSource(provider=result["provider_name"], device=result.get("device_id")),
+                steps=steps if steps is not None else None,
+                distance_meters=total_distance,
+                floors_climbed=floors_climbed,
+                elevation_meters=elevation_meters,
+                active_calories_kcal=active_cal,
+                total_calories_kcal=total_cal,
+                active_minutes=active_mins,
+                sedentary_minutes=sedentary_mins,
+                intensity_minutes=intensity_mins,
+                heart_rate=hr_stats,
             )
             data.append(summary)
 

--- a/backend/tests/api/v1/test_summaries.py
+++ b/backend/tests/api/v1/test_summaries.py
@@ -11,9 +11,11 @@ from tests.factories import (
     DataPointSeriesFactory,
     EventRecordFactory,
     ExternalDeviceMappingFactory,
+    PersonalRecordFactory,
     SeriesTypeDefinitionFactory,
     SleepDetailsFactory,
     UserFactory,
+    WorkoutDetailsFactory,
 )
 from tests.utils import api_key_headers
 
@@ -314,3 +316,536 @@ class TestSleepSummaryEndpoint:
         # Main sleep should still be tracked
         assert sleep_data["duration_minutes"] == 480  # 8 hours
         assert sleep_data["efficiency_percent"] == 90.0
+
+
+class TestActivitySummaryEndpoint:
+    """Test suite for activity summaries endpoint."""
+
+    def test_get_activity_summary_empty(self, client: TestClient, db: Session) -> None:
+        """Test activity summary returns empty data when no data points exist."""
+        user = UserFactory()
+        api_key = ApiKeyFactory()
+
+        response = client.get(
+            f"/api/v1/users/{user.id}/summaries/activity",
+            headers=api_key_headers(api_key.id),
+            params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["data"] == []
+        assert data["pagination"]["has_more"] is False
+
+    def test_get_activity_summary_with_steps(self, client: TestClient, db: Session) -> None:
+        """Test activity summary aggregates step data by day."""
+        user = UserFactory()
+        mapping = ExternalDeviceMappingFactory(user=user, provider_name="apple")
+        steps_type = SeriesTypeDefinitionFactory.get_or_create_steps()
+
+        # Create step data for a day (multiple data points)
+        base_time = datetime(2025, 12, 26, 8, 0, 0, tzinfo=timezone.utc)
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=steps_type,
+            value=Decimal("1000"),
+            recorded_at=base_time,
+        )
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=steps_type,
+            value=Decimal("500"),
+            recorded_at=base_time + timedelta(hours=1),
+        )
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=steps_type,
+            value=Decimal("750"),
+            recorded_at=base_time + timedelta(hours=2),
+        )
+
+        api_key = ApiKeyFactory()
+        response = client.get(
+            f"/api/v1/users/{user.id}/summaries/activity",
+            headers=api_key_headers(api_key.id),
+            params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 1
+
+        activity = data["data"][0]
+        assert activity["date"] == "2025-12-26"
+        assert activity["steps"] == 2250  # Sum of all steps
+        assert activity["source"]["provider"] == "apple"
+
+    def test_get_activity_summary_with_calories(self, client: TestClient, db: Session) -> None:
+        """Test activity summary aggregates calorie data."""
+        user = UserFactory()
+        mapping = ExternalDeviceMappingFactory(user=user, provider_name="garmin")
+        energy_type = SeriesTypeDefinitionFactory.get_or_create_energy()
+        basal_type = SeriesTypeDefinitionFactory.get_or_create_basal_energy()
+
+        base_time = datetime(2025, 12, 26, 10, 0, 0, tzinfo=timezone.utc)
+
+        # Active calories
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=energy_type,
+            value=Decimal("250.5"),
+            recorded_at=base_time,
+        )
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=energy_type,
+            value=Decimal("150.0"),
+            recorded_at=base_time + timedelta(hours=2),
+        )
+
+        # Basal calories
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=basal_type,
+            value=Decimal("1600.0"),
+            recorded_at=base_time,
+        )
+
+        api_key = ApiKeyFactory()
+        response = client.get(
+            f"/api/v1/users/{user.id}/summaries/activity",
+            headers=api_key_headers(api_key.id),
+            params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 1
+
+        activity = data["data"][0]
+        assert activity["active_calories_kcal"] == 400.5  # 250.5 + 150.0
+        assert activity["total_calories_kcal"] == 2000.5  # 400.5 + 1600.0
+
+    def test_get_activity_summary_with_heart_rate(self, client: TestClient, db: Session) -> None:
+        """Test activity summary includes heart rate statistics."""
+        user = UserFactory()
+        mapping = ExternalDeviceMappingFactory(user=user, provider_name="polar")
+        hr_type = SeriesTypeDefinitionFactory.get_or_create_heart_rate()
+
+        base_time = datetime(2025, 12, 26, 9, 0, 0, tzinfo=timezone.utc)
+
+        # Create multiple HR data points
+        for i, hr in enumerate([65, 120, 145, 90, 72]):
+            DataPointSeriesFactory(
+                mapping=mapping,
+                series_type=hr_type,
+                value=Decimal(str(hr)),
+                recorded_at=base_time + timedelta(minutes=i * 10),
+            )
+
+        api_key = ApiKeyFactory()
+        response = client.get(
+            f"/api/v1/users/{user.id}/summaries/activity",
+            headers=api_key_headers(api_key.id),
+            params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 1
+
+        activity = data["data"][0]
+        assert activity["heart_rate"] is not None
+        assert activity["heart_rate"]["avg_bpm"] == 98  # avg of 65, 120, 145, 90, 72 = 98.4 -> 98
+        assert activity["heart_rate"]["max_bpm"] == 145
+        assert activity["heart_rate"]["min_bpm"] == 65
+
+    def test_get_activity_summary_with_all_metrics(self, client: TestClient, db: Session) -> None:
+        """Test activity summary with all available metrics."""
+        user = UserFactory()
+        mapping = ExternalDeviceMappingFactory(user=user, provider_name="apple")
+
+        steps_type = SeriesTypeDefinitionFactory.get_or_create_steps()
+        energy_type = SeriesTypeDefinitionFactory.get_or_create_energy()
+        basal_type = SeriesTypeDefinitionFactory.get_or_create_basal_energy()
+        hr_type = SeriesTypeDefinitionFactory.get_or_create_heart_rate()
+        distance_type = SeriesTypeDefinitionFactory.get_or_create_distance_walking_running()
+        flights_type = SeriesTypeDefinitionFactory.get_or_create_flights_climbed()
+
+        base_time = datetime(2025, 12, 26, 8, 0, 0, tzinfo=timezone.utc)
+
+        # Steps
+        DataPointSeriesFactory(mapping=mapping, series_type=steps_type, value=Decimal("8500"), recorded_at=base_time)
+
+        # Energy
+        DataPointSeriesFactory(mapping=mapping, series_type=energy_type, value=Decimal("350.0"), recorded_at=base_time)
+        DataPointSeriesFactory(mapping=mapping, series_type=basal_type, value=Decimal("1800.0"), recorded_at=base_time)
+
+        # Heart rate
+        DataPointSeriesFactory(mapping=mapping, series_type=hr_type, value=Decimal("75"), recorded_at=base_time)
+        DataPointSeriesFactory(
+            mapping=mapping, series_type=hr_type, value=Decimal("130"), recorded_at=base_time + timedelta(hours=1)
+        )
+
+        # Distance
+        DataPointSeriesFactory(
+            mapping=mapping, series_type=distance_type, value=Decimal("6200.5"), recorded_at=base_time
+        )
+
+        # Flights climbed
+        DataPointSeriesFactory(mapping=mapping, series_type=flights_type, value=Decimal("12"), recorded_at=base_time)
+
+        api_key = ApiKeyFactory()
+        response = client.get(
+            f"/api/v1/users/{user.id}/summaries/activity",
+            headers=api_key_headers(api_key.id),
+            params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 1
+
+        activity = data["data"][0]
+        assert activity["date"] == "2025-12-26"
+        assert activity["source"]["provider"] == "apple"
+        assert activity["steps"] == 8500
+        assert activity["distance_meters"] == 6200.5
+        assert activity["floors_climbed"] == 12
+        assert activity["active_calories_kcal"] == 350.0
+        assert activity["total_calories_kcal"] == 2150.0  # 350 + 1800
+        assert activity["heart_rate"]["avg_bpm"] == 102  # avg(75, 130) = 102.5 -> 102
+        assert activity["heart_rate"]["max_bpm"] == 130
+        assert activity["heart_rate"]["min_bpm"] == 75
+
+        # Active/sedentary based on step threshold (30 steps/min)
+        # 8500 steps in one minute bucket -> 1 active minute
+        assert activity["active_minutes"] == 1
+        assert activity["sedentary_minutes"] == 0
+
+        # Intensity based on HR zones (using default max HR 190)
+        # HR values: 75 (below light), 130 (moderate: 122-144)
+        # 75 bpm is below 50% of 190 (95), so not counted
+        # 130 bpm is in moderate zone (64-76% of 190 = 122-144)
+        assert activity["intensity_minutes"] is not None
+        assert activity["intensity_minutes"]["moderate"] == 1
+
+    def test_get_activity_summary_multiple_days(self, client: TestClient, db: Session) -> None:
+        """Test activity summary returns data grouped by day."""
+        user = UserFactory()
+        mapping = ExternalDeviceMappingFactory(user=user, provider_name="suunto")
+        steps_type = SeriesTypeDefinitionFactory.get_or_create_steps()
+
+        # Day 1 - Dec 26
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=steps_type,
+            value=Decimal("5000"),
+            recorded_at=datetime(2025, 12, 26, 12, 0, 0, tzinfo=timezone.utc),
+        )
+
+        # Day 2 - Dec 27
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=steps_type,
+            value=Decimal("7500"),
+            recorded_at=datetime(2025, 12, 27, 14, 0, 0, tzinfo=timezone.utc),
+        )
+
+        api_key = ApiKeyFactory()
+        response = client.get(
+            f"/api/v1/users/{user.id}/summaries/activity",
+            headers=api_key_headers(api_key.id),
+            params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-28T00:00:00Z"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 2
+
+        # Ordered by date ascending
+        assert data["data"][0]["date"] == "2025-12-26"
+        assert data["data"][0]["steps"] == 5000
+        assert data["data"][1]["date"] == "2025-12-27"
+        assert data["data"][1]["steps"] == 7500
+
+    def test_get_activity_summary_with_elevation(self, client: TestClient, db: Session) -> None:
+        """Test activity summary includes elevation from workouts."""
+        user = UserFactory()
+        mapping = ExternalDeviceMappingFactory(user=user, provider_name="garmin")
+
+        # Create a workout with elevation data
+        workout_start = datetime(2025, 12, 26, 8, 0, 0, tzinfo=timezone.utc)
+        workout_end = datetime(2025, 12, 26, 9, 30, 0, tzinfo=timezone.utc)
+
+        event_record = EventRecordFactory(
+            mapping=mapping,
+            category="workout",
+            type_="running",
+            start_datetime=workout_start,
+            end_datetime=workout_end,
+            duration_seconds=5400,
+        )
+
+        WorkoutDetailsFactory(
+            event_record=event_record,
+            total_elevation_gain=Decimal("150.5"),  # 150.5 meters
+            distance=Decimal("10000.0"),  # 10km
+        )
+
+        # Also add some step data for the same day
+        steps_type = SeriesTypeDefinitionFactory.get_or_create_steps()
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=steps_type,
+            value=Decimal("12000"),
+            recorded_at=workout_end,
+        )
+
+        api_key = ApiKeyFactory()
+        response = client.get(
+            f"/api/v1/users/{user.id}/summaries/activity",
+            headers=api_key_headers(api_key.id),
+            params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 1
+
+        activity = data["data"][0]
+        assert activity["date"] == "2025-12-26"
+        assert activity["steps"] == 12000
+        assert activity["elevation_meters"] == 150.5
+        # floors_climbed calculated from elevation: 150.5 / 3 = 50
+        assert activity["floors_climbed"] == 50
+        # Distance is from time-series only (not workout), so None here
+        assert activity["distance_meters"] is None
+
+    def test_get_activity_summary_floors_from_flights_preferred(self, client: TestClient, db: Session) -> None:
+        """Test that flights_climbed is preferred over elevation for floors calculation."""
+        user = UserFactory()
+        mapping = ExternalDeviceMappingFactory(user=user, provider_name="apple")
+
+        # Create workout with elevation
+        workout_start = datetime(2025, 12, 26, 10, 0, 0, tzinfo=timezone.utc)
+        workout_end = datetime(2025, 12, 26, 11, 0, 0, tzinfo=timezone.utc)
+
+        event_record = EventRecordFactory(
+            mapping=mapping,
+            category="workout",
+            type_="hiking",
+            start_datetime=workout_start,
+            end_datetime=workout_end,
+            duration_seconds=3600,
+        )
+
+        WorkoutDetailsFactory(
+            event_record=event_record,
+            total_elevation_gain=Decimal("90.0"),  # 90m = 30 floors if calculated
+        )
+
+        # Also add flights_climbed time-series (should be preferred)
+        flights_type = SeriesTypeDefinitionFactory.get_or_create_flights_climbed()
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=flights_type,
+            value=Decimal("25"),  # 25 flights from barometer
+            recorded_at=workout_end,
+        )
+
+        api_key = ApiKeyFactory()
+        response = client.get(
+            f"/api/v1/users/{user.id}/summaries/activity",
+            headers=api_key_headers(api_key.id),
+            params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 1
+
+        activity = data["data"][0]
+        # floors_climbed should be 25 from flights_climbed (not 30 from elevation/3)
+        assert activity["floors_climbed"] == 25
+        # elevation_meters should still show the raw value
+        assert activity["elevation_meters"] == 90.0
+
+    def test_get_activity_summary_with_active_sedentary_minutes(self, client: TestClient, db: Session) -> None:
+        """Test activity summary calculates active/sedentary minutes from step data."""
+        user = UserFactory()
+        mapping = ExternalDeviceMappingFactory(user=user, provider_name="apple")
+        steps_type = SeriesTypeDefinitionFactory.get_or_create_steps()
+
+        # Create step data at minute intervals
+        # Active minutes: 3 minutes with >= 30 steps
+        # Sedentary minutes: 2 minutes with < 30 steps
+        base_time = datetime(2025, 12, 26, 9, 0, 0, tzinfo=timezone.utc)
+
+        # Minute 1: 50 steps (active)
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=steps_type,
+            value=Decimal("50"),
+            recorded_at=base_time,
+        )
+        # Minute 2: 10 steps (sedentary)
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=steps_type,
+            value=Decimal("10"),
+            recorded_at=base_time + timedelta(minutes=1),
+        )
+        # Minute 3: 45 steps (active)
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=steps_type,
+            value=Decimal("45"),
+            recorded_at=base_time + timedelta(minutes=2),
+        )
+        # Minute 4: 5 steps (sedentary)
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=steps_type,
+            value=Decimal("5"),
+            recorded_at=base_time + timedelta(minutes=3),
+        )
+        # Minute 5: 60 steps (active)
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=steps_type,
+            value=Decimal("60"),
+            recorded_at=base_time + timedelta(minutes=4),
+        )
+
+        api_key = ApiKeyFactory()
+        response = client.get(
+            f"/api/v1/users/{user.id}/summaries/activity",
+            headers=api_key_headers(api_key.id),
+            params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 1
+
+        activity = data["data"][0]
+        # 3 minutes with >= 30 steps (50, 45, 60)
+        assert activity["active_minutes"] == 3
+        # 2 minutes with < 30 steps (10, 5)
+        assert activity["sedentary_minutes"] == 2
+        # Total steps: 50 + 10 + 45 + 5 + 60 = 170
+        assert activity["steps"] == 170
+
+    def test_get_activity_summary_with_intensity_minutes(self, client: TestClient, db: Session) -> None:
+        """Test activity summary calculates intensity minutes from HR data.
+
+        Uses a 30-year-old user: max HR = 220 - 30 = 190 bpm
+        - Light: 50-63% of 190 = 95-120 bpm
+        - Moderate: 64-76% of 190 = 122-144 bpm
+        - Vigorous: 77-93% of 190 = 146-177 bpm
+        """
+        from datetime import date
+
+        user = UserFactory()
+        # Create personal record with birth_date for a 30-year-old
+        PersonalRecordFactory(user=user, birth_date=date(1995, 1, 1))
+
+        mapping = ExternalDeviceMappingFactory(user=user, provider_name="apple")
+        hr_type = SeriesTypeDefinitionFactory.get_or_create_heart_rate()
+
+        base_time = datetime(2025, 12, 26, 9, 0, 0, tzinfo=timezone.utc)
+
+        # Create HR data at different zones (user age 30, max HR = 190)
+        # Minute 1: 100 bpm (light: 50-63% of 190 = 95-120)
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=hr_type,
+            value=Decimal("100"),
+            recorded_at=base_time,
+        )
+        # Minute 2: 110 bpm (light)
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=hr_type,
+            value=Decimal("110"),
+            recorded_at=base_time + timedelta(minutes=1),
+        )
+        # Minute 3: 130 bpm (moderate: 64-76% of 190 = 122-144)
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=hr_type,
+            value=Decimal("130"),
+            recorded_at=base_time + timedelta(minutes=2),
+        )
+        # Minute 4: 140 bpm (moderate)
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=hr_type,
+            value=Decimal("140"),
+            recorded_at=base_time + timedelta(minutes=3),
+        )
+        # Minute 5: 160 bpm (vigorous: 77-93% of 190 = 146-177)
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=hr_type,
+            value=Decimal("160"),
+            recorded_at=base_time + timedelta(minutes=4),
+        )
+
+        api_key = ApiKeyFactory()
+        response = client.get(
+            f"/api/v1/users/{user.id}/summaries/activity",
+            headers=api_key_headers(api_key.id),
+            params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 1
+
+        activity = data["data"][0]
+        assert activity["intensity_minutes"] is not None
+        # 2 light minutes (100, 110)
+        assert activity["intensity_minutes"]["light"] == 2
+        # 2 moderate minutes (130, 140)
+        assert activity["intensity_minutes"]["moderate"] == 2
+        # 1 vigorous minute (160)
+        assert activity["intensity_minutes"]["vigorous"] == 1
+
+    def test_get_activity_summary_intensity_without_birth_date(self, client: TestClient, db: Session) -> None:
+        """Test activity summary uses default max HR when birth_date is not available.
+
+        Default max HR = 190 (assumes ~30 years old)
+        """
+        user = UserFactory()
+        # No personal record, so no birth_date
+
+        mapping = ExternalDeviceMappingFactory(user=user, provider_name="apple")
+        hr_type = SeriesTypeDefinitionFactory.get_or_create_heart_rate()
+
+        base_time = datetime(2025, 12, 26, 9, 0, 0, tzinfo=timezone.utc)
+
+        # Create HR data that would be in moderate zone for max HR = 190
+        # Moderate: 64-76% of 190 = 122-144 bpm
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=hr_type,
+            value=Decimal("135"),
+            recorded_at=base_time,
+        )
+
+        api_key = ApiKeyFactory()
+        response = client.get(
+            f"/api/v1/users/{user.id}/summaries/activity",
+            headers=api_key_headers(api_key.id),
+            params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 1
+
+        activity = data["data"][0]
+        assert activity["intensity_minutes"] is not None
+        assert activity["intensity_minutes"]["moderate"] == 1

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -25,6 +25,7 @@ from app.models import (
     EventRecord,
     EventRecordDetail,
     ExternalDeviceMapping,
+    PersonalRecord,
     ProviderSetting,
     SeriesTypeDefinition,
     SleepDetails,
@@ -80,6 +81,46 @@ class SeriesTypeDefinitionFactory(BaseFactory):
         # Fallback: create new one (shouldn't happen with proper seeding)
         return cls(id=80, code="steps", unit="count")
 
+    @classmethod
+    def get_or_create_energy(cls) -> SeriesTypeDefinition:
+        """Get the pre-seeded energy (active calories) series type (ID=81)."""
+        session = cls._meta.sqlalchemy_session
+        if session:
+            existing = session.query(SeriesTypeDefinition).filter(SeriesTypeDefinition.id == 81).first()
+            if existing:
+                return existing
+        return cls(id=81, code="energy", unit="kcal")
+
+    @classmethod
+    def get_or_create_basal_energy(cls) -> SeriesTypeDefinition:
+        """Get the pre-seeded basal_energy series type (ID=82)."""
+        session = cls._meta.sqlalchemy_session
+        if session:
+            existing = session.query(SeriesTypeDefinition).filter(SeriesTypeDefinition.id == 82).first()
+            if existing:
+                return existing
+        return cls(id=82, code="basal_energy", unit="kcal")
+
+    @classmethod
+    def get_or_create_distance_walking_running(cls) -> SeriesTypeDefinition:
+        """Get the pre-seeded distance_walking_running series type (ID=100)."""
+        session = cls._meta.sqlalchemy_session
+        if session:
+            existing = session.query(SeriesTypeDefinition).filter(SeriesTypeDefinition.id == 100).first()
+            if existing:
+                return existing
+        return cls(id=100, code="distance_walking_running", unit="meters")
+
+    @classmethod
+    def get_or_create_flights_climbed(cls) -> SeriesTypeDefinition:
+        """Get the pre-seeded flights_climbed series type (ID=86)."""
+        session = cls._meta.sqlalchemy_session
+        if session:
+            existing = session.query(SeriesTypeDefinition).filter(SeriesTypeDefinition.id == 86).first()
+            if existing:
+                return existing
+        return cls(id=86, code="flights_climbed", unit="count")
+
 
 class UserFactory(BaseFactory):
     """Factory for User model."""
@@ -93,6 +134,19 @@ class UserFactory(BaseFactory):
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
     external_user_id = None
+
+
+class PersonalRecordFactory(BaseFactory):
+    """Factory for PersonalRecord model."""
+
+    class Meta:
+        model = PersonalRecord
+
+    id = LazyFunction(uuid4)
+    user = factory.SubFactory(UserFactory)
+    birth_date = None
+    sex = None
+    gender = None
 
 
 class DeveloperFactory(BaseFactory):

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -234,12 +234,42 @@ export interface SleepSession {
   };
 }
 
+export interface DataSource {
+  provider: string;
+  device: string | null;
+}
+
+export interface HeartRateStats {
+  avg_bpm: number | null;
+  max_bpm: number | null;
+  min_bpm: number | null;
+}
+
+export interface IntensityMinutes {
+  light: number | null;
+  moderate: number | null;
+  vigorous: number | null;
+}
+
 export interface ActivitySummary {
   date: string;
-  steps: number;
-  calories: number;
-  distance: number; // meters
-  activeMinutes: number;
+  source: DataSource;
+  // Step and movement metrics
+  steps: number | null;
+  distance_meters: number | null;
+  // Elevation metrics
+  floors_climbed: number | null;
+  elevation_meters: number | null;
+  // Energy metrics
+  active_calories_kcal: number | null;
+  total_calories_kcal: number | null;
+  // Duration metrics
+  active_minutes: number | null;
+  sedentary_minutes: number | null;
+  // Intensity metrics (based on HR zones)
+  intensity_minutes: IntensityMinutes | null;
+  // Heart rate aggregates
+  heart_rate: HeartRateStats | null;
 }
 
 export interface ApiKey {


### PR DESCRIPTION
## Description

Implements full calculation and aggregation for the daily activity summary endpoint (`/users/{user_id}/summaries/activity`). Previously, this endpoint returned mostly null values. Now it aggregates time-series data and workout details to provide comprehensive daily activity metrics.

**Metrics implemented:**
- **Steps & Distance**: Aggregated from time-series data
- **Calories**: Active calories + basal calories from time-series (workout energy not double-counted)
- **Elevation**: Raw `elevation_meters` from workouts + calculated `floors_climbed` (prefers `flights_climbed` time-series, falls back to elevation/3m)
- **Heart Rate Stats**: Daily avg/max/min BPM from heart rate time-series
- **Active/Sedentary Minutes**: Based on step threshold (30 steps/min)
- **Intensity Minutes**: Light/moderate/vigorous zones based on age-derived max HR (220 - age)

**Technical improvements:**
- Added TypedDict return types for repository aggregate methods
- Extracted activity constants to module level for configurability
- Fixed zero-as-falsy bugs (0 now correctly returned instead of null)
- Updated frontend TypeScript types to match new schema

### Related Issue

Closes #267 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

**Breaking changes:**
- `ActivitySummary` schema fields renamed/restructured (see frontend type updates)
- Fields now use `_minutes` suffix instead of `_seconds`

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run ty check` passes

### Frontend Changes

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds

## Testing Instructions

**Steps to test:**
1. Start the application with `docker compose up -d` and run `make init` to seed data
2. Get a user ID and API key from the database
3. Call the activity summary endpoint with curl
4. Run backend tests: `cd backend && uv run pytest tests/api/v1/test_summaries.py -v`

**Expected behavior:**
- Returns daily activity summaries with all implemented metrics
- Metrics are null only when no data exists (0 returned when measured as zero)
- Intensity minutes calculated based on user's age (or default 190 max HR if no birth date)

## Screenshots

N/A - API endpoint changes

## Additional Notes

- **Double-counting prevention**: Workout energy and distance are NOT added to daily totals as they're typically already included in time-series data from providers
- **HR Zone thresholds**: Light (50-63%), Moderate (64-76%), Vigorous (77-93%) of max HR
- **Configurable constants**: All thresholds defined at module level in `summaries_service.py`
- **Frontend types updated**: `ActivitySummary` interface in `types.ts` now matches backend schema

