### PR TITLE
docs: update supported providers list

### DIFF
--- a/docs/providers/supported.mdx
+++ b/docs/providers/supported.mdx
@@ -16,7 +16,7 @@ Connect your wearable devices and fitness platforms to Open Wearables. Click on 
 | **Polar** | [Setup Guide →](/providers/polar-api-integration) | You must register for the [Polar API program](https://www.polar.com/en/business/api) |
 | **Whoop** | [Setup Guide →](/providers/whoop-api-integration) | Whoop membership required |
 | **Strava** | [Setup Guide →](/providers/strava-api-integration) | Free Strava account required |
-| **Fitbit** | [Fitbit setup guide →](/providers/fitbit-api-integration) | Free Fitbit account required |
+| **Fitbit** | [Setup Guide →](/providers/fitbit-api-integration) | Free Fitbit account required |
 | **Oura Ring** | — | Coming soon |
 
 ### SDK-based providers
@@ -24,6 +24,8 @@ Connect your wearable devices and fitness platforms to Open Wearables. Click on 
 | Provider | Setup Guide | Notes |
 |----------|-------------|--------|
 | **Apple Health** | [Setup Guide →](/providers/apple-health) | Mobile SDK coming soon! |
+| **Google Health Connect** | [Setup Guide →](/sdk/android/integration) | Via Android SDK |
+| **Samsung Health** | [Setup Guide →](/sdk/android/integration) | Via Android SDK |
 
 ## Adding New Providers
 


### PR DESCRIPTION
## Description

Add Google Health Connect and Samsung Health to the supported providers page with links to the Android SDK integration guide. Also fixes inconsistent Fitbit link text to match the rest of the table.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

## Testing Instructions

**Steps to test:**
1. Check https://docs.openwearables.io/providers/supported after deploy
2. Verify Google Health Connect and Samsung Health rows link to `/sdk/android/integration`
3. Verify Fitbit link text now says "Setup Guide →" consistently

**Expected behavior:**
All provider rows have consistent "Setup Guide →" link text, and the new SDK-based providers link to the Android SDK integration guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Fitbit provider entry: link text changed to "Setup Guide" while retaining the same destination and the "Free Fitbit account required" note.
  * Added Google Health Connect and Samsung Health to the SDK-based providers table, pointing to Android SDK integration guidance and noting "Via Android SDK."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->