### PR TITLE
chore(backend): add WHOOP 5.0 to seed data

### DIFF
--- a/backend/scripts/init/seed_activity_data.py
+++ b/backend/scripts/init/seed_activity_data.py
@@ -70,8 +70,8 @@ PROVIDER_CONFIGS: dict[ProviderName, ProviderConfig] = {
     ProviderName.WHOOP: {
         "source_name": "WHOOP",
         "manufacturer": "WHOOP Inc.",
-        "devices": ["WHOOP 4.0", "WHOOP 3.0"],
-        "os_versions": ["4.0", "3.0"],
+        "devices": ["WHOOP 5.0", "WHOOP 4.0", "WHOOP 3.0"],
+        "os_versions": ["5.0", "4.0", "3.0"],
     },
 }
 


### PR DESCRIPTION
Short update to https://github.com/the-momentum/open-wearables/pull/415

## Summary                                                                                                                                                        
- Add WHOOP 5.0 device to seed activity data provider configuration                                                                                               
- WHOOP 5.0 was released in 2024 and is the current flagship device 