### PR TITLE
docs: add Garmin webhook endpoint configuration guide

### DIFF
--- a/docs/dev-guides/ngrok-setup.mdx
+++ b/docs/dev-guides/ngrok-setup.mdx
@@ -86,7 +86,7 @@ Why might ngrok be needed for the OAuth flow? Because Garmin's OAuth callback re
     
     1. Expose your backend: `ngrok http 8000`
     2. Configure the webhook URL in your provider settings:
-       - Garmin: Use `https://abc123.ngrok-free.app/api/v1/webhooks/garmin`
+       - Garmin: Use `https://abc123.ngrok-free.app/api/v1/garmin/webhooks/push`
        - Other providers: Similar pattern
   </Accordion>
   

--- a/docs/providers/garmin-api-integration.mdx
+++ b/docs/providers/garmin-api-integration.mdx
@@ -101,12 +101,31 @@ Once you get access to the Developer Portal, you’ll find the full docs, includ
 
     **Enable endpoints**
     - Open [API Endpoints](https://apis.garmin.com/tools/endpoints)
-    - Enable the endpoints you need (activities, dailies, epochs, sleep, body composition, etc.)
+    - For **every** endpoint, set the URL to your Open Wearables webhook push endpoint:
+
+    ```
+    https://<your-domain>/api/v1/garmin/webhooks/push
+    ```
+
+    For local development with ngrok:
+    ```
+    https://<your-ngrok-id>.ngrok-free.app/api/v1/garmin/webhooks/push
+    ```
+
+    - Set delivery type to **push** (dropdown on the right)
+    - Check **enabled** for each endpoint you want to activate
+    - All endpoints use the **same URL** — Garmin distinguishes data types internally and sends the appropriate payload to this single endpoint
+
+    **Which endpoints to enable:**
+
+    Enable **all** endpoints listed on the page. Open Wearables accepts data from all Garmin data types (activities, dailies, sleeps, epochs, HRV, body compositions, stress, respiration, pulse ox, and more).
+
+    A subset of these types is actively requested during historical backfill — which ones is determined by `BACKFILL_DATA_TYPES` in `backend/app/services/providers/garmin/backfill_config.py`. All other enabled endpoints will passively receive data whenever Garmin pushes new updates.
 
     <Warning>
-    **Backfill requirement**: backfill only works once the relevant endpoints are enabled on the Endpoints page.
-    
-    Once backfill is enabled and data is ready, Garmin will deliver notifications (for now we support only push option) and Open Wearables can ingest the backfilled data.
+    **Backfill requirement**: backfill only works once the relevant endpoints are enabled on this page.
+
+    Once backfill is enabled and data is ready, Garmin will deliver notifications via push and Open Wearables can ingest the backfilled data.
     </Warning>
 
     <Note>


### PR DESCRIPTION
## Description
 - Add concrete webhook URL and configuration instructions to Garmin API integration Step 4 (was just "enable the endpoints you need")
 - Reference `backfill_config.py` as source of truth instead of hardcoding backfill types in docs
 - Fix wrong webhook path in ngrok-setup.mdx (`/api/v1/webhooks/garmin` → `/api/v1/garmin/webhooks/push`)

## Checklist

### Generala

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

NA

### Frontend Changes

NA

## Testing Instructions

NA

## Screenshots

NA

## Additional Notes

NA


