### PR TITLE
fix(event_record_service): update calorie and distance calculations in event records

### DIFF
--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -162,9 +162,8 @@ class EventRecordService(
                 end_time=record.end_datetime,
                 duration_seconds=record.duration_seconds,
                 source=self._map_source(mapping),
-                calories_kcal=None,  # Need to check where this is stored,
-                # likely in details but not in WorkoutDetails definition I saw earlier?
-                distance_meters=None,
+                calories_kcal=float(details.energy_burned) if details and details.energy_burned else None,
+                distance_meters=float(details.distance) if details and details.distance else None,
                 avg_heart_rate_bpm=int(details.heart_rate_avg) if details and details.heart_rate_avg else None,
                 max_heart_rate_bpm=details.heart_rate_max if details else None,
                 avg_pace_sec_per_km=None,  # Derived or in details?
@@ -228,8 +227,8 @@ class EventRecordService(
             end_time=record.end_datetime,
             duration_seconds=record.duration_seconds,
             source=self._map_source(mapping),
-            calories_kcal=None,
-            distance_meters=None,
+            calories_kcal=float(details.energy_burned) if details and details.energy_burned else None,
+            distance_meters=float(details.distance) if details and details.distance else None,
             avg_heart_rate_bpm=int(details.heart_rate_avg) if details and details.heart_rate_avg else None,
             max_heart_rate_bpm=details.heart_rate_max if details else None,
             avg_pace_sec_per_km=None,


### PR DESCRIPTION
## Description

- Fix bug where `calories_kcal` and `distance_meters` were always `null` in workout API responses
- The bug was only that the stored value wasn't being returned in the API response.

### Related Issue

Ref: https://github.com/the-momentum/open-wearables/issues/302


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)


## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

### Backend Changes

- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run ty check` passes


## Testing Instructions

**Steps to test:**
1. Fire the API endpoint `/api/v1/users/:user_id/events/workouts`
2. Check `calories_kcal` and `distance_meters` properties -- Were `null` before this PR; not any more.

---

NOTE: Whoop bands do not have built-in GPS. Distance data (`score.distance_meter`) is only available when the user carries their phone during the workout, as `whoop` relies on the phone's GPS for location tracking. But, this is not something I have tried myself given I am a newbie whoop user.