### PR TITLE
chore: set commit-message prefix for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       - "/sdk/python"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
     cooldown:
       default-days: 7
       semver-major-days: 30
@@ -29,6 +31,8 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
     cooldown:
       default-days: 7
       semver-major-days: 30


### PR DESCRIPTION
Adds `commit-message.prefix: "chore"` to both Dependabot ecosystem configs.

By default Dependabot generates PR titles like `chore(deps): bump X`, but `deps` is not a valid scope in our PR validation workflow (`.github/workflows/pr-validation.yml`), so these PRs fail the title check. With the explicit prefix and no `include: "scope"`, titles become `chore: bump X` which passes validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to standardize commit message formatting for automated dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->