### PR TITLE
docs: clarify that icon_url is a relative URL

### DIFF
--- a/backend/app/schemas/model_crud/data_priority/provider_setting.py
+++ b/backend/app/schemas/model_crud/data_priority/provider_setting.py
@@ -8,7 +8,13 @@ class ProviderSettingRead(BaseModel):
     name: str = Field(..., description="Display name (e.g., 'Apple Health', 'Garmin')")
     has_cloud_api: bool = Field(..., description="Whether provider uses cloud OAuth API")
     is_enabled: bool = Field(..., description="Whether provider is enabled by admin")
-    icon_url: str = Field(..., description="URL to provider icon")
+    icon_url: str = Field(
+        ...,
+        description=(
+            "Relative URL to provider icon (e.g., '/static/provider-icons/garmin.svg')."
+            " Resolve against the API base URL."
+        ),
+    )
 
 
 class ProviderSettingUpdate(BaseModel):

--- a/docs/api-reference/guides/provider-setup.mdx
+++ b/docs/api-reference/guides/provider-setup.mdx
@@ -235,3 +235,7 @@ curl -X GET "http://localhost:8000/api/v1/oauth/providers?enabled_only=true" \
   }
 ]
 ```
+
+<Note>
+  `icon_url` is a **relative URL** (e.g., `/static/provider-icons/garmin.svg`). Resolve it against your API base URL to get the full path - for example, `https://your-api.example.com/static/provider-icons/garmin.svg`.
+</Note>


### PR DESCRIPTION
## Description

LLMs consuming our API docs assume `icon_url` from `GET /api/v1/oauth/providers` is an absolute URL. Updated the schema description and added a note in the provider setup guide to make it clear it's relative and needs to be resolved against the API base URL.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. Check the OpenAPI schema at `/docs` - the `icon_url` field description should mention "Relative URL"
2. Check the docs site provider setup guide - should have a `<Note>` callout about relative URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the `icon_url` field in OAuth provider responses is a relative URL (e.g., `/static/provider-icons/garmin.svg`) that must be resolved against the API base URL to obtain the full URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->