### PR TITLE
refactor(frontend): extract copyright text to shared constant

### DIFF
--- a/frontend/src/lib/constants/app.ts
+++ b/frontend/src/lib/constants/app.ts
@@ -1,0 +1,5 @@
+export const APP_NAME = 'Open Wearables';
+
+export function getCopyrightText() {
+  return `© ${new Date().getFullYear()} ${APP_NAME}`;
+}

--- a/frontend/src/routes/accept-invite.tsx
+++ b/frontend/src/routes/accept-invite.tsx
@@ -9,6 +9,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { isAuthenticated } from '@/lib/auth/session';
 import logotype from '@/logotype.svg';
+import { getCopyrightText } from '@/lib/constants/app';
 import {
   acceptInvitationSchema,
   type AcceptInvitationFormData,
@@ -342,7 +343,7 @@ function AcceptInvitePage() {
             </div>
 
             <div className="flex items-center justify-between text-xs text-zinc-600">
-              <p>© 2025 Open Wearables</p>
+              <p>{getCopyrightText()}</p>
             </div>
           </div>
 

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -6,6 +6,7 @@ import { ArrowRight, Mail, Lock, Loader2 } from 'lucide-react';
 import logotype from '@/logotype.svg';
 import { CodePreviewCard } from '@/components/login/code-preview-card';
 import { DEFAULT_REDIRECTS } from '@/lib/constants/routes';
+import { getCopyrightText } from '@/lib/constants/app';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -115,7 +116,7 @@ function LoginPage() {
 
           {/* Footer Links */}
           <div className="flex items-center text-xs text-zinc-600">
-            <p>© 2025 Open Wearables</p>
+            <p>{getCopyrightText()}</p>
           </div>
         </div>
 

--- a/frontend/src/routes/register.tsx
+++ b/frontend/src/routes/register.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useAuth } from '@/hooks/use-auth';
+import { getCopyrightText } from '@/lib/constants/app';
 import { isAuthenticated } from '@/lib/auth/session';
 import {
   registerSchema,
@@ -203,7 +204,7 @@ function RegisterPage() {
 
           {/* Footer */}
           <div className="flex items-center justify-between text-xs text-zinc-600">
-            <p>© 2025 Open Wearables</p>
+            <p>{getCopyrightText()}</p>
             <div className="flex gap-3">
               <a href="#" className="hover:text-zinc-400 transition-colors">
                 Privacy


### PR DESCRIPTION
## Summary
Extract duplicated `© 2025 Open Wearables` copyright string from login, register, and accept-invite pages into a shared `getCopyrightText()` helper in `lib/constants/app.ts` that dynamically resolves the current year.

🤖 Generated with [Claude Code](https://claude.com/claude-code)