### PR TITLE
docs(mcp): add an MCP server section to the Overview in the documentation

### DIFF
--- a/docs/architecture/system-overview.mdx
+++ b/docs/architecture/system-overview.mdx
@@ -25,6 +25,10 @@ open-wearables/
 │       ├── routes/     # Route definitions
 │       ├── hooks/      # Custom React hooks
 │       └── lib/        # Utilities and API clients
+├── mcp/            # MCP server (Beta) - AI assistant integration
+│   └── app/
+│       ├── tools/     # MCP tool definitions
+│       └── services/  # API client for backend communication
 └── docs/            # Mintlify documentation
 ```
 
@@ -77,6 +81,22 @@ open-wearables/
 
 **Data Visualization:**
 - **Recharts** - Chart library for metrics visualization
+
+### MCP Server (Beta)
+
+**Model Context Protocol Integration:**
+- **FastMCP** - MCP server framework for AI assistant integration
+- **httpx** - Async HTTP client for backend API communication
+- **Pydantic** - Settings and data validation
+
+The MCP server enables AI assistants (Claude Desktop, Cursor) to query wearable health data through natural language. It's **decoupled from the backend** - communicating via REST API using API keys - and can be deployed independently.
+
+**Key Features:**
+- Natural language queries for health metrics (sleep, workouts, etc.)
+- User discovery and data retrieval tools
+- Unified data format regardless of wearable provider
+
+> **Note:** The MCP server is currently in **beta** and is actively being developed.
 
 ## Architecture Patterns
 


### PR DESCRIPTION
## Description

* Introduced a new section for the MCP server (Beta) in the system overview documentation.
* Added details on the Model Context Protocol integration, key features, and the server's capabilities for querying wearable health data through natural language.
* Highlighted the decoupled architecture and REST API communication for independent deployment.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

NA

### Frontend Changes

NA

## Testing Instructions

NA

## Screenshots

<img width="1474" height="852" alt="image" src="https://github.com/user-attachments/assets/76b501ae-ed72-4349-8b0b-6df2511de64f" />

--- 

<img width="1465" height="596" alt="image" src="https://github.com/user-attachments/assets/7e01a979-b359-4340-adf7-ce65e6368760" />

## Additional Notes

<!-- Any additional context or information reviewers should know -->


