### PR TITLE
feat: add SDK logs endpoint for sync observability

### DIFF
--- a/backend/app/api/routes/v1/__init__.py
+++ b/backend/app/api/routes/v1/__init__.py
@@ -16,6 +16,7 @@ from .invitations import router as invitations_router
 from .oauth import router as oauth_router
 from .oura_webhooks import router as oura_webhooks_router
 from .priorities import router as priorities_router
+from .sdk_logs import router as sdk_logs_router
 from .sdk_sync import router as sdk_sync_router
 from .sdk_token import router as sdk_token_router
 from .strava_webhooks import router as strava_webhooks_router
@@ -42,6 +43,7 @@ v1_router.include_router(oauth_router, prefix="/oauth")
 v1_router.include_router(sync_data_router, prefix="/providers", tags=["External: Data Sync"])
 v1_router.include_router(vendor_workouts_router, prefix="/providers", tags=["External: Workouts"])
 v1_router.include_router(import_xml_router, tags=["External: Apple Health Import"])
+v1_router.include_router(sdk_logs_router, tags=["External: Mobile SDK"])
 v1_router.include_router(sdk_sync_router, tags=["External: Mobile SDK"])
 v1_router.include_router(sdk_token_router, tags=["External: Mobile SDK"])
 v1_router.include_router(user_invitation_code_router, tags=["External: Mobile SDK"])

--- a/backend/app/api/routes/v1/sdk_logs.py
+++ b/backend/app/api/routes/v1/sdk_logs.py
@@ -1,0 +1,62 @@
+import uuid
+from logging import getLogger
+
+from fastapi import APIRouter, HTTPException, status
+
+from app.schemas.providers.mobile_sdk import SDKLogRequest
+from app.schemas.responses.upload import UploadDataResponse
+from app.services.raw_payload_storage import store_raw_payload
+from app.utils.auth import SDKAuthDep
+from app.utils.structured_logging import log_structured
+
+router = APIRouter()
+logger = getLogger(__name__)
+
+
+@router.post("/sdk/users/{user_id}/logs", status_code=status.HTTP_202_ACCEPTED)
+def submit_sdk_logs(
+    user_id: str,
+    body: SDKLogRequest,
+    auth: SDKAuthDep,
+) -> UploadDataResponse:
+    """Accept SDK diagnostic log events and store to raw S3 storage.
+
+    Used for observability into mobile SDK sync behavior (background task
+    lifecycle, device state, sync success/failure).
+    """
+    if auth.auth_type == "sdk_token" and (not auth.user_id or str(auth.user_id) != user_id):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Token does not match user_id",
+        )
+
+    batch_id = str(uuid.uuid4())
+    provider = (body.provider or "unknown").lower()
+    event_types = [e.eventType for e in body.events]
+
+    log_structured(
+        logger,
+        "info",
+        "SDK log events received",
+        action="sdk_logs_received",
+        batch_id=batch_id,
+        user_id=user_id,
+        provider=provider,
+        event_count=len(body.events),
+        event_types=event_types,
+        sdk_version=body.sdkVersion,
+    )
+
+    store_raw_payload(
+        source="sdk_logs",
+        provider=provider,
+        payload=body.model_dump_json(),
+        user_id=user_id,
+        trace_id=batch_id,
+    )
+
+    return UploadDataResponse(
+        status_code=202,
+        response="Log events stored successfully",
+        user_id=user_id,
+    )

--- a/backend/app/schemas/providers/mobile_sdk/__init__.py
+++ b/backend/app/schemas/providers/mobile_sdk/__init__.py
@@ -1,3 +1,6 @@
+from .sdk_log_events import (
+    SDKLogRequest,
+)
 from .sleep_state import (
     SLEEP_START_STATES,
     SleepState,
@@ -13,6 +16,8 @@ from .sync_request import (
 )
 
 __all__ = [
+    # SDKLogEvents
+    "SDKLogRequest",
     # SleepState
     "SleepState",
     "SleepStateStage",

--- a/backend/app/schemas/providers/mobile_sdk/sdk_log_events.py
+++ b/backend/app/schemas/providers/mobile_sdk/sdk_log_events.py
@@ -1,0 +1,62 @@
+# ruff: noqa: N815
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+
+class DataTypeCount(BaseModel):
+    """Count of records for a specific data type."""
+
+    type: str
+    count: int = Field(ge=0)
+
+
+class TimeRange(BaseModel):
+    startDate: datetime
+    endDate: datetime
+
+
+class HistoricalDataSyncStartEvent(BaseModel):
+    eventType: Literal["historical_data_sync_start"]
+    timestamp: datetime
+    dataTypeCounts: list[DataTypeCount] = Field(default_factory=list)
+    timeRange: TimeRange | None = None
+
+
+class HistoricalDataTypeSyncEndEvent(BaseModel):
+    eventType: Literal["historical_data_type_sync_end"]
+    timestamp: datetime
+    dataType: str
+    success: bool
+    recordCount: int | None = None
+    durationMs: int | None = None
+
+
+class DeviceStateEvent(BaseModel):
+    eventType: Literal["device_state"]
+    timestamp: datetime
+    batteryLevel: float | None = Field(None, ge=0.0, le=1.0)
+    batteryState: str | None = None
+    isLowPowerMode: bool | None = None
+    thermalState: str | None = None
+    taskType: str | None = None
+    availableRamBytes: int | None = None
+    totalRamBytes: int | None = None
+
+
+SDKLogEvent = Annotated[
+    HistoricalDataSyncStartEvent | HistoricalDataTypeSyncEndEvent | DeviceStateEvent,
+    Field(discriminator="eventType"),
+]
+
+
+class SDKLogRequest(BaseModel):
+    """Top-level request for SDK log events endpoint."""
+
+    sdkVersion: str
+    provider: str | None = None
+    events: list[SDKLogEvent] = Field(..., min_length=1, max_length=100)

--- a/backend/tests/api/v1/test_sdk_logs.py
+++ b/backend/tests/api/v1/test_sdk_logs.py
@@ -1,0 +1,202 @@
+"""Tests for SDK logs endpoint."""
+
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy.orm import Session
+from starlette.testclient import TestClient
+
+from app.services.sdk_token_service import create_sdk_user_token
+from tests.factories import ApiKeyFactory
+
+USER_ID = "123e4567-e89b-12d3-a456-426614174000"
+ENDPOINT = "/api/v1/sdk/users/{user_id}/logs/"
+
+SYNC_START_EVENT = {
+    "eventType": "historical_data_sync_start",
+    "timestamp": "2026-04-09T10:00:00Z",
+    "dataTypeCounts": [
+        {"type": "HKQuantityTypeIdentifierHeartRate", "count": 500},
+        {"type": "HKQuantityTypeIdentifierStepCount", "count": 200},
+        {"type": "workouts", "count": 3},
+        {"type": "sleep", "count": 12},
+    ],
+    "timeRange": {
+        "startDate": "2026-01-09T00:00:00Z",
+        "endDate": "2026-04-09T10:00:00Z",
+    },
+}
+
+SYNC_END_EVENT = {
+    "eventType": "historical_data_type_sync_end",
+    "timestamp": "2026-04-09T10:00:05Z",
+    "dataType": "HKQuantityTypeIdentifierHeartRate",
+    "success": True,
+    "recordCount": 500,
+    "durationMs": 1200,
+}
+
+DEVICE_STATE_EVENT = {
+    "eventType": "device_state",
+    "timestamp": "2026-04-09T10:00:00Z",
+    "batteryLevel": 0.72,
+    "batteryState": "unplugged",
+    "isLowPowerMode": False,
+    "thermalState": "nominal",
+    "taskType": "background",
+    "availableRamBytes": 1073741824,
+    "totalRamBytes": 6442450944,
+}
+
+
+def _url(user_id: str = USER_ID) -> str:
+    return ENDPOINT.format(user_id=user_id)
+
+
+def _payload(*events: dict) -> dict:
+    return {
+        "sdkVersion": "1.2.0",
+        "provider": "apple",
+        "events": list(events),
+    }
+
+
+class TestSDKLogsHappyPath:
+    @patch("app.api.routes.v1.sdk_logs.store_raw_payload")
+    def test_all_event_types_accepted(self, mock_store: MagicMock, client: TestClient, db: Session) -> None:
+        api_key = ApiKeyFactory()
+        response = client.post(
+            _url(),
+            headers={"X-Open-Wearables-API-Key": api_key.id},
+            json=_payload(SYNC_START_EVENT, SYNC_END_EVENT, DEVICE_STATE_EVENT),
+        )
+        assert response.status_code == 202
+        assert response.json()["user_id"] == USER_ID
+        mock_store.assert_called_once()
+
+    @patch("app.api.routes.v1.sdk_logs.store_raw_payload")
+    def test_sync_start_only(self, mock_store: MagicMock, client: TestClient, db: Session) -> None:
+        api_key = ApiKeyFactory()
+        response = client.post(
+            _url(),
+            headers={"X-Open-Wearables-API-Key": api_key.id},
+            json=_payload(SYNC_START_EVENT),
+        )
+        assert response.status_code == 202
+
+    @patch("app.api.routes.v1.sdk_logs.store_raw_payload")
+    def test_per_type_sync_end(self, mock_store: MagicMock, client: TestClient, db: Session) -> None:
+        api_key = ApiKeyFactory()
+        response = client.post(
+            _url(),
+            headers={"X-Open-Wearables-API-Key": api_key.id},
+            json=_payload(SYNC_END_EVENT),
+        )
+        assert response.status_code == 202
+
+    @patch("app.api.routes.v1.sdk_logs.store_raw_payload")
+    def test_device_state_only(self, mock_store: MagicMock, client: TestClient, db: Session) -> None:
+        api_key = ApiKeyFactory()
+        response = client.post(
+            _url(),
+            headers={"X-Open-Wearables-API-Key": api_key.id},
+            json=_payload(DEVICE_STATE_EVENT),
+        )
+        assert response.status_code == 202
+
+    @patch("app.api.routes.v1.sdk_logs.store_raw_payload")
+    def test_provider_omitted_defaults_to_unknown(self, mock_store: MagicMock, client: TestClient, db: Session) -> None:
+        api_key = ApiKeyFactory()
+        response = client.post(
+            _url(),
+            headers={"X-Open-Wearables-API-Key": api_key.id},
+            json={"sdkVersion": "1.0.0", "events": [DEVICE_STATE_EVENT]},
+        )
+        assert response.status_code == 202
+        mock_store.assert_called_once()
+        assert mock_store.call_args.kwargs["provider"] == "unknown"
+
+    @patch("app.api.routes.v1.sdk_logs.store_raw_payload")
+    def test_android_data_types_accepted(self, mock_store: MagicMock, client: TestClient, db: Session) -> None:
+        api_key = ApiKeyFactory()
+        event = {
+            "eventType": "historical_data_sync_start",
+            "timestamp": "2026-04-09T10:00:00Z",
+            "dataTypeCounts": [
+                {"type": "HEART_RATE", "count": 300},
+                {"type": "STEP_COUNT", "count": 150},
+            ],
+        }
+        response = client.post(
+            _url(),
+            headers={"X-Open-Wearables-API-Key": api_key.id},
+            json=_payload(event),
+        )
+        assert response.status_code == 202
+
+
+class TestSDKLogsAuth:
+    @patch("app.api.routes.v1.sdk_logs.store_raw_payload")
+    def test_sdk_token_accepted(self, mock_store: MagicMock, client: TestClient, db: Session) -> None:
+        token = create_sdk_user_token("app_123", USER_ID)
+        response = client.post(
+            _url(),
+            headers={"Authorization": f"Bearer {token}"},
+            json=_payload(DEVICE_STATE_EVENT),
+        )
+        assert response.status_code == 202
+
+    @patch("app.api.routes.v1.sdk_logs.store_raw_payload")
+    def test_api_key_accepted(self, mock_store: MagicMock, client: TestClient, db: Session) -> None:
+        api_key = ApiKeyFactory()
+        response = client.post(
+            _url(),
+            headers={"X-Open-Wearables-API-Key": api_key.id},
+            json=_payload(DEVICE_STATE_EVENT),
+        )
+        assert response.status_code == 202
+
+    def test_no_auth_returns_401(self, client: TestClient, db: Session) -> None:
+        response = client.post(
+            _url(),
+            json=_payload(DEVICE_STATE_EVENT),
+        )
+        assert response.status_code == 401
+
+    @patch("app.api.routes.v1.sdk_logs.store_raw_payload")
+    def test_token_user_id_mismatch_returns_403(self, mock_store: MagicMock, client: TestClient, db: Session) -> None:
+        token = create_sdk_user_token("app_123", "00000000-0000-0000-0000-000000000000")
+        response = client.post(
+            _url(),
+            headers={"Authorization": f"Bearer {token}"},
+            json=_payload(DEVICE_STATE_EVENT),
+        )
+        assert response.status_code == 403
+
+
+class TestSDKLogsValidation:
+    def test_empty_events_rejected(self, client: TestClient, db: Session) -> None:
+        api_key = ApiKeyFactory()
+        response = client.post(
+            _url(),
+            headers={"X-Open-Wearables-API-Key": api_key.id},
+            json={"sdkVersion": "1.0.0", "provider": "apple", "events": []},
+        )
+        assert response.status_code in (400, 422)
+
+    def test_unknown_event_type_rejected(self, client: TestClient, db: Session) -> None:
+        api_key = ApiKeyFactory()
+        response = client.post(
+            _url(),
+            headers={"X-Open-Wearables-API-Key": api_key.id},
+            json=_payload({"eventType": "something_unknown", "timestamp": "2026-04-09T10:00:00Z"}),
+        )
+        assert response.status_code in (400, 422)
+
+    def test_missing_sdk_version_rejected(self, client: TestClient, db: Session) -> None:
+        api_key = ApiKeyFactory()
+        response = client.post(
+            _url(),
+            headers={"X-Open-Wearables-API-Key": api_key.id},
+            json={"provider": "apple", "events": [DEVICE_STATE_EVENT]},
+        )
+        assert response.status_code in (400, 422)

--- a/backend/tests/api/v1/test_sdk_logs.py
+++ b/backend/tests/api/v1/test_sdk_logs.py
@@ -9,7 +9,7 @@ from app.services.sdk_token_service import create_sdk_user_token
 from tests.factories import ApiKeyFactory
 
 USER_ID = "123e4567-e89b-12d3-a456-426614174000"
-ENDPOINT = "/api/v1/sdk/users/{user_id}/logs/"
+ENDPOINT = "/api/v1/sdk/users/{user_id}/logs"
 
 SYNC_START_EVENT = {
     "eventType": "historical_data_sync_start",


### PR DESCRIPTION
## Description

New `POST /sdk/users/{user_id}/logs` endpoint for collecting diagnostic events from the mobile SDK. Accepts three event types (`historical_data_sync_start`, `historical_data_type_sync_end`, `device_state`) and stores raw payloads to S3. 

This gives us visibility into background sync lifecycle, per-type completion, and device state (battery, thermal, RAM) when sync issues occur.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. Start the app locally
2. `POST /api/v1/sdk/users/{user_id}/logs` with SDK token or API key, body with events array
3. Check S3 bucket under `raw-payloads/{provider}/sdk_logs/` for stored payload

**Expected behavior:**
- 202 response with `user_id` in body
- Raw payload saved to S3 under `sdk_logs` source prefix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile SDK can submit log events (device state and historical sync details). Requests are validated, normalized (provider defaults to "unknown" if omitted), and accepted with 202 responses; submissions are recorded and traced with a batch identifier.
* **Tests**
  * Added comprehensive end-to-end tests covering auth behaviors, payload validations, event variations, and storage invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->