### PR TITLE
fix(api): resolve N+1 query in workouts endpoint

### DIFF
--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from sqlalchemy import UUID as SQL_UUID
 from sqlalchemy import Date, Integer, String, and_, asc, case, cast, desc, func, tuple_
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Query
+from sqlalchemy.orm import Query, selectinload
 
 from app.database import DbSession
 from app.models import EventRecord, ExternalDeviceMapping, SleepDetails
@@ -68,9 +68,13 @@ class EventRecordRepository(
         query_params: EventRecordQueryParams,
         user_id: str,
     ) -> tuple[list[tuple[EventRecord, ExternalDeviceMapping]], int]:
-        query: Query = db_session.query(EventRecord, ExternalDeviceMapping).join(
-            ExternalDeviceMapping,
-            EventRecord.external_device_mapping_id == ExternalDeviceMapping.id,
+        query: Query = (
+            db_session.query(EventRecord, ExternalDeviceMapping)
+            .join(
+                ExternalDeviceMapping,
+                EventRecord.external_device_mapping_id == ExternalDeviceMapping.id,
+            )
+            .options(selectinload(EventRecord.detail))
         )
 
         filters = [ExternalDeviceMapping.user_id == UUID(user_id)]

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -1,6 +1,8 @@
 from logging import Logger, getLogger
 from uuid import UUID
 
+from sqlalchemy.orm import selectinload
+
 from app.database import DbSession
 from app.models import (
     EventRecord,
@@ -198,6 +200,7 @@ class EventRecordService(
         # This is a simplified fetch, ideally we should have a dedicated repo method
         record = (
             db_session.query(EventRecord)
+            .options(selectinload(EventRecord.detail))
             .filter(EventRecord.id == workout_id, EventRecord.category == "workout")
             .first()
         )


### PR DESCRIPTION
## Description

Fixes N+1 database query issue in the `/api/v1/users/{user_id}/events/workouts` endpoint. When fetching workouts, the system was executing separate queries for each workout's details due to SQLAlchemy lazy loading on the `EventRecord.detail` relationship.

**Before**: 1 + (N × 2) queries for N workouts (one for `event_record_detail`, one for `workout_details` per record)
**After**: 2-3 queries total regardless of N

### Related Issue

Fixes OPEN-WEARABLES-BACKEND-13
https://sentry.mntm.dev/organizations/momentum/issues/28016/

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run ty check` passes

### Frontend Changes

N/A - Backend only changes

## Testing Instructions

**Steps to test:**
1. Start the server with `docker compose up -d`
2. Call the workouts endpoint: `curl "http://localhost:8000/api/v1/users/{user_id}/events/workouts?start_date=2024-01-01&end_date=2024-12-31"`
3. Check Sentry for reduced query count or enable SQL echo to verify single query batch

**Expected behavior:**
- Endpoint returns same workout data as before
- Database queries reduced from N+1 to 2-3 total queries
- No more N+1 query warnings in Sentry

## Screenshots

N/A - Performance fix

## Additional Notes

The fix uses SQLAlchemy's `selectinload` which issues a single `SELECT ... WHERE record_id IN (...)` query for all related details instead of one query per record. This also benefits the `/api/v1/users/{user_id}/events/sleep` endpoint which uses the same underlying query method.