### PR TITLE
docs: add ngrok setup guide for local backend exposure

### DIFF
--- a/docs/dev-guides/ngrok-setup.mdx
+++ b/docs/dev-guides/ngrok-setup.mdx
@@ -1,0 +1,121 @@
+---
+title: "Exposing local backend with ngrok"
+description: "Quick setup guide for testing webhooks, OAuth flows (Garmin), and mobile SDK integrations"
+---
+
+When testing webhooks (Garmin OAuth callback, Garmin data push) or the Apple Health SDK, you need to expose your local backend to the internet. ngrok provides a simple solution with minimal configuration.
+
+<Note>
+Why might ngrok be needed for the OAuth flow? Because Garmin's OAuth callback requires HTTPS. Other currently supported cloud providers work with HTTP, so localhost is fine.
+</Note>
+
+## Quick Start
+
+<Steps>
+  <Step title="Install ngrok">
+    Download from [ngrok.com](https://ngrok.com/download) or use a package manager:
+    
+    ```bash
+    # macOS
+    brew install ngrok
+    
+    # Or download directly
+    ```
+  </Step>
+  
+  <Step title="Start your backend">
+    Ensure your Open Wearables backend is running locally (typically on port 8000):
+    
+    ```bash
+    docker compose up
+    ```
+  </Step>
+  
+  <Step title="Expose with ngrok">
+    Run ngrok to create a public tunnel:
+    
+    ```bash
+    ngrok http 8000
+    ```
+  </Step>
+  
+  <Step title="Use the public URL">
+    ngrok will display a public URL like:
+    
+    ```
+    Forwarding  https://abc123.ngrok-free.app -> http://localhost:8000
+    ```
+    
+    Use this HTTPS URL for:
+    - **Garmin OAuth** (requires HTTPS)
+    - Webhook endpoints
+    - Mobile SDK webhook (e.g. [Apple Health sync endpoint](/api-reference/sdk/sync-data-healthion))
+  </Step>
+</Steps>
+
+## Common Use Cases
+
+<AccordionGroup>
+  <Accordion title="OAuth Flow Testing">
+    **Garmin (requires HTTPS):**
+    
+    Garmin OAuth requires HTTPS, so you need ngrok:
+    
+    1. Start ngrok: `ngrok http 8000`
+    2. Copy the HTTPS URL (e.g., `https://abc123.ngrok-free.app`)
+    3. Use it as the `redirect_uri` parameter:
+    
+    ```bash
+    curl "http://localhost:8000/api/v1/oauth/garmin/authorize?user_id=USER_ID&redirect_uri=https://abc123.ngrok-free.app/oauth/callback" \
+      -H "X-Open-Wearables-API-Key: YOUR_API_KEY"
+    ```
+    
+    **Polar & Suunto (HTTP works):**
+    
+    These providers don't require HTTPS, so you can test locally without ngrok:
+    
+    ```bash
+    # Use localhost directly
+    curl "http://localhost:8000/api/v1/oauth/polar/authorize?user_id=USER_ID&redirect_uri=http://localhost:8000/oauth/callback" \
+      -H "X-Open-Wearables-API-Key: YOUR_API_KEY"
+    ```
+  </Accordion>
+  
+  <Accordion title="Webhook Testing">
+    For testing webhook endpoints (e.g., Garmin data push):
+    
+    1. Expose your backend: `ngrok http 8000`
+    2. Configure the webhook URL in your provider settings:
+       - Garmin: Use `https://abc123.ngrok-free.app/api/v1/webhooks/garmin`
+       - Other providers: Similar pattern
+  </Accordion>
+  
+  <Accordion title="Mobile SDK Integration">
+    When testing Apple Health SDK or mobile app integrations:
+    
+    1. Start ngrok: `ngrok http 8000`
+    2. Configure your mobile app to use the ngrok URL:
+       - Update API base URL to `https://abc123.ngrok-free.app`
+       - Same approach
+  </Accordion>
+</AccordionGroup>
+
+## Tips
+
+<Tip>
+**Static domain:** For a consistent URL that doesn't change on restart, you can set a custom domain in ngrok (requires account):
+
+```bash
+ngrok http 8000 --domain=your-custom-domain.ngrok-free.app
+```
+</Tip>
+
+<Warning>
+**Security:** Only use ngrok for development/testing. Never expose production backends through ngrok without proper authentication and rate limiting.
+</Warning>
+
+## Related Guides
+
+- [Backend E2E Integration](/dev-guides/backend-e2e-integration) - Complete integration walkthrough
+- [Provider Setup](/provider-setup/index) - Configure OAuth credentials
+

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -39,7 +39,8 @@
             "pages": [
               "dev-guides/backend-e2e-integration",
               "dev-guides/how-to-add-new-provider",
-              "dev-guides/aws-setup"
+              "dev-guides/aws-setup",
+              "dev-guides/ngrok-setup"
             ]
           },
           {


### PR DESCRIPTION
## Description

Adds ngrok setup guide to developer documentation. This guide helps developers expose their local backend to the internet for testing webhooks (Garmin OAuth callbacks, Garmin data push) and mobile SDK integrations (Apple Health SDK).

### Related Issue

NA

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

NA

### Frontend Changes

NA

## Testing Instructions

1. Run Mintlify locally: cd docs && mintlify dev
2. Navigate to the Developer Guides section
3. Open the "Exposing local backend with ngrok" guide
4. Review content 

## Screenshots

<img width="1510" height="856" alt="image" src="https://github.com/user-attachments/assets/f1c45530-6f57-421d-ad9e-76a919f75f47" />

## Additional Notes

NA


