### PR TITLE
fix(backend): truncate fractional step count from Apple Health SDK

### DIFF
--- a/backend/app/services/apple/healthkit/import_service.py
+++ b/backend/app/services/apple/healthkit/import_service.py
@@ -209,6 +209,9 @@ class ImportService:
 
             detail_field = get_detail_field_from_workout_statistic_type(stat.type)
             if detail_field:
+                # Apple SDK may send fractional Decimals for integer fields (e.g. stepCount)
+                if detail_field in ("steps_count", "moving_time_seconds"):
+                    value = int(value)
                 stats_dict[detail_field] = value
 
         return EventRecordMetrics(**stats_dict), time_series_samples, duration

--- a/backend/tests/schemas/test_schema_validation.py
+++ b/backend/tests/schemas/test_schema_validation.py
@@ -93,6 +93,18 @@ class TestEventRecordDetailCreateValidation:
         assert detail.heart_rate_avg == Decimal("145.5")
         assert detail.steps_count == 8500
 
+    def test_steps_count_rejects_fractional_decimal(self) -> None:
+        """Should raise ValidationError when steps_count is a fractional Decimal."""
+        record_id = uuid4()
+
+        with pytest.raises(ValidationError) as exc_info:
+            EventRecordDetailCreate(
+                record_id=record_id,
+                steps_count=Decimal("2981.57515735105"),
+            )
+
+        assert "steps_count" in str(exc_info.value)
+
     def test_missing_required_field_record_id(self) -> None:
         """Should raise ValidationError when record_id is missing."""
         # Act & Assert


### PR DESCRIPTION
## Description

Cast fractional Decimals (e.g. stepCount) from Apple Health SDK to int before building EventRecordMetrics to prevent Pydantic validation errors.

## Checklist

### General

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] New and existing tests pass locally

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes

### Frontend Changes

NA

## Testing Instructions

NA

## Screenshots

NA

## Additional Notes

NA


