### PR TITLE
fix(frontend): pair page redirect for unauthenticated users

### DIFF
--- a/frontend/src/hooks/api/use-health.ts
+++ b/frontend/src/hooks/api/use-health.ts
@@ -38,11 +38,11 @@ export function useDisconnectProvider(provider: string, userId: string) {
  * Get user connections for a user
  * Uses GET /api/v1/users/{user_id}/connections
  */
-export function useUserConnections(userId: string) {
+export function useUserConnections(userId: string, enabled: boolean = true) {
   return useQuery({
     queryKey: queryKeys.connections.all(userId),
     queryFn: () => healthService.getUserConnections(userId),
-    enabled: !!userId,
+    enabled: !!userId && enabled,
   });
 }
 

--- a/frontend/src/routes/users/$userId/pair.index.tsx
+++ b/frontend/src/routes/users/$userId/pair.index.tsx
@@ -14,6 +14,7 @@ import { useOAuthProviders } from '@/hooks/api/use-oauth-providers';
 import { useUserConnections } from '@/hooks/api/use-health';
 import { useMemo } from 'react';
 import { API_CONFIG } from '@/lib/api/config';
+import { isAuthenticated } from '@/lib/auth/session';
 
 export const Route = createFileRoute('/users/$userId/pair/')({
   component: PairWearablePage,
@@ -33,7 +34,7 @@ function PairWearablePage() {
     useOAuthConnect({ userId, redirectUrl });
 
   const { data: apiProviders, isLoading } = useOAuthProviders(true, true);
-  const { data: connections } = useUserConnections(userId);
+  const { data: connections } = useUserConnections(userId, isAuthenticated());
 
   const connectedProviders = useMemo(() => {
     if (!connections) return new Set<string>();


### PR DESCRIPTION
## Summary
Hot fix - pair page (`/users/:id/pair`) was redirecting unauthenticated users to `/login` because `useUserConnections` hit an authenticated endpoint, got 401, and the global API client redirected.

Now connections query is only enabled when user has an active session. Unauthenticated users won't see "Connected" badges - this is a temporary trade-off, not the target solution.

## Follow-up
Ideally all users (including unauthenticated) should see connection status. This requires introducing an auth mechanism for users without accounts - similar to what we have for invitation codes in the mobile flow. Tracked separately.

## Test plan
- [ ] Open a pair link in incognito - should show providers without redirect
- [ ] Open a pair link while logged in - should show providers with connected badges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication-aware data loading efficiency. Connection data is now fetched only when you are properly authenticated, preventing unnecessary API requests from running in the background. This optimization reduces overall server load and improves application performance and responsiveness for all users, especially those not logged in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->