### PR TITLE
fix: distinguish login error types instead of showing generic credentials error

### DIFF
--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { toast } from 'sonner';
 import { authService } from '../lib/api';
+import { ApiError } from '@/lib/errors/api-error';
 import { setSession, clearSession, isAuthenticated } from '../lib/auth/session';
 import type {
   LoginRequest,
@@ -23,8 +24,28 @@ export function useAuth() {
       navigate({ to: DEFAULT_REDIRECTS.authenticated });
     },
     onError: (error: unknown) => {
-      const message = error instanceof Error ? error.message : 'Login failed';
-      toast.error(message);
+      if (error instanceof ApiError) {
+        switch (error.code) {
+          case 'UNAUTHORIZED':
+            toast.error('Incorrect email or password');
+            break;
+          case 'NETWORK_ERROR':
+            toast.error(
+              'Unable to connect to the server. Please check your connection.'
+            );
+            break;
+          case 'TIMEOUT':
+            toast.error('Request timed out. Please try again.');
+            break;
+          case 'SERVER_ERROR':
+            toast.error('Server error. Please try again later.');
+            break;
+          default:
+            toast.error('Login failed. Please try again.');
+        }
+      } else {
+        toast.error('Login failed. Please try again.');
+      }
     },
   });
 


### PR DESCRIPTION
## Description

Fixes #547 - Login form now shows context-appropriate error messages (network, timeout,  server error) instead of "Incorrect email or password" for all failures. 
One of the developers recently lost ~30 minutes debugging "incorrect credentials" during app setup - turned out the backend wasn't running and error message was really misleading. 

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

NA

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

## Testing Instructions

Disable the backend container for a moment and try to log in on the frontend. 

Optionally, you can test some other edge cases (like returning 500 temporarily from the backend login endpoint).

## Screenshots

<img width="1307" height="810" alt="image" src="https://github.com/user-attachments/assets/83d79523-1533-4967-83cb-f977fe9e59b4" />


## Additional Notes

NA




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login error messages to provide clearer feedback when authentication fails, including handling for network timeouts and server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->