### PR TITLE
feat: Save health scores from Garmin and Whoop

### DIFF
--- a/backend/app/constants/health_scores.py
+++ b/backend/app/constants/health_scores.py
@@ -12,11 +12,22 @@ HEALTH_SCORE_RANGES: dict[HealthScoreCategory, dict[ProviderName, ScoreRange]] =
     HealthScoreCategory.SLEEP: {
         ProviderName.INTERNAL: ScoreRange(0, 100),
         ProviderName.OURA: ScoreRange(1, 100),
+        ProviderName.GARMIN: ScoreRange(1, 100),
+        ProviderName.WHOOP: ScoreRange(0, 100),
     },
     HealthScoreCategory.READINESS: {
         ProviderName.OURA: ScoreRange(1, 100),
     },
     HealthScoreCategory.ACTIVITY: {
         ProviderName.OURA: ScoreRange(1, 100),
+    },
+    HealthScoreCategory.STRESS: {
+        ProviderName.GARMIN: ScoreRange(0, 100),
+    },
+    HealthScoreCategory.RECOVERY: {
+        ProviderName.WHOOP: ScoreRange(0, 100),
+    },
+    HealthScoreCategory.STRAIN: {
+        ProviderName.WHOOP: ScoreRange(0, 21),
     },
 }

--- a/backend/app/constants/health_scores.py
+++ b/backend/app/constants/health_scores.py
@@ -24,6 +24,9 @@ HEALTH_SCORE_RANGES: dict[HealthScoreCategory, dict[ProviderName, ScoreRange]] =
     HealthScoreCategory.STRESS: {
         ProviderName.GARMIN: ScoreRange(0, 100),
     },
+    HealthScoreCategory.BODY_BATTERY: {
+        ProviderName.GARMIN: ScoreRange(0, 100),
+    },
     HealthScoreCategory.RECOVERY: {
         ProviderName.WHOOP: ScoreRange(0, 100),
     },

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -12,14 +12,17 @@ from app.database import DbSession
 from app.models import DataPointSeries, EventRecord
 from app.repositories import DataSourceRepository, EventRecordRepository, UserConnectionRepository
 from app.repositories.data_point_series_repository import DataPointSeriesRepository
-from app.schemas.enums import SeriesType
+from app.schemas.enums import HealthScoreCategory, ProviderName, SeriesType
 from app.schemas.model_crud.activities import (
     EventRecordCreate,
     EventRecordDetailCreate,
+    HealthScoreCreate,
+    ScoreComponent,
     SleepStage,
     TimeSeriesSampleCreate,
 )
 from app.services.event_record_service import event_record_service
+from app.services.health_score_service import health_score_service
 from app.services.providers.api_client import make_authenticated_request
 from app.services.providers.templates.base_247_data import Base247DataTemplate
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
@@ -181,11 +184,43 @@ class Garmin247Data(Base247DataTemplate):
 
         return sorted(stages, key=lambda s: s.start_time)
 
+    def _normalize_sleep_health_score(
+        self,
+        normalized_sleep: dict[str, Any],
+        user_id: UUID,
+    ) -> HealthScoreCreate | None:
+        """Extract sleep health score from a normalized Garmin sleep record."""
+        sleep_score = normalized_sleep.get("sleep_score")
+        sleep_qualifier = normalized_sleep.get("sleep_qualifier")
+        sleep_score_components = normalized_sleep.get("sleep_score_components")
+
+        if sleep_score is None and sleep_qualifier is None:
+            return None
+
+        start_time_str = normalized_sleep.get("start_time")
+        if not start_time_str:
+            return None
+        try:
+            recorded_at = datetime.fromisoformat(start_time_str.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            return None
+
+        return HealthScoreCreate(
+            id=uuid4(),
+            user_id=user_id,
+            provider=ProviderName.GARMIN,
+            category=HealthScoreCategory.SLEEP,
+            value=sleep_score,
+            qualifier=sleep_qualifier,
+            recorded_at=recorded_at,
+            components=sleep_score_components,
+        )
+
     def normalize_sleep(
         self,
         raw_sleep: dict[str, Any],
         user_id: UUID,
-    ) -> dict[str, Any]:
+    ) -> tuple[dict[str, Any], HealthScoreCreate | None]:
         """Normalize Garmin sleep data to internal schema."""
         start_ts = raw_sleep.get("startTimeInSeconds", 0)
         duration = raw_sleep.get("durationInSeconds", 0)
@@ -214,9 +249,13 @@ class Garmin247Data(Base247DataTemplate):
         sleep_score = None
         overall_score = raw_sleep.get("overallSleepScore")
         if overall_score and isinstance(overall_score, dict):
-            sleep_score = overall_score.get("value") or overall_score.get("qualifierKey")
+            sleep_score = overall_score.get("value")
+            sleep_qualifier = overall_score.get("qualifier")
 
-        return {
+        sleep_scores = raw_sleep.get("sleepScores", [])
+        sleep_score_components = {key: ScoreComponent(qualifier=value.get("qualifierKey")) for key, value in sleep_scores.items()}
+
+        normalized = {
             "id": uuid4(),
             "user_id": user_id,
             "provider": self.provider_name,
@@ -236,10 +275,13 @@ class Garmin247Data(Base247DataTemplate):
             "avg_respiration": raw_sleep.get("respirationAvg"),
             "avg_spo2_percent": raw_sleep.get("avgOxygenSaturation"),
             "sleep_score": sleep_score,
+            "sleep_qualifier": sleep_qualifier,
+            "sleep_score_components": sleep_score_components,
             "validation": raw_sleep.get("validation"),
             "garmin_summary_id": raw_sleep.get("summaryId"),
             "raw": raw_sleep,
         }
+        return normalized, self._normalize_sleep_health_score(normalized, user_id)
 
     def _build_sleep_record(
         self,
@@ -341,13 +383,50 @@ class Garmin247Data(Base247DataTemplate):
         """Fetch daily summaries from Garmin /wellness-api/rest/dailies."""
         return self._fetch_in_chunks(db, user_id, "/wellness-api/rest/dailies", start_time, end_time)
 
+    def _normalize_dailies_health_scores(
+        self,
+        normalized_daily: dict[str, Any],
+        user_id: UUID,
+    ) -> list[HealthScoreCreate]:
+        """Extract stress and body battery health scores from a normalized Garmin daily."""
+        scores: list[HealthScoreCreate] = []
+        start_ts = normalized_daily.get("start_time_seconds")
+        calendar_date = normalized_daily.get("calendar_date")
+        if start_ts:
+            recorded_at = self._from_epoch_seconds(start_ts)
+        elif calendar_date:
+            try:
+                recorded_at = datetime.strptime(calendar_date, "%Y-%m-%d").replace(hour=12, tzinfo=timezone.utc)
+            except ValueError:
+                return scores
+        else:
+            return scores
+
+        avg_stress = normalized_daily.get("avg_stress")
+        stress_qualifier = normalized_daily.get("stress_qualifier", "").replace("_", " ").title()
+        # averageStressLevel is -1 when there is not enough data to calculate
+        if avg_stress is not None and avg_stress != -1:
+            scores.append(
+                HealthScoreCreate(
+                    id=uuid4(),
+                    user_id=user_id,
+                    provider=ProviderName.GARMIN,
+                    category=HealthScoreCategory.STRESS,
+                    value=avg_stress,
+                    qualifier=stress_qualifier,
+                    recorded_at=recorded_at,
+                )
+            )
+
+        return scores
+
     def normalize_dailies(
         self,
         raw_daily: dict[str, Any],
         user_id: UUID,
-    ) -> dict[str, Any]:
+    ) -> tuple[dict[str, Any], list[HealthScoreCreate]]:
         """Normalize Garmin daily summary to internal schema."""
-        return {
+        normalized = {
             "user_id": user_id,
             "calendar_date": raw_daily.get("calendarDate"),
             "start_time_seconds": raw_daily.get("startTimeInSeconds"),
@@ -363,15 +442,14 @@ class Garmin247Data(Base247DataTemplate):
             "resting_heart_rate": raw_daily.get("restingHeartRateInBeatsPerMinute"),
             "avg_stress": raw_daily.get("averageStressLevel"),
             "max_stress": raw_daily.get("maxStressLevel"),
+            "stress_qualifier": raw_daily.get("stressQualifier"),
             "moderate_intensity_minutes": (raw_daily.get("moderateIntensityDurationInSeconds") or 0) // 60,
             "vigorous_intensity_minutes": (raw_daily.get("vigorousIntensityDurationInSeconds") or 0) // 60,
-            "body_battery_charged": raw_daily.get("bodyBatteryChargedValue"),
-            "body_battery_drained": raw_daily.get("bodyBatteryDrainedValue"),
-            "body_battery_highest": raw_daily.get("bodyBatteryHighestValue"),
-            "body_battery_lowest": raw_daily.get("bodyBatteryLowestValue"),
+
             "heart_rate_samples": raw_daily.get("timeOffsetHeartRateSamples"),
             "garmin_summary_id": raw_daily.get("summaryId"),
         }
+        return normalized, self._normalize_dailies_health_scores(normalized, user_id)
 
     def _build_dailies_samples(
         self,
@@ -432,15 +510,19 @@ class Garmin247Data(Base247DataTemplate):
         self,
         db: DbSession,
         user_id: UUID,
-        normalized_daily: dict[str, Any],
+        normalized_daily: tuple[dict[str, Any], list[HealthScoreCreate]],
     ) -> int:
-        """Save daily data to DataPointSeries (multiple series types).
+        """Save daily data to DataPointSeries and health scores.
 
         Uses bulk_create with ON CONFLICT DO UPDATE for efficient upserts.
         """
-        samples = self._build_dailies_samples(user_id, normalized_daily)
+        daily_data, health_scores = normalized_daily
+        samples = self._build_dailies_samples(user_id, daily_data)
         if samples:
             self.data_point_repo.bulk_create(db, samples)
+        if health_scores:
+            health_score_service.bulk_create(db, health_scores)
+            db.commit()
         return len(samples)
 
     def _collect_heart_rate_samples(
@@ -891,7 +973,7 @@ class Garmin247Data(Base247DataTemplate):
         user_id: UUID,
         raw_stress: dict[str, Any],
     ) -> list[TimeSeriesSampleCreate]:
-        """Build time series samples from stress data (no DB interaction)."""
+        """Build individual stress level and body battery time series samples from a stressDetails record."""
         samples: list[TimeSeriesSampleCreate] = []
         start_ts = raw_stress.get("startTimeInSeconds", 0)
 
@@ -900,8 +982,8 @@ class Garmin247Data(Base247DataTemplate):
 
         zone_offset = offset_to_iso(raw_stress.get("startTimeOffsetInSeconds"))
 
-        # Stress level values
-        stress_values = raw_stress.get("stressLevelValues", {})
+        # Stress level values (negative values are special states: off-wrist, motion, etc.)
+        stress_values = raw_stress.get("timeOffsetStressLevelValues", {})
         if stress_values and isinstance(stress_values, dict):
             for offset_str, stress_value in stress_values.items():
                 try:
@@ -924,7 +1006,7 @@ class Garmin247Data(Base247DataTemplate):
                     pass
 
         # Body battery values
-        battery_values = raw_stress.get("bodyBatteryValues", {})
+        battery_values = raw_stress.get("timeOffsetBodyBatteryValues", {})
         if battery_values and isinstance(battery_values, dict):
             for offset_str, battery_value in battery_values.items():
                 try:
@@ -954,10 +1036,7 @@ class Garmin247Data(Base247DataTemplate):
         user_id: UUID,
         raw_stress: dict[str, Any],
     ) -> int:
-        """Save stress level data to DataPointSeries.
-
-        Uses bulk_create with ON CONFLICT DO UPDATE for efficient upserts.
-        """
+        """Save individual stress level and body battery timeseries from a stressDetails record."""
         samples = self._build_stress_samples(user_id, raw_stress)
         if samples:
             self.data_point_repo.bulk_create(db, samples)
@@ -1562,14 +1641,16 @@ class Garmin247Data(Base247DataTemplate):
         all_records: list[EventRecordCreate] = []
         all_workout_details: list[EventRecordDetailCreate] = []
         all_sleep_details: list[EventRecordDetailCreate] = []
+        all_health_scores: list[HealthScoreCreate] = []
 
         for item in items:
             try:
                 # DataPointSeries types - accumulate samples
                 match summary_type:
                     case "dailies":
-                        normalized = self.normalize_dailies(item, user_id)
+                        normalized, health_scores = self.normalize_dailies(item, user_id)
                         all_samples.extend(self._build_dailies_samples(user_id, normalized))
+                        all_health_scores.extend(health_scores)
                     case "epochs":
                         normalized = self.normalize_epochs([item], user_id)
                         all_samples.extend(self._build_epochs_samples(user_id, normalized))
@@ -1594,12 +1675,14 @@ class Garmin247Data(Base247DataTemplate):
 
                     # EventRecord types - accumulate records + details
                     case "sleeps":
-                        normalized = self.normalize_sleep(item, user_id)
+                        normalized, health_score = self.normalize_sleep(item, user_id)
                         result = self._build_sleep_record(user_id, normalized)
                         if result:
                             record, detail = result
                             all_records.append(record)
                             all_sleep_details.append(detail)
+                        if health_score:
+                            all_health_scores.append(health_score)
                     case "activities" | "activityDetails":
                         result = self._build_activity_record(user_id, item)
                         if result:
@@ -1649,6 +1732,10 @@ class Garmin247Data(Base247DataTemplate):
                 event_record_service.bulk_create_details(db, workout_details, detail_type="workout")
 
             count += len(inserted_ids)
+
+        if all_health_scores:
+            health_score_service.bulk_create(db, all_health_scores)
+            db.commit()
 
         return count
 
@@ -1709,7 +1796,7 @@ class Garmin247Data(Base247DataTemplate):
         self,
         raw_stats: dict[str, Any],
         user_id: UUID,
-    ) -> dict[str, Any]:
+    ) -> tuple[dict[str, Any], list[HealthScoreCreate]]:
         """Delegate to normalize_dailies."""
         return self.normalize_dailies(raw_stats, user_id)
 

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -247,12 +247,13 @@ class Garmin247Data(Base247DataTemplate):
 
         # Extract sleep score if available
         sleep_score = None
+        sleep_qualifier = None
         overall_score = raw_sleep.get("overallSleepScore")
         if overall_score and isinstance(overall_score, dict):
             sleep_score = overall_score.get("value")
             sleep_qualifier = overall_score.get("qualifier")
 
-        sleep_scores = raw_sleep.get("sleepScores", [])
+        sleep_scores = raw_sleep.get("sleepScores") or {}
         sleep_score_components = {
             key: ScoreComponent(qualifier=value.get("qualifierKey")) for key, value in sleep_scores.items()
         }
@@ -405,7 +406,8 @@ class Garmin247Data(Base247DataTemplate):
             return scores
 
         avg_stress = normalized_daily.get("avg_stress")
-        stress_qualifier = normalized_daily.get("stress_qualifier", "").replace("_", " ").title()
+        raw_qualifier = normalized_daily.get("stress_qualifier")
+        stress_qualifier = raw_qualifier.replace("_", " ").title() if raw_qualifier else None
         # averageStressLevel is -1 when there is not enough data to calculate
         if avg_stress is not None and avg_stress != -1:
             scores.append(

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -986,7 +986,7 @@ class Garmin247Data(Base247DataTemplate):
         zone_offset = offset_to_iso(raw_stress.get("startTimeOffsetInSeconds"))
 
         # Stress level values (negative values are special states: off-wrist, motion, etc.)
-        stress_values = raw_stress.get("timeOffsetStressLevelValues", {})
+        stress_values = raw_stress.get("timeOffsetStressLevelValues") or raw_stress.get("stressLevelValues", {})
         if stress_values and isinstance(stress_values, dict):
             for offset_str, stress_value in stress_values.items():
                 try:
@@ -1009,7 +1009,7 @@ class Garmin247Data(Base247DataTemplate):
                     pass
 
         # Body battery values
-        battery_values = raw_stress.get("timeOffsetBodyBatteryValues", {})
+        battery_values = raw_stress.get("timeOffsetBodyBatteryValues") or raw_stress.get("bodyBatteryValues", {})
         if battery_values and isinstance(battery_values, dict):
             for offset_str, battery_value in battery_values.items():
                 try:

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -216,7 +216,7 @@ class Garmin247Data(Base247DataTemplate):
             components=sleep_score_components,
         )
 
-    def normalize_sleep(
+    def normalize_sleep(  # type: ignore[override]
         self,
         raw_sleep: dict[str, Any],
         user_id: UUID,
@@ -253,7 +253,9 @@ class Garmin247Data(Base247DataTemplate):
             sleep_qualifier = overall_score.get("qualifier")
 
         sleep_scores = raw_sleep.get("sleepScores", [])
-        sleep_score_components = {key: ScoreComponent(qualifier=value.get("qualifierKey")) for key, value in sleep_scores.items()}
+        sleep_score_components = {
+            key: ScoreComponent(qualifier=value.get("qualifierKey")) for key, value in sleep_scores.items()
+        }
 
         normalized = {
             "id": uuid4(),
@@ -445,7 +447,6 @@ class Garmin247Data(Base247DataTemplate):
             "stress_qualifier": raw_daily.get("stressQualifier"),
             "moderate_intensity_minutes": (raw_daily.get("moderateIntensityDurationInSeconds") or 0) // 60,
             "vigorous_intensity_minutes": (raw_daily.get("vigorousIntensityDurationInSeconds") or 0) // 60,
-
             "heart_rate_samples": raw_daily.get("timeOffsetHeartRateSamples"),
             "garmin_summary_id": raw_daily.get("summaryId"),
         }
@@ -1792,7 +1793,7 @@ class Garmin247Data(Base247DataTemplate):
         """Use dailies for daily stats."""
         return self.get_dailies_data(db, user_id, start_date, end_date)
 
-    def normalize_daily_activity(
+    def normalize_daily_activity(  # type: ignore[override]
         self,
         raw_stats: dict[str, Any],
         user_id: UUID,

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -971,6 +971,31 @@ class Garmin247Data(Base247DataTemplate):
     # Stress Data - /wellness-api/rest/stressDetails
     # -------------------------------------------------------------------------
 
+    def _normalize_body_battery_health_score(
+        self,
+        user_id: UUID,
+        raw_stress: dict[str, Any],
+    ) -> HealthScoreCreate | None:
+        """Extract peak body battery health score from a stressDetails record."""
+        start_ts = raw_stress.get("startTimeInSeconds", 0)
+        if not start_ts:
+            return None
+        battery_values = raw_stress.get("timeOffsetBodyBatteryValues") or raw_stress.get("bodyBatteryValues", {})
+        if not battery_values or not isinstance(battery_values, dict):
+            return None
+        valid = [v for v in battery_values.values() if v is not None and v >= 0]
+        if not valid:
+            return None
+        return HealthScoreCreate(
+            id=uuid4(),
+            user_id=user_id,
+            provider=ProviderName.GARMIN,
+            category=HealthScoreCategory.BODY_BATTERY,
+            value=max(valid),
+            recorded_at=self._from_epoch_seconds(start_ts),
+            zone_offset=offset_to_iso(raw_stress.get("startTimeOffsetInSeconds")),
+        )
+
     def _build_stress_samples(
         self,
         user_id: UUID,
@@ -1039,10 +1064,14 @@ class Garmin247Data(Base247DataTemplate):
         user_id: UUID,
         raw_stress: dict[str, Any],
     ) -> int:
-        """Save individual stress level and body battery timeseries from a stressDetails record."""
+        """Save individual stress/body battery timeseries
+        and peak body battery health score from a stressDetails record."""
         samples = self._build_stress_samples(user_id, raw_stress)
         if samples:
             self.data_point_repo.bulk_create(db, samples)
+        if score := self._normalize_body_battery_health_score(user_id, raw_stress):
+            health_score_service.bulk_create(db, [score])
+            db.commit()
         return len(samples)
 
     # -------------------------------------------------------------------------
@@ -1663,6 +1692,8 @@ class Garmin247Data(Base247DataTemplate):
                         all_samples.extend(self._build_hrv_samples(user_id, item))
                     case "stressDetails":
                         all_samples.extend(self._build_stress_samples(user_id, item))
+                        if score := self._normalize_body_battery_health_score(user_id, item):
+                            all_health_scores.append(score)
                     case "respiration":
                         all_samples.extend(self._build_respiration_samples(user_id, item))
                     case "pulseox":

--- a/backend/app/services/providers/whoop/data_247.py
+++ b/backend/app/services/providers/whoop/data_247.py
@@ -11,13 +11,16 @@ from app.database import DbSession
 from app.models import DataPointSeries, DataSource, EventRecord
 from app.repositories import EventRecordRepository, UserConnectionRepository
 from app.repositories.data_source_repository import DataSourceRepository
-from app.schemas.enums import SeriesType, get_series_type_id
+from app.schemas.enums import HealthScoreCategory, ProviderName, SeriesType, get_series_type_id
 from app.schemas.model_crud.activities import (
     EventRecordCreate,
     EventRecordDetailCreate,
+    HealthScoreCreate,
+    ScoreComponent,
     TimeSeriesSampleCreate,
 )
 from app.services.event_record_service import event_record_service
+from app.services.health_score_service import health_score_service
 from app.services.providers.api_client import make_authenticated_request
 from app.services.providers.templates.base_247_data import Base247DataTemplate
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
@@ -136,11 +139,47 @@ class Whoop247Data(Base247DataTemplate):
 
         return all_sleep_data
 
-    def normalize_sleep(
+    def _normalize_sleep_health_score(
+        self,
+        normalized: dict[str, Any],
+        user_id: UUID,
+    ) -> HealthScoreCreate | None:
+        """Build a HealthScoreCreate for Whoop sleep score."""
+        if normalized.get("score_state") != "SCORED":
+            return None
+        performance = normalized.get("sleep_performance_percentage")
+        timestamp = normalized.get("timestamp")
+        if performance is None or timestamp is None:
+            return None
+        if isinstance(timestamp, str):
+            try:
+                timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            except (ValueError, AttributeError):
+                return None
+        components = {
+            k: ScoreComponent(value=v)
+            for k, v in {
+                "sleep_consistency_percentage": normalized.get("sleep_consistency_percentage"),
+                "sleep_efficiency_percentage": normalized.get("sleep_efficiency_percentage"),
+                "respiratory_rate": normalized.get("respiratory_rate"),
+            }.items()
+            if v is not None
+        }
+        return HealthScoreCreate(
+            id=uuid4(),
+            user_id=user_id,
+            provider=ProviderName.WHOOP,
+            category=HealthScoreCategory.SLEEP,
+            value=performance,
+            recorded_at=timestamp,
+            components=components or None,
+        )
+
+    def normalize_sleep(  # type: ignore[override]
         self,
         raw_sleep: dict[str, Any],
         user_id: UUID,
-    ) -> dict[str, Any]:
+    ) -> tuple[dict[str, Any], HealthScoreCreate | None]:
         """Normalize Whoop sleep data to our schema."""
         # Extract basic fields
         sleep_id = raw_sleep.get("id")
@@ -187,7 +226,7 @@ class Whoop247Data(Base247DataTemplate):
             with suppress(ValueError, TypeError):
                 internal_id = UUID(sleep_id)
 
-        return {
+        normalized = {
             "id": internal_id,
             "user_id": user_id,
             "provider": self.provider_name,
@@ -206,8 +245,14 @@ class Whoop247Data(Base247DataTemplate):
             },
             "whoop_sleep_id": sleep_id,
             "whoop_cycle_id": cycle_id,
+            "score_state": raw_sleep.get("score_state"),
+            "sleep_performance_percentage": score.get("sleep_performance_percentage"),
+            "sleep_consistency_percentage": score.get("sleep_consistency_percentage"),
+            "sleep_efficiency_percentage": efficiency,
+            "respiratory_rate": score.get("respiratory_rate"),
             "raw": raw_sleep,  # Keep raw for debugging
         }
+        return normalized, self._normalize_sleep_health_score(normalized, user_id)
 
     def save_sleep_data(
         self,
@@ -307,11 +352,14 @@ class Whoop247Data(Base247DataTemplate):
         """Load sleep data from API and save to database."""
         raw_data = self.get_sleep_data(db, user_id, start_time, end_time)
         count = 0
+        health_scores: list[HealthScoreCreate] = []
         for item in raw_data:
             try:
-                normalized = self.normalize_sleep(item, user_id)
+                normalized, health_score = self.normalize_sleep(item, user_id)
                 self.save_sleep_data(db, user_id, normalized)
                 count += 1
+                if health_score:
+                    health_scores.append(health_score)
             except Exception as e:
                 log_structured(
                     self.logger,
@@ -320,6 +368,9 @@ class Whoop247Data(Base247DataTemplate):
                     provider="whoop",
                     task="load_and_save_sleep",
                 )
+        if health_scores:
+            health_score_service.bulk_create(db, health_scores)
+            db.commit()
         return count
 
     def load_and_save_all(
@@ -589,11 +640,36 @@ class Whoop247Data(Base247DataTemplate):
 
         return all_recovery_data
 
-    def normalize_recovery(
+    def _normalize_recovery_health_score(
+        self,
+        normalized: dict[str, Any],
+        user_id: UUID,
+    ) -> HealthScoreCreate | None:
+        """Build a HealthScoreCreate for Whoop recovery score."""
+        recovery_score = normalized.get("recovery_score")
+        timestamp = normalized.get("timestamp")
+        if recovery_score is None or timestamp is None:
+            return None
+        components = {
+            k: ScoreComponent(value=normalized.get(k))
+            for k in ("resting_heart_rate", "hrv_rmssd_milli", "spo2_percentage", "skin_temp_celsius")
+            if normalized.get(k) is not None
+        }
+        return HealthScoreCreate(
+            id=uuid4(),
+            user_id=user_id,
+            provider=ProviderName.WHOOP,
+            category=HealthScoreCategory.RECOVERY,
+            value=recovery_score,
+            recorded_at=timestamp,
+            components=components or None,
+        )
+
+    def normalize_recovery(  # type: ignore[override]
         self,
         raw_recovery: dict[str, Any],
         user_id: UUID,
-    ) -> dict[str, Any]:
+    ) -> tuple[dict[str, Any], HealthScoreCreate | None]:
         """Normalize Whoop recovery data to our schema.
 
         Extracts recovery metrics from the score object:
@@ -613,7 +689,7 @@ class Whoop247Data(Base247DataTemplate):
 
         # Only process scored records
         if score_state != "SCORED":
-            return {}
+            return {}, None
 
         # Parse timestamp
         timestamp = None
@@ -623,7 +699,7 @@ class Whoop247Data(Base247DataTemplate):
             except (ValueError, AttributeError):
                 timestamp = datetime.now(timezone.utc)
 
-        return {
+        normalized = {
             "user_id": user_id,
             "provider": self.provider_name,
             "timestamp": timestamp,
@@ -636,6 +712,7 @@ class Whoop247Data(Base247DataTemplate):
             "skin_temp_celsius": score.get("skin_temp_celsius"),
             "raw": raw_recovery,
         }
+        return normalized, self._normalize_recovery_health_score(normalized, user_id)
 
     def save_recovery_data(
         self,
@@ -710,12 +787,15 @@ class Whoop247Data(Base247DataTemplate):
         """
         raw_data = self.get_recovery_data(db, user_id, start_time, end_time)
         total_count = 0
+        health_scores: list[HealthScoreCreate] = []
 
         for item in raw_data:
             try:
-                normalized = self.normalize_recovery(item, user_id)
+                normalized, health_score = self.normalize_recovery(item, user_id)
                 if normalized:  # Skip unscored records
                     total_count += self.save_recovery_data(db, user_id, normalized)
+                    if health_score:
+                        health_scores.append(health_score)
             except Exception as e:
                 log_structured(
                     self.logger,
@@ -724,6 +804,10 @@ class Whoop247Data(Base247DataTemplate):
                     provider="whoop",
                     task="load_and_save_recovery",
                 )
+
+        if health_scores:
+            health_score_service.bulk_create(db, health_scores)
+            db.commit()
 
         return total_count
 

--- a/backend/app/services/providers/whoop/workouts.py
+++ b/backend/app/services/providers/whoop/workouts.py
@@ -212,7 +212,7 @@ class WhoopWorkouts(BaseWorkoutsTemplate):
             components=components or None,
         )
 
-    def _normalize_workout(
+    def _normalize_workout(  # type: ignore[override]
         self,
         raw_workout: WhoopWorkoutJSON,
         user_id: UUID,

--- a/backend/app/services/providers/whoop/workouts.py
+++ b/backend/app/services/providers/whoop/workouts.py
@@ -5,13 +5,17 @@ from uuid import UUID, uuid4
 
 from app.constants.workout_types.whoop import get_unified_workout_type
 from app.database import DbSession
+from app.schemas.enums import HealthScoreCategory, ProviderName
 from app.schemas.model_crud.activities import (
     EventRecordCreate,
     EventRecordDetailCreate,
     EventRecordMetrics,
+    HealthScoreCreate,
+    ScoreComponent,
 )
 from app.schemas.providers.whoop import WhoopWorkoutCollectionJSON, WhoopWorkoutJSON
 from app.services.event_record_service import event_record_service
+from app.services.health_score_service import health_score_service
 from app.services.providers.templates.base_workouts import BaseWorkoutsTemplate
 from app.services.raw_payload_storage import store_raw_payload
 from app.utils.structured_logging import log_structured
@@ -172,12 +176,48 @@ class WhoopWorkouts(BaseWorkoutsTemplate):
 
         return metrics
 
+    def _normalize_strain_health_score(
+        self,
+        raw_workout: WhoopWorkoutJSON,
+        user_id: UUID,
+    ) -> HealthScoreCreate | None:
+        """Extract strain health score from a Whoop workout record."""
+        if not raw_workout.score or raw_workout.score.strain is None:
+            return None
+        try:
+            recorded_at = datetime.fromisoformat(raw_workout.start.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            return None
+        score = raw_workout.score
+        components = {
+            k: ScoreComponent(value=v)
+            for k, v in {
+                "average_heart_rate": score.average_heart_rate,
+                "max_heart_rate": score.max_heart_rate,
+                "kilojoule": score.kilojoule,
+                "percent_recorded": score.percent_recorded,
+                "distance_meter": score.distance_meter,
+                "altitude_gain_meter": score.altitude_gain_meter,
+                "altitude_change_meter": score.altitude_change_meter,
+            }.items()
+            if v is not None
+        }
+        return HealthScoreCreate(
+            id=uuid4(),
+            user_id=user_id,
+            provider=ProviderName.WHOOP,
+            category=HealthScoreCategory.STRAIN,
+            value=score.strain,
+            recorded_at=recorded_at,
+            components=components or None,
+        )
+
     def _normalize_workout(
         self,
         raw_workout: WhoopWorkoutJSON,
         user_id: UUID,
-    ) -> tuple[EventRecordCreate, EventRecordDetailCreate]:
-        """Normalize Whoop workout to EventRecordCreate and EventRecordDetailCreate."""
+    ) -> tuple[EventRecordCreate, EventRecordDetailCreate, HealthScoreCreate | None]:
+        """Normalize Whoop workout to EventRecordCreate, EventRecordDetailCreate, and strain HealthScoreCreate."""
         workout_id = uuid4()
 
         # Get workout type from sport_name (sport_id deprecated after 09/01/2025)
@@ -212,7 +252,7 @@ class WhoopWorkouts(BaseWorkoutsTemplate):
             **metrics,
         )
 
-        return workout_create, workout_detail_create
+        return workout_create, workout_detail_create, self._normalize_strain_health_score(raw_workout, user_id)
 
     def _build_bundles(
         self,
@@ -223,7 +263,7 @@ class WhoopWorkouts(BaseWorkoutsTemplate):
         for raw_workout in raw:
             # Only process workouts that are scored
             if raw_workout.score_state == "SCORED" or raw_workout.score is not None:
-                record, details = self._normalize_workout(raw_workout, user_id)
+                record, details, _ = self._normalize_workout(raw_workout, user_id)
                 yield record, details
 
     def load_data(
@@ -325,10 +365,19 @@ class WhoopWorkouts(BaseWorkoutsTemplate):
 
         # Process and save all workouts
         count = 0
-        for record, details in self._build_bundles(all_workouts, user_id):
-            created_record = event_record_service.create(db, record)
-            detail_for_record = details.model_copy(update={"record_id": created_record.id})
-            event_record_service.create_detail(db, detail_for_record)
-            count += 1
+        strain_scores: list[HealthScoreCreate] = []
+        for raw_workout in all_workouts:
+            if raw_workout.score_state == "SCORED" or raw_workout.score is not None:
+                record, details, strain_score = self._normalize_workout(raw_workout, user_id)
+                created_record = event_record_service.create(db, record)
+                detail_for_record = details.model_copy(update={"record_id": created_record.id})
+                event_record_service.create_detail(db, detail_for_record)
+                count += 1
+                if strain_score:
+                    strain_scores.append(strain_score)
+
+        if strain_scores:
+            health_score_service.bulk_create(db, strain_scores)
+            db.commit()
 
         return count

--- a/backend/tests/providers/garmin/test_garmin_247.py
+++ b/backend/tests/providers/garmin/test_garmin_247.py
@@ -179,7 +179,7 @@ class TestGarmin247Data:
     def test_normalize_sleep(self, garmin_247: Garmin247Data, sample_sleep: dict[str, Any]) -> None:
         """Test normalizing sleep data."""
         user_id = uuid4()
-        normalized = garmin_247.normalize_sleep(sample_sleep, user_id)
+        normalized, _ = garmin_247.normalize_sleep(sample_sleep, user_id)
 
         assert normalized["user_id"] == user_id
         assert normalized["provider"] == "garmin"
@@ -238,7 +238,7 @@ class TestGarmin247Data:
             },
         }
 
-        normalized = garmin_247.normalize_sleep(sleep_data, user_id)
+        normalized, _ = garmin_247.normalize_sleep(sleep_data, user_id)
 
         actual_end = datetime.fromisoformat(normalized["end_time"])
         expected_end = datetime.fromtimestamp(awake_end_ts, tz=timezone.utc)
@@ -254,7 +254,7 @@ class TestGarmin247Data:
             "durationInSeconds": 28800,
         }
 
-        normalized = garmin_247.normalize_sleep(sleep_data, user_id)
+        normalized, _ = garmin_247.normalize_sleep(sleep_data, user_id)
 
         # Should handle missing stage data gracefully
         stages = normalized["stages"]
@@ -270,7 +270,7 @@ class TestGarmin247Data:
     def test_normalize_dailies(self, garmin_247: Garmin247Data, sample_daily: dict[str, Any]) -> None:
         """Test normalizing daily summary data."""
         user_id = uuid4()
-        normalized = garmin_247.normalize_dailies(sample_daily, user_id)
+        normalized, _ = garmin_247.normalize_dailies(sample_daily, user_id)
 
         assert normalized["user_id"] == user_id
         assert normalized["calendar_date"] == "2024-01-15"
@@ -295,7 +295,7 @@ class TestGarmin247Data:
             "durationInSeconds": 86400,
         }
 
-        normalized = garmin_247.normalize_dailies(daily_data, user_id)
+        normalized, _ = garmin_247.normalize_dailies(daily_data, user_id)
 
         assert normalized["steps"] is None
         assert normalized["active_calories"] is None
@@ -508,7 +508,7 @@ class TestGarmin247Data:
     def test_build_dailies_samples(self, garmin_247: Garmin247Data, sample_daily: dict[str, Any]) -> None:
         """Test _build_dailies_samples returns samples without DB call."""
         user_id = uuid4()
-        normalized = garmin_247.normalize_dailies(sample_daily, user_id)
+        normalized, _ = garmin_247.normalize_dailies(sample_daily, user_id)
         samples = garmin_247._build_dailies_samples(user_id, normalized)
 
         # 5 metrics (steps, calories, resting_hr, floors, distance) + 3 HR samples
@@ -560,8 +560,8 @@ class TestGarmin247Data:
         user_id = uuid4()
         stress_data = {
             "startTimeInSeconds": 1705276800,
-            "stressLevelValues": {"0": 25, "300": 30, "600": -1},  # -1 is skipped
-            "bodyBatteryValues": {"0": 80, "300": 78},
+            "timeOffsetStressLevelValues": {"0": 25, "300": 30, "600": -1},  # -1 is skipped
+            "timeOffsetBodyBatteryValues": {"0": 80, "300": 78},
         }
         samples = garmin_247._build_stress_samples(user_id, stress_data)
         assert len(samples) == 4  # 2 stress + 2 battery
@@ -569,7 +569,7 @@ class TestGarmin247Data:
     def test_build_sleep_record(self, garmin_247: Garmin247Data, sample_sleep: dict[str, Any]) -> None:
         """Test _build_sleep_record returns record + detail without DB call."""
         user_id = uuid4()
-        normalized = garmin_247.normalize_sleep(sample_sleep, user_id)
+        normalized, _ = garmin_247.normalize_sleep(sample_sleep, user_id)
         result = garmin_247._build_sleep_record(user_id, normalized)
 
         assert result is not None
@@ -655,8 +655,8 @@ class TestGarmin247Data:
         """Test batch processing multiple stress items."""
         user = UserFactory()
         items = [
-            {"startTimeInSeconds": 1705276800, "stressLevelValues": {"0": 25, "300": 30}},
-            {"startTimeInSeconds": 1705363200, "stressLevelValues": {"0": 40}},
+            {"startTimeInSeconds": 1705276800, "timeOffsetStressLevelValues": {"0": 25, "300": 30}},
+            {"startTimeInSeconds": 1705363200, "timeOffsetStressLevelValues": {"0": 40}},
         ]
 
         count = garmin_247.process_items_batch(db, user.id, "stressDetails", items)
@@ -705,7 +705,7 @@ class TestGarmin247Data:
         user = UserFactory()
         items = [
             {"startTimeInSeconds": 0},  # Missing timestamp -> skipped
-            {"startTimeInSeconds": 1705276800, "stressLevelValues": {"0": 50}},  # Valid
+            {"startTimeInSeconds": 1705276800, "timeOffsetStressLevelValues": {"0": 50}},  # Valid
         ]
 
         count = garmin_247.process_items_batch(db, user.id, "stressDetails", items)

--- a/docs/providers/coverage.mdx
+++ b/docs/providers/coverage.mdx
@@ -14,7 +14,7 @@ This guide provides a comprehensive overview of data type support across all int
 | **Sleep** | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | **24/7 Data** | ✅ | ✅ | ❌ | ✅ | ✅ | ◐ | ✅ | ❌ |
 | **Timeseries** | ✅ | ✅ | ◐ | ✅ | ✅ | ❌ | ✅ | ❌ |
-| **Health Scores** | ❌ | 🔜 | ❌ | ❌ | ✅ | 🔜 | ❌ | ❌ |
+| **Health Scores** | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
 
 <Accordion title="Legend">
   - ✅ **Full support** — Fully implemented and collecting data
@@ -233,14 +233,14 @@ Health scores are composite metrics that summarize a specific aspect of health i
 
 | Score | Internal | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
 |-------|:--------:|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| Sleep score | 🔜 | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Sleep score | 🔜 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Readiness score | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Activity score | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| Recovery score | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Recovery score | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | Resilience score | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Stress score | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Body battery | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Strain score | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Stress score | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Body battery | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Strain score | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 
 <Note>
   **Internal scores** are calculated by Open Wearables from raw data, independent of any provider. They are available for any provider that reports the required underlying data.

--- a/docs/providers/coverage.mdx
+++ b/docs/providers/coverage.mdx
@@ -233,13 +233,13 @@ Health scores are composite metrics that summarize a specific aspect of health i
 
 | Score | Internal | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
 |-------|:--------:|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| Sleep score | 🔜 | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Sleep score | 🔜 | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
 | Readiness score | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Activity score | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | Recovery score | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | Resilience score | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Stress score | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Body battery | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Body battery | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Strain score | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 
 <Note>

--- a/docs/providers/coverage.mdx
+++ b/docs/providers/coverage.mdx
@@ -239,7 +239,7 @@ Health scores are composite metrics that summarize a specific aspect of health i
 | Recovery score | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | Resilience score | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Stress score | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Body battery | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Body battery | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Strain score | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 
 <Note>


### PR DESCRIPTION
## Description

Save health scores from Garmin and Whoop

Resolves #797 
Resolves #798

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added health-score support: Garmin now provides sleep, stress and body‑battery scores; Whoop now provides sleep, recovery and strain scores. Scores are collected and persisted alongside activity and sleep data.

* **Documentation**
  * Coverage matrix updated to reflect new provider/score support.

* **Tests**
  * Tests and fixtures updated to the new health‑score return shapes and provider payload fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->