### PR TITLE
docs: add PR title convention guidelines to contributing documentation

### DIFF
--- a/contributing/pull-requests.md
+++ b/contributing/pull-requests.md
@@ -64,6 +64,24 @@ pagination in the workouts list endpoint.
 Closes #123
 ```
 
+## PR Title Convention
+
+**PR titles must follow the same [Conventional Commits](https://www.conventionalcommits.org/) format as commit messages.**
+
+The CI workflow automatically validates PR titles to ensure they follow this convention. Your PR title should use the format:
+
+```
+<type>(<optional scope>): <description>
+```
+
+### Examples
+
+- `feat: add user profile endpoint`
+- `fix(auth): resolve token refresh issue`
+- `docs: update API documentation`
+- `ci: add PR title validation to workflow`
+- `refactor(backend): simplify authentication logic`
+
 ## Creating a Pull Request
 
 1. **Create a branch** from `main`:


### PR DESCRIPTION
## Description

Adds documentation about PR title conventions to the pull request guidelines. This clarifies that PR titles must follow the same Conventional Commits format as commit messages, which is already enforced by CI validation (introduced [here](https://github.com/the-momentum/open-wearables/pull/338))

### Related Issue

NA

## Checklist

### General

NA

### Backend Changes

NA

### Frontend Changes

NA

## Testing Instructions

NA

## Screenshots

NA

## Additional Notes

NA


