### PR TITLE
fix(backend): backfill Garmin sleep end_datetime from stage timeline

### DIFF
--- a/backend/scripts/data_migrations/backfill_garmin_sleep_end_datetime.py
+++ b/backend/scripts/data_migrations/backfill_garmin_sleep_end_datetime.py
@@ -96,29 +96,28 @@ def main() -> None:
     args = parser.parse_args()
 
     with psycopg.connect(get_conninfo()) as conn, conn.cursor() as cur:
-        cur.execute(PREVIEW_QUERY)
-        rows = cur.fetchall()
-
-        if not rows:
-            print("No records to update.")
-            return
-
-        print(f"{'ID':<38} {'Start':<22} {'Current End':<22} {'New End':<22} {'Diff (min)':<10}")
-        print("-" * 114)
-        for row in rows:
-            record_id, start, current_end, current_dur, new_end, new_dur = row
-            diff_min = (new_dur - (current_dur or 0)) // 60
-            print(f"{record_id}   {start!s:<22} {current_end!s:<22} {new_end!s:<22} {diff_min:>+8}")
-
-        print(f"\nTotal: {len(rows)} record(s) to update.")
-
         if args.dry_run:
+            cur.execute(PREVIEW_QUERY)
+            rows = cur.fetchall()
+
+            if not rows:
+                print("No records to update.")
+                return
+
+            print(f"{'ID':<38} {'Start':<22} {'Current End':<22} {'New End':<22} {'Diff (min)':<10}")
+            print("-" * 114)
+            for row in rows:
+                record_id, start, current_end, current_dur, new_end, new_dur = row
+                diff_min = (new_dur - (current_dur or 0)) // 60
+                print(f"{record_id}   {start!s:<22} {current_end!s:<22} {new_end!s:<22} {diff_min:>+8}")
+
+            print(f"\nTotal: {len(rows)} record(s) to update.")
             print("\nDry run - no changes made.")
             return
 
         cur.execute(UPDATE_QUERY)
         conn.commit()
-        print(f"\nUpdated {cur.rowcount} record(s).")
+        print(f"Updated {cur.rowcount} record(s).")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Data backfill for #748. Standalone script that recomputes `end_datetime` and `duration_seconds` on existing Garmin sleep records using the last stage end from `sleep_stages` JSONB.

### Usage

Requires `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` env vars.

```bash
# Preview changes
docker compose exec app uv run python scripts/backfill_garmin_sleep_end_datetime.py --dry-run

# Apply
docker compose exec app uv run python scripts/backfill_garmin_sleep_end_datetime.py
```

### What it does

Single UPDATE query that finds `MAX(end_time)` across all sleep stages and sets `end_datetime` to that value (only where it's later than current `end_datetime`). Recalculates `duration_seconds` accordingly.

### What it doesn't touch

`sleep_total_duration_minutes` - already correct (deep + light + rem, no awake).

## Approach

Standalone script instead of Alembic data migration - gives us `--dry-run`, doesn't block deploys, and can be re-run safely.

Not fully convinced about running data backfills inside regular Alembic migrations long-term. That said, projects like [Superset](https://github.com/apache/superset) and [Polar](https://github.com/polarsource/polar) do exactly that, and at our current scale it would be fine too. Down the road we might want a post-deploy migration system like [Sentry's](https://github.com/getsentry/sentry/blob/d26544689bfbbb81b0c2873f98e592920dcc91ec/src/sentry/new_migrations/monkey/executor.py) ([docs](https://develop.sentry.dev/database-migrations/)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Garmin sleep records that previously had end times earlier than actual, improving accuracy of sleep end times and duration calculations.
  * Applied a one-time data backfill to update affected historical sleep entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->