### PR TITLE
fix(backend): skip SDK-based providers in sync_vendor_data task

### DIFF
--- a/backend/app/integrations/celery/tasks/sync_vendor_data_task.py
+++ b/backend/app/integrations/celery/tasks/sync_vendor_data_task.py
@@ -69,6 +69,9 @@ def sync_vendor_data(
             if providers:
                 connections = [c for c in connections if c.provider in providers]
 
+            # Only sync cloud API providers - SDK-based ones (Apple, Google, Samsung) use process_payload
+            connections = [c for c in connections if factory.get_provider(c.provider).has_cloud_api]
+
             if not connections:
                 log_structured(
                     logger,

--- a/backend/tests/tasks/test_sync_vendor_data_task.py
+++ b/backend/tests/tasks/test_sync_vendor_data_task.py
@@ -219,17 +219,23 @@ class TestSyncVendorDataTask:
         mock_session_local.return_value.__enter__.return_value = db
         mock_session_local.return_value.__exit__.return_value = None
 
-        # Mock provider to raise an error
-        mock_get_provider.side_effect = Exception("Provider API unavailable")
+        # Mock provider that fails during sync
+        mock_workouts = MagicMock()
+        mock_workouts.load_data.side_effect = Exception("Provider API unavailable")
+
+        mock_strategy = MagicMock()
+        mock_strategy.has_cloud_api = True
+        mock_strategy.workouts = mock_workouts
+        mock_get_provider.return_value = mock_strategy
 
         # Act
         result = sync_vendor_data(str(user.id))
 
         # Assert
         assert str(result["user_id"]) == str(user.id)
-        assert "garmin" in result["errors"]
-        assert "Provider API unavailable" in result["errors"]["garmin"]
-        assert result["providers_synced"] == {}
+        assert "garmin" in result["providers_synced"]
+        assert result["providers_synced"]["garmin"]["params"]["workouts"]["success"] is False
+        assert "Provider API unavailable" in result["providers_synced"]["garmin"]["params"]["workouts"]["error"]
 
     @patch("app.integrations.celery.tasks.sync_vendor_data_task.SessionLocal")
     @patch("app.services.providers.factory.ProviderFactory.get_provider")
@@ -294,6 +300,35 @@ class TestSyncVendorDataTask:
         assert "garmin" in result["providers_synced"]
         assert "workouts" not in result["providers_synced"]["garmin"]["params"]
         assert result["errors"] == {}
+
+    @patch("app.integrations.celery.tasks.sync_vendor_data_task.SessionLocal")
+    @patch("app.services.providers.factory.ProviderFactory.get_provider")
+    def test_sync_vendor_data_skips_push_based_provider(
+        self,
+        mock_get_provider: MagicMock,
+        mock_session_local: MagicMock,
+        db: Session,
+        mock_celery_app: MagicMock,
+    ) -> None:
+        """Test that push-based providers (no cloud API) are filtered out entirely."""
+        # Arrange
+        user = UserFactory()
+        UserConnectionFactory(user=user, provider="apple", status=ConnectionStatus.ACTIVE)
+
+        mock_session_local.return_value.__enter__.return_value = db
+        mock_session_local.return_value.__exit__.return_value = None
+
+        mock_strategy = MagicMock()
+        mock_strategy.has_cloud_api = False
+        mock_get_provider.return_value = mock_strategy
+
+        # Act
+        result = sync_vendor_data(str(user.id))
+
+        # Assert - SDK provider is filtered out, never enters sync loop
+        assert "apple" not in result["providers_synced"]
+        assert result["errors"] == {}
+        assert result["message"] == "No active provider connections found"
 
     def test_sync_vendor_data_invalid_user_id(self, mock_celery_app: MagicMock) -> None:
         """Test handling of invalid user ID format."""


### PR DESCRIPTION
## Description

Skip SDK-based providers (Apple, Google, Samsung) in sync_vendor_data Celery task. These are push-only - they don't have a cloud API to pull from. The task was calling `load_data()` on them which raised `NotImplementedError` ~14k times on our internal environment since Feb.

**This probably deserves a bigger refactor down the line - not super happy with the solution, but at least our Sentry stops getting spammed.**

Fixes:
- `NotImplementedError: Apple Health uses process_payload for data ingestion, not load_data`  ~9k occurences in last 30 days in our internal instance
- `NotImplementedError: SamsungWorkouts does not support API-based data loading` ~4.3k occurences in last 30 days in our internal instance
- https://github.com/the-momentum/open-wearables/issues/646 - it turns out the old code was still updating last_synced_at for SDK providers even though load_data() threw every time. The exception was caught and logged to Sentry, but execution continued to update_last_synced_at as if the sync succeeded.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. Create/have a user with an active Apple Health connection
2. Trigger `sync_vendor_data` task for that user
3. Apple should not appear in `providers_synced` and no `NotImplementedError` should be logged

**Expected behavior:**
SDK-based providers are filtered out before the sync loop - no errors, no logs, no `last_synced_at` update for them.