### PR TITLE
chore: add Dependabot configuration for Python and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  # --- Python (uv) ---
+  - package-ecosystem: "uv"
+    directories:
+      - "/backend"
+      - "/mcp"
+      - "/sdk/python"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      python-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      python-major:
+        patterns: ["*"]
+        update-types: ["major"]
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+
+  # --- npm ---
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      npm-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      npm-major:
+        patterns: ["*"]
+        update-types: ["major"]
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
- Configures Dependabot for automated dependency updates
- Python (uv) for backend, mcp, and sdk/python
- npm for frontend
- Groups minor/patch updates into single PRs to reduce noise
- Adds cooldown periods (30d major, 7d minor, 3d patch) so we don't get PRs for freshly released versions

Important, per [documentation](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-)
Defines a cooldown period for dependency updates, allowing updates to be delayed for a configurable number of days. The cooldown option is only available for version updates, not security updates.

So I believe for security updates, at least for uv updates, we'll wait with merging anyway (per https://github.com/the-momentum/open-wearables/pull/703) or change the uv config for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated weekly dependency updates for Python and npm packages to maintain current versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->