### PR TITLE
chore: migrate docs links from docs.openwearables.io to openwearables.io/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-**Documentation**: https://docs.openwearables.io
+**Documentation**: https://openwearables.io/docs
 
 ---
 
@@ -89,7 +89,7 @@ Get Open Wearables up and running in minutes.
    docker compose up -d
    ```
    
-   For local development setup without Docker take a look at [docs](https://docs.openwearables.io/quickstart#local-development-setup)
+   For local development setup without Docker take a look at [docs](https://openwearables.io/docs/quickstart#local-development-setup)
 
 4. **Log in to the developer portal:**
 

--- a/frontend/src/components/layout/simple-sidebar.tsx
+++ b/frontend/src/components/layout/simple-sidebar.tsx
@@ -31,7 +31,7 @@ const menuItems = [
   },
   {
     title: 'Documentation',
-    url: 'https://docs.openwearables.io/',
+    url: 'https://openwearables.io/docs',
     icon: FileText,
     external: true,
   },

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
 
 [project.urls]
 Homepage = "https://github.com/TudorGR/open-wearables"
-Documentation = "https://docs.openwearables.io"
+Documentation = "https://openwearables.io/docs"
 Repository = "https://github.com/TudorGR/open-wearables"
 Issues = "https://github.com/TudorGR/open-wearables/issues"
 


### PR DESCRIPTION
## Description

Updates all references to the documentation URL from docs.openwearables.io to openwearables.io/docs across README, frontend sidebar, and Python SDK metadata.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

No backend changes.

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

## Testing Instructions

Steps to test:
1. Click the Documentation link in the sidebar
2. Verify it navigates to https://openwearables.io/docs

Expected behavior: All docs links resolve to openwearables.io/docs instead of docs.openwearables.io.

Screenshots

N/A

Additional Notes

Pure URL migration — no logic or functionality changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links throughout the application and project configuration to direct users to the new documentation URL location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->