### PR TITLE
feat: store raw API responses via store_raw_payload

### DIFF
--- a/backend/app/services/providers/whoop/data_247.py
+++ b/backend/app/services/providers/whoop/data_247.py
@@ -20,6 +20,7 @@ from app.services.event_record_service import event_record_service
 from app.services.providers.api_client import make_authenticated_request
 from app.services.providers.templates.base_247_data import Base247DataTemplate
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
+from app.services.raw_payload_storage import store_raw_payload
 from app.services.timeseries_service import timeseries_service
 from app.utils.structured_logging import log_structured
 
@@ -93,6 +94,13 @@ class Whoop247Data(Base247DataTemplate):
 
             try:
                 response = self._make_api_request(db, user_id, "/v2/activity/sleep", params=params)
+                store_raw_payload(
+                    source="api_response",
+                    provider="whoop",
+                    payload=response,
+                    user_id=str(user_id),
+                    trace_id="/v2/activity/sleep",
+                )
 
                 # Extract records from response
                 records = response.get("records", []) if isinstance(response, dict) else []
@@ -402,6 +410,13 @@ class Whoop247Data(Base247DataTemplate):
         """
         try:
             response = self._make_api_request(db, user_id, "/v2/user/measurement/body")
+            store_raw_payload(
+                source="api_response",
+                provider="whoop",
+                payload=response,
+                user_id=str(user_id),
+                trace_id="/v2/user/measurement/body",
+            )
             return response if isinstance(response, dict) else {}
         except Exception as e:
             log_structured(
@@ -543,6 +558,13 @@ class Whoop247Data(Base247DataTemplate):
 
             try:
                 response = self._make_api_request(db, user_id, "/v2/recovery", params=params)
+                store_raw_payload(
+                    source="api_response",
+                    provider="whoop",
+                    payload=response,
+                    user_id=str(user_id),
+                    trace_id="/v2/recovery",
+                )
 
                 # Extract records from response
                 records = response.get("records", []) if isinstance(response, dict) else []

--- a/backend/app/services/providers/whoop/workouts.py
+++ b/backend/app/services/providers/whoop/workouts.py
@@ -13,6 +13,7 @@ from app.schemas.model_crud.activities import (
 from app.schemas.providers.whoop import WhoopWorkoutCollectionJSON, WhoopWorkoutJSON
 from app.services.event_record_service import event_record_service
 from app.services.providers.templates.base_workouts import BaseWorkoutsTemplate
+from app.services.raw_payload_storage import store_raw_payload
 from app.utils.structured_logging import log_structured
 
 
@@ -47,6 +48,13 @@ class WhoopWorkouts(BaseWorkoutsTemplate):
 
             try:
                 response = self._make_api_request(db, user_id, "/v2/activity/workout", params=params)
+                store_raw_payload(
+                    source="api_response",
+                    provider="whoop",
+                    payload=response,
+                    user_id=str(user_id),
+                    trace_id="/v2/activity/workout",
+                )
 
                 # Parse response
                 if isinstance(response, dict):
@@ -275,6 +283,13 @@ class WhoopWorkouts(BaseWorkoutsTemplate):
 
             try:
                 response = self.get_workouts_from_api(db, user_id, **params)
+                store_raw_payload(
+                    source="api_response",
+                    provider="whoop",
+                    payload=response,
+                    user_id=str(user_id),
+                    trace_id="/v2/activity/workout",
+                )
 
                 # Parse response
                 if isinstance(response, dict):


### PR DESCRIPTION
## Description

Wire up `store_raw_payload` for the Whoop provider - same pattern as Oura/Ultrahuman/Garmin. Covers all API data paths: sleep, recovery, body measurement, and workouts.

No-op by default (`RAW_PAYLOAD_STORAGE=disabled`) - needs to be explicitly enabled via env var to `log` or `s3`. Whoop doesn't have webhooks so only API response storage.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. Enable raw payload storage (`RAW_PAYLOAD_STORAGE=log` or `s3`)
2. Trigger a Whoop sync
3. Verify raw payloads are captured in the configured backend

**Expected behavior:**
Raw API responses from Whoop are stored, matching Oura/Ultrahuman/Garmin behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Infrastructure**
  * Enhanced data capture across Whoop API integrations, now systematically recording all responses from sleep, body measurement, recovery, and workout endpoints for improved system reliability and data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->