### PR TITLE
feat: store raw API responses and webhook payloads for Oura integration

### DIFF
--- a/backend/app/api/routes/v1/oura_webhooks.py
+++ b/backend/app/api/routes/v1/oura_webhooks.py
@@ -15,6 +15,7 @@ from app.database import DbSession
 from app.models import Developer
 from app.schemas.providers.oura import OuraWebhookNotification
 from app.services.providers.oura.webhook_service import oura_webhook_service
+from app.services.raw_payload_storage import store_raw_payload
 from app.utils.auth import get_current_developer
 from app.utils.structured_logging import log_structured
 
@@ -73,6 +74,12 @@ def oura_webhook_notification(
         payload = json.loads(body)
     except (json.JSONDecodeError, ValueError):
         raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    store_raw_payload(
+        source="webhook",
+        provider="oura",
+        payload=payload,
+    )
 
     try:
         notification = OuraWebhookNotification(**payload)

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -24,6 +24,7 @@ from app.services.event_record_service import event_record_service
 from app.services.providers.api_client import make_authenticated_request
 from app.services.providers.templates.base_247_data import Base247DataTemplate
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
+from app.services.raw_payload_storage import store_raw_payload
 from app.services.timeseries_service import timeseries_service
 from app.utils.structured_logging import log_structured
 
@@ -81,6 +82,13 @@ class Oura247Data(Base247DataTemplate):
 
             try:
                 response = self._make_api_request(db, user_id, endpoint, params=request_params)
+                store_raw_payload(
+                    source="api_response",
+                    provider="oura",
+                    payload=response,
+                    user_id=str(user_id),
+                    trace_id=endpoint,
+                )
 
                 data = response.get("data", []) if isinstance(response, dict) else []
                 all_data.extend(data)

--- a/backend/app/services/providers/oura/workouts.py
+++ b/backend/app/services/providers/oura/workouts.py
@@ -15,6 +15,7 @@ from app.schemas.model_crud.activities import (
 from app.schemas.providers.oura import OuraWorkoutCollectionJSON, OuraWorkoutJSON
 from app.services.event_record_service import event_record_service
 from app.services.providers.templates.base_workouts import BaseWorkoutsTemplate
+from app.services.raw_payload_storage import store_raw_payload
 from app.utils.structured_logging import log_structured
 
 
@@ -45,6 +46,13 @@ class OuraWorkouts(BaseWorkoutsTemplate):
 
             try:
                 response = self._make_api_request(db, user_id, "/v2/usercollection/workout", params=params)
+                store_raw_payload(
+                    source="api_response",
+                    provider="oura",
+                    payload=response,
+                    user_id=str(user_id),
+                    trace_id="/v2/usercollection/workout",
+                )
 
                 if isinstance(response, dict):
                     collection = OuraWorkoutCollectionJSON(**response)


### PR DESCRIPTION
## Description

Wire up `store_raw_payload` for the Oura provider - same pattern we already have for Ultrahuman (API responses) and Garmin (webhooks). Covers all data paths: 247 data via `_paginate()`, workouts, and incoming webhook notifications.

No-op by default (`RAW_PAYLOAD_STORAGE=disabled`) - needs to be explicitly enabled via env var to `log` or `s3`.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. Enable raw payload storage (`RAW_PAYLOAD_STORAGE=log` or `s3`)
2. Trigger an Oura sync or receive a webhook notification
3. Verify raw payloads are captured in the configured backend

**Expected behavior:**
Raw API responses and webhook payloads from Oura are stored, matching Ultrahuman/Garmin behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced backend data persistence for Oura integration payloads across webhooks and API response endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->