### PR TITLE
docs: add CodeRabbit config for documentation enforcement

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,31 @@
+inheritance: true
+
+reviews:
+  instructions: |
+    For every PR that modifies backend API endpoints, provider integrations,
+    or data schemas: flag if no corresponding documentation update is included
+    in docs/. Suggest specific doc files that likely need updating.
+
+  path_instructions:
+    - path: "backend/app/api/**"
+      instructions: |
+        If API endpoints are added, modified, or removed, check whether
+        corresponding documentation in docs/api-reference/ has been updated.
+        If not, flag it as a required change.
+
+    - path: "backend/app/services/providers/**"
+      instructions: |
+        If a new provider is added or an existing provider's data mapping
+        changes, verify that docs/providers/ pages are updated accordingly.
+        Check coverage tables and supported data types.
+
+    - path: "backend/app/schemas/**"
+      instructions: |
+        If data models or enums change (e.g. new provider, new data type),
+        check if docs/architecture/unified-data-model.mdx and related pages
+        reflect these changes.
+
+    - path: "docs/**"
+      instructions: |
+        Verify documentation accuracy against the actual code in this PR.
+        Ensure code examples are correct and API references match current endpoints.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@
 - [ ] I have performed a self-review of my code
 - [ ] I have added tests that prove my fix/feature works (if applicable)
 - [ ] New and existing tests pass locally
+- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)
 
 ### Backend Changes
 


### PR DESCRIPTION
## Summary

- Added `.coderabbit.yaml` with `path_instructions` that flag PRs touching API endpoints, providers, or schemas without corresponding docs updates
- Added documentation checklist item to PR template
- Uses `inheritance: true` so existing CodeRabbit panel settings are preserved

## Test plan

- [ ] Open a test PR that changes `backend/app/api/` without touching `docs/` - CodeRabbit should flag it
- [ ] Verify existing CodeRabbit review behavior is unchanged

## Note

I decided to put only custom config in coderabbit.yml - there's an option to export the existing configuration in the panel by calling `@coderabbitai configuration`, but at this point I just want to test the behaviour so I don't want to bloat the config file too much. 