### PR TITLE
fix: set TTL on Celery pidbox reply keys to prevent Redis memory leak

### DIFF
--- a/backend/app/integrations/celery/core.py
+++ b/backend/app/integrations/celery/core.py
@@ -65,6 +65,8 @@ def create_celery() -> Celery:
         task_default_queue="default",
         task_default_exchange="default",
         result_expires=3 * 24 * 3600,
+        control_queue_ttl=300,
+        control_queue_expires=300,
         task_queues={
             "default": {},
             "sdk_sync": {},


### PR DESCRIPTION
## Description

The change adds two configuration parameters to Celery (control_queue_ttl=300, control_queue_expires=300) in core.py:54-55.                                                  

**What these parameters do:**
- control_queue_ttl - sets a TTL (300s) on messages in control queues (pidbox reply keys), after which Redis automatically removes them
- control_queue_expires - sets an expiration time (300s) on the control queues themselves, after which Redis deletes them                                                    
                                                                                                                           
**Problem:**

Celery creates temporary pidbox reply keys in Redis every time a worker responds to control commands (e.g. celery inspect). Without a TTL, these keys persist in Redis indefinitely, causing a memory leak.

**Impact on existing logic:**
- None - the change does not affect task routing, scheduling (beat), serialization, or any business logic
- These parameters only apply to Celery's internal control communication mechanism (pidbox), used for commands like inspect, ping, shutdown
- Tasks, queues (default, sdk_sync), and beat schedule remain unchanged
- 300s is a safe value - control commands complete in seconds, so 5 minutes provides plenty of headroom

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

NA

## Testing Instructions


## Screenshots

NA

## Additional Notes

NA




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted backend queue lifecycle settings to add explicit time-to-live and expiration for control messages, improving queue lifecycle management and resource handling without changing task behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->