### PR TITLE
docs: update mobile sdk docs 

### DIFF
--- a/docs/sdk/android/integration.mdx
+++ b/docs/sdk/android/integration.mdx
@@ -220,18 +220,15 @@ class MyApplication : Application() {
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `host` | `String` | **Required.** The Open Wearables API URL |
-| `customSyncUrl` | `String?` | Optional custom sync endpoint URL |
+| `host` | `String` | **Required.** The Open Wearables API base URL (host only, without path suffix) |
+
+<Info>
+  Provide only the base host URL, e.g. `https://your-domain.com`. Do **not** append `/api/v1/` or any other path — the SDK adds the required path prefix automatically.
+</Info>
 
 ```kotlin
 // For self-hosted Open Wearables
 sdk.configure(host = "https://your-domain.com")
-
-// With custom sync URL
-sdk.configure(
-    host = "https://your-domain.com",
-    customSyncUrl = "https://custom-endpoint.com/sync"
-)
 ```
 
 ### Session Restoration
@@ -252,6 +249,10 @@ if (sdk.isSessionValid()) {
 ## Step 3: Sign In
 
 After getting credentials from your backend, sign in with the SDK.
+
+<Info>
+  The `userId` parameter is the **Open Wearables User ID** (UUID) — the `id` returned by the [Create User](/api-reference/users/create-user) endpoint. Do **not** pass your own `external_user_id` here.
+</Info>
 
 ### Token-Based Authentication (Recommended)
 

--- a/docs/sdk/flutter/integration.mdx
+++ b/docs/sdk/flutter/integration.mdx
@@ -204,7 +204,11 @@ Future<void> main() async {
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `host` | `String` | **Required.** The Open Wearables API URL (e.g. `https://api.openwearables.io`) |
+| `host` | `String` | **Required.** The Open Wearables API base URL — host only, without path suffix (e.g. `https://api.openwearables.io`) |
+
+<Info>
+  Provide only the base host URL, e.g. `https://your-domain.com`. Do **not** append `/api/v1/` or any other path — the SDK adds the required path prefix automatically.
+</Info>
 
 ```dart
 // For self-hosted Open Wearables
@@ -232,6 +236,10 @@ if (OpenWearablesHealthSdk.isSignedIn) {
 ## Step 3: Sign In
 
 After getting credentials from your backend, sign in with the SDK:
+
+<Info>
+  The `userId` parameter is the **Open Wearables User ID** (UUID) — the `id` returned by the [Create User](/api-reference/users/create-user) endpoint. Do **not** pass your own `external_user_id` here.
+</Info>
 
 ### Token-Based Authentication (Recommended)
 

--- a/docs/sdk/ios/integration.mdx
+++ b/docs/sdk/ios/integration.mdx
@@ -229,7 +229,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 | Parameter | Description |
 |-----------|-------------|
-| `host` | The Open Wearables API URL (e.g. `https://api.openwearables.io`) |
+| `host` | The Open Wearables API base URL — host only, without path suffix (e.g. `https://api.openwearables.io`) |
+
+<Info>
+  Provide only the base host URL, e.g. `https://your-domain.com`. Do **not** append `/api/v1/` or any other path — the SDK adds the required path prefix automatically.
+</Info>
 
 ```swift
 // For self-hosted Open Wearables
@@ -255,6 +259,10 @@ if sdk.isSessionValid {
 ## Step 3: Sign In
 
 After getting credentials from your backend, sign in with the SDK. The SDK supports two authentication modes:
+
+<Info>
+  The `userId` parameter is the **Open Wearables User ID** (UUID) — the `id` returned by the [Create User](/api-reference/users/create-user) endpoint. Do **not** pass your own `external_user_id` here.
+</Info>
 
 ### Token-Based Authentication (Recommended)
 


### PR DESCRIPTION
## Description

- Added info notes across Android, iOS, and Flutter SDK integration guides clarifying that the `host` parameter in `.configure()` should be the base URL only (e.g. `https://your-domain.com`) — the SDK appends `/api/v1/` automatically
- Added info notes clarifying that `userId` in `.signIn()` is the Open Wearables `id` from the Create User endpoint, not the `external_user_id`
- Removed deprecated `customSyncUrl` parameter from Android docs (no longer exists in the SDK)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified host parameter requirements across Android, Flutter, and iOS integration guides to specify base URL configuration only.
  * Added guidance clarifying that userId should reference the Open Wearables User ID from Create User operation.
  * Updated session restoration and sign-in flow documentation with informational notes for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->