### PR TITLE
docs: add explicit rule against calling repositories from routes

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -344,6 +344,7 @@ app/api/routes/
 - Define functions as `async` by default
 - Use **kebab-case** for paths: `/heart-rate`, `/import-data`
 - Keep route code minimal, delegate to services
+- **Never call repositories directly from routes** - always go through a service layer
 - **No trailing slashes:** Use `""` (empty string) instead of `"/"` for root routes on prefixed routers. A `"/"` path creates a trailing-slash canonical URL, causing FastAPI 307 redirects that break behind HTTPS reverse proxies.
 
 **Flow:**


### PR DESCRIPTION
## Description

Makes the existing convention explicit - routes should always go through the service layer, never call repositories directly. This was already implied by the documented flow diagrams but wasn't stated as a clear rule.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal architectural guidelines and best practices documentation.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->