### PR TITLE
chore: add CodeRabbit check for data migration impact

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -19,6 +19,13 @@ reviews:
         changes, verify that docs/providers/ pages are updated accordingly.
         Check coverage tables and supported data types.
 
+    - path: "backend/app/services/providers/**"
+      instructions: |
+        If data normalization, mapping, or calculation logic changes: flag
+        that existing records in the database will NOT be affected. Require
+        the PR to state whether a data migration or backfill is needed for
+        historical records, or explicitly note that only new data is affected.
+
     - path: "backend/app/schemas/**"
       instructions: |
         If data models or enums change (e.g. new provider, new data type),


### PR DESCRIPTION
Adds a CodeRabbit review rule for `backend/app/services/providers/**` that flags when data normalization/mapping logic changes, reminding PR authors to state whether a data migration or backfill is needed for historical records.

Motivated by #748 where the Garmin sleep fix only affects new incoming data (but neither Coderabbit nor the PR description mention that at all)