### PR TITLE
docs: add setup guide and update provider coverage matrix for Whoop integration

### DIFF
--- a/docs/api-reference/guides/provider-coverage.mdx
+++ b/docs/api-reference/guides/provider-coverage.mdx
@@ -37,8 +37,9 @@ This guide provides a comprehensive overview of data type support across all int
 | Data Type | Unit | Apple | Garmin | Polar | Suunto | Whoop | Strava |
 |-----------|------|:-----:|:------:|:-----:|:------:|:-----:|:------:|
 | `heart_rate` | bpm | ✅ | ◐/🔜 | ◐ | ✅ | ❌ | ❌ |
-| `resting_heart_rate` | bpm | ✅ | 🔜 | ❌ | ❌ | 🔜 | ❌ |
-| `heart_rate_variability_sdnn` | ms | ✅ | 🔜 | ◐ | ✅ | 🔜 | ❌ |
+| `resting_heart_rate` | bpm | ✅ | 🔜 | ❌ | ❌ | ✅ | ❌ |
+| `heart_rate_variability_sdnn` | ms | ✅ | 🔜 | ◐ | ✅ | ❌ | ❌ |
+| `heart_rate_variability_rmssd` | ms | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
 | `heart_rate_recovery_one_minute` | bpm | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `walking_heart_rate_average` | bpm | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
@@ -54,7 +55,7 @@ This guide provides a comprehensive overview of data type support across all int
 
 | Data Type | Unit | Apple | Garmin | Polar | Suunto | Whoop | Strava |
 |-----------|------|:-----:|:------:|:-----:|:------:|:-----:|:------:|
-| `oxygen_saturation` | % | ✅ | 🔜 | ❌ | ✅ | ❌ | ❌ |
+| `oxygen_saturation` | % | ✅ | 🔜 | ❌ | ✅ | ✅ | ❌ |
 | `blood_glucose` | mg/dL | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `blood_pressure_systolic` | mmHg | ✅ | 🔜 | ❌ | ❌ | ❌ | ❌ |
 | `blood_pressure_diastolic` | mmHg | ✅ | 🔜 | ❌ | ❌ | ❌ | ❌ |
@@ -65,12 +66,12 @@ This guide provides a comprehensive overview of data type support across all int
 
 | Data Type | Unit | Apple | Garmin | Polar | Suunto | Whoop | Strava |
 |-----------|------|:-----:|:------:|:-----:|:------:|:-----:|:------:|
-| `height` | cm | ✅ | 🔜 | 🔜 | ❌ | 🔜 | ❌ |
-| `weight` | kg | ✅ | 🔜 | 🔜 | ❌ | 🔜 | ❌ |
+| `height` | cm | ✅ | 🔜 | 🔜 | ❌ | ✅ | ❌ |
+| `weight` | kg | ✅ | 🔜 | 🔜 | ❌ | ✅ | ❌ |
 | `body_fat_percentage` | % | ✅ | 🔜 | ❌ | ❌ | ❌ | ❌ |
 | `body_mass_index` | kg/m² | ✅ | 🔜 | ❌ | ❌ | ❌ | ❌ |
 | `lean_body_mass` | kg | ✅ | 🔜 | ❌ | ❌ | ❌ | ❌ |
-| `body_temperature` | °C | ✅ | ❌ | ❌ | ❌ | 🔜 | ❌ |
+| `body_temperature` | °C | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
 
 ### Fitness Metrics
 
@@ -78,6 +79,7 @@ This guide provides a comprehensive overview of data type support across all int
 |-----------|------|:-----:|:------:|:-----:|:------:|:-----:|:------:|
 | `vo2_max` | mL/kg/min | ✅ | 🔜 | ❌ | ❌ | ❌ | ❌ |
 | `six_minute_walk_test_distance` | meters | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `recovery_score` | score | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
 
 ### Activity - Basic
 
@@ -257,14 +259,16 @@ Key differences and limitations to be aware of when working with each provider:
 </Accordion>
 
 <Accordion title="Whoop">
-  **Integration Method:** OAuth 2.0
-  
-  - Full workout support with 80+ workout type mappings to unified taxonomy
+  **Integration Method:** OAuth 2.0 (pull-based polling)
+
+  - Data synced via periodic polling (default: every hour); Whoop supports webhooks but handler not yet implemented
+  - Full workout support with 145+ workout type mappings to unified taxonomy
   - Workout metrics include: avg/max heart rate, calories, distance, elevation gain, moving time
   - Continuous heart rate data is **not available** via API (only during workouts)
   - Does not track steps (device limitation)
   - Sleep data fully implemented with all stages and efficiency
-  - Recovery data (HRV, resting HR, recovery score) available but not yet implemented
+  - Recovery data fully implemented: recovery score, resting heart rate, HRV (RMSSD), SpO2, skin temperature
+  - Body measurements (height, weight) synced from user profile
   - Strain scores available but not yet implemented
 </Accordion>
 

--- a/docs/api-reference/guides/provider-setup.mdx
+++ b/docs/api-reference/guides/provider-setup.mdx
@@ -8,7 +8,7 @@ description: 'Provider-specific configuration, requirements, and sync parameters
 Each wearable provider has different requirements and parameters for syncing data. This guide covers the specifics for each supported provider.
 
 <Warning>
-  Provider names in API paths must be **lowercase**: `garmin`, `polar`, `suunto`, `apple`
+  Provider names in API paths must be **lowercase**: `garmin`, `polar`, `suunto`, `whoop`, `apple`
 </Warning>
 
 ## Garmin
@@ -101,6 +101,65 @@ curl -X POST "http://localhost:8000/api/v1/providers/suunto/users/{user_id}/sync
 
 # Sync only workouts
 curl -X POST "http://localhost:8000/api/v1/providers/suunto/users/{user_id}/sync?data_type=workouts" \
+  -H "X-Open-Wearables-API-Key: YOUR_API_KEY"
+```
+
+---
+
+## Whoop
+
+Whoop uses OAuth 2.0 and supports both workouts and 24/7 data (sleep, recovery, body measurements).
+
+### Setup
+
+1. Create an application at [developer.whoop.com](https://developer.whoop.com)
+2. Set your redirect URI to `http://localhost:8000/api/v1/oauth/whoop/callback`
+3. Configure environment variables:
+
+```bash
+WHOOP_CLIENT_ID=your-client-id
+WHOOP_CLIENT_SECRET=your-client-secret
+WHOOP_REDIRECT_URI=http://localhost:8000/api/v1/oauth/whoop/callback
+WHOOP_DEFAULT_SCOPE=offline read:cycles read:sleep read:recovery read:workout
+```
+
+### Sync Parameters
+
+Whoop does not require provider-specific query parameters. Use the standard `data_type` parameter to control what gets synced.
+
+| `data_type` Value | Description |
+|-------------------|-------------|
+| `workouts` | Workout/exercise sessions |
+| `247` | Sleep sessions, recovery metrics, body measurements |
+| `all` | Both workouts and 24/7 data |
+
+<Note>
+  When no date range is specified, Whoop defaults to syncing the last 30 days of data.
+</Note>
+
+### Data Collected
+
+**Workouts:** heart rate (avg/max), energy burned, distance, elevation gain, duration.
+
+**Sleep (247):** total duration, time in bed, efficiency score, sleep stages (deep, light, REM, awake), nap detection.
+
+**Recovery (247):** recovery score, resting heart rate, HRV (RMSSD), SpO2 percentage, skin temperature.
+
+**Body measurements (247):** height, weight.
+
+### Example
+
+```bash
+# Sync all Whoop data
+curl -X POST "http://localhost:8000/api/v1/providers/whoop/users/{user_id}/sync?data_type=all" \
+  -H "X-Open-Wearables-API-Key: YOUR_API_KEY"
+
+# Sync only workouts
+curl -X POST "http://localhost:8000/api/v1/providers/whoop/users/{user_id}/sync?data_type=workouts" \
+  -H "X-Open-Wearables-API-Key: YOUR_API_KEY"
+
+# Sync only sleep & recovery data
+curl -X POST "http://localhost:8000/api/v1/providers/whoop/users/{user_id}/sync?data_type=247" \
   -H "X-Open-Wearables-API-Key: YOUR_API_KEY"
 ```
 

--- a/docs/provider-setup/index.mdx
+++ b/docs/provider-setup/index.mdx
@@ -14,10 +14,10 @@ Connect your wearable devices and fitness platforms to Open Wearables. Click on 
 | **Suunto** | [Setup Guide →](/provider-setup/suunto-api-integration) | You must apply for [Suunto Developer Program](https://www.suunto.com/en-gb/partners/partners/) |
 | **Garmin** | [Setup Guide →](/provider-setup/garmin-api-integration) | You must apply for [Garmin Developer Program](https://developer.garmin.com/) |
 | **Polar** | [Setup Guide →](/provider-setup/polar-api-integration) | You must register for the [Polar API program](https://www.polar.com/en/business/api) |
+| **Whoop** | [Setup Guide →](/provider-setup/whoop-api-integration) | Whoop membership required |
 | **Strava** | [Setup Guide →](/provider-setup/strava-api-integration) | Free Strava account required |
 | **Fitbit** | — | Coming soon |
 | **Oura Ring** | — | Coming soon |
-| **Whoop** | — | Coming soon |
 
 ### SDK-based providers
 

--- a/docs/provider-setup/whoop-api-integration.mdx
+++ b/docs/provider-setup/whoop-api-integration.mdx
@@ -1,0 +1,166 @@
+---
+title: "Whoop API Integration"
+description: "Setup guide for Whoop integration"
+---
+
+<Note>
+**Need help with your Whoop integration?** Pop into our [Discord](https://discord.gg/qrcfFnNE6H) if you have questions or want to discover how Open Wearables can solve your problems.
+</Note>
+
+## Overview
+
+Whoop provides access to workout, sleep, recovery, and body measurement data through their REST API. The integration uses OAuth 2.0 for authentication and pull-based syncing to fetch data.
+
+### Supported data types
+
+| Data Type | Support |
+|-----------|---------|
+| Workouts / Activities | Yes |
+| Sleep (with stages) | Yes |
+| Recovery (score, resting HR, HRV, SpO2, skin temp) | Yes |
+| Body measurements (height, weight) | Yes |
+| Continuous heart rate / activity samples | No (not available via API) |
+
+### Data delivery
+
+| Method | Description |
+|--------|-------------|
+| **Polling (pull)** | Open Wearables periodically fetches workout, sleep, recovery, and body measurement data via the Whoop API (default: every hour via Celery Beat) |
+
+<Info>
+**Webhooks:** Whoop supports webhooks for `workout`, `sleep`, and `recovery` events (created, updated, deleted). Open Wearables does not yet implement a Whoop webhook handler — data is currently synced via periodic polling only. Webhook support is planned for a future release.
+</Info>
+
+## What you need by the end
+
+- **App credentials**: Client ID + Client Secret
+- **OAuth scopes** configured
+- **Redirect URI** registered in the Whoop Developer Dashboard
+
+## Prerequisites
+
+- A Whoop account with an active membership
+
+## Application walkthrough
+
+<Steps>
+  <Step title="Sign up for Whoop">
+    You must have a Whoop membership to develop on the Whoop Developer Platform. Your Whoop account is also your developer login.
+
+    If you don't have one yet, [join Whoop here](https://www.whoop.com/).
+  </Step>
+
+  <Step title="Create a Team in the Developer Dashboard">
+    Go to the [Whoop Developer Dashboard](https://dash.whoop.com/) and sign in with your Whoop account credentials.
+
+    Before creating an app, you'll be prompted to create a **Team**. Choose a name for your team and click **Create Team**.
+
+    <Note>
+    You can invite other developers to your team later from the Team section of the Developer Dashboard. They'll need a Whoop account to be added.
+    </Note>
+  </Step>
+
+  <Step title="Create an App">
+    In the Developer Dashboard, go to the app creation flow:
+
+    - **App Name**: Your application name
+    - **Scopes**: Select the scopes your app needs (see table below)
+    - **Redirect URIs**: Add your OAuth callback URL (e.g. `http://localhost:8000/api/v1/oauth/whoop/callback` for local development)
+
+    After creating the app, you'll receive:
+    - **Client ID**
+    - **Client Secret**
+
+    <Warning>
+    Your Client Secret should never be logged or shared. It should only be used server-side and never exposed in client, web, or mobile applications.
+    </Warning>
+  </Step>
+
+  <Step title="Configure credentials in Open Wearables">
+    Add the following to your `.env` file:
+
+```bash
+#--- Whoop ---#
+WHOOP_CLIENT_ID=your-whoop-client-id
+WHOOP_CLIENT_SECRET=your-whoop-client-secret
+WHOOP_REDIRECT_URI=http://localhost:8000/api/v1/oauth/whoop/callback
+WHOOP_DEFAULT_SCOPE=offline read:cycles read:sleep read:recovery read:workout
+```
+
+    **Configuration details:**
+
+    | Variable | Description |
+    |----------|-------------|
+    | `WHOOP_CLIENT_ID` | Client ID from the Whoop Developer Dashboard |
+    | `WHOOP_CLIENT_SECRET` | Client Secret from the Whoop Developer Dashboard |
+    | `WHOOP_REDIRECT_URI` | Must match a redirect URI registered in the Developer Dashboard. For local dev: `http://localhost:8000/api/v1/oauth/whoop/callback` |
+    | `WHOOP_DEFAULT_SCOPE` | OAuth scopes requested during authorization. The `offline` scope is required for refresh tokens |
+
+  </Step>
+
+  <Step title="Verify the integration">
+    Once everything is configured:
+
+    1. Start your Open Wearables instance
+    2. Connect a Whoop account through the OAuth flow
+    3. Trigger a sync — Open Wearables will fetch workouts, sleep, recovery, and body measurement data
+  </Step>
+
+  <Step title="Submit your app for production (when ready)">
+    While developing, your app works in development mode. When you're ready to launch:
+
+    1. Go to the Developer Dashboard
+    2. Submit your app for approval
+  </Step>
+</Steps>
+
+## Rate Limits
+
+Whoop applies two rate limits by default:
+
+| Limit | Value |
+|-------|-------|
+| Per minute | 100 requests |
+| Per day | 10,000 requests |
+
+**How Open Wearables uses the quota:** Each sync cycle per user makes ~4-7 API requests (workouts, sleep, recovery, and body measurements — each paginated at 25 items per page). With the default polling interval of 1 hour, that's roughly **~120 requests per user per day**. This means the default rate limits comfortably support **~60-80 connected users** per app.
+
+If you need to support more users right now, you can request increased rate limits from Whoop via the [Developer Dashboard](https://dash.whoop.com/).
+
+<Info>
+We're working on optimizing the sync strategy (webhook-based updates instead of periodic polling, smarter pagination) to significantly increase the number of supported users without requiring a rate limit increase from Whoop.
+</Info>
+
+## OAuth Scopes Reference
+
+| Scope | Description |
+|-------|-------------|
+| `offline` | Required to receive refresh tokens for long-lived access |
+| `read:cycles` | Read physiological cycle data |
+| `read:sleep` | Read sleep data (sessions, stages, efficiency) |
+| `read:recovery` | Read recovery data (score, resting HR, HRV, SpO2, skin temp) |
+| `read:workout` | Read workout/activity data |
+| `read:body_measurement` | Read body measurements (height, weight) |
+| `read:profile` | Read user profile information |
+
+The default scope `offline read:cycles read:sleep read:recovery read:workout` covers all data types currently processed by Open Wearables.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="API Reference" icon="terminal" href="/api-reference/introduction">
+    Explore the Open Wearables API endpoints.
+  </Card>
+  <Card title="Architecture" icon="diagram" href="/architecture/system-overview">
+    Understand the overall system architecture.
+  </Card>
+</CardGroup>
+
+## Support
+
+<Note>
+**Need Help?**
+- Join our [Discord](https://discord.gg/qrcfFnNE6H) and ask a question.
+- Check [GitHub Discussions](https://github.com/the-momentum/open-wearables/discussions).
+- Check the [Whoop Developer Documentation](https://developer.whoop.com/docs/developing/getting-started).
+</Note>


### PR DESCRIPTION
## Description

 - Add Whoop provider setup guide with OAuth walkthrough, rate limits, and sync strategy details- Fix provider coverage matrix: recovery data, body measurements, resting HR, SpO2, and body temperature are implemented (not "coming soon")
- Add HRV RMSSD and recovery_score rows to coverage tables
- Update workout type mapping count from 80+ to 145+
- Update provider index to link Whoop setup guide

## Checklist

NA

