### PR TITLE
feat: add recovery data handling to Whoop247Data service

### DIFF
--- a/backend/app/schemas/series_types.py
+++ b/backend/app/schemas/series_types.py
@@ -23,6 +23,8 @@ class SeriesType(str, Enum):
     heart_rate_variability_sdnn = "heart_rate_variability_sdnn"
     heart_rate_recovery_one_minute = "heart_rate_recovery_one_minute"
     walking_heart_rate_average = "walking_heart_rate_average"
+    recovery_score = "recovery_score"
+    heart_rate_variability_rmssd = "heart_rate_variability_rmssd"
 
     # =========================================================================
     # BIOMETRICS - Blood & Respiratory (IDs 20-39)
@@ -125,6 +127,8 @@ SERIES_TYPE_DEFINITIONS: list[tuple[int, SeriesType, str]] = [
     (3, SeriesType.heart_rate_variability_sdnn, "ms"),
     (4, SeriesType.heart_rate_recovery_one_minute, "bpm"),
     (5, SeriesType.walking_heart_rate_average, "bpm"),
+    (6, SeriesType.recovery_score, "score"),
+    (7, SeriesType.heart_rate_variability_rmssd, "ms"),
     # -------------------------------------------------------------------------
     # BIOMETRICS - Blood & Respiratory (IDs 20-39)
     # -------------------------------------------------------------------------


### PR DESCRIPTION
## Description

- Introduced new recovery metrics including recovery_score and heart_rate_variability_rmssd to SeriesType.
- Enhanced Whoop247Data class with methods to fetch, normalize, and save recovery data from the Whoop API.
- Updated load_and_save_recovery method to handle recovery data synchronization.

### Related Issue

Ref: https://github.com/the-momentum/open-wearables/issues/228

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] New and existing tests pass locally

### Backend Changes

- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check` passes
- [x] `uv run ty check` passes

## Testing Instructions

**Steps to test:**
1. Two new series types have been added. So, needs a sync with the command below.

```bash
docker exec -it backend__open-wearables python scripts/init/seed_series_types.py
```

2. Trigger the Whoop sync with the URL endpoint: `/api/v1/providers/:provider/users/:user_id/sync?data_type=247`

**Expected behavior:**

- Table `data_point_series` gets new rows inserted with recovery data synced from Whoop.
- Documentation: https://support.whoop.com/s/article/WHOOP-Recovery
