### PR TITLE
refactor(frontend): implementation of reusable Button, Dialog, and Input components

### DIFF
--- a/frontend/src/components/layout/simple-sidebar.tsx
+++ b/frontend/src/components/layout/simple-sidebar.tsx
@@ -10,6 +10,7 @@ import {
 import logotype from '@/logotype.svg';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/hooks/use-auth';
+import { Button } from '@/components/ui/button';
 
 const menuItems = [
   {
@@ -95,14 +96,15 @@ export function SimpleSidebar() {
 
       {/* Footer */}
       <div className="p-3">
-        <button
+        <Button
+          variant="ghost"
           onClick={() => logout()}
           disabled={isLoggingOut}
-          className="w-full flex items-center gap-3 px-3 py-2 rounded-md text-sm text-zinc-400 hover:bg-zinc-900/50 hover:text-red-400 transition-colors disabled:opacity-50"
+          className="w-full justify-start gap-3 px-3 text-zinc-400 hover:text-red-400"
         >
           <LogOut className="h-4 w-4" />
           {isLoggingOut ? 'Logging out...' : 'Logout'}
-        </button>
+        </Button>
       </div>
     </aside>
   );

--- a/frontend/src/components/pages/dashboard/dashboard-error-state.tsx
+++ b/frontend/src/components/pages/dashboard/dashboard-error-state.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 
 export interface DashboardErrorStateProps {
   onRetry: () => void;
@@ -15,12 +16,9 @@ export function DashboardErrorState({
         <p className="text-zinc-400 mb-4">
           Failed to load dashboard data. Please try again.
         </p>
-        <button
-          onClick={onRetry}
-          className="px-4 py-2 bg-white text-black rounded-md text-sm font-medium hover:bg-zinc-200 transition-colors"
-        >
+        <Button variant="outline" onClick={onRetry}>
           Retry
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -102,7 +102,7 @@ const AlertDialogAction = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Action
     ref={ref}
-    className={cn(buttonVariants(), className)}
+    className={cn(buttonVariants({ variant: 'destructive' }), className)}
     {...props}
   />
 ));

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -5,29 +5,33 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer active:scale-[0.98]',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer',
   {
     variants: {
       variant: {
         default:
-          'bg-primary text-primary-foreground border border-border/50 hover:bg-primary-hover hover:shadow-[0_0_20px_hsla(185,100%,50%,0.4)]',
+          'bg-white text-black hover:bg-zinc-200 border border-transparent',
         destructive:
-          'bg-destructive text-destructive-foreground border border-border/50 hover:bg-destructive-muted hover:shadow-[0_0_15px_hsla(350,100%,55%,0.3)]',
+          'bg-red-500/10 text-red-400 border border-red-500/30 hover:border-red-500/50 hover:shadow-[0_0_15px_hsla(350,100%,55%,0.3)]',
+        'destructive-outline':
+          'border border-border/50 bg-background hover:bg-card hover:border-red-500/50 hover:text-red-400 hover:shadow-[0_0_10px_hsla(350,100%,55%,0.2)]',
         outline:
           'border border-border/50 bg-background hover:bg-card hover:border-primary/50 hover:shadow-[0_0_10px_hsla(185,100%,50%,0.2)]',
         secondary:
-          'bg-secondary text-secondary-foreground border border-border/50 hover:bg-secondary-hover hover:shadow-[0_0_12px_hsla(315,100%,60%,0.2)]',
+          'bg-zinc-800 text-zinc-100 hover:bg-zinc-700 border border-zinc-700/50',
         ghost:
           'border border-transparent hover:border-border/50 hover:bg-card hover:text-foreground hover:shadow-[0_0_8px_hsla(185,100%,50%,0.15)]',
+        'ghost-faded':
+          'border border-transparent text-zinc-500 hover:border-border/50 hover:bg-card hover:text-zinc-300 hover:shadow-[0_0_8px_hsla(185,100%,50%,0.15)]',
         link: 'text-primary underline-offset-4 hover:underline',
-        // New neon variant for highlighted CTAs
-        neon: 'bg-transparent border border-primary text-primary hover:bg-primary/10 hover:shadow-[0_0_25px_hsla(185,100%,60%,0.5),inset_0_0_20px_hsla(185,100%,50%,0.1)]',
+        neon: 'bg-primary text-primary-foreground border border-border/50 hover:bg-primary-hover hover:shadow-[0_0_20px_hsla(185,100%,50%,0.4)] transition-all duration-300 ease-out active:scale-[0.98]',
       },
       size: {
         default: 'h-10 px-4 py-2',
         sm: 'h-9 rounded-md px-3',
         lg: 'h-11 rounded-md px-8',
         icon: 'h-10 w-10',
+        'icon-sm': 'h-8 w-8',
       },
     },
     defaultVariants: {

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -13,7 +13,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
           'placeholder:text-muted-foreground',
           'transition-all duration-300 ease-out',
           'hover:border-primary/30',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
           'focus-visible:border-primary/50 focus-visible:shadow-[0_0_15px_hsla(185,100%,50%,0.15)]',
           'disabled:cursor-not-allowed disabled:opacity-50',
           'md:text-sm',

--- a/frontend/src/components/user/profile-section.tsx
+++ b/frontend/src/components/user/profile-section.tsx
@@ -1,9 +1,18 @@
 import { useState, useEffect } from 'react';
-import { Link as LinkIcon, Check, Pencil, X } from 'lucide-react';
+import { Link as LinkIcon, Check, Pencil } from 'lucide-react';
 import { useUserConnections } from '@/hooks/api/use-health';
 import { useUser, useUpdateUser } from '@/hooks/api/use-users';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { formatDate, truncateId } from '@/lib/utils/format';
 import { copyToClipboard } from '@/lib/utils/clipboard';
 import { ConnectionCard } from '@/components/user/connection-card';
@@ -76,13 +85,15 @@ export function ProfileSection({ userId }: ProfileSectionProps) {
         <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl overflow-hidden">
           <div className="px-6 py-4 border-b border-zinc-800 flex items-center justify-between">
             <h2 className="text-sm font-medium text-white">User Information</h2>
-            <button
+            <Button
+              variant="outline"
+              size="sm"
               onClick={() => setIsEditDialogOpen(true)}
-              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-zinc-400 hover:text-white hover:bg-zinc-800 rounded-md transition-colors"
+              className="text-zinc-400 hover:text-white"
             >
               <Pencil className="h-3.5 w-3.5" />
               Edit
-            </button>
+            </Button>
           </div>
           <div className="p-6">
             {userLoading ? (
@@ -163,10 +174,7 @@ export function ProfileSection({ userId }: ProfileSectionProps) {
             ) : (
               <div className="text-center py-8">
                 <p className="text-zinc-500 mb-4">No providers connected yet</p>
-                <button
-                  onClick={handleCopyPairLink}
-                  className="inline-flex items-center gap-2 px-4 py-2 bg-zinc-800 text-white rounded-md text-sm font-medium hover:bg-zinc-700 transition-colors"
-                >
+                <Button variant="outline" onClick={handleCopyPairLink}>
                   {copied ? (
                     <>
                       <Check className="h-4 w-4 text-emerald-500" />
@@ -178,7 +186,7 @@ export function ProfileSection({ userId }: ProfileSectionProps) {
                       Copy Pairing Link
                     </>
                   )}
-                </button>
+                </Button>
               </div>
             )}
           </div>
@@ -186,108 +194,92 @@ export function ProfileSection({ userId }: ProfileSectionProps) {
       </div>
 
       {/* Edit User Dialog */}
-      {isEditDialogOpen && (
-        <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4">
-          <div className="bg-zinc-900 border border-zinc-800 rounded-xl w-full max-w-md shadow-2xl">
-            <div className="p-6 border-b border-zinc-800 flex items-center justify-between">
-              <div>
-                <h2 className="text-lg font-medium text-white">Edit User</h2>
-                <p className="text-sm text-zinc-500 mt-1">
-                  Update user information
-                </p>
-              </div>
-              <button
-                onClick={() => setIsEditDialogOpen(false)}
-                className="p-2 text-zinc-400 hover:text-white hover:bg-zinc-800 rounded-md transition-colors"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-            <div className="p-6 space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <Label htmlFor="first_name" className="text-zinc-300">
-                    First Name
-                  </Label>
-                  <Input
-                    id="first_name"
-                    value={editForm.first_name}
-                    onChange={(e) =>
-                      setEditForm({ ...editForm, first_name: e.target.value })
-                    }
-                    placeholder="John"
-                    className="bg-zinc-800 border-zinc-700"
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="last_name" className="text-zinc-300">
-                    Last Name
-                  </Label>
-                  <Input
-                    id="last_name"
-                    value={editForm.last_name}
-                    onChange={(e) =>
-                      setEditForm({ ...editForm, last_name: e.target.value })
-                    }
-                    placeholder="Doe"
-                    className="bg-zinc-800 border-zinc-700"
-                  />
-                </div>
-              </div>
+      <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Edit User</DialogTitle>
+            <DialogDescription>Update user information</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
-                <Label htmlFor="email" className="text-zinc-300">
-                  Email
+                <Label htmlFor="first_name" className="text-zinc-300">
+                  First Name
                 </Label>
                 <Input
-                  id="email"
-                  type="email"
-                  value={editForm.email}
+                  id="first_name"
+                  value={editForm.first_name}
                   onChange={(e) =>
-                    setEditForm({ ...editForm, email: e.target.value })
+                    setEditForm({ ...editForm, first_name: e.target.value })
                   }
-                  placeholder="john@example.com"
+                  placeholder="John"
                   className="bg-zinc-800 border-zinc-700"
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="external_user_id" className="text-zinc-300">
-                  External User ID
+                <Label htmlFor="last_name" className="text-zinc-300">
+                  Last Name
                 </Label>
                 <Input
-                  id="external_user_id"
-                  value={editForm.external_user_id}
+                  id="last_name"
+                  value={editForm.last_name}
                   onChange={(e) =>
-                    setEditForm({
-                      ...editForm,
-                      external_user_id: e.target.value,
-                    })
+                    setEditForm({ ...editForm, last_name: e.target.value })
                   }
-                  placeholder="external-123"
+                  placeholder="Doe"
                   className="bg-zinc-800 border-zinc-700"
                 />
-                <p className="text-xs text-zinc-500">
-                  Optional identifier from your system
-                </p>
               </div>
             </div>
-            <div className="p-6 border-t border-zinc-800 flex justify-end gap-3">
-              <button
-                onClick={() => setIsEditDialogOpen(false)}
-                className="px-4 py-2 text-sm font-medium text-zinc-400 hover:text-white hover:bg-zinc-800 rounded-md transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleEditSubmit}
-                disabled={isUpdating}
-                className="px-4 py-2 text-sm font-medium bg-white text-black rounded-md hover:bg-zinc-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {isUpdating ? 'Saving...' : 'Save Changes'}
-              </button>
+            <div className="space-y-2">
+              <Label htmlFor="email" className="text-zinc-300">
+                Email
+              </Label>
+              <Input
+                id="email"
+                type="email"
+                value={editForm.email}
+                onChange={(e) =>
+                  setEditForm({ ...editForm, email: e.target.value })
+                }
+                placeholder="john@example.com"
+                className="bg-zinc-800 border-zinc-700"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="external_user_id" className="text-zinc-300">
+                External User ID
+              </Label>
+              <Input
+                id="external_user_id"
+                value={editForm.external_user_id}
+                onChange={(e) =>
+                  setEditForm({
+                    ...editForm,
+                    external_user_id: e.target.value,
+                  })
+                }
+                placeholder="external-123"
+                className="bg-zinc-800 border-zinc-700"
+              />
+              <p className="text-xs text-zinc-500">
+                Optional identifier from your system
+              </p>
             </div>
           </div>
-        </div>
-      )}
+          <DialogFooter className="gap-3">
+            <Button
+              variant="outline"
+              onClick={() => setIsEditDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleEditSubmit} disabled={isUpdating}>
+              {isUpdating ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/frontend/src/components/users/users-table.tsx
+++ b/frontend/src/components/users/users-table.tsx
@@ -28,6 +28,7 @@ import type { UserRead, UserQueryParams } from '@/lib/api/types';
 import { copyToClipboard } from '@/lib/utils/clipboard';
 import { truncateId } from '@/lib/utils/format';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { useAppleXmlUpload } from '@/hooks/api/use-users';
 import {
   Pagination,
@@ -198,9 +199,8 @@ export function UsersTable({
           </code>
           <Button
             variant="ghost"
-            size="icon"
+            size="icon-sm"
             onClick={() => handleCopyId(row.original.id)}
-            className="h-6 w-6"
           >
             {copiedId === row.original.id ? (
               <Check className="h-3 w-3 text-emerald-500" />
@@ -324,11 +324,10 @@ export function UsersTable({
             )}
           </Button>
           <Button
-            variant="outline"
+            variant="destructive-outline"
             size="icon"
             onClick={() => onDelete(row.original.id)}
             disabled={isDeleting}
-            className="hover:text-red-400 hover:bg-destructive/10"
           >
             <Trash2 className="h-4 w-4" />
           </Button>
@@ -397,12 +396,12 @@ export function UsersTable({
       <div className="p-4 border-b border-zinc-800">
         <div className="relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-500" />
-          <input
+          <Input
             type="text"
             placeholder="Search by name or email..."
             value={globalFilter}
             onChange={(e) => setGlobalFilter(e.target.value)}
-            className="w-full bg-zinc-900 border border-zinc-800 rounded-md pl-9 pr-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-700 focus:border-zinc-700 transition-all"
+            className="bg-zinc-900 border-zinc-800 px-9"
           />
           {isLoading && (
             <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-500 animate-spin" />

--- a/frontend/src/routes/_authenticated/settings/credentials-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/credentials-tab.tsx
@@ -7,6 +7,17 @@ import {
   useDeleteApiKey,
 } from '@/hooks/api/use-credentials';
 import { copyToClipboard } from '@/lib/utils/clipboard';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 
 export function CredentialsTab() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
@@ -80,12 +91,7 @@ export function CredentialsTab() {
     return (
       <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-12 text-center">
         <p className="text-zinc-400 mb-4">Failed to load API keys</p>
-        <button
-          onClick={() => refetch()}
-          className="px-4 py-2 bg-white text-black rounded-md text-sm font-medium hover:bg-zinc-200 transition-colors"
-        >
-          Retry
-        </button>
+        <Button onClick={() => refetch()}>Retry</Button>
       </div>
     );
   }
@@ -100,13 +106,10 @@ export function CredentialsTab() {
             Manage your API keys and widget embed codes
           </p>
         </div>
-        <button
-          onClick={() => setIsCreateDialogOpen(true)}
-          className="flex items-center gap-2 px-4 py-2 bg-white text-black rounded-md text-sm font-medium hover:bg-zinc-200 transition-colors"
-        >
+        <Button onClick={() => setIsCreateDialogOpen(true)}>
           <Plus className="h-4 w-4" />
           Create API Key
-        </button>
+        </Button>
       </div>
 
       {/* API Keys Table */}
@@ -151,22 +154,24 @@ export function CredentialsTab() {
                         <code className="font-mono text-xs bg-zinc-800 text-zinc-300 px-2 py-1 rounded">
                           {visibleKeys.has(key.id) ? key.id : maskKey(key.id)}
                         </code>
-                        <button
+                        <Button
+                          variant="ghost-faded"
+                          size="icon-sm"
                           onClick={() => toggleKeyVisibility(key.id)}
-                          className="p-1 text-zinc-500 hover:text-zinc-300 transition-colors"
                         >
                           {visibleKeys.has(key.id) ? (
                             <EyeOff className="h-4 w-4" />
                           ) : (
                             <Eye className="h-4 w-4" />
                           )}
-                        </button>
-                        <button
+                        </Button>
+                        <Button
+                          variant="ghost-faded"
+                          size="icon-sm"
                           onClick={() => copyToClipboard(key.id)}
-                          className="p-1 text-zinc-500 hover:text-zinc-300 transition-colors"
                         >
                           <Copy className="h-4 w-4" />
-                        </button>
+                        </Button>
                       </div>
                     </td>
                     <td className="px-6 py-4 text-xs text-zinc-500">
@@ -174,13 +179,14 @@ export function CredentialsTab() {
                     </td>
                     <td className="px-6 py-4">
                       <div className="flex justify-end">
-                        <button
+                        <Button
+                          variant="destructive-outline"
+                          size="icon-sm"
                           onClick={() => handleDelete(key.id)}
                           disabled={deleteMutation.isPending}
-                          className="p-2 text-zinc-500 hover:text-red-400 hover:bg-zinc-800 rounded-md transition-colors disabled:opacity-50"
                         >
                           <Trash2 className="h-4 w-4" />
-                        </button>
+                        </Button>
                       </div>
                     </td>
                   </tr>
@@ -195,68 +201,59 @@ export function CredentialsTab() {
             <p className="text-sm text-zinc-500 mb-4">
               Create your first key to get started
             </p>
-            <button
+            <Button
+              variant="outline"
               onClick={() => setIsCreateDialogOpen(true)}
-              className="inline-flex items-center gap-2 px-4 py-2 bg-zinc-800 text-white rounded-md text-sm font-medium hover:bg-zinc-700 transition-colors"
             >
               <Plus className="h-4 w-4" />
               Create API Key
-            </button>
+            </Button>
           </div>
         )}
       </div>
 
       {/* Create Dialog */}
-      {isCreateDialogOpen && (
-        <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4">
-          <div className="bg-zinc-900 border border-zinc-800 rounded-xl w-full max-w-md shadow-2xl">
-            <div className="p-6 border-b border-zinc-800">
-              <h2 className="text-lg font-medium text-white">
-                Create New API Key
-              </h2>
-              <p className="text-sm text-zinc-500 mt-1">
-                Generate a new API key for your application
-              </p>
-            </div>
-            <div className="p-6">
-              <div className="space-y-1.5">
-                <label className="text-xs font-medium text-zinc-300">
-                  Key Name
-                </label>
-                <input
-                  type="text"
-                  placeholder="e.g., Production API Key"
-                  value={keyName}
-                  onChange={(e) => setKeyName(e.target.value)}
-                  className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
-                />
-                <p className="text-[10px] text-zinc-600">
-                  A descriptive name to identify this key
-                </p>
-              </div>
-            </div>
-            <div className="p-6 border-t border-zinc-800 flex justify-end gap-3">
-              <button
-                onClick={() => {
-                  setIsCreateDialogOpen(false);
-                  setKeyName('');
-                }}
-                disabled={createMutation.isPending}
-                className="px-4 py-2 text-sm text-zinc-400 hover:text-white transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleCreate}
-                disabled={createMutation.isPending}
-                className="px-4 py-2 bg-white text-black rounded-md text-sm font-medium hover:bg-zinc-200 transition-colors disabled:opacity-50"
-              >
-                {createMutation.isPending ? 'Creating...' : 'Create Key'}
-              </button>
-            </div>
+      <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Create New API Key</DialogTitle>
+            <DialogDescription>
+              Generate a new API key for your application
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5">
+            <Label htmlFor="key_name" className="text-zinc-300">
+              Key Name
+            </Label>
+            <Input
+              id="key_name"
+              type="text"
+              placeholder="e.g., Production API Key"
+              value={keyName}
+              onChange={(e) => setKeyName(e.target.value)}
+              className="bg-zinc-800 border-zinc-700"
+            />
+            <p className="text-[10px] text-zinc-600">
+              A descriptive name to identify this key
+            </p>
           </div>
-        </div>
-      )}
+          <DialogFooter className="gap-3">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setIsCreateDialogOpen(false);
+                setKeyName('');
+              }}
+              disabled={createMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handleCreate} disabled={createMutation.isPending}>
+              {createMutation.isPending ? 'Creating...' : 'Create Key'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/routes/_authenticated/settings/providers-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/providers-tab.tsx
@@ -5,6 +5,7 @@ import {
 } from '@/hooks/api/use-oauth-providers';
 import { Loader2, CheckCircle2 } from 'lucide-react';
 import { ProviderItem } from '@/components/settings/providers/provider-item';
+import { Button } from '@/components/ui/button';
 
 export function ProvidersTab() {
   const {
@@ -65,12 +66,9 @@ export function ProvidersTab() {
     return (
       <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-12 text-center">
         <p className="text-zinc-400 mb-4">Failed to load OAuth providers</p>
-        <button
-          onClick={() => refetch()}
-          className="px-4 py-2 bg-white text-black rounded-md text-sm font-medium hover:bg-zinc-200 transition-colors"
-        >
+        <Button variant="outline" onClick={() => refetch()}>
           Retry
-        </button>
+        </Button>
       </div>
     );
   }
@@ -93,11 +91,7 @@ export function ProvidersTab() {
           </p>
         </div>
         {hasChanges && (
-          <button
-            onClick={handleSave}
-            disabled={updateMutation.isPending}
-            className="flex items-center gap-2 px-4 py-2 bg-white text-black rounded-md text-sm font-medium hover:bg-zinc-200 transition-colors disabled:opacity-50"
-          >
+          <Button onClick={handleSave} disabled={updateMutation.isPending}>
             {updateMutation.isPending ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -109,7 +103,7 @@ export function ProvidersTab() {
                 Save Changes
               </>
             )}
-          </button>
+          </Button>
         )}
       </div>
 

--- a/frontend/src/routes/_authenticated/settings/team-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/team-tab.tsx
@@ -29,6 +29,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
 
 export function TeamTab() {
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
@@ -146,13 +149,10 @@ export function TeamTab() {
             Manage your team and their access
           </p>
         </div>
-        <button
-          onClick={() => setIsInviteModalOpen(true)}
-          className="flex items-center gap-2 px-4 py-2 bg-white text-black rounded-md text-sm font-medium hover:bg-zinc-200 transition-colors"
-        >
+        <Button onClick={() => setIsInviteModalOpen(true)}>
           <UserPlus className="h-4 w-4" />
           Invite Member
-        </button>
+        </Button>
       </div>
 
       {/* Pending Invitations */}
@@ -223,15 +223,18 @@ export function TeamTab() {
                     </td>
                     <td className="px-6 py-4">
                       <div className="flex justify-end gap-1">
-                        <button
+                        <Button
+                          variant="outline"
+                          size="icon"
                           onClick={() => handleResendInvitation(invitation.id)}
                           disabled={resendInvitationMutation.isPending}
-                          className="p-2 text-zinc-500 hover:text-blue-400 hover:bg-zinc-800 rounded-md transition-colors disabled:opacity-50"
                           title="Resend invitation"
                         >
                           <RotateCw className="h-4 w-4" />
-                        </button>
-                        <button
+                        </Button>
+                        <Button
+                          variant="destructive-outline"
+                          size="icon"
                           onClick={() =>
                             setRevokeTarget({
                               id: invitation.id,
@@ -239,11 +242,10 @@ export function TeamTab() {
                             })
                           }
                           disabled={revokeInvitationMutation.isPending}
-                          className="p-2 text-zinc-500 hover:text-red-400 hover:bg-zinc-800 rounded-md transition-colors disabled:opacity-50"
                           title="Revoke invitation"
                         >
                           <Trash2 className="h-4 w-4" />
-                        </button>
+                        </Button>
                       </div>
                     </td>
                   </tr>
@@ -310,16 +312,18 @@ export function TeamTab() {
                         <code className="font-mono text-xs bg-zinc-800 text-zinc-300 px-2 py-1 rounded">
                           {truncateId(developer.id)}
                         </code>
-                        <button
+                        <Button
+                          variant="ghost-faded"
+                          size="icon-sm"
                           onClick={() => handleCopyId(developer.id)}
-                          className="p-1 text-zinc-500 hover:text-zinc-300 transition-colors"
+                          title="Copy ID"
                         >
                           {copiedId === developer.id ? (
                             <Check className="h-3 w-3 text-emerald-500" />
                           ) : (
                             <Copy className="h-3 w-3" />
                           )}
-                        </button>
+                        </Button>
                       </div>
                     </td>
                     <td className="px-6 py-4 text-xs text-zinc-500">
@@ -328,7 +332,9 @@ export function TeamTab() {
                     <td className="px-6 py-4">
                       <div className="flex justify-end">
                         {me?.id !== developer.id && (
-                          <button
+                          <Button
+                            variant="destructive-outline"
+                            size="icon"
                             onClick={() =>
                               setDeleteTarget({
                                 id: developer.id,
@@ -336,11 +342,10 @@ export function TeamTab() {
                               })
                             }
                             disabled={deleteMutation.isPending}
-                            className="p-2 text-zinc-500 hover:text-red-400 hover:bg-zinc-800 rounded-md transition-colors disabled:opacity-50"
                             title="Remove team member"
                           >
                             <Trash2 className="h-4 w-4" />
-                          </button>
+                          </Button>
                         )}
                       </div>
                     </td>
@@ -356,13 +361,13 @@ export function TeamTab() {
             <p className="text-sm text-zinc-500 mb-4">
               Invite your first team member to get started
             </p>
-            <button
+            <Button
+              variant="outline"
               onClick={() => setIsInviteModalOpen(true)}
-              className="inline-flex items-center gap-2 px-4 py-2 bg-zinc-800 text-white rounded-md text-sm font-medium hover:bg-zinc-700 transition-colors"
             >
               <UserPlus className="h-4 w-4" />
               Invite Member
-            </button>
+            </Button>
           </div>
         )}
       </div>
@@ -383,10 +388,11 @@ export function TeamTab() {
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-1.5 py-4">
-            <label className="text-xs font-medium text-zinc-300">
+            <Label htmlFor="invite_email" className="text-xs text-zinc-300">
               Email Address
-            </label>
-            <input
+            </Label>
+            <Input
+              id="invite_email"
               type="email"
               placeholder="colleague@example.com"
               value={inviteEmail}
@@ -400,36 +406,35 @@ export function TeamTab() {
                   handleInvite();
                 }
               }}
-              className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
+              className="bg-zinc-800 border-zinc-700"
             />
             <p className="text-[10px] text-zinc-600">
               They will receive an email with instructions to join
             </p>
           </div>
           <DialogFooter className="gap-3">
-            <button
+            <Button
+              variant="outline"
               onClick={() => {
                 setIsInviteModalOpen(false);
                 setInviteEmail('');
               }}
               disabled={createInvitationMutation.isPending}
-              className="px-4 py-2 text-sm text-zinc-400 hover:text-white transition-colors"
             >
               Cancel
-            </button>
-            <button
+            </Button>
+            <Button
               onClick={handleInvite}
               disabled={
                 createInvitationMutation.isPending ||
                 !inviteEmail.trim() ||
                 !isValidEmail(inviteEmail.trim())
               }
-              className="px-4 py-2 bg-white text-black rounded-md text-sm font-medium hover:bg-zinc-200 transition-colors disabled:opacity-50"
             >
               {createInvitationMutation.isPending
                 ? 'Sending...'
                 : 'Send Invitation'}
-            </button>
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -448,20 +453,20 @@ export function TeamTab() {
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="gap-3">
-            <button
+            <Button
+              variant="outline"
               onClick={() => setDeleteTarget(null)}
               disabled={deleteMutation.isPending}
-              className="px-4 py-2 text-sm text-zinc-400 hover:text-white transition-colors"
             >
               Cancel
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="destructive"
               onClick={handleDelete}
               disabled={deleteMutation.isPending}
-              className="px-4 py-2 bg-red-600 text-white rounded-md text-sm font-medium hover:bg-red-700 transition-colors disabled:opacity-50"
             >
               {deleteMutation.isPending ? 'Removing...' : 'Remove'}
-            </button>
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -480,20 +485,20 @@ export function TeamTab() {
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="gap-3">
-            <button
+            <Button
+              variant="outline"
               onClick={() => setRevokeTarget(null)}
               disabled={revokeInvitationMutation.isPending}
-              className="px-4 py-2 text-sm text-zinc-400 hover:text-white transition-colors"
             >
               Cancel
-            </button>
-            <button
+            </Button>
+            <Button
+              variant="destructive"
               onClick={handleRevokeInvitation}
               disabled={revokeInvitationMutation.isPending}
-              className="px-4 py-2 bg-red-600 text-white rounded-md text-sm font-medium hover:bg-red-700 transition-colors disabled:opacity-50"
             >
               {revokeInvitationMutation.isPending ? 'Revoking...' : 'Revoke'}
-            </button>
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/frontend/src/routes/_authenticated/users/$userId.tsx
+++ b/frontend/src/routes/_authenticated/users/$userId.tsx
@@ -193,13 +193,12 @@ function UserDetailPage() {
       <div className="p-8">
         <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-12 text-center">
           <p className="text-zinc-400">User not found</p>
-          <Link
-            to="/users"
-            className="mt-4 inline-flex items-center gap-2 px-4 py-2 bg-zinc-800 text-white rounded-md text-sm font-medium hover:bg-zinc-700 transition-colors"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            Back to Users
-          </Link>
+          <Button variant="outline" className="mt-4" asChild>
+            <Link to="/users">
+              <ArrowLeft className="h-4 w-4" />
+              Back to Users
+            </Link>
+          </Button>
         </div>
       </div>
     );
@@ -235,10 +234,10 @@ function UserDetailPage() {
           )}
         </div>
         <div className="flex items-center gap-2">
-          <button
+          <Button
+            variant="secondary"
             onClick={handleUploadClick}
             disabled={isUploading}
-            className="flex items-center gap-2 px-4 py-2 bg-white text-black rounded-md text-sm font-medium hover:bg-zinc-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isUploading ? (
               <>
@@ -251,7 +250,7 @@ function UserDetailPage() {
                 Upload Apple Health XML
               </>
             )}
-          </button>
+          </Button>
           <input
             ref={fileInputRef}
             type="file"
@@ -259,10 +258,7 @@ function UserDetailPage() {
             onChange={(e) => handleUpload(userId, e)}
             className="hidden"
           />
-          <button
-            onClick={handleCopyPairLink}
-            className="flex items-center gap-2 px-4 py-2 bg-white text-black rounded-md text-sm font-medium hover:bg-zinc-200 transition-colors"
-          >
+          <Button variant="secondary" onClick={handleCopyPairLink}>
             {copied ? (
               <>
                 <Check className="h-4 w-4 text-emerald-600" />
@@ -274,11 +270,11 @@ function UserDetailPage() {
                 Copy Pairing Link
               </>
             )}
-          </button>
-          <button
+          </Button>
+          <Button
+            variant="secondary"
             onClick={handleGenerateToken}
             disabled={isGeneratingToken}
-            className="flex items-center gap-2 px-4 py-2 bg-white text-black rounded-md text-sm font-medium hover:bg-zinc-200 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isGeneratingToken ? (
               <>
@@ -291,16 +287,13 @@ function UserDetailPage() {
                 Generate SDK Token
               </>
             )}
-          </button>
+          </Button>
           <AlertDialog>
             <AlertDialogTrigger asChild>
-              <button
-                disabled={isDeleting}
-                className="flex items-center gap-2 px-4 py-2 bg-red-600 text-white rounded-md text-sm font-medium hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
+              <Button variant="destructive" disabled={isDeleting}>
                 <Trash2 className="h-4 w-4" />
                 {isDeleting ? 'Deleting...' : 'Delete User'}
-              </button>
+              </Button>
             </AlertDialogTrigger>
             <AlertDialogContent>
               <AlertDialogHeader>
@@ -312,10 +305,7 @@ function UserDetailPage() {
               </AlertDialogHeader>
               <AlertDialogFooter>
                 <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={handleDelete}
-                  className="bg-red-600 text-white hover:bg-red-700"
-                >
+                <AlertDialogAction onClick={handleDelete}>
                   Delete
                 </AlertDialogAction>
               </AlertDialogFooter>
@@ -361,7 +351,7 @@ function UserDetailPage() {
                   id="token"
                   readOnly
                   value={tokenData?.access_token || ''}
-                  className="bg-zinc-800 border-zinc-700 font-mono text-sm"
+                  className="bg-zinc-800 border-zinc-700 font-mono text-sm focus-visible:ring-0"
                 />
                 <Button
                   onClick={handleCopyToken}

--- a/frontend/src/routes/_authenticated/users/index.tsx
+++ b/frontend/src/routes/_authenticated/users/index.tsx
@@ -5,6 +5,16 @@ import { useUsers, useDeleteUser, useCreateUser } from '@/hooks/api/use-users';
 import type { UserCreate, UserQueryParams } from '@/lib/api/types';
 import { UsersTable } from '@/components/users/users-table';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 
 const initialFormState: UserCreate = {
   external_user_id: '',
@@ -147,13 +157,10 @@ function UsersPage() {
             Manage your platform users and their wearable connections
           </p>
         </div>
-        <button
-          onClick={() => setIsCreateDialogOpen(true)}
-          className="flex items-center gap-2 px-4 py-2 bg-white text-black rounded-md text-sm font-medium hover:bg-zinc-200 transition-colors"
-        >
+        <Button onClick={() => setIsCreateDialogOpen(true)}>
           <Plus className="h-4 w-4" />
           Add User
-        </button>
+        </Button>
       </div>
 
       {total > 0 || queryParams.search ? (
@@ -183,158 +190,163 @@ function UsersPage() {
         </div>
       )}
 
-      {isCreateDialogOpen && (
-        <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4">
-          <div className="bg-zinc-900 border border-zinc-800 rounded-xl w-full max-w-md shadow-2xl">
-            <div className="p-6 border-b border-zinc-800">
-              <h2 className="text-lg font-medium text-white">
-                Create New User
-              </h2>
-              <p className="text-sm text-zinc-500 mt-1">
-                Create a new user to connect wearable devices and collect health
-                data.
+      <Dialog
+        open={isCreateDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            handleCloseCreateDialog();
+          } else {
+            setIsCreateDialogOpen(true);
+          }
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Create New User</DialogTitle>
+            <DialogDescription>
+              Create a new user to connect wearable devices and collect health
+              data.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="external_user_id" className="text-zinc-300">
+                External User ID
+              </Label>
+              <Input
+                id="external_user_id"
+                type="text"
+                placeholder="e.g., user_12345 or external system ID"
+                value={formData.external_user_id || ''}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    external_user_id: e.target.value,
+                  })
+                }
+                maxLength={255}
+                className="bg-zinc-800 border-zinc-700"
+              />
+              {formErrors.external_user_id && (
+                <p className="text-xs text-red-500">
+                  {formErrors.external_user_id}
+                </p>
+              )}
+              <p className="text-[10px] text-zinc-600">
+                Your unique identifier for this user (max 255 characters)
               </p>
             </div>
-            <div className="p-6 space-y-4">
+            <div className="grid grid-cols-2 gap-4">
               <div className="space-y-1.5">
-                <label className="text-xs font-medium text-zinc-300">
-                  External User ID
-                </label>
-                <input
+                <Label htmlFor="first_name" className="text-zinc-300">
+                  First Name
+                </Label>
+                <Input
+                  id="first_name"
                   type="text"
-                  placeholder="e.g., user_12345 or external system ID"
-                  value={formData.external_user_id || ''}
+                  placeholder="John"
+                  value={formData.first_name || ''}
                   onChange={(e) =>
-                    setFormData({
-                      ...formData,
-                      external_user_id: e.target.value,
-                    })
+                    setFormData({ ...formData, first_name: e.target.value })
                   }
-                  maxLength={255}
-                  className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
+                  maxLength={100}
+                  className="bg-zinc-800 border-zinc-700"
                 />
-                {formErrors.external_user_id && (
+                {formErrors.first_name && (
                   <p className="text-xs text-red-500">
-                    {formErrors.external_user_id}
+                    {formErrors.first_name}
                   </p>
                 )}
-                <p className="text-[10px] text-zinc-600">
-                  Your unique identifier for this user (max 255 characters)
-                </p>
-              </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div className="space-y-1.5">
-                  <label className="text-xs font-medium text-zinc-300">
-                    First Name
-                  </label>
-                  <input
-                    type="text"
-                    placeholder="John"
-                    value={formData.first_name || ''}
-                    onChange={(e) =>
-                      setFormData({ ...formData, first_name: e.target.value })
-                    }
-                    maxLength={100}
-                    className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
-                  />
-                  {formErrors.first_name && (
-                    <p className="text-xs text-red-500">
-                      {formErrors.first_name}
-                    </p>
-                  )}
-                </div>
-                <div className="space-y-1.5">
-                  <label className="text-xs font-medium text-zinc-300">
-                    Last Name
-                  </label>
-                  <input
-                    type="text"
-                    placeholder="Doe"
-                    value={formData.last_name || ''}
-                    onChange={(e) =>
-                      setFormData({ ...formData, last_name: e.target.value })
-                    }
-                    maxLength={100}
-                    className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
-                  />
-                  {formErrors.last_name && (
-                    <p className="text-xs text-red-500">
-                      {formErrors.last_name}
-                    </p>
-                  )}
-                </div>
               </div>
               <div className="space-y-1.5">
-                <label className="text-xs font-medium text-zinc-300">
-                  Email
-                </label>
-                <input
-                  type="email"
-                  placeholder="john.doe@example.com"
-                  value={formData.email || ''}
+                <Label htmlFor="last_name" className="text-zinc-300">
+                  Last Name
+                </Label>
+                <Input
+                  id="last_name"
+                  type="text"
+                  placeholder="Doe"
+                  value={formData.last_name || ''}
                   onChange={(e) =>
-                    setFormData({ ...formData, email: e.target.value })
+                    setFormData({ ...formData, last_name: e.target.value })
                   }
-                  className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
+                  maxLength={100}
+                  className="bg-zinc-800 border-zinc-700"
                 />
-                {formErrors.email && (
-                  <p className="text-xs text-red-500">{formErrors.email}</p>
+                {formErrors.last_name && (
+                  <p className="text-xs text-red-500">{formErrors.last_name}</p>
                 )}
               </div>
             </div>
-            <div className="p-6 border-t border-zinc-800 flex justify-end gap-3">
-              <Button variant="outline" onClick={handleCloseCreateDialog}>
-                Cancel
-              </Button>
-              <Button
-                onClick={handleCreateUser}
-                disabled={createUser.isPending}
-              >
-                {createUser.isPending ? 'Creating...' : 'Create User'}
-              </Button>
+            <div className="space-y-1.5">
+              <Label htmlFor="email" className="text-zinc-300">
+                Email
+              </Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="john.doe@example.com"
+                value={formData.email || ''}
+                onChange={(e) =>
+                  setFormData({ ...formData, email: e.target.value })
+                }
+                className="bg-zinc-800 border-zinc-700"
+              />
+              {formErrors.email && (
+                <p className="text-xs text-red-500">{formErrors.email}</p>
+              )}
             </div>
           </div>
-        </div>
-      )}
+          <DialogFooter className="gap-3">
+            <Button variant="outline" onClick={handleCloseCreateDialog}>
+              Cancel
+            </Button>
+            <Button onClick={handleCreateUser} disabled={createUser.isPending}>
+              {createUser.isPending ? 'Creating...' : 'Create User'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
-      {deleteUserId && (
-        <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 p-4">
-          <div className="bg-zinc-900 border border-zinc-800 rounded-xl w-full max-w-md shadow-2xl">
-            <div className="p-6 border-b border-zinc-800">
-              <h2 className="text-lg font-medium text-white">Delete User?</h2>
-              <p className="text-sm text-zinc-500 mt-1">
-                This action cannot be undone. This will permanently delete the
-                user and all associated data including:
-              </p>
-            </div>
-            <div className="p-6">
-              <ul className="list-disc list-inside text-sm text-zinc-500 space-y-1">
-                <li>All wearable device connections</li>
-                <li>All health data (sleep, activity)</li>
-                <li>All automation triggers for this user</li>
-              </ul>
-              <div className="mt-4 p-3 bg-zinc-800 rounded-md">
-                <p className="text-xs text-zinc-500">User ID:</p>
-                <code className="font-mono text-sm text-zinc-300">
-                  {deleteUserId}
-                </code>
-              </div>
-            </div>
-            <div className="p-6 border-t border-zinc-800 flex justify-end gap-3">
-              <Button variant="outline" onClick={() => setDeleteUserId(null)}>
-                Cancel
-              </Button>
-              <Button
-                variant="destructive"
-                onClick={handleDeleteUser}
-                disabled={deleteUser.isPending}
-              >
-                {deleteUser.isPending ? 'Deleting...' : 'Delete User'}
-              </Button>
+      <Dialog
+        open={!!deleteUserId}
+        onOpenChange={(open) => !open && setDeleteUserId(null)}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete User?</DialogTitle>
+            <DialogDescription>
+              This action cannot be undone. This will permanently delete the
+              user and all associated data including:
+            </DialogDescription>
+          </DialogHeader>
+          <div>
+            <ul className="list-disc list-inside text-sm text-zinc-500 space-y-1">
+              <li>All wearable device connections</li>
+              <li>All health data (sleep, activity)</li>
+              <li>All automation triggers for this user</li>
+            </ul>
+            <div className="mt-4 p-3 bg-zinc-800 rounded-md">
+              <p className="text-xs text-zinc-500">User ID:</p>
+              <code className="font-mono text-sm text-zinc-300">
+                {deleteUserId}
+              </code>
             </div>
           </div>
-        </div>
-      )}
+          <DialogFooter className="gap-3">
+            <Button variant="outline" onClick={() => setDeleteUserId(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDeleteUser}
+              disabled={deleteUser.isPending}
+            >
+              {deleteUser.isPending ? 'Deleting...' : 'Delete User'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/routes/accept-invite.tsx
+++ b/frontend/src/routes/accept-invite.tsx
@@ -24,6 +24,9 @@ import {
   CheckCircle2,
   Loader2,
 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 
 export const Route = createFileRoute('/accept-invite')({
   component: AcceptInvitePage,
@@ -57,9 +60,6 @@ const STATUS_CONFIG = {
       'This invitation link is invalid or has expired. Please contact your team administrator for a new invitation.',
   },
 } as const;
-
-const INPUT_CLASS =
-  'w-full bg-zinc-900/50 border border-zinc-800 rounded-md px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-700 focus:border-zinc-700 transition-all shadow-sm';
 
 function AcceptInvitePage() {
   const { token } = Route.useSearch();
@@ -198,16 +198,16 @@ function AcceptInvitePage() {
               >
                 <div className="grid grid-cols-2 gap-3">
                   <div className="space-y-1.5">
-                    <label
+                    <Label
                       htmlFor="first_name"
-                      className="text-xs font-medium text-zinc-300"
+                      className="text-xs text-zinc-300"
                     >
                       First name
-                    </label>
-                    <input
+                    </Label>
+                    <Input
                       id="first_name"
                       placeholder="John"
-                      className={INPUT_CLASS}
+                      className="bg-zinc-900/50 border-zinc-800"
                       {...form.register('first_name')}
                     />
                     {form.formState.errors.first_name && (
@@ -217,16 +217,16 @@ function AcceptInvitePage() {
                     )}
                   </div>
                   <div className="space-y-1.5">
-                    <label
+                    <Label
                       htmlFor="last_name"
-                      className="text-xs font-medium text-zinc-300"
+                      className="text-xs text-zinc-300"
                     >
                       Last name
-                    </label>
-                    <input
+                    </Label>
+                    <Input
                       id="last_name"
                       placeholder="Doe"
-                      className={INPUT_CLASS}
+                      className="bg-zinc-900/50 border-zinc-800"
                       {...form.register('last_name')}
                     />
                     {form.formState.errors.last_name && (
@@ -238,18 +238,15 @@ function AcceptInvitePage() {
                 </div>
 
                 <div className="space-y-1.5">
-                  <label
-                    htmlFor="password"
-                    className="text-xs font-medium text-zinc-300"
-                  >
+                  <Label htmlFor="password" className="text-xs text-zinc-300">
                     Password
-                  </label>
+                  </Label>
                   <div className="relative">
-                    <input
+                    <Input
                       type={showPassword ? 'text' : 'password'}
                       id="password"
                       placeholder="At least 8 characters"
-                      className={`${INPUT_CLASS} pr-10`}
+                      className="bg-zinc-900/50 border-zinc-800 pr-10"
                       {...form.register('password')}
                     />
                     <button
@@ -272,18 +269,18 @@ function AcceptInvitePage() {
                 </div>
 
                 <div className="space-y-1.5">
-                  <label
+                  <Label
                     htmlFor="confirmPassword"
-                    className="text-xs font-medium text-zinc-300"
+                    className="text-xs text-zinc-300"
                   >
                     Confirm password
-                  </label>
+                  </Label>
                   <div className="relative">
-                    <input
+                    <Input
                       type={showConfirmPassword ? 'text' : 'password'}
                       id="confirmPassword"
                       placeholder="Confirm your password"
-                      className={`${INPUT_CLASS} pr-10`}
+                      className="bg-zinc-900/50 border-zinc-800 pr-10"
                       {...form.register('confirmPassword')}
                     />
                     <button
@@ -313,10 +310,10 @@ function AcceptInvitePage() {
                   </p>
                 )}
 
-                <button
+                <Button
                   type="submit"
                   disabled={acceptInvitationMutation.isPending}
-                  className="w-full bg-white text-black hover:bg-zinc-200 font-medium text-sm h-9 rounded-md transition-colors flex items-center justify-center gap-2 shadow-[0_0_15px_rgba(255,255,255,0.1)] disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="w-full"
                 >
                   {acceptInvitationMutation.isPending ? (
                     <>
@@ -329,7 +326,7 @@ function AcceptInvitePage() {
                       <ArrowRight className="w-4 h-4 opacity-60" />
                     </>
                   )}
-                </button>
+                </Button>
               </form>
 
               <p className="text-center text-sm text-zinc-500">

--- a/frontend/src/routes/forgot-password.tsx
+++ b/frontend/src/routes/forgot-password.tsx
@@ -8,7 +8,10 @@ import {
   forgotPasswordSchema,
   type ForgotPasswordFormData,
 } from '@/lib/validation/auth.schemas';
-import { Activity, ArrowLeft, Mail, CheckCircle } from 'lucide-react';
+import { Activity, ArrowLeft, Mail, CheckCircle, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 
 export const Route = createFileRoute('/forgot-password')({
   component: ForgotPasswordPage,
@@ -94,18 +97,15 @@ function ForgotPasswordPage() {
           <div className="p-8 space-y-6">
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
               <div className="space-y-1.5">
-                <label
-                  htmlFor="email"
-                  className="text-xs font-medium text-zinc-300"
-                >
+                <Label htmlFor="email" className="text-xs text-zinc-300">
                   Email address
-                </label>
+                </Label>
                 <div className="relative group">
-                  <input
+                  <Input
                     type="email"
                     id="email"
                     {...form.register('email')}
-                    className="w-full bg-zinc-900/50 border border-zinc-800 rounded-md px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-700 focus:border-zinc-700 transition-all shadow-sm"
+                    className="bg-zinc-900/50 border-zinc-800 pr-10"
                     placeholder="you@example.com"
                   />
                   <div className="absolute inset-y-0 right-3 flex items-center pointer-events-none opacity-0 group-focus-within:opacity-100 transition-opacity">
@@ -119,35 +119,20 @@ function ForgotPasswordPage() {
                 )}
               </div>
 
-              <button
+              <Button
                 type="submit"
                 disabled={isForgotPasswordPending}
-                className="w-full bg-white text-black hover:bg-zinc-200 font-medium text-sm h-9 rounded-md transition-colors flex items-center justify-center gap-2 shadow-[0_0_15px_rgba(255,255,255,0.1)] disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full"
               >
                 {isForgotPasswordPending ? (
                   <>
-                    <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
-                      <circle
-                        className="opacity-25"
-                        cx="12"
-                        cy="12"
-                        r="10"
-                        stroke="currentColor"
-                        strokeWidth="4"
-                        fill="none"
-                      />
-                      <path
-                        className="opacity-75"
-                        fill="currentColor"
-                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                      />
-                    </svg>
+                    <Loader2 className="h-4 w-4 animate-spin" />
                     Sending...
                   </>
                 ) : (
                   'Send Reset Link'
                 )}
-              </button>
+              </Button>
             </form>
           </div>
         )}

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -2,9 +2,12 @@ import { createFileRoute, redirect } from '@tanstack/react-router';
 import { useState } from 'react';
 import { useAuth } from '@/hooks/use-auth';
 import { isAuthenticated } from '@/lib/auth/session';
-import { ArrowRight, Mail, Lock } from 'lucide-react';
+import { ArrowRight, Mail, Lock, Loader2 } from 'lucide-react';
 import logotype from '@/logotype.svg';
 import { CodePreviewCard } from '@/components/login/code-preview-card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 
 export const Route = createFileRoute('/login')({
   component: LoginPage,
@@ -52,19 +55,16 @@ function LoginPage() {
             <form className="space-y-4" onSubmit={handleLogin}>
               {/* Email Input */}
               <div className="space-y-1.5">
-                <label
-                  htmlFor="email"
-                  className="text-xs font-medium text-zinc-300"
-                >
+                <Label htmlFor="email" className="text-xs text-zinc-300">
                   Email address
-                </label>
+                </Label>
                 <div className="relative group">
-                  <input
+                  <Input
                     type="email"
                     id="email"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
-                    className="w-full bg-zinc-900/50 border border-zinc-800 rounded-md px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-700 focus:border-zinc-700 transition-all shadow-sm"
+                    className="bg-zinc-900/50 border-zinc-800 pr-10"
                     placeholder="developer@example.com"
                     required
                   />
@@ -76,19 +76,16 @@ function LoginPage() {
 
               {/* Password Input */}
               <div className="space-y-1.5">
-                <label
-                  htmlFor="password"
-                  className="text-xs font-medium text-zinc-300"
-                >
+                <Label htmlFor="password" className="text-xs text-zinc-300">
                   Password
-                </label>
+                </Label>
                 <div className="relative group">
-                  <input
+                  <Input
                     type="password"
                     id="password"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
-                    className="w-full bg-zinc-900/50 border border-zinc-800 rounded-md px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-700 focus:border-zinc-700 transition-all shadow-sm"
+                    className="bg-zinc-900/50 border-zinc-800 pr-10"
                     placeholder="••••••••"
                     required
                   />
@@ -99,29 +96,10 @@ function LoginPage() {
               </div>
 
               {/* Submit Button */}
-              <button
-                type="submit"
-                disabled={isLoggingIn}
-                className="w-full bg-white text-black hover:bg-zinc-200 font-medium text-sm h-9 rounded-md transition-colors flex items-center justify-center gap-2 shadow-[0_0_15px_rgba(255,255,255,0.1)] disabled:opacity-50 disabled:cursor-not-allowed"
-              >
+              <Button type="submit" disabled={isLoggingIn} className="w-full">
                 {isLoggingIn ? (
                   <>
-                    <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
-                      <circle
-                        className="opacity-25"
-                        cx="12"
-                        cy="12"
-                        r="10"
-                        stroke="currentColor"
-                        strokeWidth="4"
-                        fill="none"
-                      />
-                      <path
-                        className="opacity-75"
-                        fill="currentColor"
-                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                      />
-                    </svg>
+                    <Loader2 className="h-4 w-4 animate-spin" />
                     Signing in...
                   </>
                 ) : (
@@ -130,7 +108,7 @@ function LoginPage() {
                     <ArrowRight className="w-4 h-4 opacity-60" />
                   </>
                 )}
-              </button>
+              </Button>
             </form>
           </div>
 

--- a/frontend/src/routes/register.tsx
+++ b/frontend/src/routes/register.tsx
@@ -17,7 +17,11 @@ import {
   ShieldCheck,
   Zap,
   Bot,
+  Loader2,
 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 
 export const Route = createFileRoute('/register')({
   component: RegisterPage,
@@ -80,18 +84,15 @@ function RegisterPage() {
             <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
               {/* Email */}
               <div className="space-y-1.5">
-                <label
-                  htmlFor="email"
-                  className="text-xs font-medium text-zinc-300"
-                >
+                <Label htmlFor="email" className="text-xs text-zinc-300">
                   Email address
-                </label>
+                </Label>
                 <div className="relative group">
-                  <input
+                  <Input
                     type="email"
                     id="email"
                     {...form.register('email')}
-                    className="w-full bg-zinc-900/50 border border-zinc-800 rounded-md px-3 py-2 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-700 focus:border-zinc-700 transition-all shadow-sm"
+                    className="bg-zinc-900/50 border-zinc-800 pr-10"
                     placeholder="developer@example.com"
                   />
                   <div className="absolute inset-y-0 right-3 flex items-center pointer-events-none opacity-0 group-focus-within:opacity-100 transition-opacity">
@@ -107,18 +108,15 @@ function RegisterPage() {
 
               {/* Password */}
               <div className="space-y-1.5">
-                <label
-                  htmlFor="password"
-                  className="text-xs font-medium text-zinc-300"
-                >
+                <Label htmlFor="password" className="text-xs text-zinc-300">
                   Password
-                </label>
+                </Label>
                 <div className="relative group">
-                  <input
+                  <Input
                     type={showPassword ? 'text' : 'password'}
                     id="password"
                     {...form.register('password')}
-                    className="w-full bg-zinc-900/50 border border-zinc-800 rounded-md px-3 py-2 pr-10 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-700 focus:border-zinc-700 transition-all shadow-sm"
+                    className="bg-zinc-900/50 border-zinc-800 pr-10"
                     placeholder="At least 8 characters"
                   />
                   <button
@@ -142,18 +140,18 @@ function RegisterPage() {
 
               {/* Confirm Password */}
               <div className="space-y-1.5">
-                <label
+                <Label
                   htmlFor="confirmPassword"
-                  className="text-xs font-medium text-zinc-300"
+                  className="text-xs text-zinc-300"
                 >
                   Confirm password
-                </label>
+                </Label>
                 <div className="relative group">
-                  <input
+                  <Input
                     type={showConfirmPassword ? 'text' : 'password'}
                     id="confirmPassword"
                     {...form.register('confirmPassword')}
-                    className="w-full bg-zinc-900/50 border border-zinc-800 rounded-md px-3 py-2 pr-10 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-700 focus:border-zinc-700 transition-all shadow-sm"
+                    className="bg-zinc-900/50 border-zinc-800 pr-10"
                     placeholder="Confirm your password"
                   />
                   <button
@@ -176,29 +174,10 @@ function RegisterPage() {
               </div>
 
               {/* Submit */}
-              <button
-                type="submit"
-                disabled={isRegistering}
-                className="w-full bg-white text-black hover:bg-zinc-200 font-medium text-sm h-9 rounded-md transition-colors flex items-center justify-center gap-2 shadow-[0_0_15px_rgba(255,255,255,0.1)] disabled:opacity-50 disabled:cursor-not-allowed"
-              >
+              <Button type="submit" disabled={isRegistering} className="w-full">
                 {isRegistering ? (
                   <>
-                    <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
-                      <circle
-                        className="opacity-25"
-                        cx="12"
-                        cy="12"
-                        r="10"
-                        stroke="currentColor"
-                        strokeWidth="4"
-                        fill="none"
-                      />
-                      <path
-                        className="opacity-75"
-                        fill="currentColor"
-                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                      />
-                    </svg>
+                    <Loader2 className="h-4 w-4 animate-spin" />
                     Creating account...
                   </>
                 ) : (
@@ -207,7 +186,7 @@ function RegisterPage() {
                     <ArrowRight className="w-4 h-4 opacity-60" />
                   </>
                 )}
-              </button>
+              </Button>
             </form>
 
             <p className="text-center text-sm text-zinc-500">

--- a/frontend/src/routes/reset-password.tsx
+++ b/frontend/src/routes/reset-password.tsx
@@ -8,7 +8,17 @@ import {
   resetPasswordSchema,
   type ResetPasswordFormData,
 } from '@/lib/validation/auth.schemas';
-import { Activity, Eye, EyeOff, AlertCircle, ArrowLeft } from 'lucide-react';
+import {
+  Activity,
+  Eye,
+  EyeOff,
+  AlertCircle,
+  ArrowLeft,
+  Loader2,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 
 export const Route = createFileRoute('/reset-password')({
   component: ResetPasswordPage,
@@ -130,18 +140,15 @@ function ResetPasswordPage() {
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
             {/* New Password */}
             <div className="space-y-1.5">
-              <label
-                htmlFor="password"
-                className="text-xs font-medium text-zinc-300"
-              >
+              <Label htmlFor="password" className="text-xs text-zinc-300">
                 New password
-              </label>
+              </Label>
               <div className="relative group">
-                <input
+                <Input
                   type={showPassword ? 'text' : 'password'}
                   id="password"
                   {...form.register('password')}
-                  className="w-full bg-zinc-900/50 border border-zinc-800 rounded-md px-3 py-2 pr-10 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-700 focus:border-zinc-700 transition-all shadow-sm"
+                  className="bg-zinc-900/50 border-zinc-800 pr-10"
                   placeholder="At least 8 characters"
                 />
                 <button
@@ -165,18 +172,18 @@ function ResetPasswordPage() {
 
             {/* Confirm Password */}
             <div className="space-y-1.5">
-              <label
+              <Label
                 htmlFor="confirmPassword"
-                className="text-xs font-medium text-zinc-300"
+                className="text-xs text-zinc-300"
               >
                 Confirm new password
-              </label>
+              </Label>
               <div className="relative group">
-                <input
+                <Input
                   type={showConfirmPassword ? 'text' : 'password'}
                   id="confirmPassword"
                   {...form.register('confirmPassword')}
-                  className="w-full bg-zinc-900/50 border border-zinc-800 rounded-md px-3 py-2 pr-10 text-sm text-white placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-700 focus:border-zinc-700 transition-all shadow-sm"
+                  className="bg-zinc-900/50 border-zinc-800 pr-10"
                   placeholder="Confirm your password"
                 />
                 <button
@@ -198,35 +205,20 @@ function ResetPasswordPage() {
               )}
             </div>
 
-            <button
+            <Button
               type="submit"
               disabled={isResetPasswordPending}
-              className="w-full bg-white text-black hover:bg-zinc-200 font-medium text-sm h-9 rounded-md transition-colors flex items-center justify-center gap-2 shadow-[0_0_15px_rgba(255,255,255,0.1)] disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full"
             >
               {isResetPasswordPending ? (
                 <>
-                  <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24">
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                      fill="none"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    />
-                  </svg>
+                  <Loader2 className="h-4 w-4 animate-spin" />
                   Resetting password...
                 </>
               ) : (
                 'Reset Password'
               )}
-            </button>
+            </Button>
           </form>
         </div>
 

--- a/frontend/src/routes/users/$userId/pair.index.tsx
+++ b/frontend/src/routes/users/$userId/pair.index.tsx
@@ -87,13 +87,15 @@ function PairWearablePage() {
           >
             <AlertCircle className="w-5 h-5 text-red-400 shrink-0" />
             <p className="text-sm text-red-300 flex-1">{error}</p>
-            <button
+            <Button
+              variant="destructive"
+              size="icon"
               onClick={reset}
               aria-label="Dismiss error"
-              className="text-red-400/70 hover:text-red-300 transition-colors"
+              // className="text-red-400/70 hover:text-red-300 hover:bg-transparent"
             >
               <X className="w-5 h-5" />
-            </button>
+            </Button>
           </motion.div>
         )}
       </AnimatePresence>


### PR DESCRIPTION
## Description

Refactor frontend to consistently use reusable UI components (Button, Dialog, Input, Label) instead of raw HTML elements with hardcoded styles. This improves design system consistency, accessibility, and maintainability.

**Key changes:**
- Update Button component with new variants: default (white), neon (cyan glow), secondary (zinc-800), destructive (red tint), destructive-outline, ghost-faded
- Add icon-sm size variant for smaller icon buttons
- Refactor custom dialog implementations to use Dialog component from UI library in profile-section, users/index, and credentials-tab
- Replace raw input elements with Input component across auth pages (login, register, accept-invite, reset-password, forgot-password), team-tab, and users-table search
- Replace raw label elements with Label component for proper accessibility
- Update Input component focus styles with subtle ring effect
- Replace hardcoded button elements with Button component variants throughout the codebase for consistent styling and design system enforcement
- Add proper htmlFor/id associations between labels and inputs for accessibility

### Related Issue

Fixes #347

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

N/A - Frontend only changes

### Frontend Changes

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

## Testing Instructions

**Steps to test:**
1. Navigate to login, register, forgot-password, reset-password, and accept-invite pages - verify inputs have consistent focus styles with subtle cyan glow
2. Navigate to Users page - test create user dialog, delete user dialog, and search bar styling
3. Navigate to Settings > Team tab - test invite modal and button variants
4. Navigate to Settings > Credentials tab - test create API key dialog
5. Navigate to a user detail page - test edit user dialog and button variants
6. Hover over various buttons to verify hover states match the new variant definitions

**Expected behavior:**
- All buttons use consistent styling based on their variant (default=white, destructive=red tint, outline=border only, etc.)
- All inputs have consistent focus states with subtle ring and cyan glow
- All dialogs have consistent styling with animations and built-in close button
- Labels are properly associated with inputs (clicking label focuses input)

## Screenshots

<img width="1232" height="1120" alt="image" src="https://github.com/user-attachments/assets/dd4e0a00-7d72-407d-a802-ed09d5a678ab" />

## Additional Notes

- The Button component now has 8 variants: default, secondary, destructive, destructive-outline, outline, ghost, ghost-faded, neon, link
- The Input component focus ring was reduced from ring-2 with offset to ring-1 without offset for a subtler effect
- All custom dialog implementations were replaced with the Dialog component which provides animations, backdrop, and accessibility features via Radix UI