### PR TITLE
docs: add Samsung Health developer mode warning

### DIFF
--- a/docs/app/introduction.mdx
+++ b/docs/app/introduction.mdx
@@ -15,7 +15,7 @@ Whether you're into self-tracking and want to own your health data, or you're a 
 </Info>
 
 <Warning>
-  **Samsung Health on Android requires Developer Mode.** Samsung Health restricts third-party access to health data by default. To use the Open Wearables app with Samsung Health, you need to [enable Developer Mode](https://developer.samsung.com/health/data/guide/developer-mode.html) in the Samsung Health app first. This does not apply if you use Health Connect as your data source.
+  **Samsung Health on Android requires Developer Mode.** Samsung Health only allows data access to apps registered through Samsung's official partnership program. Since the Open Wearables app is not a registered Samsung partner, you need to [enable Developer Mode](https://developer.samsung.com/health/data/guide/developer-mode.html) in the Samsung Health app for it to work. This does not apply if you use Health Connect as your data source.
 </Warning>
 
 ## How it works


### PR DESCRIPTION
## Description

Samsung Health blocks third-party data access unless Developer Mode is enabled. Added a prominent warning to the app introduction page so users know about this before trying to connect.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

## Testing Instructions

**Steps to test:**
1. Open https://openwearables.io/docs/app/introduction
2. Verify the warning block appears between the beta info and "How it works" section

**Expected behavior:**
A yellow warning callout with a link to Samsung's developer mode guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a warning to the introduction clarifying that Samsung Health on Android requires Developer Mode to grant third-party data access; this requirement does not apply when using Health Connect as the data source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->