### PR TITLE
fix: hide sync buttons for SDK-based providers

### DIFF
--- a/backend/app/api/routes/v1/connections.py
+++ b/backend/app/api/routes/v1/connections.py
@@ -16,7 +16,9 @@ factory = ProviderFactory()
 def _with_capabilities(conn: object) -> UserConnectionWithCapabilities:
     enriched = UserConnectionWithCapabilities.model_validate(conn)
     with contextlib.suppress(ValueError):
-        enriched.max_historical_days = factory.get_provider(enriched.provider).capabilities.max_historical_days
+        caps = factory.get_provider(enriched.provider).capabilities
+        enriched.max_historical_days = caps.max_historical_days
+        enriched.supports_pull = caps.supports_pull
     return enriched
 
 

--- a/backend/app/schemas/model_crud/user_management/user_connection.py
+++ b/backend/app/schemas/model_crud/user_management/user_connection.py
@@ -65,3 +65,4 @@ class UserConnectionWithCapabilities(UserConnectionRead):
     """
 
     max_historical_days: int | None = None
+    supports_pull: bool = False

--- a/frontend/src/components/user/connection-card.tsx
+++ b/frontend/src/components/user/connection-card.tsx
@@ -427,6 +427,7 @@ export function ConnectionCard({ connection, className }: ConnectionCardProps) {
             {/* Unconstrained providers: Sync History dropdown + Force Live Sync */}
             {(connection.max_historical_days === null ||
               connection.max_historical_days === undefined) &&
+              connection.supports_pull &&
               !isPermanentlyFailed && (
                 <>
                   <DropdownMenu>

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -214,6 +214,7 @@ export interface UserConnection {
   created_at: string;
   updated_at: string;
   max_historical_days?: number | null;
+  supports_pull?: boolean;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- SDK providers (Apple, Samsung, Google) don't have a cloud API we can pull from, so showing "Sync Now" / "Sync History" is misleading
- Surfaces the existing `supports_pull` capability flag from backend to frontend via the connections endpoint
- Gates the unconstrained sync buttons on `supports_pull` - SDK providers get no sync buttons, Garmin keeps its constrained "Sync 30-day History" button, API providers are unchanged

Closes #642

## Test plan

- [ ] Connect an SDK provider (Apple/Samsung/Google) and verify no sync buttons appear on the card
- [ ] Connect an API provider (Whoop/Oura/etc.) and verify sync buttons still work
- [ ] Verify Garmin still shows the "Sync 30-day History" button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pull operation capability detection for data connections to enhance provider compatibility visibility.

* **Improvements**
  * Sync options now display conditionally based on provider capabilities, ensuring only applicable actions are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->