### PR TITLE
feat(seo): trigger LP sitemap sync on docs change

### DIFF
--- a/.github/workflows/notify-lp-sitemap.yml
+++ b/.github/workflows/notify-lp-sitemap.yml
@@ -1,0 +1,21 @@
+name: Notify LP sitemap on docs change
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sitemap sync in open-wearables-lp
+        run: |
+          curl -sf -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.LP_REPO_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/the-momentum/open-wearables-lp/dispatches \
+            -d '{"event_type":"docs-updated"}'


### PR DESCRIPTION
Adds a GitHub Action that fires a `repository_dispatch` event to `open-wearables-lp` whenever files under `docs/` change on main.

The LP repo listens for this event and automatically updates its sitemap with the latest docs pages.

**Setup required:** Add a secret `LP_REPO_PAT` to this repo — a PAT with `repo` + `workflow` scopes that has write access to `the-momentum/open-wearables-lp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated notification system for documentation changes to keep related systems synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->