### PR TITLE
feat: add reset_db target to Makefile and implement reset_database script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,6 @@ create_migration:  ## Create a new migration. Use 'make create_migration m="Desc
 
 downgrade:  ## Revert the last migration
 	$(DOCKER_EXEC) $(ALEMBIC_CMD) downgrade -1
+
+reset_db:  ## Truncate all tables in the database (WARNING: deletes all data)
+	$(DOCKER_EXEC) uv run python scripts/reset_database.py

--- a/backend/scripts/reset_database.py
+++ b/backend/scripts/reset_database.py
@@ -1,0 +1,51 @@
+"""
+Script to truncate all tables in the database.
+This will delete all data but keep the schema intact.
+"""
+
+import sys
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.database import BaseDbModel, SessionLocal
+
+
+def truncate_all_tables() -> None:
+    """Truncate all tables in the database."""
+    db: Session = SessionLocal()
+    try:
+        # Disable foreign key checks temporarily
+        db.execute(text("SET session_replication_role = 'replica';"))
+
+        # Get all table names
+        inspector = BaseDbModel.metadata
+        table_names = [table.name for table in inspector.sorted_tables]
+
+        # Truncate all tables
+        for table_name in table_names:
+            db.execute(text(f'TRUNCATE TABLE "{table_name}" CASCADE;'))
+            print(f"✓ Truncated table: {table_name}")
+
+        # Re-enable foreign key checks
+        db.execute(text("SET session_replication_role = 'origin';"))
+
+        db.commit()
+        print("\n✓ Database truncated successfully!")
+    except Exception as e:
+        db.rollback()
+        print(f"\n✗ Error truncating database: {e}")
+        sys.exit(1)
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    print("⚠️  WARNING: This will delete ALL data from the database!")
+    response = input("Are you sure you want to continue? (yes/no): ")
+
+    if response.lower() != "yes":
+        print("Operation cancelled.")
+        sys.exit(0)
+
+    truncate_all_tables()


### PR DESCRIPTION
## Description

During development, I often reset the database, so it's worth having a single command at hand. I haven't found anything built into SQLAlchemy to handle this. There might be a smarter way to do it, but this works fine, and I don't think we need to pay too much attention to the implementation here. :)

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

NA

## Testing Instructions

Just run the script 

`make reset_db`

**Expected behavior:**

Truncates all database tables. 

## Screenshots

<img width="642" height="395" alt="image" src="https://github.com/user-attachments/assets/d5da0914-af44-41cc-bf7f-76238088f147" />


## Additional Notes

NA


