### PR TITLE
docs: fix 'No users found' troubleshooting section for MCP

### DIFF
--- a/docs/mcp-server/claude-desktop.mdx
+++ b/docs/mcp-server/claude-desktop.mdx
@@ -94,6 +94,4 @@ docker compose up -d
 
 ### No users found
 
-The API key determines which users you can see. Ensure:
-1. Users have been created via the API or SDK
-2. Your API key has access to those users
+Make sure `OPEN_WEARABLES_API_URL` in `mcp/config/.env` points to the **API base URL** (e.g. `https://api.openwearables.io` or `http://localhost:8000`), not the URL of your Open Wearables dashboard/frontend. The MCP server calls `GET /api/v1/users` on this URL - if it points to the wrong service, you'll get a 404 ("Resource not found").

--- a/docs/mcp-server/cursor.mdx
+++ b/docs/mcp-server/cursor.mdx
@@ -80,6 +80,4 @@ docker compose up -d
 
 ### No users found
 
-The API key determines which users you can see. Ensure:
-1. Users have been created via the API or SDK
-2. Your API key has access to those users
+Make sure `OPEN_WEARABLES_API_URL` in `mcp/config/.env` points to the **API base URL** (e.g. `https://api.openwearables.io` or `http://localhost:8000`), not the URL of your Open Wearables dashboard/frontend. The MCP server calls `GET /api/v1/users` on this URL - if it points to the wrong service, you'll get a 404 ("Resource not found").


### PR DESCRIPTION
## Summary
- Replace misleading "No users found" troubleshooting advice in MCP server docs (both Claude Desktop and Cursor pages)
- The old text suggested checking API key permissions, but the actual common cause might be rather `OPEN_WEARABLES_API_URL` pointing to the frontend/dashboard instead of the API

## Test plan
- [ ] Verify docs render correctly on Mintlify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated troubleshooting documentation for "No users found" configuration errors in MCP server guides. Clarified that the environment URL configuration must point to the correct API base endpoint, not the dashboard or frontend interface. Added detailed explanation of how incorrect URL routing produces 404 errors when the server makes user queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->