### PR TITLE
fix: round total minutes before splitting in formatBedtime

### DIFF
--- a/frontend/src/lib/utils/format.test.ts
+++ b/frontend/src/lib/utils/format.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { formatBedtime } from './format';
+
+describe('formatBedtime', () => {
+  it('formats integer minutes without regression', () => {
+    expect(formatBedtime(690)).toBe('11:30 AM');
+  });
+
+  it('rounds fractional minutes near hour boundary without displaying :60', () => {
+    expect(formatBedtime(719.7)).toBe('12:00 PM');
+    expect(formatBedtime(59.8)).toBe('1:00 AM');
+  });
+
+  it('wraps hours when rounding pushes past end of day', () => {
+    expect(formatBedtime(1439.7)).toBe('12:00 AM');
+  });
+});

--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -91,8 +91,9 @@ export function formatBedtime(minutes: number | null | undefined): string {
   if (minutes === null || minutes === undefined) return '-';
   // Handle wrap-around for late nights
   const normalizedMinutes = minutes >= 1440 ? minutes - 1440 : minutes;
-  const hours = Math.floor(normalizedMinutes / 60);
-  const mins = Math.round(normalizedMinutes % 60);
+  const totalMinutes = Math.round(normalizedMinutes);
+  const hours = Math.floor(totalMinutes / 60) % 24;
+  const mins = totalMinutes % 60;
   const period = hours >= 12 ? 'PM' : 'AM';
   const displayHours = hours > 12 ? hours - 12 : hours === 0 ? 12 : hours;
   return `${displayHours}:${mins.toString().padStart(2, '0')} ${period}`;


### PR DESCRIPTION
### Root cause

`Math.round(normalizedMinutes % 60)` can produce `60` when the fractional remainder is ≥ 59.5. This happens because **rounding is applied after splitting**, when it should be applied **before**.

### Proposed fix (2 lines changed)

```diff
  const normalizedMinutes = minutes >= 1440 ? minutes - 1440 : minutes;
- const hours = Math.floor(normalizedMinutes / 60);
- const mins = Math.round(normalizedMinutes % 60);
+ const totalMinutes = Math.round(normalizedMinutes);
+ const hours = Math.floor(totalMinutes / 60) % 24;
+ const mins = totalMinutes % 60;
```

Round the total first, then split with integer math — `mins` can **never** be 60.

### Proof with real data

`formatBedtime` receives fractional minutes from averaging bedtimes in `calculateSleepStats` (sleep.ts:167-170). With real sleep summaries:

| Record | `start_time` (UTC) | Minutes from midnight | After `<360` adjust |
|--------|-------------------|----------------------|-------------------|
| 1 | `2026-02-26T01:13:21Z` | 73 | **1513** |
| 2 | `2026-03-09T01:10:42Z` | 70 | **1510** |
| 3 | `null` | filtered out | — |

**Average: `(1513 + 1510) / 2 = 1511.5`** (fractional → triggers the bug path)

| Step | Before fix | After fix |
|------|-----------|-----------|
| normalizedMinutes | 71.5 | 71.5 |
| totalMinutes | — | **72** (rounded first) |
| hours | `Math.floor(71.5/60)` = 1 | `Math.floor(72/60) % 24` = 1 |
| mins | `Math.round(11.5)` = 12 | `72 % 60` = 12 |
| **Result** | 1:12 AM | **1:12 AM** |

This specific input doesn't hit `:60`, but the **bug-triggering input** `719.7` does:

| Step | Before fix | After fix |
|------|-----------|-----------|
| hours | `Math.floor(719.7/60)` = 11 | `Math.floor(720/60) % 24` = 12 |
| mins | `Math.round(59.7)` = **60** ❌ | `720 % 60` = **0** ✅ |
| **Result** | **11:60 AM** ❌ | **12:00 PM** ✅ |

### Tests added

```
✓ formats integer minutes without regression (690 → "11:30 AM")
✓ rounds fractional minutes near hour boundary without displaying :60 (719.7 → "12:00 PM", 59.8 → "1:00 AM")
✓ wraps hours when rounding pushes past end of day (1439.7 → "12:00 AM")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected bedtime time formatting to properly handle fractional minute inputs and edge cases that previously resulted in invalid time values or incorrect midnight wrapping.

* **Tests**
  * Added test coverage for bedtime formatting including standard inputs, rounding edge cases, and day boundary transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->