### PR TITLE
ci: separate PR validation to dedicated workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,43 +14,6 @@ on:
       - synchronize
 
 jobs:
-  # Validate PR title follows conventional commits
-  validate-pr-title:
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Validate PR title
-        uses: amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            feat
-            fix
-            docs
-            style
-            refactor
-            perf
-            test
-            build
-            ci
-            chore
-            revert
-          scopes: |
-            backend
-            frontend
-            api
-            auth
-            integrations
-            dashboard
-            settings
-            users
-          requireScope: false
-          subjectPattern: ^.+$
-          subjectPatternError: |
-            The subject "{subject}" doesn't match the required pattern. Please ensure the PR title has a proper description after the type (and optional scope).
-
   # Detect which parts of the codebase changed
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,46 @@
+name: Validate PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          scopes: |
+            backend
+            frontend
+            api
+            auth
+            integrations
+            dashboard
+            settings
+            users
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            The subject "{subject}" doesn't match the required pattern. Please ensure the PR title has a proper description after the type (and optional scope).
+


### PR DESCRIPTION
## Description

The PR title validation job was running on both `pull_request` and `push` events, causing an error when merging PRs to main because the action requires a pull request context. Extracting this to separate workflow that runs only on pull requests seems to be the best option.

### Related Issue

NA

## Checklist

### General

NA

### Backend Changes

NA

### Frontend Changes

NA

## Testing Instructions

NA

## Screenshots

NA

## Additional Notes

NA


