### PR TITLE
docs: add uv lock instruction to backend AGENTS.md

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -217,9 +217,6 @@ make downgrade                             # Rollback
 ```bash
 cd backend
 
-# Add new dependencies (updates pyproject.toml, lockfile, and venv)
-uv add <package-name>
-
 # Lint and format (run after changes)
 uv run ruff check . --fix && uv run ruff format .
 


### PR DESCRIPTION
## Description

As you can see in [this PR](https://github.com/the-momentum/open-wearables/pull/398), the agents don't seem to realise that after modifying the `.toml` file, you need to run the uv lock command to update `uv.lock`.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

NA

## Testing Instructions

NA

## Screenshots

NA

## Additional Notes

NA


