### PR TITLE
fix: formatBedtime displays "11:60 PM" when rounding pushes minutes to 6

### DIFF
--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -91,8 +91,12 @@ export function formatBedtime(minutes: number | null | undefined): string {
   if (minutes === null || minutes === undefined) return '-';
   // Handle wrap-around for late nights
   const normalizedMinutes = minutes >= 1440 ? minutes - 1440 : minutes;
-  const hours = Math.floor(normalizedMinutes / 60);
-  const mins = Math.round(normalizedMinutes % 60);
+  let hours = Math.floor(normalizedMinutes / 60);
+  let mins = Math.round(normalizedMinutes % 60);
+  if (mins === 60) {
+    mins = 0;
+    hours = (hours + 1) % 24;
+  }
   const period = hours >= 12 ? 'PM' : 'AM';
   const displayHours = hours > 12 ? hours - 12 : hours === 0 ? 12 : hours;
   return `${displayHours}:${mins.toString().padStart(2, '0')} ${period}`;


### PR DESCRIPTION
Fixes #640

`formatBedtime` in `frontend/src/lib/utils/format.ts` displayed invalid times like "11:60 PM" when `Math.round` pushed minutes to 60. Adds a carry check after rounding: if `mins === 60`, resets mins to 0 and increments hours with 24-hour wraparound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed an edge case in bedtime time formatting. Previously, certain calculations during time rounding could produce incorrect time values. The system now properly handles minute overflow by resetting to the next hour and ensures hour values correctly cycle within a 24-hour period, improving bedtime display accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->