### PR TITLE
fix(backend): update last_synced_at when data arrives via Garmin webhook

### DIFF
--- a/backend/app/api/routes/v1/garmin_webhooks.py
+++ b/backend/app/api/routes/v1/garmin_webhooks.py
@@ -364,6 +364,7 @@ def garmin_ping_notification(
         processed_count = 0
         errors: list[str] = []
         processed_activities: list[dict] = []
+        synced_user_ids: set[UUID] = set()
 
         # Process activities via callback URLs
         if "activities" in payload:
@@ -507,6 +508,19 @@ def garmin_ping_notification(
         # Commit all batch-inserted wellness data (bulk_create defers commit to caller)
         db.commit()
 
+        # Extract user IDs from wellness results and update last_synced_at
+        for result in wellness_results.values():
+            if isinstance(result, dict):
+                for item in result.get("items", []):
+                    if item.get("saved", 0) > 0:
+                        synced_user_ids.add(UUID(item["internal_user_id"]))
+        if synced_user_ids:
+            user_connection_repo = UserConnectionRepository()
+            for uid in synced_user_ids:
+                connection = user_connection_repo.get_active_connection(db, uid, "garmin")
+                if connection:
+                    user_connection_repo.update_last_synced_at(db, connection)
+
         # Collect user IDs with new success transitions from wellness results
         users_with_new_success: set[str] = set()
         for result in wellness_results.values():
@@ -649,6 +663,7 @@ def garmin_push_notification(
         saved_count = 0
         errors: list[str] = []
         processed_activities: list[dict] = []
+        synced_user_ids: set[UUID] = set()
 
         # Get Garmin workouts service via factory
         factory = ProviderFactory()
@@ -752,6 +767,8 @@ def garmin_push_notification(
                         },
                     )
                     processed_count += 1
+                    if created_ids:
+                        synced_user_ids.add(internal_user_id)
                     log_structured(
                         logger,
                         "info",
@@ -862,8 +879,11 @@ def garmin_push_notification(
             for uid, items in user_items.items():
                 trace_id = get_trace_id(uid) or request_trace_id
                 try:
-                    type_count += garmin_247.process_items_batch(db, uid, data_type, items)
+                    count = garmin_247.process_items_batch(db, uid, data_type, items)
+                    type_count += count
                     type_users.add(str(uid))
+                    if count > 0:
+                        synced_user_ids.add(uid)
                 except Exception as e:
                     log_structured(
                         logger,
@@ -896,6 +916,12 @@ def garmin_push_notification(
 
         # Commit all batch-inserted wellness data (bulk_create defers commit to caller)
         db.commit()
+
+        # Update last_synced_at for all users that received data via push
+        for uid in synced_user_ids:
+            connection = user_connection_repo.get_active_connection(db, uid, "garmin")
+            if connection:
+                user_connection_repo.update_last_synced_at(db, connection)
 
         # Also add users from activity processing (only if newly succeeded)
         for act in processed_activities:


### PR DESCRIPTION
## Description

  - Garmin webhook endpoints (push/ping) processed and saved incoming data correctly but never updated `last_synced_at` on the user connection
  - Added tracking of user IDs that successfully received data during webhook processing
  - After commit, `last_synced_at` is now updated for all affected connections
 
## Checklist

### General

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] New and existing tests pass locally

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [ ] `pnpm run lint` passes
- [ ] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds

## Testing Instructions

<!-- Describe how reviewers can test your changes -->

**Steps to test:**
1.
2.
3.

**Expected behavior:**



## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->



## Additional Notes

<!-- Any additional context or information reviewers should know -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliably records "last synced" timestamps for Garmin connections during webhook processing (both ping and push flows).
  * Ensures newly received activity and wellness data trigger immediate sync-time updates so recently synced users are recognized promptly.
  * Adjusts processing order to update sync timestamps before triggering downstream backfill/notification steps, reducing missed or delayed sync detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->