### PR TITLE
fix: handle UUID serialization in structured logging (#496)

### DIFF
--- a/backend/app/utils/structured_logging.py
+++ b/backend/app/utils/structured_logging.py
@@ -2,8 +2,16 @@
 
 import json
 import sys
+import uuid
 from logging import Logger
 from typing import Any
+
+
+def json_serial(obj: Any) -> str:
+    """JSON serializer for objects not serializable by default json code"""
+    if isinstance(obj, uuid.UUID):
+        return str(obj)
+    raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
 
 
 def log_structured(
@@ -61,7 +69,7 @@ def log_structured(
     # Emit as single-line JSON directly to stdout
     # This bypasses logger formatters (like Celery's) that add prefixes
     # Platforms will parse this JSON string correctly
-    json_str = json.dumps(log_entry)
+    json_str = json.dumps(log_entry, default=json_serial)
 
     # Always use stdout to avoid Railway's automatic level conversion
     # Platforms can convert stderr logs to level.error automatically, which creates


### PR DESCRIPTION
Fixed the UUID serialization bug in structured_logging.py. 

The logger was crashing whenever it encountered a UUID object (like user_id), which masked the actual API failures developers needed to see. I've added a helper to handle the conversion and passed it to `json.dumps` so that UUIDs are now correctly logged as strings.

This fixes the issue across all providers (Whoop, Garmin, etc.) since they all rely on this utility.

Fixes #496
