### PR TITLE
feat: display data scope on user's connection card

### DIFF
--- a/frontend/src/components/user/connection-card.tsx
+++ b/frontend/src/components/user/connection-card.tsx
@@ -45,10 +45,7 @@ function formatTypeName(typeName: string): string {
 // Parse scope string into individual scope items
 // Handles both comma-separated (Strava) and space-separated (Whoop, Polar) formats
 function parseScopeString(scope: string): string[] {
-  return scope
-    .split(/[,\s]+/)
-    .map((s) => s.trim())
-    .filter(Boolean);
+  return scope.split(/[,\s]+/).filter(Boolean);
 }
 
 export function ConnectionCard({ connection, className }: ConnectionCardProps) {
@@ -94,6 +91,9 @@ export function ConnectionCard({ connection, className }: ConnectionCardProps) {
         .filter(([, v]) => v.timed_out > 0)
         .map(([type, v]) => ({ type, timedOutCount: v.timed_out }))
     : [];
+
+  // Parse scope items once for display
+  const scopeItems = connection.scope ? parseScopeString(connection.scope) : [];
 
   // Get failed types from summary
   const failedTypes = backfillStatus?.summary
@@ -179,13 +179,13 @@ export function ConnectionCard({ connection, className }: ConnectionCardProps) {
 
       <CardContent className="space-y-4">
         {/* Show data scope */}
-        {connection.scope && parseScopeString(connection.scope).length > 0 && (
+        {scopeItems.length > 0 && (
           <div className="space-y-1.5">
             <p className="text-xs font-medium text-muted-foreground">
               Data scope
             </p>
             <div className="flex flex-wrap gap-1.5">
-              {parseScopeString(connection.scope).map((scopeItem) => (
+              {scopeItems.map((scopeItem) => (
                 <Badge
                   key={scopeItem}
                   variant="secondary"


### PR DESCRIPTION
## Description

Show OAuth scope as badges in the user connection card. Parses both comma-separated and space-separated formats (provider-specific, we don't unifiy this at this point). Hidden when scope is empty. 

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

NA

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

## Testing Instructions

<!-- Describe how reviewers can test your changes -->

Check user's profile tab.

## Screenshots

<img width="587" height="245" alt="image" src="https://github.com/user-attachments/assets/d68b1a3c-d1a2-45e3-aab8-213392df22c0" />

## Additional Notes

<!-- Any additional context or information reviewers should know -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Data scope" section to connection cards that displays scope information when available, showing each scope item as a badge in a responsive layout for clearer visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->