### PR TITLE
docs: correct default admin account password

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ open-wearables/
 # Start all services
 docker compose up -d
 
-# Admin account and series type definitions are auto-created on startup (admin@admin.com / secret123)
+# Admin account and series type definitions are auto-created on startup (admin@admin.com / your-secure-password)
 # Seed sample test data (optional)
 make seed
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Get Open Wearables up and running in minutes.
 
 4. **Log in to the developer portal:**
 
-   An admin account is automatically created on startup using the `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables (defaults: `admin@admin.com` / `secret123`).
+   An admin account is automatically created on startup using the `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables (defaults: `admin@admin.com` / `your-secure-password`).
 
    Open http://localhost:3000 to access the developer portal and create API keys.
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -61,7 +61,7 @@ class Settings(BaseSettings):
 
     # ADMIN ACCOUNT SEED
     admin_email: str = "admin@admin.com"
-    admin_password: SecretStr = SecretStr("secret123")
+    admin_password: SecretStr = SecretStr("your-secure-password")
 
     # Time to live for sleep state in Redis
     redis_sleep_ttl_seconds: int = 24 * 3600  # 24 hours

--- a/contributing/developing.md
+++ b/contributing/developing.md
@@ -23,7 +23,7 @@ cd open-wearables
 # Start all services with hot-reload (recommended for development)
 make watch
 
-# Admin account is auto-created on startup (admin@admin.com / secret123)
+# Admin account is auto-created on startup (admin@admin.com / your-secure-password)
 # Seed sample test data (optional)
 make seed
 ```

--- a/docs/deployment/railway.mdx
+++ b/docs/deployment/railway.mdx
@@ -20,7 +20,7 @@ Railway provides the fastest way to get a production Open Wearables instance run
 />
 
 <Tip>
-An admin account is created automatically on first startup (`admin@admin.com` / `secret123`). To use custom credentials, set `ADMIN_EMAIL` and `ADMIN_PASSWORD` on the **Backend** service before deploying (as shown on the video)
+An admin account is created automatically on first startup (`admin@admin.com` / `your-secure-password`). To use custom credentials, set `ADMIN_EMAIL` and `ADMIN_PASSWORD` on the **Backend** service before deploying (as shown on the video)
 </Tip>
 
 ## What gets deployed

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -133,7 +133,7 @@ Get Open Wearables running locally and start integrating wearable device data.
      Should return: `{"message": "Server is running!"}`
 
   2. **Create an API key**:
-     An admin account is automatically created on startup using the `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables (defaults: `admin@admin.com` / `secret123`).
+     An admin account is automatically created on startup using the `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables (defaults: `admin@admin.com` / `your-secure-password`).
 
      Use the admin panel at http://localhost:3000/ to log in and generate API keys.
 


### PR DESCRIPTION
## Description

Update the default admin password in the root-level README.md file to match the current default value from `backend/config.env`:

EDIT: updated all other references as requested by @bartmichalak 

```
cat backend/config/.env | grep ADMIN
#--- ADMIN SEED ---#
ADMIN_EMAIL=admin@admin.com
ADMIN_PASSWORD=your-secure-password
```

## Checklist

~Note: I have left all checklist items unchecked, since this is a one-line docs change.~

### General

- [X] My code follows the project's code style
- [X] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] New and existing tests pass locally

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [ ] `pnpm run lint` passes
- [ ] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds

## Testing Instructions

<!-- Describe how reviewers can test your changes -->

**Steps to test:**
1. Clone the repository
2. Follow the setup instructions in README.md
3. Attempt to login to http://localhost:3000 with the provided credentials

**Expected behavior:**

Login should now work correctly after following the readme.


## Additional Notes

Hi folks! 👋 

I hope you don't mind such a simple contribution, but I hit this issue during setup yesterday. Feel free to reject the PR if you'd rather update the default value of the env var to match the docs rather than the other way round.

On a separate note: I love what you're doing here. I've been in the wearables space building fitIQ for the last 3 years and I've evaluated a lot of the commercial wearable aggregators out there during that time. All of them fell short for me, not least the eye-watering cost but also the operational side - when things failed (which they always did), I wasn't just debugging my system and the provider's API, but a third black box in the middle. It's really exciting to me that someone's making a proper go of filling that space transparently and with a permissive license.

fitIQ is currently WHOOP-only, but wearable expansion is always somewhere near the top of the priority list. I'm not sure if I could adopt OpenWearables as things stand today (in no small part due to how tightly coupled my own system is to WHOOP), but I am going to keep a keen eye on things. If that changes, I'd love to contribute properly in the future too.

All the best,

Nick




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the default admin password placeholder across the getting-started guide, quickstart, deployment tips, contributing notes, and README — now shown as "your-secure-password" in examples and setup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->