### PR TITLE
feat(backend): add --email and --password CLI args to seed_admin script

### DIFF
--- a/backend/scripts/init/seed_admin.py
+++ b/backend/scripts/init/seed_admin.py
@@ -1,31 +1,37 @@
 #!/usr/bin/env python3
 """Seed default admin developer account if it doesn't exist."""
 
+import argparse
+
 from app.database import SessionLocal
 from app.schemas.developer import DeveloperCreate
 from app.services import developer_service
 
-ADMIN_EMAIL = "admin@admin.com"
-ADMIN_PASSWORD = "secret123"
+DEFAULT_EMAIL = "admin@admin.com"
+DEFAULT_PASSWORD = "secret123"
 
 
-def seed_admin() -> None:
+def seed_admin(email: str, password: str) -> None:
     """Create default admin developer if it doesn't exist."""
     with SessionLocal() as db:
         existing = developer_service.crud.get_all(
             db,
-            filters={"email": ADMIN_EMAIL},
+            filters={"email": email},
             offset=0,
             limit=1,
             sort_by=None,
         )
         if existing:
-            print(f"Admin developer {ADMIN_EMAIL} already exists, skipping.")
+            print(f"Admin developer {email} already exists, skipping.")
             return
 
-        developer_service.register(db, DeveloperCreate(email=ADMIN_EMAIL, password=ADMIN_PASSWORD))
-        print(f"✓ Created default admin developer: {ADMIN_EMAIL} / {ADMIN_PASSWORD}")
+        developer_service.register(db, DeveloperCreate(email=email, password=password))
+        print(f"✓ Created default admin developer: {email}")
 
 
 if __name__ == "__main__":
-    seed_admin()
+    parser = argparse.ArgumentParser(description="Seed default admin developer account.")
+    parser.add_argument("--email", default=DEFAULT_EMAIL, help="Admin email (default: admin@admin.com)")
+    parser.add_argument("--password", default=DEFAULT_PASSWORD, help="Admin password (default: secret123)")
+    args = parser.parse_args()
+    seed_admin(args.email, args.password)


### PR DESCRIPTION
## Description

Allow configuring admin credentials when running the seed script, instead of relying on hardcoded defaults. Useful for production deployments.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

NA

## Testing Instructions

```bash

uv run python scripts/init/seed_admin.py --email "admin@yourcomany.com" --password "StrongPassword123!"

# With docker

docker compose exec app uv run python scripts/init/seed_admin.py --email "admin@yourcomany.com" --password "StrongPassword123!"
```

## Screenshots

NA

## Additional Notes

NA


