### PR TITLE
fix: make save button a floating bar in provider settings

### DIFF
--- a/frontend/src/routes/_authenticated/settings/providers-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/providers-tab.tsx
@@ -33,7 +33,7 @@ export function ProvidersTab() {
   }, [providers, hasInitialized]);
 
   const hasChanges = useMemo(() => {
-    if (!providers) return false;
+    if (!providers || !hasInitialized) return false;
 
     return providers.some(
       (provider) => localToggleStates[provider.provider] !== provider.is_enabled

--- a/frontend/src/routes/_authenticated/settings/providers-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/providers-tab.tsx
@@ -83,28 +83,11 @@ export function ProvidersTab() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-xl font-medium text-white">OAuth Providers</h2>
-          <p className="text-sm text-zinc-500 mt-1">
-            Configure which OAuth providers are available to your end users
-          </p>
-        </div>
-        {hasChanges && (
-          <Button onClick={handleSave} disabled={updateMutation.isPending}>
-            {updateMutation.isPending ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Saving...
-              </>
-            ) : (
-              <>
-                <CheckCircle2 className="h-4 w-4" />
-                Save Changes
-              </>
-            )}
-          </Button>
-        )}
+      <div>
+        <h2 className="text-xl font-medium text-white">OAuth Providers</h2>
+        <p className="text-sm text-zinc-500 mt-1">
+          Configure which OAuth providers are available to your end users
+        </p>
       </div>
 
       <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl overflow-hidden">
@@ -130,6 +113,25 @@ export function ProvidersTab() {
           ))}
         </div>
       </div>
+
+      {hasChanges && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-4 rounded-lg border border-zinc-700 bg-zinc-900 px-6 py-3 shadow-lg shadow-black/50">
+          <p className="text-sm text-zinc-300">You have unsaved changes</p>
+          <Button onClick={handleSave} disabled={updateMutation.isPending}>
+            {updateMutation.isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              <>
+                <CheckCircle2 className="h-4 w-4" />
+                Save Changes
+              </>
+            )}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #816

The "Save Changes" button in provider settings was positioned in the header row and scrolled out of view when toggling providers further down the list. Users were toggling integrations, missing the button entirely, and leaving without saving.

Moved it to a floating bar fixed to the bottom center of the viewport - always visible when there are unsaved changes.

## Demo

https://github.com/user-attachments/assets/6e9d2f51-809c-4473-819f-7ce37a7c63cc

## Changes

- Replaced the inline header button with a fixed floating bar (`bottom-6`, centered)
- Bar shows "You have unsaved changes" label + save button
- Styled with border, solid background, and drop shadow so it stands out from page content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Moved the conditional "Save Changes" action from the header into a fixed bottom notification bar with existing save/loading visuals.

* **Bug Fixes**
  * Prevented premature "unsaved changes" detection on initial load so the Save bar only appears after settings have finished initializing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->