### PR TITLE
fix(frontend): set NODE_ENV=production in Docker build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,7 +19,8 @@ RUN pnpm install --frozen-lockfile
 # Copy source files
 COPY . .
 
-# Build the application
+# Build the application in production mode
+ENV NODE_ENV=production
 RUN pnpm run build
 
 # Determine build output directory and prepare it for copying
@@ -50,6 +51,7 @@ COPY --from=builder /app/.output ./.output
 EXPOSE 3000
 
 # Set the port for Nitro
+ENV NODE_ENV=production
 ENV PORT=3000
 ENV HOST=0.0.0.0
 


### PR DESCRIPTION
## Summary

- Fixes `jsxDevRuntimeExports.jsxDEV is not a function` SSR crash on production
- Adds `ENV NODE_ENV=production` in both builder and runtime stages of the frontend Dockerfile

Caused by the TanStack Start bump in #809 (1.167.8 -> 1.167.16) which started respecting `NODE_ENV` when choosing JSX runtime for SSR bundles. Since `.env` has `NODE_ENV=development`, the production Docker build was importing `jsxDEV` from `react/jsx-dev-runtime` instead of `jsx` from `react/jsx-runtime`.

## Test plan

- [x] Rebuild frontend Docker image and verify no SSR errors in logs
- [x] Verify pages render correctly via browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and runtime configuration for improved deployment consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->