### PR TITLE
fix(docs): use YouTube embed URL instead of share URL in iframe

### DIFF
--- a/docs/sdk/flutter/example-app.mdx
+++ b/docs/sdk/flutter/example-app.mdx
@@ -79,7 +79,7 @@ Use the Open Wearables MCP server to chat with health data using AI:
 <iframe
   className="w-full rounded-lg"
   style={{ aspectRatio: '16/9' }}
-  src="https://www.youtube.com/watch?v=Jb8N2jNbs1Y"
+  src="https://www.youtube.com/embed/Jb8N2jNbs1Y?si=sy1Ri66JO0TseSbf"
   title="Talk to health data via MCP"
   frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION
## Description

Fixes YouTube video not loading on the example app docs page - changed youtu.be share link to youtube.com/embed format for iframe compatibility.

## Checklist

### General

NA

### Backend Changes

NA

### Frontend Changes

NA

## Testing Instructions

NA

## Screenshots

NA

## Additional Notes

NA




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated embedded video in the Flutter SDK example app documentation for improved presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->