### PR TITLE
fix: redirect to dashboard after login instead of users page

### DIFF
--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -19,7 +19,7 @@ export function useAuth() {
     onSuccess: (data) => {
       setSession(data.access_token, data.developer_id);
       toast.success('Logged in successfully');
-      navigate({ to: '/users' });
+      navigate({ to: '/dashboard' });
     },
     onError: (error: unknown) => {
       const message = error instanceof Error ? error.message : 'Login failed';
@@ -39,7 +39,7 @@ export function useAuth() {
     onSuccess: (data) => {
       setSession(data.access_token, data.developer_id);
       toast.success('Account created successfully');
-      navigate({ to: '/users' });
+      navigate({ to: '/dashboard' });
     },
     onError: (error: unknown) => {
       const message =

--- a/frontend/src/routes/forgot-password.tsx
+++ b/frontend/src/routes/forgot-password.tsx
@@ -14,7 +14,7 @@ export const Route = createFileRoute('/forgot-password')({
   component: ForgotPasswordPage,
   beforeLoad: () => {
     if (typeof window !== 'undefined' && isAuthenticated()) {
-      throw redirect({ to: '/users' });
+      throw redirect({ to: '/dashboard' });
     }
   },
 });

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -9,10 +9,10 @@ export const Route = createFileRoute('/')({
     if (typeof window === 'undefined') {
       return;
     }
-    // Redirect to users if authenticated, otherwise to login
+    // Redirect to dashboard if authenticated, otherwise to login
     if (isAuthenticated()) {
       throw redirect({
-        to: '/users',
+        to: '/dashboard',
       });
     } else {
       throw redirect({
@@ -29,7 +29,7 @@ function IndexRedirect() {
   // Handle client-side redirect after hydration
   useEffect(() => {
     if (isAuthenticated()) {
-      navigate({ to: '/users' });
+      navigate({ to: '/dashboard' });
     } else {
       navigate({ to: '/login' });
     }

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute('/login')({
   component: LoginPage,
   beforeLoad: () => {
     if (typeof window !== 'undefined' && isAuthenticated()) {
-      throw redirect({ to: '/users' });
+      throw redirect({ to: '/dashboard' });
     }
   },
 });

--- a/frontend/src/routes/reset-password.tsx
+++ b/frontend/src/routes/reset-password.tsx
@@ -17,7 +17,7 @@ export const Route = createFileRoute('/reset-password')({
   }),
   beforeLoad: () => {
     if (typeof window !== 'undefined' && isAuthenticated()) {
-      throw redirect({ to: '/users' });
+      throw redirect({ to: '/dashboard' });
     }
   },
 });


### PR DESCRIPTION
## Description

Redirect authenticated users to the dashboard instead of the users page after login.

### Related Issue

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

NA

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

## Testing Instructions

Steps to test:
**Test login redirect:**
1. Log out (if logged in)
2. Log in via /login
3. Verify redirect to /dashboard instead of /users

**Test registration redirect:**
1. Log out
2. Register a new account via /register
3. Verify redirect to /dashboard after registration

**Test root route redirect:**
1. While logged in, navigate to / (root)
2. Verify redirect to /dashboard

**Test auth page guards:**
1. While logged in, try accessing /login, /forgot-password, or /reset-password
2. Verify redirect to /dashboard (instead of allowing access to those pages)

**Test logout and re-login flow:**
1. Log out
2. Log back in
3. Verify redirect to /dashboard works correctly



## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->



## Additional Notes

NA


