### PR TITLE
fix(docs): add missing sidebarTitle to docs pages with SEO titles

### DIFF
--- a/docs/api-reference/guides/apple-xml-import.mdx
+++ b/docs/api-reference/guides/apple-xml-import.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Import Apple Health XML Export | Open Wearables"
+sidebarTitle: "Apple Health XML Import"
 description: "Import complete Apple Health data exports via XML. Direct upload for small files, S3 presigned URL for large exports. Authentication via Bearer token or API key."
 keywords: ["apple health xml import", "apple health export api", "healthkit xml upload", "apple health data import"]
 "og:title": "Import Apple Health XML Export | Open Wearables"

--- a/docs/api-reference/guides/error-handling.mdx
+++ b/docs/api-reference/guides/error-handling.mdx
@@ -1,5 +1,6 @@
 ---
 title: "API Error Handling | Open Wearables Reference"
+sidebarTitle: "Error Handling"
 description: "Reference for Open Wearables API error codes, response formats, and resolution steps. Covers auth failures, validation errors, rate limits, and 404s with HTTP status codes."
 keywords: ["open wearables api errors", "health api error handling", "wearable api error codes", "open wearables http errors"]
 "og:title": "API Error Handling | Open Wearables Reference"

--- a/docs/api-reference/guides/provider-setup.mdx
+++ b/docs/api-reference/guides/provider-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Wearable Provider Setup and Sync Guide | Open Wearables"
+sidebarTitle: "Provider Setup"
 description: "Provider-specific configuration and sync parameters for all supported wearables. Covers Garmin, Polar, Suunto, Whoop, and Apple Health. API path conventions included."
 keywords: ["wearable provider setup", "garmin sync configuration", "health api provider config", "open wearables provider params"]
 "og:title": "Wearable Provider Setup and Sync Guide | Open Wearables"

--- a/docs/architecture/system-overview.mdx
+++ b/docs/architecture/system-overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Open Wearables Platform Architecture | System Overview"
+sidebarTitle: "System Overview"
 description: "Open Wearables uses FastAPI, PostgreSQL, Redis, and Celery in a layered monorepo. Self-hosted via Docker Compose. Covers backend structure, MCP server, frontend stack, and data flow."
 keywords: ["wearable platform architecture", "health data api architecture", "open wearables stack", "self-hosted wearable system"]
 "og:title": "Open Wearables Platform Architecture | System Overview"

--- a/docs/architecture/unified-data-model.mdx
+++ b/docs/architecture/unified-data-model.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Wearable Data Normalization | Open Wearables Unified Data Model"
+sidebarTitle: "Unified Data Model"
 description: "Open Wearables normalizes health data from all providers into a single schema. Open algorithms, no black boxes. Covers events, time series, device mapping, and entity relationships."
 keywords: ["wearable data normalization", "unified health data model", "health data schema", "health data aggregation"]
 "og:title": "Wearable Data Normalization | Open Wearables Unified Data Model"

--- a/docs/dev-guides/aws-setup.mdx
+++ b/docs/dev-guides/aws-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: "AWS S3 Setup for Apple Health XML Imports | Open Wearables"
+sidebarTitle: "AWS Setup for XML Imports"
 description: "Configure AWS S3 and SNS for large Apple Health XML uploads. SNS triggers automatic processing when files land in S3. Covers creating the required AWS resources step by step."
 keywords: ["aws s3 apple health import", "aws sns health data", "open wearables aws setup", "s3 presigned url health xml"]
 "og:title": "AWS S3 Setup for Apple Health XML Imports | Open Wearables"

--- a/docs/dev-guides/ngrok-setup.mdx
+++ b/docs/dev-guides/ngrok-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Expose Local Backend with ngrok | Open Wearables"
+sidebarTitle: "Exposing Local Backend with ngrok"
 description: "Use ngrok to expose your local Open Wearables backend for Garmin OAuth callbacks, webhook testing, and Apple Health SDK integration. Quick setup with minimal configuration."
 keywords: ["ngrok open wearables", "expose local backend webhooks", "garmin oauth ngrok", "local health api testing"]
 "og:title": "Expose Local Backend with ngrok | Open Wearables"

--- a/docs/dev-guides/raw-payload-storage.mdx
+++ b/docs/dev-guides/raw-payload-storage.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Raw Payload Storage | Open Wearables Debug Tool"
+sidebarTitle: "Raw Payload Storage"
 description: "Capture raw JSON payloads from wearable providers before processing. Useful for debugging data issues, testing ingestion changes, and reproducing parsing bugs locally."
 keywords: ["raw payload storage wearables", "wearable data debug", "health api payload capture", "open wearables debug"]
 "og:title": "Raw Payload Storage | Open Wearables Debug Tool"

--- a/docs/faqs.mdx
+++ b/docs/faqs.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Open Wearables FAQs | Common Questions Answered"
+sidebarTitle: "FAQs"
 description: "Answers to common Open Wearables questions: what it is, pricing, supported providers, self-hosting, API keys, and data privacy. MIT license, $0 per user."
 keywords: ["open wearables faq", "wearable api questions", "open wearables pricing", "open wearables self-hosted"]
 "og:title": "Open Wearables FAQs | Common Questions Answered"

--- a/docs/providers/apple-health.mdx
+++ b/docs/providers/apple-health.mdx
@@ -1,5 +1,6 @@
 ---
 title: "HealthKit Integration with Open Wearables | Apple Health"
+sidebarTitle: "Apple Health"
 description: "Integrate Apple Health via HealthKit using the Open Wearables Flutter SDK. Push-based sync for steps, heart rate, sleep, workouts, and HRV. Requires iOS 13+ and Apple Developer account."
 keywords: ["healthkit integration", "apple health api", "apple health data", "healthkit open source"]
 "og:title": "HealthKit Integration with Open Wearables | Apple Health"

--- a/docs/providers/fitbit-api-integration.mdx
+++ b/docs/providers/fitbit-api-integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Fitbit API Integration | Open Wearables"
+sidebarTitle: "Fitbit API Integration"
 description: "Connect Fitbit via OAuth 2.0 to sync workout and activity data. Free Fitbit account required. Pull-based syncing only, no webhooks. No special developer permissions needed."
 keywords: ["fitbit api integration", "fitbit oauth", "fitbit health data", "fitbit api"]
 "og:title": "Fitbit API Integration | Open Wearables"

--- a/docs/providers/garmin-api-integration.mdx
+++ b/docs/providers/garmin-api-integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Garmin API Integration | Open Wearables"
+sidebarTitle: "Garmin API Integration"
 description: "Connect Garmin devices via Garmin Connect OAuth 2.0. Syncs activities, sleep, HRV, body composition, and daily summaries. Requires legal entity and Garmin Developer Program approval."
 keywords: ["garmin api", "garmin connect api", "garmin health data", "garmin api integration"]
 "og:title": "Garmin API Integration | Open Wearables"

--- a/docs/providers/polar-api-integration.mdx
+++ b/docs/providers/polar-api-integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Polar API Integration | Open Wearables"
+sidebarTitle: "Polar API Integration"
 description: "Connect Polar devices via the AccessLink API with OAuth 2.0. Syncs exercise and workout data. Client ID and Secret from Polar AccessLink Admin. Free Polar Flow account required."
 keywords: ["polar api", "polar api integration", "polar health data", "polar fitness api"]
 "og:title": "Polar API Integration | Open Wearables"

--- a/docs/providers/strava-api-integration.mdx
+++ b/docs/providers/strava-api-integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Strava API Integration | Open Wearables"
+sidebarTitle: "Strava API Integration"
 description: "Connect Strava via OAuth 2.0 for personal activity sync. Single-user only, no analytics layer. Real-time webhooks for new activities plus polling for historical data."
 keywords: ["strava api integration", "strava oauth", "strava activity data", "strava api"]
 "og:title": "Strava API Integration | Open Wearables"

--- a/docs/providers/supported.mdx
+++ b/docs/providers/supported.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Supported Wearable Device Integrations | Open Wearables"
+sidebarTitle: "Supported Providers"
 description: "Open Wearables supports 9 providers: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Ultrahuman, Apple Health, and Google Health Connect. Cloud OAuth and SDK-based integrations."
 keywords: ["wearable device integrations", "supported wearables api", "wearable api providers", "open wearables"]
 "og:title": "Supported Wearable Device Integrations | Open Wearables"

--- a/docs/providers/suunto-api-integration.mdx
+++ b/docs/providers/suunto-api-integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Suunto API Integration | Open Wearables"
+sidebarTitle: "Suunto API Integration"
 description: "Connect Suunto devices via OAuth 2.0 to sync workout, sleep, and 24/7 health metrics. Requires Suunto Developer Program access. Full data type coverage across all Suunto devices."
 keywords: ["suunto api integration", "suunto oauth", "suunto health data", "suunto api"]
 "og:title": "Suunto API Integration | Open Wearables"

--- a/docs/providers/ultrahuman-api-integration.mdx
+++ b/docs/providers/ultrahuman-api-integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Ultrahuman Ring API Integration | Open Wearables"
+sidebarTitle: "Ultrahuman API Integration"
 description: "Connect Ultrahuman Ring Air via OAuth 2.0 to sync sleep stages, HRV, and 24/7 heart rate. Requires Ultrahuman Partnership API access. Pull-based syncing with daily metrics."
 keywords: ["ultrahuman api integration", "ultrahuman ring api", "ultrahuman health data", "ultrahuman hrv"]
 "og:title": "Ultrahuman Ring API Integration | Open Wearables"

--- a/docs/providers/whoop-api-integration.mdx
+++ b/docs/providers/whoop-api-integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Whoop API Integration | Open Wearables"
+sidebarTitle: "Whoop API Integration"
 description: "Connect Whoop via OAuth 2.0. Syncs workouts, sleep with stages, recovery scores, HRV, SpO2, and body measurements. Requires an active Whoop membership. Polling-based sync."
 keywords: ["whoop api", "whoop data integration", "whoop health data", "whoop api open source"]
 "og:title": "Whoop API Integration | Open Wearables"

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Wearable API Quickstart | Open Wearables Setup Guide"
+sidebarTitle: "Quickstart"
 description: "Make your first wearable API call in 5 minutes with this quickstart. Covers Docker setup, environment config, and your first authenticated health data request."
 keywords: ["wearable api quickstart", "open wearables setup", "health data api tutorial", "open wearables"]
 "og:title": "Wearable API Quickstart | Open Wearables Setup Guide"

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Open Wearables Roadmap: Current Features and Upcoming Plans"
+sidebarTitle: "Roadmap"
 description: "Track what's available and what's next in Open Wearables. Covers provider integrations, health scores in development, webhooks, and the AI health roadmap."
 keywords: ["open wearables roadmap", "wearable platform updates", "open source health api", "open wearables"]
 "og:title": "Open Wearables Roadmap: Current Features and Upcoming Plans"

--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Open Wearables Support | GitHub, Discord, and Docs"
+sidebarTitle: "Support"
 description: "Get Open Wearables support via GitHub Discussions, Issues, and Discord. Links to API docs, quickstart guide, FAQs, and provider setup guides for integration help."
 keywords: ["open wearables support", "wearable api help", "health data sdk support", "open wearables"]
 "og:title": "Open Wearables Support | GitHub, Discord, and Docs"


### PR DESCRIPTION
## Description

#822 added SEO frontmatter to all doc pages, but 21 pages were missing a `sidebarTitle` field - so the full SEO title (e.g. "Wearable API Quickstart | Open Wearables Setup Guide") was showing in the sidebar instead of the clean short name. This adds `sidebarTitle` to those 21 pages so the sidebar is back to normal while keeping the SEO titles intact.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation navigation by adding dedicated sidebar labels across multiple guide sections, including API references, architecture documentation, developer setup guides, provider integrations, quickstart, FAQ, roadmap, and support resources for clearer and more intuitive site navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->