### PR TITLE
fix(frontend): use date range as limit for activity summary API request

### DIFF
--- a/backend/app/api/routes/v1/summaries.py
+++ b/backend/app/api/routes/v1/summaries.py
@@ -26,7 +26,7 @@ async def get_activity_summary(
     db: DbSession,
     _api_key: ApiKeyDep,
     cursor: str | None = None,
-    limit: Annotated[int, Query(ge=1, le=100)] = 50,
+    limit: Annotated[int, Query(ge=1, le=400)] = 50,
 ) -> PaginatedResponse[ActivitySummary]:
     """Returns daily aggregated activity metrics.
 

--- a/frontend/src/components/user/activity-section.tsx
+++ b/frontend/src/components/user/activity-section.tsx
@@ -331,7 +331,7 @@ export function ActivitySection({
     {
       start_date: startDate,
       end_date: endDate,
-      limit: 100,
+      limit: dateRange,
     }
   );
 


### PR DESCRIPTION
## Description

Closes: https://github.com/the-momentum/open-wearables/issues/421

Fixes Activity Summary "Days Tracked" being capped at 100 when selecting larger date ranges (e.g., 365 days).

Changes:
- Backend: Increased max limit from 100 to 400 for the activity summary endpoint to accommodate 365-day queries
- Frontend: Changed hardcoded limit: 100 to use the selected dateRange value dynamically

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds
