### PR TITLE
chore: add production docker-compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -102,6 +102,8 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        VITE_API_URL: ${VITE_API_URL:?Set VITE_API_URL in your environment}
     container_name: frontend__open-wearables
     image: open-wearables-frontend:latest
     pull_policy: never


### PR DESCRIPTION
## Description

Production-ready docker-compose that uses the prod Dockerfile for frontend (Nitro SSR build instead of vite dev server), drops dev-only `develop.watch` configs, and sets `restart: unless-stopped` on all services.

Usage: `docker compose -f docker-compose.prod.yml up -d --build`

## Testing Instructions

**Steps to test:**
1. Deploy to server with `docker compose -f docker-compose.prod.yml up -d --build`
2. Verify frontend serves built assets (not vite dev server)
3. Verify all services restart after failure

**Expected behavior:**
All services come up with production configs, frontend runs Nitro SSR server on port 3000.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured production deployment infrastructure for the complete application stack, including database services, backend services, caching layer, task processing, monitoring capabilities, and frontend components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->