### PR TITLE
docs: fix localhost links in API reference

### DIFF
--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -22,14 +22,14 @@ Internal endpoints (dashboard management, team settings, webhook receivers) are 
   <Card
     title="Swagger UI (full API)"
     icon="terminal"
-    href="http://localhost:8000/docs"
+    href="https://api.openwearables.io/docs"
   >
     Interactive API explorer with all endpoints, including internal
   </Card>
   <Card
     title="OpenAPI JSON"
     icon="file-code"
-    href="http://localhost:8000/openapi.json"
+    href="https://api.openwearables.io/openapi.json"
   >
     Machine-readable OpenAPI 3.1 specification
   </Card>
@@ -185,8 +185,8 @@ Many endpoints support filtering and sorting. Check individual endpoint document
 ## OpenAPI Specification
 
 The complete OpenAPI specification is available at:
-- **Swagger UI:** `http://localhost:8000/docs`
-- **OpenAPI JSON:** `http://localhost:8000/openapi.json`
+- **Swagger UI:** `https://api.openwearables.io/docs`
+- **OpenAPI JSON:** `https://api.openwearables.io/openapi.json`
 
 <Tip>
   The OpenAPI specification is auto-generated from the API code and is always the most accurate reference.


### PR DESCRIPTION
## Summary
- Swagger UI and OpenAPI JSON links in the API reference intro pointed to `localhost:8000` - updated them to `api.openwearables.io`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API reference documentation links to point to the production API documentation endpoints in the introduction guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->