### PR TITLE
fix(frontend): inline decimal.js-light to fix SSR build error

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -19,7 +19,11 @@ const config = defineConfig({
   },
   plugins: [
     devtools(),
-    nitro(),
+    nitro({
+      // decimal.js-light has "main": "decimal" (no extension) in package.json
+      // which breaks ESM resolution when externalized. Force inline bundling.
+      externals: { inline: ['decimal.js-light'] },
+    }),
     // this is the plugin that enables path aliases
     viteTsConfigPaths({
       projects: ['./tsconfig.json'],


### PR DESCRIPTION
## Summary
- `decimal.js-light` (transitive dep from `recharts`) has `"main": "decimal"` without file extension in its package.json, which breaks ESM resolution in Nitro's server build
- Force inline bundling via `externals.inline` so it doesn't get externalized

<img width="1439" height="635" alt="image" src="https://github.com/user-attachments/assets/061446d7-de00-4ed6-8dcc-fe9cfb3fe663" />


It doesn't brake anything, just spamming the logs.