### PR TITLE
fix(setup) fixes Docker setup here (astra / image building)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,9 +4,7 @@ FROM python:3.13-slim AS builder
     apt-get install -y --no-install-recommends build-essential libpq-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-    RUN pip install --no-cache-dir --upgrade pyopenssl
-
-    COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+    RUN pip install --no-cache-dir --upgrade pip pyopenssl uv
 
     WORKDIR /root_project
 
@@ -24,10 +22,9 @@ FROM python:3.13-slim
     apt-get install -y --no-install-recommends libpq5 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+    RUN pip install --no-cache-dir uv
 
     WORKDIR /root_project
-
-    COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
     COPY --from=builder /opt/venv /opt/venv
     COPY --from=builder /root_project /root_project

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     build:
         context: ./backend
         dockerfile: Dockerfile
+    pull_policy: build
     container_name: backend__open-wearables
     image: open-wearables-platform:latest
     command: scripts/start/app.sh
@@ -135,6 +136,7 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile.dev
+    pull_policy: build
     container_name: frontend__open-wearables
     image: open-wearables-frontend:dev
     ports:


### PR DESCRIPTION
## Description

Feel free to ignore. Without this, we can't start the docker services. As for some reason the image can't access astra/uv during image builds Even after upgrading to lhe latest docker version we ran into issues when starting up the compose setup. These changes fix it on our env

- astral.sh not responding
- adds pull policy config

no python experts, using uv over astra's uv might be slower, but this works everywhere 😇 

## Checklist

### General

- [?] My code follows the project's code style
- [x] I have performed a self-review of my code
- [-] I have added tests that prove my fix/feature works (if applicable)
- [🤷 ] New and existing tests pass locally

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [ ] `pnpm run lint` passes
- [ ] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds

## Testing Instructions

<!-- Describe how reviewers can test your changes -->

**Steps to test:**
1. `docker compose build` on a blank new env. Fails here. With this - works here.
