### PR TITLE
docs: add paid ngrok plan warning

### DIFF
--- a/docs/dev-guides/ngrok-setup.mdx
+++ b/docs/dev-guides/ngrok-setup.mdx
@@ -5,6 +5,10 @@ description: "Quick setup guide for testing webhooks, OAuth flows (Garmin), and 
 
 When testing webhooks (Garmin OAuth callback, Garmin data push) or the Apple Health SDK, you need to expose your local backend to the internet. ngrok provides a simple solution with minimal configuration.
 
+<Warning>
+**Paid ngrok plan required.** The free ngrok plan shows an [interstitial page](https://ngrok.com/docs/pricing-limits/free-plan-limits#removing-the-interstitial-page) before forwarding requests. This breaks webhook delivery and OAuth callbacks because the provider never reaches your backend. You need a paid ngrok plan to remove the interstitial.
+</Warning>
+
 <Note>
 Why might ngrok be needed for the OAuth flow? Because Garmin's OAuth callback requires HTTPS. Other currently supported cloud providers work with HTTP, so localhost is fine.
 </Note>

--- a/docs/dev-guides/ngrok-setup.mdx
+++ b/docs/dev-guides/ngrok-setup.mdx
@@ -5,9 +5,9 @@ description: "Quick setup guide for testing webhooks, OAuth flows (Garmin), and 
 
 When testing webhooks (Garmin OAuth callback, Garmin data push) or the Apple Health SDK, you need to expose your local backend to the internet. ngrok provides a simple solution with minimal configuration.
 
-<Warning>
-**Paid ngrok plan required.** The free ngrok plan shows an [interstitial page](https://ngrok.com/docs/pricing-limits/free-plan-limits#removing-the-interstitial-page) before forwarding requests. This breaks webhook delivery and OAuth callbacks because the provider never reaches your backend. You need a paid ngrok plan to remove the interstitial.
-</Warning>
+<Note>
+**ngrok free plan note:** The free plan shows an [interstitial page](https://ngrok.com/docs/pricing-limits/free-plan-limits#removing-the-interstitial-page) for browser requests. This doesn't affect webhooks or API calls (POST requests go through fine), but it **will break OAuth callbacks** since those are browser redirects. To avoid this, use a paid ngrok plan or add the `ngrok-skip-browser-warning` header.
+</Note>
 
 <Note>
 Why might ngrok be needed for the OAuth flow? Because Garmin's OAuth callback requires HTTPS. Other currently supported cloud providers work with HTTP, so localhost is fine.

--- a/docs/providers/garmin-api-integration.mdx
+++ b/docs/providers/garmin-api-integration.mdx
@@ -112,9 +112,9 @@ Once you get access to the Developer Portal, you’ll find the full docs, includ
     https://<your-ngrok-id>.ngrok-free.app/api/v1/garmin/webhooks/push
     ```
 
-    <Warning>
-    **Paid ngrok plan required.** The free ngrok plan shows an [interstitial page](https://ngrok.com/docs/pricing-limits/free-plan-limits#removing-the-interstitial-page) before forwarding requests. This breaks Garmin webhook delivery and OAuth callbacks. You need a paid ngrok plan to remove the interstitial.
-    </Warning>
+    <Note>
+    **ngrok free plan note:** The free plan shows an [interstitial page](https://ngrok.com/docs/pricing-limits/free-plan-limits#removing-the-interstitial-page) for browser requests. This doesn't affect webhook delivery (POST requests go through fine), but it **will break the OAuth callback** since that's a browser redirect. To avoid this, use a paid ngrok plan or add the `ngrok-skip-browser-warning` header.
+    </Note>
 
     - Set delivery type to **push** (dropdown on the right)
     - Check **enabled** for each endpoint you want to activate

--- a/docs/providers/garmin-api-integration.mdx
+++ b/docs/providers/garmin-api-integration.mdx
@@ -112,6 +112,10 @@ Once you get access to the Developer Portal, you’ll find the full docs, includ
     https://<your-ngrok-id>.ngrok-free.app/api/v1/garmin/webhooks/push
     ```
 
+    <Warning>
+    **Paid ngrok plan required.** The free ngrok plan shows an [interstitial page](https://ngrok.com/docs/pricing-limits/free-plan-limits#removing-the-interstitial-page) before forwarding requests. This breaks Garmin webhook delivery and OAuth callbacks. You need a paid ngrok plan to remove the interstitial.
+    </Warning>
+
     - Set delivery type to **push** (dropdown on the right)
     - Check **enabled** for each endpoint you want to activate
     - All endpoints use the **same URL** — Garmin distinguishes data types internally and sends the appropriate payload to this single endpoint


### PR DESCRIPTION
## Description

Free ngrok plan shows an interstitial page that silently eats webhook deliveries and OAuth callbacks. Added warnings in the Garmin integration guide and ngrok setup guide so devs don't waste time debugging why Garmin can't reach their local backend.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

## Testing Instructions

**Steps to test:**
1. Run docs locally and check the warning renders on `/providers/garmin-api-integration` and `/dev-guides/ngrok-setup`

**Expected behavior:**
Warning box visible with link to ngrok pricing docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added notes to the ngrok and Garmin API guides: the ngrok free plan injects a browser interstitial that does not block POST-based webhooks but can break OAuth browser redirects (callback flows). Guidance added to use a paid ngrok plan or add the ngrok-skip-browser-warning header to mitigate the issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->