### PR TITLE
fix: hide Sync Now button for SDK-based providers

### DIFF
--- a/frontend/src/components/user/connection-card.tsx
+++ b/frontend/src/components/user/connection-card.tsx
@@ -373,8 +373,10 @@ export function ConnectionCard({ connection, className }: ConnectionCardProps) {
             </div>
           )}
 
-        {/* Sync button - only for non-Garmin providers */}
-        {connection.provider !== 'garmin' && (
+        {/* Sync button - only for cloud API-based providers (excludes SDK and Garmin) */}
+        {!['garmin', 'apple', 'samsung', 'google', 'auto-health-export'].includes(
+          connection.provider
+        ) && (
           <div className="flex gap-2">
             <Button
               variant="outline"


### PR DESCRIPTION
Fixes #642

### Changes
- Hide the "Sync Now" button on the connection card for SDK-based providers: `apple`, `samsung`, `google`, and `auto-health-export`.
- Maintained existing behavior where the button is hidden for `garmin` (due to special backfill handling).

### Why
- SDK-based providers rely on data being pushed from the mobile device. Showing a "Sync Now" button is misleading as we cannot force a sync from the cloud side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated "Sync Now" button availability for health data providers. The button no longer appears for Apple, Samsung, Google, Garmin, and auto-health-export connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->