### PR TITLE
chore: use local ruff in pre-commit to match CI version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,15 +1,18 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.2
-    hooks:
-      # Run the linter
-      - id: ruff-check
-        args: [--fix]
-      # Run the formatter
-      - id: ruff-format
-
   - repo: local
     hooks:
+      - id: ruff-check
+        name: ruff check
+        entry: sh -c 'cd backend && uv run ruff check --fix'
+        language: system
+        files: ^backend/.*\.py$
+        pass_filenames: false
+      - id: ruff-format
+        name: ruff format
+        entry: sh -c 'cd backend && uv run ruff format'
+        language: system
+        files: ^backend/.*\.py$
+        pass_filenames: false
       - id: ty
         name: ty check
         entry: sh -c 'cd backend && uv run ty check .'


### PR DESCRIPTION
## Description

Pre-commit was using `ruff-pre-commit` pinned at `v0.14.2`, while CI installs `ruff==0.14.14` via `uv sync --group code-quality`. This version drift occasionally caused local pre-commit to pass while [CI failed](https://github.com/the-momentum/open-wearables/actions/runs/23295434140/job/67741541309) (or vice versa).

Switched ruff hooks from the remote `ruff-pre-commit` repo to local hooks that run `uv run ruff` from the backend directory - same as CI does. Now there's a single source of truth for the ruff version: `pyproject.toml` / `uv.lock`.

The previous config already required a local environment for the `ty` hook (`cd backend && uv run ty check`), so this doesn't add any extra setup burden for developers.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. `pre-commit run ruff-check --all-files`
2. `pre-commit run ruff-format --all-files`

**Expected behavior:**
Both hooks pass using the same ruff version as CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated code quality checks configuration to use local implementations for more efficient pre-commit processes during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->