### PR TITLE
chore: add prettier format check to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,13 @@ repos:
         files: ^backend/.*\.py$
         pass_filenames: false
 
+      - id: prettier-check
+        name: prettier check
+        entry: sh -c 'cd frontend && pnpm run format:check'
+        language: system
+        files: ^frontend/src/.*\.(ts|tsx|js|jsx|json|css|md)$
+        pass_filenames: false
+
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:


### PR DESCRIPTION
## Description

Adds `pnpm run format:check` as a pre-commit hook so frontend formatting issues get caught before commit, not in CI. Only triggers when frontend source files are staged.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling configuration to include additional code formatting verification in the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->