### PR TITLE
fix(backend): unify uvicorn log format and remove duplicate log lines

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from logging import INFO, StreamHandler, basicConfig
 from pathlib import Path
@@ -22,6 +23,13 @@ basicConfig(
     format="[%(asctime)s - %(name)s] (%(levelname)s) %(message)s",
     handlers=[StreamHandler(sys.stdout)],
 )
+
+# Remove uvicorn's default handlers to prevent duplicate logs (uvicorn.error)
+# and ensure access logs (uvicorn.access) also get timestamps via the root logger
+for _name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+    _logger = logging.getLogger(_name)
+    _logger.handlers.clear()
+    _logger.propagate = True
 
 api = FastAPI(title=settings.api_name)
 celery_app = create_celery()


### PR DESCRIPTION
## Description

Fixed duplicate log lines in backend output - uvicorn logged each message twice (once with timestamp, once without). Access logs (`uvicorn.access`) were also missing timestamps entirely. Now all logs go through a single root logger with consistent format.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. Run the backend locally with `fastapi dev`
2. Make a few API requests and check logs

**Expected behavior:**
- Each log line appears only once
- All log lines (including access logs) have timestamps in format `[2026-03-18 14:29:05,166 - uvicorn.access] (INFO) ...`

## Screenshots 

Before:

<img width="652" height="338" alt="image" src="https://github.com/user-attachments/assets/cc2cf450-f7b6-4298-a69f-47ac91e058dd" />

After:

<img width="1812" height="1009" alt="image" src="https://github.com/user-attachments/assets/f42bdbc5-e768-4674-aa7b-e4eaa356f6bf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application logging configuration to eliminate duplicate log entries and ensure consistent timestamp formatting across access logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->