### PR TITLE
feat(backend): filter unknown Apple HealthKit types instead of return…

### DIFF
--- a/backend/tests/api/v1/test_sdk_sync_validation.py
+++ b/backend/tests/api/v1/test_sdk_sync_validation.py
@@ -1,0 +1,159 @@
+"""Tests for SDK sync endpoint validation with unknown types.
+
+Verifies that unknown type values in records, sleep, workouts, and workout statistics
+are silently filtered out and the endpoint returns 202.
+"""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def mock_process_apple_upload() -> Generator[MagicMock, None, None]:
+    """Mock Celery task to prevent actual task execution."""
+    with patch("app.api.routes.v1.sdk_sync.process_apple_upload") as mock:
+        mock.delay.return_value = None
+        yield mock
+
+
+class TestSyncWithUnknownTypes:
+    """Tests that unknown type values are filtered and the endpoint returns 202."""
+
+    def _post_sync(self, client: TestClient, api_v1_prefix: str, api_key_header: dict, payload: dict) -> object:
+        return client.post(
+            f"{api_v1_prefix}/sdk/users/test-user-id/sync/apple",
+            headers=api_key_header,
+            json=payload,
+        )
+
+    def test_sync_with_unknown_record_type_returns_202(
+        self, client: TestClient, api_v1_prefix: str, api_key_header: dict
+    ) -> None:
+        payload = {
+            "data": {
+                "records": [
+                    {
+                        "uuid": "TEST0001-0000-0000-0000-000000000001",
+                        "type": "HKQuantityTypeIdentifierSomeNewAppleType",
+                        "startDate": "2025-01-15T10:00:00Z",
+                        "endDate": "2025-01-15T10:05:00Z",
+                        "unit": "count",
+                        "value": 42,
+                    }
+                ]
+            }
+        }
+        response = self._post_sync(client, api_v1_prefix, api_key_header, payload)
+        assert response.status_code == 200
+
+    def test_sync_with_unknown_workout_type_returns_202(
+        self, client: TestClient, api_v1_prefix: str, api_key_header: dict
+    ) -> None:
+        payload = {
+            "data": {
+                "workouts": [
+                    {
+                        "uuid": "TEST0002-0000-0000-0000-000000000002",
+                        "type": "brand_new_sport",
+                        "startDate": "2025-01-15T14:00:00Z",
+                        "endDate": "2025-01-15T15:00:00Z",
+                        "workoutStatistics": [
+                            {"type": "duration", "unit": "s", "value": 3600},
+                        ],
+                    }
+                ]
+            }
+        }
+        response = self._post_sync(client, api_v1_prefix, api_key_header, payload)
+        assert response.status_code == 200
+
+    def test_sync_with_unknown_sleep_type_returns_202(
+        self, client: TestClient, api_v1_prefix: str, api_key_header: dict
+    ) -> None:
+        payload = {
+            "data": {
+                "sleep": [
+                    {
+                        "uuid": "TEST0003-0000-0000-0000-000000000003",
+                        "type": "HKCategoryTypeIdentifierSomeNewSleepType",
+                        "startDate": "2025-01-15T22:00:00Z",
+                        "endDate": "2025-01-15T22:30:00Z",
+                        "unit": None,
+                        "value": 3,
+                    }
+                ]
+            }
+        }
+        response = self._post_sync(client, api_v1_prefix, api_key_header, payload)
+        assert response.status_code == 200
+
+    def test_sync_with_unknown_workout_statistic_type_returns_202(
+        self, client: TestClient, api_v1_prefix: str, api_key_header: dict
+    ) -> None:
+        payload = {
+            "data": {
+                "workouts": [
+                    {
+                        "uuid": "TEST0004-0000-0000-0000-000000000004",
+                        "type": "running",
+                        "startDate": "2025-01-15T08:00:00Z",
+                        "endDate": "2025-01-15T08:30:00Z",
+                        "workoutStatistics": [
+                            {"type": "duration", "unit": "s", "value": 1800},
+                            {"type": "brandNewStatistic", "unit": "units", "value": 99.9},
+                        ],
+                    }
+                ]
+            }
+        }
+        response = self._post_sync(client, api_v1_prefix, api_key_header, payload)
+        assert response.status_code == 200
+
+    def test_sync_with_mix_of_known_and_unknown_types_returns_202(
+        self, client: TestClient, api_v1_prefix: str, api_key_header: dict
+    ) -> None:
+        payload = {
+            "data": {
+                "records": [
+                    {
+                        "uuid": "TEST0005-0000-0000-0000-000000000001",
+                        "type": "HKQuantityTypeIdentifierHeartRate",
+                        "startDate": "2025-01-15T10:00:00Z",
+                        "endDate": "2025-01-15T10:01:00Z",
+                        "unit": "bpm",
+                        "value": 72,
+                    },
+                    {
+                        "uuid": "TEST0005-0000-0000-0000-000000000002",
+                        "type": "HKQuantityTypeIdentifierFutureMetric",
+                        "startDate": "2025-01-15T10:01:00Z",
+                        "endDate": "2025-01-15T10:02:00Z",
+                        "unit": "count",
+                        "value": 5,
+                    },
+                ],
+                "workouts": [
+                    {
+                        "uuid": "TEST0005-0000-0000-0000-000000000003",
+                        "type": "running",
+                        "startDate": "2025-01-15T08:00:00Z",
+                        "endDate": "2025-01-15T08:30:00Z",
+                        "workoutStatistics": [
+                            {"type": "distance", "unit": "m", "value": 5000},
+                        ],
+                    },
+                    {
+                        "uuid": "TEST0005-0000-0000-0000-000000000004",
+                        "type": "underwater_basket_weaving",
+                        "startDate": "2025-01-15T09:00:00Z",
+                        "endDate": "2025-01-15T09:45:00Z",
+                        "workoutStatistics": [],
+                    },
+                ],
+            }
+        }
+        response = self._post_sync(client, api_v1_prefix, api_key_header, payload)
+        assert response.status_code == 200

--- a/backend/tests/schemas/test_apple_sync_request.py
+++ b/backend/tests/schemas/test_apple_sync_request.py
@@ -1,0 +1,151 @@
+"""Tests for Apple HealthKit sync request schema validation.
+
+Tests that unknown type values are filtered out before Pydantic validation,
+so the endpoint doesn't return 400 for new/unknown HealthKit types.
+"""
+
+from app.schemas.apple.healthkit.sync_request import SyncRequestData
+
+
+def _make_record(type_value: str | None = "HKQuantityTypeIdentifierHeartRate", **overrides: object) -> dict:
+    """Helper to create a minimal valid record dict."""
+    record = {
+        "uuid": "00000000-0000-0000-0000-000000000001",
+        "type": type_value,
+        "startDate": "2025-01-15T10:00:00Z",
+        "endDate": "2025-01-15T10:05:00Z",
+        "unit": "bpm",
+        "value": 72,
+    }
+    record.update(overrides)
+    return record
+
+
+def _make_sleep(type_value: str | None = "HKCategoryTypeIdentifierSleepAnalysis", **overrides: object) -> dict:
+    """Helper to create a minimal valid sleep dict."""
+    sleep = {
+        "uuid": "00000000-0000-0000-0000-000000000002",
+        "type": type_value,
+        "startDate": "2025-01-15T22:00:00Z",
+        "endDate": "2025-01-15T22:30:00Z",
+        "unit": None,
+        "value": 3,
+    }
+    sleep.update(overrides)
+    return sleep
+
+
+def _make_workout(
+    type_value: str | None = "running",
+    statistics: list[dict] | None = None,
+    **overrides: object,
+) -> dict:
+    """Helper to create a minimal valid workout dict."""
+    workout: dict = {
+        "uuid": "00000000-0000-0000-0000-000000000003",
+        "type": type_value,
+        "startDate": "2025-01-15T08:00:00Z",
+        "endDate": "2025-01-15T08:30:00Z",
+        "workoutStatistics": statistics or [{"type": "duration", "unit": "s", "value": 1800}],
+    }
+    workout.update(overrides)
+    return workout
+
+
+class TestFilterUnknownRecordTypes:
+    def test_metric_record_with_valid_type_preserved(self) -> None:
+        data = SyncRequestData.model_validate({"records": [_make_record()]})
+        assert len(data.records) == 1
+        assert data.records[0].type is not None
+        assert data.records[0].type.value == "HKQuantityTypeIdentifierHeartRate"
+
+    def test_metric_record_with_unknown_type_filtered_out(self) -> None:
+        data = SyncRequestData.model_validate(
+            {"records": [_make_record(type_value="HKQuantityTypeIdentifierSomeNewAppleType")]}
+        )
+        assert len(data.records) == 0
+
+    def test_metric_record_with_none_type_preserved(self) -> None:
+        data = SyncRequestData.model_validate({"records": [_make_record(type_value=None)]})
+        assert len(data.records) == 1
+        assert data.records[0].type is None
+
+
+class TestFilterUnknownSleepTypes:
+    def test_sleep_record_with_unknown_type_filtered_out(self) -> None:
+        data = SyncRequestData.model_validate(
+            {"sleep": [_make_sleep(type_value="HKCategoryTypeIdentifierSomeNewSleepType")]}
+        )
+        assert len(data.sleep) == 0
+
+
+class TestFilterUnknownWorkoutTypes:
+    def test_workout_with_unknown_type_filtered_out(self) -> None:
+        data = SyncRequestData.model_validate({"workouts": [_make_workout(type_value="underwater_basket_weaving")]})
+        assert len(data.workouts) == 0
+
+    def test_workout_statistic_with_unknown_type_filtered_out(self) -> None:
+        """Unknown stat is removed from workoutStatistics, workout itself is kept."""
+        data = SyncRequestData.model_validate(
+            {
+                "workouts": [
+                    _make_workout(
+                        statistics=[
+                            {"type": "duration", "unit": "s", "value": 1800},
+                            {"type": "brandNewStatistic", "unit": "units", "value": 99.9},
+                        ]
+                    )
+                ]
+            }
+        )
+        assert len(data.workouts) == 1
+        assert len(data.workouts[0].workoutStatistics) == 1
+        assert data.workouts[0].workoutStatistics[0].type.value == "duration"
+
+
+class TestMixedKnownAndUnknown:
+    def test_mixed_known_and_unknown_types(self) -> None:
+        """Valid items preserved, invalid items removed across all categories."""
+        data = SyncRequestData.model_validate(
+            {
+                "records": [
+                    _make_record(type_value="HKQuantityTypeIdentifierHeartRate"),
+                    _make_record(type_value="HKQuantityTypeIdentifierFutureMetric"),
+                ],
+                "sleep": [
+                    _make_sleep(),
+                    _make_sleep(type_value="HKCategoryTypeIdentifierNewSleep"),
+                ],
+                "workouts": [
+                    _make_workout(type_value="running"),
+                    _make_workout(type_value="underwater_basket_weaving"),
+                ],
+            }
+        )
+        assert len(data.records) == 1
+        assert len(data.sleep) == 1
+        assert len(data.workouts) == 1
+
+    def test_valid_payload_unchanged(self) -> None:
+        """Standard valid payload passes through without any items removed."""
+        data = SyncRequestData.model_validate(
+            {
+                "records": [
+                    _make_record(type_value="HKQuantityTypeIdentifierHeartRate"),
+                    _make_record(type_value="HKQuantityTypeIdentifierStepCount", unit="count", value=100),
+                ],
+                "sleep": [_make_sleep()],
+                "workouts": [
+                    _make_workout(
+                        statistics=[
+                            {"type": "duration", "unit": "s", "value": 1800},
+                            {"type": "averageHeartRate", "unit": "bpm", "value": 150},
+                        ]
+                    )
+                ],
+            }
+        )
+        assert len(data.records) == 2
+        assert len(data.sleep) == 1
+        assert len(data.workouts) == 1
+        assert len(data.workouts[0].workoutStatistics) == 2


### PR DESCRIPTION
## Description

Currently the `/sync/apple` endpoint returns **400** when the SDK sends a batch containing unknown HealthKit type values (e.g. a new `HKQuantityTypeIdentifier` that Apple added but we haven't mapped yet). This rejects the **entire payload**, including all valid records in the same batch.

- Add `model_validator(mode='before')` on `SyncRequestData` to filter out records, sleep, workouts, and workout statistics with unknown `type` values before Pydantic validation
- Unknown items are silently dropped and logged via structured logging - the endpoint no longer returns 400 when Apple adds new HealthKit types
- No changes to enums, field annotations, routes, or downstream services                                                                   

## Checklist

### General

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] New and existing tests pass locally

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [ ] `pnpm run lint` passes
- [ ] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds

## Testing Instructions

Call `/sync/apple` endpoint with unknown types.

## Screenshots

NA

## Additional Notes

NA


