### PR TITLE
docs: add MinIO setup for local raw payload storage

### DIFF
--- a/docs/dev-guides/raw-payload-storage.mdx
+++ b/docs/dev-guides/raw-payload-storage.mdx
@@ -129,7 +129,7 @@ Raw payloads storage is designed to never break your data ingestion pipeline:
 ## Example Setup
 
 <Tabs>
-  <Tab title="Development">
+  <Tab title="Development (Log)">
     ```bash
     RAW_PAYLOAD_STORAGE=log
     ```
@@ -139,6 +139,46 @@ Raw payloads storage is designed to never break your data ingestion pipeline:
     ```bash
     docker compose logs -f backend | grep raw_payload
     ```
+  </Tab>
+  <Tab title="Development (MinIO)">
+    [MinIO](https://min.io/) is an S3-compatible object store you can run locally. This lets you browse stored payloads via a web UI without needing an AWS account.
+
+    **1. Start MinIO** (on the same Docker network as the app):
+
+    ```bash
+    docker run -d \
+      --name minio-open-wearables \
+      --hostname minio \
+      --network open-wearables_default \
+      -p 9002:9000 -p 9003:9001 \
+      -e MINIO_ROOT_USER=minioadmin \
+      -e MINIO_ROOT_PASSWORD=minioadmin \
+      minio/minio server /data --console-address ":9001"
+    ```
+
+    <Warning>
+      Use `--hostname minio` to register a clean DNS name in the Docker network. Boto3 rejects hostnames with special characters (e.g. double underscores), so container names like `minio__open-wearables` won't work as endpoint URLs.
+    </Warning>
+
+    **2. Create the bucket** - open the MinIO Console at [http://localhost:9003](http://localhost:9003) (login `minioadmin` / `minioadmin`) and create a bucket called `raw-payloads`, or use the CLI:
+
+    ```bash
+    docker exec minio-open-wearables mc alias set local http://localhost:9000 minioadmin minioadmin
+    docker exec minio-open-wearables mc mb local/raw-payloads
+    ```
+
+    **3. Configure env vars** in `backend/config/.env`:
+
+    ```bash
+    RAW_PAYLOAD_STORAGE=s3
+    RAW_PAYLOAD_S3_BUCKET=raw-payloads
+    RAW_PAYLOAD_S3_ENDPOINT_URL=http://minio:9000
+    AWS_ACCESS_KEY_ID=minioadmin
+    AWS_SECRET_ACCESS_KEY=minioadmin
+    AWS_REGION=us-east-1
+    ```
+
+    Payloads will appear in the MinIO Console under the `raw-payloads` bucket.
   </Tab>
   <Tab title="Production (S3)">
     ```bash


### PR DESCRIPTION
## Summary
- Added a "Development (MinIO)" tab to the raw payload storage docs with step-by-step local setup
- Renamed existing "Development" tab to "Development (Log)" for clarity
- Includes a warning about boto3 rejecting hostnames with special characters (e.g. double underscores)

## Note 

I found it useful to have access to logs locally when debugging integrations in a more convenient way than in a Docker container :)