### PR TITLE
docs(integrations): iOS SDK docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -41,6 +41,14 @@
             "pages": [
               "sdk/index",
               {
+                "group": "iOS (Swift)",
+                "pages": [
+                  "sdk/ios/index",
+                  "sdk/ios/integration",
+                  "sdk/ios/troubleshooting"
+                ]
+              },
+              {
                 "group": "Flutter",
                 "pages": [
                   "sdk/flutter/index",

--- a/docs/sdk/flutter/index.mdx
+++ b/docs/sdk/flutter/index.mdx
@@ -8,9 +8,16 @@ description: "Background health data sync for Flutter apps using Apple HealthKit
 
 The Open Wearables Flutter SDK (`health_bg_sync`) enables secure background synchronization of health data from Apple HealthKit (iOS) to the Open Wearables platform.
 
-<Card title="GitHub Repository" icon="github" href="https://github.com/the-momentum/open_wearables_health_sdk">
-  View source code, report issues, and contribute to the Flutter SDK.
-</Card>
+On iOS, the Flutter SDK is a **wrapper around the [native iOS SDK](/sdk/ios)** (`OpenWearablesHealthSDK`). This means all the core sync logic — background execution, streaming uploads, Keychain storage, and retry mechanisms — is handled by the native Swift implementation under the hood. The Flutter layer provides a convenient Dart API for cross-platform apps.
+
+<CardGroup cols={2}>
+  <Card title="Flutter SDK Repository" icon="github" href="https://github.com/the-momentum/open_wearables_health_sdk">
+    View source code, report issues, and contribute to the Flutter SDK.
+  </Card>
+  <Card title="Native iOS SDK" icon="apple" href="/sdk/ios">
+    See the native iOS SDK documentation for details on the underlying implementation.
+  </Card>
+</CardGroup>
 
 ## Features
 

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -20,8 +20,8 @@ Unlike cloud-based providers (Garmin, Polar, Suunto) that use webhooks and OAuth
   <Step title="Apple Health (HealthKit)" icon="heart-pulse">
     Health data is stored locally on the user's iOS device in Apple Health.
   </Step>
-  <Step title="Your Flutter App + Sync SDK" icon="mobile">
-    The SDK reads data from HealthKit and handles background synchronization automatically.
+  <Step title="Your App + Sync SDK" icon="mobile">
+    The SDK reads data from HealthKit and handles background synchronization automatically. Available as a native iOS (Swift) SDK or as a Flutter wrapper.
   </Step>
   <Step title="Open Wearables Platform" icon="cloud-arrow-up">
     Data is pushed to `POST /sdk/users/{user_id}/sync/apple` and normalized to the unified data model.
@@ -48,11 +48,11 @@ Unlike cloud-based providers (Garmin, Polar, Suunto) that use webhooks and OAuth
 ## Available SDKs
 
 <CardGroup cols={2}>
-  <Card title="Flutter" icon="mobile" href="/sdk/flutter">
-    Flutter SDK for iOS with Apple HealthKit support.
+  <Card title="iOS (Swift)" icon="apple" href="/sdk/ios">
+    Native iOS SDK — the core implementation for Apple HealthKit sync.
   </Card>
-  <Card title="More Coming Soon" icon="clock">
-    Android Health Connect, native iOS (Swift), and Android (Kotlin) SDKs are on our roadmap.
+  <Card title="Flutter" icon="mobile" href="/sdk/flutter">
+    Flutter SDK for iOS — a wrapper around the native iOS SDK for cross-platform apps.
   </Card>
 </CardGroup>
 
@@ -82,6 +82,11 @@ The SDK uses a secure token-based authentication flow that keeps your API keys s
 
 ## Next Steps
 
-<Card title="Flutter SDK" icon="arrow-right" href="/sdk/flutter">
-  Get started with the Flutter SDK
-</Card>
+<CardGroup cols={2}>
+  <Card title="iOS SDK" icon="arrow-right" href="/sdk/ios">
+    Get started with the native iOS SDK (Swift)
+  </Card>
+  <Card title="Flutter SDK" icon="arrow-right" href="/sdk/flutter">
+    Get started with the Flutter SDK
+  </Card>
+</CardGroup>

--- a/docs/sdk/ios/index.mdx
+++ b/docs/sdk/ios/index.mdx
@@ -1,0 +1,253 @@
+---
+title: "iOS SDK"
+sidebarTitle: "Overview"
+description: "Native iOS SDK for background health data sync from Apple HealthKit"
+---
+
+## Introduction
+
+The Open Wearables iOS SDK (`OpenWearablesHealthSDK`) is a native Swift SDK for secure background synchronization of health data from Apple HealthKit to the Open Wearables platform.
+
+This is the **core native implementation** that powers health data sync on iOS. The [Flutter SDK](/sdk/flutter) uses this SDK under the hood as a wrapper.
+
+<Card title="GitHub Repository" icon="github" href="https://github.com/the-momentum/open_wearables_ios_sdk">
+  View source code, report issues, and contribute to the iOS SDK.
+</Card>
+
+## Features
+
+- **Background Sync** - Health data syncs even when your app is in the background via HealthKit observer queries and `BGTaskScheduler`
+- **Streaming Sync** - Memory-efficient streaming processing for large datasets
+- **Resumable Sessions** - Sync sessions survive app restarts and device reboots
+- **Dual Authentication** - Token-based auth with auto-refresh or API key authentication
+- **Secure Storage** - Credentials stored in iOS Keychain with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`
+- **Automatic Retry** - Persistent outbox with retry logic for failed uploads
+- **Per-User Isolation** - State isolation between different user sessions
+- **Network Monitoring** - Connectivity-aware sync with automatic resume
+- **Wide Data Support** - Steps, heart rate, workouts, sleep, and 40+ data types
+
+## Requirements
+
+| Requirement | Details |
+|-------------|---------|
+| iOS Version | iOS 14.0+ |
+| Swift | Swift 5.0+ |
+| Xcode | Xcode 14+ |
+| Apple Developer Account | Required for HealthKit entitlement |
+| HealthKit Capability | Must be enabled in Xcode |
+| Physical Device | HealthKit doesn't work in iOS Simulator |
+
+## Installation
+
+<Tabs>
+  <Tab title="Swift Package Manager">
+    Add the package to your `Package.swift`:
+
+    ```swift
+    dependencies: [
+        .package(url: "https://github.com/the-momentum/open_wearables_ios_sdk.git", from: "0.1.0")
+    ]
+    ```
+
+    Or in Xcode: **File** → **Add Package Dependencies** → paste the repository URL.
+  </Tab>
+
+  <Tab title="CocoaPods">
+    Add to your `Podfile`:
+
+    ```ruby
+    pod 'OpenWearablesHealthSDK', '~> 0.1.0'
+    ```
+
+    Then run:
+
+    ```bash
+    pod install
+    ```
+  </Tab>
+</Tabs>
+
+### iOS Configuration
+
+Add the following to your `Info.plist`:
+
+```xml
+<!-- Health data permission -->
+<key>NSHealthShareUsageDescription</key>
+<string>This app syncs your health data to your account.</string>
+
+<!-- Background modes for sync -->
+<key>UIBackgroundModes</key>
+<array>
+    <string>fetch</string>
+    <string>processing</string>
+</array>
+
+<!-- Background task identifiers -->
+<key>BGTaskSchedulerPermittedIdentifiers</key>
+<array>
+    <string>com.openwearables.healthsdk.task.refresh</string>
+    <string>com.openwearables.healthsdk.task.process</string>
+</array>
+```
+
+Then enable HealthKit capability in Xcode:
+
+1. Open your `.xcodeproj` or `.xcworkspace` in Xcode
+2. Select your target → **Signing & Capabilities**
+3. Click **+ Capability** → Add **HealthKit**
+4. Check **Background Delivery** if you want updates while app is closed
+
+## Quick Start
+
+Here's the minimal code to get health sync working:
+
+```swift
+import OpenWearablesHealthSDK
+
+class HealthService {
+    let sdk = OpenWearablesHealthSDK.shared
+
+    func initialize() {
+        // 1. Set up logging (optional)
+        sdk.onLog = { message in
+            print("[Health] \(message)")
+        }
+
+        // 2. Handle auth errors (optional)
+        sdk.onAuthError = { statusCode, message in
+            print("Auth error: \(statusCode) - \(message)")
+        }
+
+        // 3. Configure the SDK with your host
+        sdk.configure(host: "https://api.openwearables.io")
+
+        // 4. Check if already signed in (session restored from Keychain)
+        if sdk.restoreSession() {
+            print("Session restored")
+            return
+        }
+
+        // 5. Get credentials from YOUR backend, then sign in
+        let credentials = yourBackend.getHealthCredentials()
+
+        sdk.signIn(
+            userId: credentials.userId,
+            accessToken: credentials.accessToken,
+            refreshToken: credentials.refreshToken,
+            apiKey: nil
+        )
+
+        // 6. Request health permissions
+        sdk.requestAuthorization(types: ["steps", "heartRate", "sleep", "workout"]) { granted in
+            if granted {
+                // 7. Start background sync
+                sdk.startBackgroundSync { started in
+                    print("Sync started: \(started)")
+                }
+            }
+        }
+    }
+}
+```
+
+## AppDelegate Setup
+
+For background URL session support, add to your `AppDelegate`:
+
+```swift
+func application(
+    _ application: UIApplication,
+    handleEventsForBackgroundURLSession identifier: String,
+    completionHandler: @escaping () -> Void
+) {
+    OpenWearablesHealthSDK.setBackgroundCompletionHandler(completionHandler)
+}
+```
+
+## Documentation
+
+<CardGroup cols={2}>
+  <Card title="Integration Guide" icon="book" href="/sdk/ios/integration">
+    Complete guide to integrating the SDK including authentication flow, backend setup, and best practices.
+  </Card>
+  <Card title="Troubleshooting" icon="wrench" href="/sdk/ios/troubleshooting">
+    Common issues and their solutions for native iOS.
+  </Card>
+</CardGroup>
+
+## Supported Health Data Types
+
+The SDK supports 40+ health data types across multiple categories:
+
+<AccordionGroup>
+  <Accordion title="Activity & Fitness">
+    | Type | Description |
+    |------|-------------|
+    | `steps` | Step count |
+    | `distanceWalkingRunning` | Walking/running distance |
+    | `distanceCycling` | Cycling distance |
+    | `flightsClimbed` | Floors climbed |
+    | `walkingSpeed` | Average walking speed |
+    | `walkingStepLength` | Step length |
+    | `sixMinuteWalkTestDistance` | 6-minute walk test |
+  </Accordion>
+
+  <Accordion title="Heart & Vitals">
+    | Type | Description |
+    |------|-------------|
+    | `heartRate` | Heart rate measurements |
+    | `restingHeartRate` | Resting heart rate |
+    | `heartRateVariabilitySDNN` | HRV (SDNN) |
+    | `vo2Max` | VO2 max |
+    | `oxygenSaturation` | Blood oxygen |
+    | `respiratoryRate` | Breathing rate |
+    | `bloodPressure` | Blood pressure readings |
+  </Accordion>
+
+  <Accordion title="Body Measurements">
+    | Type | Description |
+    |------|-------------|
+    | `bodyMass` | Weight |
+    | `height` | Height |
+    | `bmi` | Body Mass Index |
+    | `bodyFatPercentage` | Body fat % |
+    | `leanBodyMass` | Lean body mass |
+    | `waistCircumference` | Waist circumference (iOS 16+) |
+    | `bodyTemperature` | Body temperature |
+  </Accordion>
+
+  <Accordion title="Sleep & Mindfulness">
+    | Type | Description |
+    |------|-------------|
+    | `sleep` | Sleep sessions and stages |
+    | `mindfulSession` | Meditation/mindfulness sessions |
+  </Accordion>
+
+  <Accordion title="Nutrition">
+    | Type | Description |
+    |------|-------------|
+    | `dietaryEnergyConsumed` | Calories consumed |
+    | `dietaryCarbohydrates` | Carbs |
+    | `dietaryProtein` | Protein |
+    | `dietaryFatTotal` | Total fat |
+    | `dietaryWater` | Water intake |
+  </Accordion>
+
+  <Accordion title="Workouts">
+    | Type | Description |
+    |------|-------------|
+    | `workout` | All workout types with metadata (distance, energy, heart rate, running metrics, elevation, weather, swimming) |
+  </Accordion>
+</AccordionGroup>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Integration Guide" icon="arrow-right" href="/sdk/ios/integration">
+    Complete step-by-step integration guide.
+  </Card>
+  <Card title="API Reference" icon="code" href="https://github.com/the-momentum/open_wearables_ios_sdk">
+    Full API documentation on GitHub.
+  </Card>
+</CardGroup>

--- a/docs/sdk/ios/integration.mdx
+++ b/docs/sdk/ios/integration.mdx
@@ -1,0 +1,584 @@
+---
+title: "Integration Guide"
+sidebarTitle: "Integration Guide"
+description: "Complete guide to integrating the native iOS SDK with your Swift application"
+---
+
+## Overview
+
+This guide walks you through the complete integration of the Open Wearables iOS SDK into a native Swift application, from backend setup to production deployment.
+
+<Steps>
+  <Step title="Set up backend authentication endpoint" />
+  <Step title="Configure the SDK in your iOS app" />
+  <Step title="Implement sign-in flow" />
+  <Step title="Request health permissions" />
+  <Step title="Start background sync" />
+</Steps>
+
+## Authentication Architecture
+
+The SDK supports two authentication modes: **token-based** (recommended) and **API key**. The token-based flow keeps your API keys safe on your backend:
+
+<Steps>
+  <Step title="Mobile App requests credentials" icon="mobile">
+    User initiates health connection in your iOS app. App calls your backend.
+  </Step>
+  <Step title="Your Backend generates token" icon="server">
+    Your backend calls Open Wearables API with your **API Key** (server-to-server, HTTPS).
+    ```
+    POST https://api.openwearables.io/v1/tokens
+    X-API-Key: sk_live_your_secret_key
+    ```
+  </Step>
+  <Step title="Backend returns credentials" icon="key">
+    Open Wearables returns `userId` + `accessToken` (+ optional `refreshToken`). Your backend passes these to the mobile app (**not the API Key!**).
+  </Step>
+  <Step title="SDK stores & syncs" icon="lock">
+    iOS SDK stores credentials in Keychain and uses `accessToken` to sync health data directly to Open Wearables.
+  </Step>
+</Steps>
+
+<Warning>
+  **Never embed your API Key in the mobile app.** The API Key should only exist on your backend server. Only the `accessToken` is passed to the mobile app.
+</Warning>
+
+## Step 1: Backend Setup
+
+Your backend needs a single endpoint that generates access tokens for your users.
+
+### Generate Access Token
+
+When a user wants to connect their health data, your backend should:
+
+1. Authenticate the user (your own auth system)
+2. Call Open Wearables API to generate an access token
+3. Return the token to the mobile app
+
+<Tabs>
+  <Tab title="Node.js">
+```javascript
+// Express.js example
+const express = require('express');
+const app = express();
+
+app.post('/api/health/connect', authenticateUser, async (req, res) => {
+  try {
+    // 1. Get your authenticated user
+    const userId = req.user.id;
+    
+    // 2. Call Open Wearables API to generate token
+    const response = await fetch('https://api.openwearables.io/v1/tokens', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': process.env.OPENWEARABLES_API_KEY, // Secret! Never expose!
+      },
+      body: JSON.stringify({
+        externalId: userId.toString(), // Your user's ID
+      }),
+    });
+    
+    if (!response.ok) {
+      throw new Error('Failed to generate token');
+    }
+    
+    const { userId: owUserId, accessToken } = await response.json();
+    
+    // 3. Return credentials to mobile app (NOT the API Key!)
+    res.json({ 
+      userId: owUserId, 
+      accessToken 
+    });
+  } catch (error) {
+    console.error('Health connect error:', error);
+    res.status(500).json({ error: 'Failed to connect health' });
+  }
+});
+```
+  </Tab>
+
+  <Tab title="Python">
+```python
+# FastAPI example
+from fastapi import FastAPI, Depends, HTTPException
+import httpx
+import os
+
+app = FastAPI()
+
+@app.post("/api/health/connect")
+async def connect_health(current_user = Depends(get_current_user)):
+    # 1. Call Open Wearables API to generate token
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            "https://api.openwearables.io/v1/tokens",
+            headers={
+                "Content-Type": "application/json",
+                "X-API-Key": os.environ["OPENWEARABLES_API_KEY"],
+            },
+            json={
+                "externalId": str(current_user.id),
+            },
+        )
+        
+        if response.status_code != 200:
+            raise HTTPException(500, "Failed to generate token")
+        
+        data = response.json()
+    
+    # 2. Return credentials to mobile app
+    return {
+        "userId": data["userId"],
+        "accessToken": data["accessToken"],
+    }
+```
+  </Tab>
+
+  <Tab title="Ruby">
+```ruby
+# Rails controller example
+class HealthController < ApplicationController
+  before_action :authenticate_user!
+
+  def connect
+    # 1. Call Open Wearables API to generate token
+    response = HTTParty.post(
+      'https://api.openwearables.io/v1/tokens',
+      headers: {
+        'Content-Type' => 'application/json',
+        'X-API-Key' => ENV['OPENWEARABLES_API_KEY']
+      },
+      body: {
+        externalId: current_user.id.to_s
+      }.to_json
+    )
+
+    if response.success?
+      # 2. Return credentials to mobile app
+      render json: {
+        userId: response['userId'],
+        accessToken: response['accessToken']
+      }
+    else
+      render json: { error: 'Failed to connect' }, status: 500
+    end
+  end
+end
+```
+  </Tab>
+</Tabs>
+
+<Note>
+  The `externalId` parameter links the Open Wearables user to your user. Use your internal user ID to easily correlate data later.
+</Note>
+
+## Step 2: SDK Configuration
+
+Configure the SDK once at app startup, typically in your `AppDelegate` or app initialization code.
+
+```swift
+import OpenWearablesHealthSDK
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+
+        let sdk = OpenWearablesHealthSDK.shared
+
+        // Optional: Set up logging
+        sdk.onLog = { message in
+            print("[HealthSDK] \(message)")
+        }
+
+        // Optional: Handle auth errors
+        sdk.onAuthError = { statusCode, message in
+            print("Auth error \(statusCode): \(message)")
+        }
+
+        // Configure with your host
+        sdk.configure(host: "https://api.openwearables.io")
+
+        return true
+    }
+
+    // Required for background URL session support
+    func application(
+        _ application: UIApplication,
+        handleEventsForBackgroundURLSession identifier: String,
+        completionHandler: @escaping () -> Void
+    ) {
+        OpenWearablesHealthSDK.setBackgroundCompletionHandler(completionHandler)
+    }
+}
+```
+
+### Configuration Options
+
+| Parameter | Description |
+|-----------|-------------|
+| `host` | The Open Wearables API URL (e.g. `https://api.openwearables.io`) |
+
+```swift
+// For self-hosted Open Wearables
+sdk.configure(host: "https://your-domain.com")
+```
+
+### Session Restoration
+
+The SDK automatically persists credentials in the iOS Keychain. On app launch, call `configure()` to restore any existing session:
+
+```swift
+sdk.configure(host: "https://api.openwearables.io")
+
+// Check if user was previously signed in
+if sdk.restoreSession() {
+    print("Welcome back!")
+    // User is already signed in, can resume sync
+} else {
+    // Need to sign in first
+}
+```
+
+## Step 3: Sign In
+
+After getting credentials from your backend, sign in with the SDK. The SDK supports two authentication modes:
+
+### Token-Based Authentication (Recommended)
+
+```swift
+func connectHealth() {
+    // 1. Get credentials from YOUR backend
+    yourAPI.post("/api/health/connect") { result in
+        switch result {
+        case .success(let credentials):
+            // 2. Sign in with the SDK
+            OpenWearablesHealthSDK.shared.signIn(
+                userId: credentials.userId,
+                accessToken: credentials.accessToken,
+                refreshToken: credentials.refreshToken, // Optional: enables auto-refresh
+                apiKey: nil
+            )
+            print("Connected: \(credentials.userId)")
+
+        case .failure(let error):
+            print("Failed to connect: \(error)")
+        }
+    }
+}
+```
+
+### API Key Authentication
+
+For simpler setups (e.g. internal tools), you can use API key authentication directly:
+
+```swift
+OpenWearablesHealthSDK.shared.signIn(
+    userId: "user123",
+    accessToken: nil,
+    refreshToken: nil,
+    apiKey: "your_api_key"
+)
+```
+
+<Warning>
+  API key authentication embeds the key in the app. Only use this for internal or trusted applications. For production apps, always use token-based authentication.
+</Warning>
+
+### Automatic Token Refresh
+
+When you provide a `refreshToken`, the SDK automatically handles 401 responses by refreshing the access token and retrying the request. No additional configuration is needed.
+
+You can also update tokens manually if needed:
+
+```swift
+OpenWearablesHealthSDK.shared.updateTokens(
+    accessToken: newAccessToken,
+    refreshToken: newRefreshToken
+)
+```
+
+## Step 4: Request Permissions
+
+Request access to specific health data types:
+
+```swift
+func requestHealthPermissions() {
+    OpenWearablesHealthSDK.shared.requestAuthorization(
+        types: [
+            "steps",
+            "heartRate",
+            "restingHeartRate",
+            "sleep",
+            "workout",
+            "activeEnergy",
+            "bodyMass",
+        ]
+    ) { granted in
+        if granted {
+            print("Health permissions granted")
+        } else {
+            print("Some permissions were denied")
+        }
+    }
+}
+```
+
+<Note>
+  On iOS, users can grant partial permissions. The SDK will sync whatever data the user allows. Apple's privacy model means your app cannot determine which specific types were denied.
+</Note>
+
+### iOS Permission UI
+
+When requesting permissions, iOS shows a system dialog listing all requested data types. Users can toggle each type individually.
+
+<Tip>
+  Request only the data types you actually need. Requesting too many types can overwhelm users and reduce acceptance rates.
+</Tip>
+
+## Step 5: Start Background Sync
+
+Enable background sync to keep data flowing even when your app is in the background:
+
+```swift
+OpenWearablesHealthSDK.shared.startBackgroundSync { started in
+    print("Background sync started: \(started)")
+}
+```
+
+### Background Sync Behavior
+
+| Mechanism | Description |
+|-----------|-------------|
+| HealthKit Observer Queries | Immediate delivery when new health data is written |
+| BGAppRefreshTask | Scheduled every ~15 minutes (system-managed) |
+| BGProcessingTask | Network-required background processing |
+
+<Warning>
+  Background sync frequency is controlled by iOS and may vary based on battery level, network conditions, and user behavior. The 15-minute interval is a minimum - actual syncs may be less frequent.
+</Warning>
+
+### Manual Sync
+
+Trigger an immediate sync when needed:
+
+```swift
+OpenWearablesHealthSDK.shared.syncNow {
+    print("Sync completed")
+}
+```
+
+### Stop Sync
+
+```swift
+OpenWearablesHealthSDK.shared.stopBackgroundSync()
+```
+
+## Complete Integration Example
+
+Here's a complete service class showing the full integration:
+
+```swift
+import OpenWearablesHealthSDK
+import Foundation
+
+class HealthSyncService {
+    static let shared = HealthSyncService()
+
+    private let sdk = OpenWearablesHealthSDK.shared
+    private let backendURL: String
+    private var authToken: String?
+
+    var isConnected: Bool {
+        // Check if SDK has an active session
+        return sdk.restoreSession()
+    }
+
+    private init() {
+        self.backendURL = "https://your-backend.com"
+    }
+
+    /// Initialize the health sync service
+    func initialize() {
+        sdk.onLog = { message in
+            print("[HealthSync] \(message)")
+        }
+
+        sdk.onAuthError = { statusCode, message in
+            print("[HealthSync] Auth error \(statusCode): \(message)")
+            if statusCode == 401 {
+                // Handle token expiration in your app
+                NotificationCenter.default.post(name: .healthAuthExpired, object: nil)
+            }
+        }
+
+        sdk.configure(host: "https://api.openwearables.io")
+    }
+
+    /// Connect health data for the current user
+    func connect(authToken: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        self.authToken = authToken
+
+        // 1. Get credentials from your backend
+        var request = URLRequest(url: URL(string: "\(backendURL)/api/health/connect")!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            guard let self = self else { return }
+
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            guard let data = data,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let userId = json["userId"] as? String,
+                  let accessToken = json["accessToken"] as? String else {
+                completion(.failure(NSError(domain: "", code: -1, userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to parse credentials"
+                ])))
+                return
+            }
+
+            // 2. Sign in with SDK
+            self.sdk.signIn(
+                userId: userId,
+                accessToken: accessToken,
+                refreshToken: json["refreshToken"] as? String,
+                apiKey: nil
+            )
+
+            // 3. Request permissions and start sync
+            self.sdk.requestAuthorization(types: [
+                "steps", "heartRate", "sleep", "workout", "activeEnergy"
+            ]) { granted in
+                if granted {
+                    self.sdk.startBackgroundSync { started in
+                        if started {
+                            completion(.success(()))
+                        } else {
+                            completion(.failure(NSError(domain: "", code: -1, userInfo: [
+                                NSLocalizedDescriptionKey: "Failed to start sync"
+                            ])))
+                        }
+                    }
+                } else {
+                    completion(.failure(NSError(domain: "", code: -1, userInfo: [
+                        NSLocalizedDescriptionKey: "Health permissions not granted"
+                    ])))
+                }
+            }
+        }.resume()
+    }
+
+    /// Disconnect health data
+    func disconnect() {
+        sdk.stopBackgroundSync()
+        sdk.signOut()
+    }
+
+    /// Trigger an immediate sync
+    func syncNow(completion: @escaping () -> Void) {
+        sdk.syncNow {
+            completion()
+        }
+    }
+
+    /// Force a full re-sync of all data
+    func resyncAllData() {
+        sdk.resetAnchors()
+        sdk.syncNow { }
+    }
+}
+
+extension Notification.Name {
+    static let healthAuthExpired = Notification.Name("healthAuthExpired")
+}
+```
+
+### Using the Service
+
+```swift
+class HealthViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        HealthSyncService.shared.initialize()
+    }
+
+    @IBAction func connectHealthTapped(_ sender: Any) {
+        guard let authToken = getAuthToken() else { return }
+
+        HealthSyncService.shared.connect(authToken: authToken) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    self.showAlert(title: "Success", message: "Health data connected!")
+                case .failure(let error):
+                    self.showAlert(title: "Error", message: error.localizedDescription)
+                }
+            }
+        }
+    }
+
+    @IBAction func disconnectTapped(_ sender: Any) {
+        HealthSyncService.shared.disconnect()
+        showAlert(title: "Disconnected", message: "Health sync stopped.")
+    }
+
+    @IBAction func syncNowTapped(_ sender: Any) {
+        HealthSyncService.shared.syncNow {
+            DispatchQueue.main.async {
+                self.showAlert(title: "Sync", message: "Sync completed!")
+            }
+        }
+    }
+
+    private func showAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}
+```
+
+## Data Sync Endpoint
+
+The SDK sends health data to:
+
+```
+POST /sdk/users/{user_id}/sync/apple/healthkit
+```
+
+Data is automatically normalized to the Open Wearables unified data model and can be accessed through the standard API endpoints.
+
+## Internal Architecture
+
+The SDK uses a modular architecture with several internal components:
+
+| Component | Purpose |
+|-----------|---------|
+| **Anchors** | Per-user `HKQueryAnchor` persistence for incremental sync |
+| **Background** | HealthKit observer queries + `BGTaskScheduler` management |
+| **Keychain** | Secure credential storage using iOS Security framework |
+| **Outbox** | Persistent upload queue with retry logic for failed uploads |
+| **Session** | Resumable sync state tracking (survives app restarts) |
+| **Types** | HealthKit type mapping and data serialization |
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Troubleshooting" icon="wrench" href="/sdk/ios/troubleshooting">
+    Common issues and solutions for native iOS.
+  </Card>
+  <Card title="Data Types" icon="database" href="/architecture/data-types">
+    Available health metrics and data formats.
+  </Card>
+</CardGroup>

--- a/docs/sdk/ios/troubleshooting.mdx
+++ b/docs/sdk/ios/troubleshooting.mdx
@@ -1,0 +1,288 @@
+---
+title: "Troubleshooting"
+sidebarTitle: "Troubleshooting"
+description: "Common issues and solutions for the native iOS SDK"
+---
+
+## Common Issues
+
+<AccordionGroup>
+  <Accordion title="HealthKit permissions not showing">
+    **Symptoms:** The health permissions dialog doesn't appear when calling `requestAuthorization()`.
+
+    **Solutions:**
+
+    1. **Verify Info.plist configuration:**
+       ```xml
+       <key>NSHealthShareUsageDescription</key>
+       <string>This app syncs your health data to your account.</string>
+       ```
+
+    2. **Check HealthKit capability in Xcode:**
+       - Open your `.xcodeproj` or `.xcworkspace`
+       - Select target → Signing & Capabilities
+       - Ensure HealthKit is listed
+
+    3. **Run on physical device:**
+       HealthKit doesn't work in the iOS Simulator. Always test on a real device.
+
+    4. **Check provisioning profile:**
+       Your Apple Developer account must have HealthKit capability enabled for the App ID.
+  </Accordion>
+
+  <Accordion title="Background sync not working">
+    **Symptoms:** Data only syncs when the app is in the foreground.
+
+    **Solutions:**
+
+    1. **Verify background modes in Info.plist:**
+       ```xml
+       <key>UIBackgroundModes</key>
+       <array>
+           <string>fetch</string>
+           <string>processing</string>
+       </array>
+
+       <key>BGTaskSchedulerPermittedIdentifiers</key>
+       <array>
+           <string>com.openwearables.healthsdk.task.refresh</string>
+           <string>com.openwearables.healthsdk.task.process</string>
+       </array>
+       ```
+
+    2. **Add AppDelegate handler:**
+       Make sure you've added the background URL session handler:
+       ```swift
+       func application(
+           _ application: UIApplication,
+           handleEventsForBackgroundURLSession identifier: String,
+           completionHandler: @escaping () -> Void
+       ) {
+           OpenWearablesHealthSDK.setBackgroundCompletionHandler(completionHandler)
+       }
+       ```
+
+    3. **Check Background App Refresh setting:**
+       - Go to iOS Settings → Your App → Background App Refresh
+       - Ensure it's enabled
+
+    4. **Check Low Power Mode:**
+       Background tasks are suspended when Low Power Mode is active.
+
+    5. **Wait for system scheduling:**
+       iOS controls when background tasks run. Initial syncs may take 15+ minutes to trigger.
+  </Accordion>
+
+  <Accordion title="Sign-in fails or token errors">
+    **Symptoms:** Auth errors or failed sync after sign-in.
+
+    **Solutions:**
+
+    1. **Check token expiration:**
+       Access tokens expire. Ensure your backend generates fresh tokens.
+
+    2. **Verify API Key:**
+       Double-check your API Key on the backend is correct and active.
+
+    3. **Check network connectivity:**
+       Ensure the device can reach your Open Wearables host.
+
+    4. **Enable token refresh:**
+       Provide a `refreshToken` during sign-in to enable automatic token refresh:
+       ```swift
+       sdk.signIn(
+           userId: userId,
+           accessToken: accessToken,
+           refreshToken: refreshToken,
+           apiKey: nil
+       )
+       ```
+
+    5. **Listen for auth errors:**
+       ```swift
+       sdk.onAuthError = { statusCode, message in
+           print("Auth error \(statusCode): \(message)")
+           // Handle re-authentication in your app
+       }
+       ```
+  </Accordion>
+
+  <Accordion title="Data not appearing in Open Wearables">
+    **Symptoms:** Sync seems to complete but data doesn't show up in the API.
+
+    **Solutions:**
+
+    1. **Check logs for errors:**
+       ```swift
+       sdk.onLog = { message in
+           print("[HealthSDK] \(message)")
+       }
+       ```
+
+    2. **Verify health data exists:**
+       Open Apple Health and confirm data exists for the requested types.
+
+    3. **Check date range:**
+       The SDK syncs data incrementally. New data may not exist yet.
+
+    4. **Reset anchors for full sync:**
+       ```swift
+       sdk.resetAnchors()
+       sdk.syncNow { }
+       ```
+
+    5. **Check permissions:**
+       Users may have denied specific data types even if they approved the overall request.
+
+    6. **Check the outbox:**
+       Failed uploads are queued in the persistent outbox. Enable logging to see retry attempts.
+  </Accordion>
+
+  <Accordion title="Sync doesn't resume after app restart">
+    **Symptoms:** Sync session lost after app is killed or device restarts.
+
+    **Solutions:**
+
+    1. **Ensure configure() is called on launch:**
+       The SDK automatically restores sync state when `configure()` is called:
+       ```swift
+       // In AppDelegate or app init
+       sdk.configure(host: "https://api.openwearables.io")
+       ```
+       The SDK checks for tracked types and active sync state during configuration and auto-resumes if needed.
+
+    2. **Check Keychain access:**
+       Credentials use `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`. The device must be unlocked at least once after boot for the SDK to access stored credentials.
+
+    3. **Verify user hasn't changed:**
+       The SDK isolates state per user. If a different user signs in, previous sync state is cleared.
+  </Accordion>
+
+  <Accordion title="High memory usage during sync">
+    **Symptoms:** App uses excessive memory during large syncs.
+
+    **Solutions:**
+
+    The SDK uses streaming sync by default, processing data in chunks to minimize memory usage. If you're still seeing high memory:
+
+    1. **Check data volume:**
+       Initial full syncs can process large amounts of historical data. This is normal and memory should stabilize after the first sync.
+
+    2. **Check for memory leaks in your code:**
+       Ensure you're not holding strong references to SDK callbacks that prevent deallocation.
+  </Accordion>
+</AccordionGroup>
+
+## HealthKit Entitlement Issues
+
+If you see "Missing HealthKit entitlement" errors:
+
+1. **In Xcode:**
+   - Target → Signing & Capabilities → Add HealthKit
+   - Check "Background Delivery" for background updates
+
+2. **In Apple Developer Portal:**
+   - App IDs → Your App → Capabilities
+   - Enable HealthKit
+
+3. **Regenerate provisioning profiles** after making changes
+
+### Background Delivery Limitations
+
+iOS has strict limits on background execution:
+
+| Factor | Impact |
+|--------|--------|
+| Battery Level | Background tasks paused below 20% |
+| Low Power Mode | All background tasks suspended |
+| User Behavior | iOS learns when you use the app and schedules accordingly |
+| Network | Background tasks require network connectivity |
+| Device Locked | SDK monitors protected data availability and resumes after unlock |
+
+<Tip>
+  For critical sync operations, prompt users to open the app and trigger `syncNow()` manually.
+</Tip>
+
+## Testing Background Sync
+
+To test background sync during development:
+
+1. Run app on device
+2. Navigate to home screen
+3. Wait 15+ minutes (or use Xcode's debug menu)
+4. Check logs for sync activity
+
+In Xcode, you can simulate background fetch:
+- Debug → Simulate Background Fetch
+
+You can also trigger background task processing from Xcode's debugger:
+
+```
+e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"com.openwearables.healthsdk.task.refresh"]
+```
+
+## Debugging Tips
+
+### Enable Debug Logging
+
+```swift
+let sdk = OpenWearablesHealthSDK.shared
+
+sdk.onLog = { message in
+    print("[HealthSDK] \(message)")
+}
+
+sdk.onAuthError = { statusCode, message in
+    print("[HealthSDK] Auth error \(statusCode): \(message)")
+}
+```
+
+### Check Stored Session
+
+```swift
+// Verify session can be restored
+let restored = sdk.restoreSession()
+print("Session restored: \(restored)")
+```
+
+### Force Fresh Start
+
+If things are in a bad state:
+
+```swift
+// Clear everything and start fresh
+sdk.stopBackgroundSync()
+sdk.signOut()
+sdk.resetAnchors()
+
+// Re-initialize
+sdk.configure(host: "https://api.openwearables.io")
+```
+
+## Network Monitoring
+
+The SDK includes built-in network monitoring via `NWPathMonitor`. When the device loses connectivity:
+
+1. Active uploads are queued in the persistent outbox
+2. When connectivity returns, the outbox is automatically retried
+3. Failed uploads older than 30 seconds are retried on the next sync cycle
+
+## Getting Help
+
+If you're still experiencing issues:
+
+<CardGroup cols={2}>
+  <Card title="GitHub Issues" icon="github" href="https://github.com/the-momentum/open_wearables_ios_sdk/issues">
+    Report bugs or request features on the SDK repository.
+  </Card>
+  <Card title="Discussions" icon="comments" href="https://github.com/the-momentum/open-wearables/discussions">
+    Ask questions and get help from the community.
+  </Card>
+</CardGroup>
+
+When reporting issues, please include:
+- Xcode version
+- SDK version
+- iOS version and device model
+- Relevant logs from `onLog` callback
+- Steps to reproduce


### PR DESCRIPTION
## Description

Add native iOS SDK (`OpenWearablesHealthSDK`) documentation to the docs site, mirroring the existing Flutter SDK docs structure. The Flutter SDK is now documented as a wrapper around this native iOS implementation.

**Changes:**
- Created `docs/sdk/ios/` with three pages: Overview, Integration Guide, and Troubleshooting
- Updated `docs/sdk/index.mdx` — added iOS SDK card, updated architecture description, removed "More Coming Soon" placeholder
- Updated `docs/sdk/flutter/index.mdx` — added note that Flutter SDK is a wrapper around the native iOS SDK with link to iOS docs
- Updated `docs/docs.json` — added iOS (Swift) navigation group under Sync SDK

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] ~~I have added tests that prove my fix/feature works (if applicable)~~ N/A — docs only
- [ ] ~~New and existing tests pass locally~~ N/A — docs only

### Backend Changes

No backend changes.

### Frontend Changes

No frontend changes.

## Testing Instructions

**Steps to test:**
1. `cd docs && npm i -g mint && mint dev --port 3333`
2. Open `http://localhost:3333/sdk` — verify iOS SDK card appears alongside Flutter
3. Navigate to iOS SDK section — verify Overview, Integration Guide, and Troubleshooting pages render correctly
4. Navigate to Flutter SDK Overview — verify the wrapper note and link to native iOS SDK are present

**Expected behavior:**

iOS SDK docs are accessible under Sync SDK → iOS (Swift) in the sidebar. Flutter SDK intro mentions it wraps the native iOS SDK. All links between pages work correctly.

## Screenshots



## Additional Notes

iOS SDK source: https://github.com/the-momentum/open_wearables_ios_sdk

The iOS docs intentionally skip the "Open Wearables App" (example-app) page since that's specific to the Flutter SDK demo app.