### PR TITLE
chore: add .claude/ directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,7 +164,7 @@ volumes
 
 # AI instruction local overrides (not committed)
 CLAUDE.local.md
-.claude/settings.local.json
+.claude/
 *.local.mdc
 
 # Exception: AI tool configs that should be tracked


### PR DESCRIPTION
## Description

Ignore the entire `.claude/` directory instead of just `.claude/settings.local.json` - keeps all local Claude Code config out of version control.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration file management settings to improve local development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->