### PR TITLE
fix(backend): create user provider connections in seed script

### DIFF
--- a/backend/app/services/providers/factory.py
+++ b/backend/app/services/providers/factory.py
@@ -1,3 +1,4 @@
+from app.schemas.oauth import ProviderName
 from app.services.providers.apple.strategy import AppleStrategy
 from app.services.providers.base_strategy import BaseProviderStrategy
 from app.services.providers.garmin.strategy import GarminStrategy
@@ -11,15 +12,15 @@ class ProviderFactory:
 
     def get_provider(self, provider_name: str) -> BaseProviderStrategy:
         match provider_name:
-            case "apple":
+            case ProviderName.APPLE.value:
                 return AppleStrategy()
-            case "garmin":
+            case ProviderName.GARMIN.value:
                 return GarminStrategy()
-            case "suunto":
+            case ProviderName.SUUNTO.value:
                 return SuuntoStrategy()
-            case "polar":
+            case ProviderName.POLAR.value:
                 return PolarStrategy()
-            case "whoop":
+            case ProviderName.WHOOP.value:
                 return WhoopStrategy()
             case _:
                 raise ValueError(f"Unknown provider: {provider_name}")


### PR DESCRIPTION
## Description

Fixed the seed script to properly create user provider connections by updating last_synced_at after connection creation, which mirrors the real-world sync flow. 

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

NA

## Testing Instructions

`docker compose -f docker-compose.yml exec app uv run python scripts/init/seed_activity_data.py` 

## Screenshots

<img width="1185" height="588" alt="image" src="https://github.com/user-attachments/assets/39652eb6-6250-42bc-8ba3-36621b874a9e" />

## Additional Notes

NA


