### PR TITLE
docs: update Apple sync endpoint path

### DIFF
--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -24,7 +24,7 @@ Unlike cloud-based providers (Garmin, Polar, Suunto) that use webhooks and OAuth
     The SDK reads data from HealthKit and handles background synchronization automatically.
   </Step>
   <Step title="Open Wearables Platform" icon="cloud-arrow-up">
-    Data is pushed to `POST /sdk/users/{user_id}/sync/apple/healthkit` and normalized to the unified data model.
+    Data is pushed to `POST /sdk/users/{user_id}/sync/apple` and normalized to the unified data model.
   </Step>
 </Steps>
 


### PR DESCRIPTION
## Description

Updates the Apple HealthKit sync endpoint path in SDK documentation from:
`/sdk/users/{user_id}/sync/apple/healthkit` 
to 
`/sdk/users/{user_id}/sync/apple`

## Checklist

NA
