### PR TITLE
docs: rename Authorize Provider to Get Provider Authorization URL

### DIFF
--- a/backend/app/api/routes/v1/oauth.py
+++ b/backend/app/api/routes/v1/oauth.py
@@ -34,7 +34,12 @@ def get_oauth_strategy(provider: ProviderName) -> BaseProviderStrategy:
     return strategy
 
 
-@router.get("/{provider}/authorize", response_model=AuthorizationURLResponse, tags=["External: Providers"])
+@router.get(
+    "/{provider}/authorize",
+    summary="Get Provider Authorization URL",
+    response_model=AuthorizationURLResponse,
+    tags=["External: Providers"],
+)
 def authorize_provider(
     provider: ProviderName,
     user_id: Annotated[UUID, Query(description="User ID to connect")],

--- a/backend/app/api/routes/v1/oauth.py
+++ b/backend/app/api/routes/v1/oauth.py
@@ -37,6 +37,7 @@ def get_oauth_strategy(provider: ProviderName) -> BaseProviderStrategy:
 @router.get(
     "/{provider}/authorize",
     summary="Get Provider Authorization URL",
+    status_code=status.HTTP_200_OK,
     response_model=AuthorizationURLResponse,
     tags=["External: Providers"],
 )


### PR DESCRIPTION
## Summary
- Adds explicit `summary` to the authorize endpoint so the docs page title reads "Get Provider Authorization URL" instead of the auto-generated "Authorize Provider"
- Makes it immediately clear this endpoint returns a URL for user redirect, not that it performs the authorization itself

## Test plan
- [ ] Check the deployed docs page title after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved API documentation for the OAuth provider authorization endpoint: added an explicit summary and response status to make the endpoint description and expected response clearer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->