### PR TITLE
feat: add per-user data summary endpoint and dashboard display

### DIFF
--- a/backend/app/api/routes/v1/summaries.py
+++ b/backend/app/api/routes/v1/summaries.py
@@ -10,8 +10,9 @@ from app.schemas.responses.activity import (
     RecoverySummary,
     SleepSummary,
 )
+from app.schemas.responses.dashboard import UserDataSummaryResponse
 from app.schemas.utils import PaginatedResponse
-from app.services import ApiKeyDep
+from app.services import ApiKeyDep, system_info_service
 from app.services.summaries_service import summaries_service
 from app.utils.dates import parse_query_datetime
 
@@ -93,3 +94,13 @@ def get_body_summary(
     Returns null if no body data exists for the user.
     """
     return summaries_service.get_body_summary(db, user_id, average_period, latest_window_hours)
+
+
+@router.get("/users/{user_id}/summaries/data")
+def get_data_summary(
+    user_id: UUID,
+    db: DbSession,
+    _api_key: ApiKeyDep,
+) -> UserDataSummaryResponse:
+    """Returns per-user data counts grouped by series type, event type, and provider."""
+    return system_info_service.get_user_data_summary(db, user_id)

--- a/backend/app/repositories/data_point_series_repository.py
+++ b/backend/app/repositories/data_point_series_repository.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import IntegrityError as SQLAIntegrityError
 
 from app.database import DbSession
 from app.models import DataPointSeries, DataSource, DeviceTypePriority, ProviderPriority
+from app.models.series_type_definition import SeriesTypeDefinition
 from app.repositories.data_source_repository import DataSourceRepository
 from app.repositories.repositories import CrudRepository
 from app.schemas.enums import (
@@ -328,6 +329,26 @@ class DataPointSeriesRepository(
             return []
 
         return [count for _, count in daily_counts]
+
+    def get_user_counts_by_provider_and_type(self, db_session: DbSession, user_id: UUID) -> list[tuple[str, str, int]]:
+        """Get data point counts for a user grouped by provider and series type.
+
+        Returns list of (provider, series_type_code, count) tuples ordered by provider, then count descending.
+        """
+        results = (
+            db_session.query(
+                DataSource.provider,
+                SeriesTypeDefinition.code,
+                func.count(self.model.id).label("count"),
+            )
+            .join(DataSource, self.model.data_source_id == DataSource.id)
+            .join(SeriesTypeDefinition, self.model.series_type_definition_id == SeriesTypeDefinition.id)
+            .filter(DataSource.user_id == user_id)
+            .group_by(DataSource.provider, SeriesTypeDefinition.code)
+            .order_by(DataSource.provider, func.count(self.model.id).desc())
+            .all()
+        )
+        return [(provider, code, count) for provider, code, count in results]
 
     def get_count_by_series_type(self, db_session: DbSession) -> list[tuple[int, int]]:
         """Get count of data points grouped by series type ID.

--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -306,6 +306,28 @@ class EventRecordRepository(
 
         return query.limit(limit + 1).all(), total_count
 
+    def get_user_event_counts_by_provider(
+        self, db_session: DbSession, user_id: UUID
+    ) -> list[tuple[str, str, str | None, int]]:
+        """Get event record counts for a user grouped by provider, category, and type.
+
+        Returns list of (provider, category, type, count) tuples ordered by provider, then count descending.
+        """
+        results = (
+            db_session.query(
+                DataSource.provider,
+                self.model.category,
+                self.model.type,
+                func.count(self.model.id).label("count"),
+            )
+            .join(DataSource, self.model.data_source_id == DataSource.id)
+            .filter(DataSource.user_id == user_id)
+            .group_by(DataSource.provider, self.model.category, self.model.type)
+            .order_by(DataSource.provider, func.count(self.model.id).desc())
+            .all()
+        )
+        return [(provider, category, event_type, count) for provider, category, event_type, count in results]
+
     def get_count_by_workout_type(self, db_session: DbSession) -> list[tuple[str | None, int]]:
         """Get count of workouts grouped by workout type.
 

--- a/backend/app/schemas/responses/dashboard/__init__.py
+++ b/backend/app/schemas/responses/dashboard/__init__.py
@@ -1,0 +1,6 @@
+from .user_data_summary import ProviderDataCount, UserDataSummaryResponse
+
+__all__ = [
+    "ProviderDataCount",
+    "UserDataSummaryResponse",
+]

--- a/backend/app/schemas/responses/dashboard/user_data_summary.py
+++ b/backend/app/schemas/responses/dashboard/user_data_summary.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+
+
+class ProviderDataCount(BaseModel):
+    """Data counts for a single provider."""
+
+    provider: str
+    data_points: int
+    series_counts: dict[str, int]
+    workout_count: int
+    sleep_count: int
+
+
+class UserDataSummaryResponse(BaseModel):
+    """Per-user data summary with counts by type and provider."""
+
+    user_id: str
+    total_data_points: int
+    total_workouts: int
+    total_sleep_events: int
+    series_type_counts: dict[str, int]
+    workout_type_counts: dict[str, int]
+    by_provider: list[ProviderDataCount]

--- a/backend/app/services/system_info_service.py
+++ b/backend/app/services/system_info_service.py
@@ -1,9 +1,12 @@
+from collections import defaultdict
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from logging import Logger, getLogger
+from uuid import UUID
 
 from app.database import DbSession
 from app.schemas.enums import get_series_type_from_id
+from app.schemas.responses.dashboard import ProviderDataCount, UserDataSummaryResponse
 from app.schemas.responses.upload import (
     CountWithGrowth,
     DataPointsInfo,
@@ -121,6 +124,61 @@ class SystemInfoService:
                 top_series_types=top_series_types,
                 top_workout_types=top_workout_types,
             ),
+        )
+
+    def get_user_data_summary(self, db_session: DbSession, user_id: UUID) -> UserDataSummaryResponse:
+        """Get per-user data summary with counts by type and provider."""
+        # Query time-series counts grouped by provider + series type
+        series_rows = self.timeseries_service.crud.get_user_counts_by_provider_and_type(db_session, user_id)
+
+        # Query event counts grouped by provider + category + type
+        event_rows = self.event_record_service.crud.get_user_event_counts_by_provider(db_session, user_id)
+
+        # Aggregate into per-provider and overall totals
+        provider_series: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+        provider_workouts: dict[str, int] = defaultdict(int)
+        provider_sleep: dict[str, int] = defaultdict(int)
+        provider_data_points: dict[str, int] = defaultdict(int)
+        series_type_totals: dict[str, int] = defaultdict(int)
+        workout_type_totals: dict[str, int] = defaultdict(int)
+
+        for provider, code, count in series_rows:
+            provider_series[provider][code] += count
+            provider_data_points[provider] += count
+            series_type_totals[code] += count
+
+        for provider, category, event_type, count in event_rows:
+            if category == "workout":
+                provider_workouts[provider] += count
+                workout_type_totals[event_type or "unknown"] += count
+            elif category == "sleep":
+                provider_sleep[provider] += count
+
+        # Build per-provider breakdown
+        all_providers = set(provider_series) | set(provider_workouts) | set(provider_sleep)
+        by_provider = sorted(
+            [
+                ProviderDataCount(
+                    provider=p,
+                    data_points=provider_data_points.get(p, 0),
+                    series_counts=dict(provider_series.get(p, {})),
+                    workout_count=provider_workouts.get(p, 0),
+                    sleep_count=provider_sleep.get(p, 0),
+                )
+                for p in all_providers
+            ],
+            key=lambda x: x.data_points + x.workout_count + x.sleep_count,
+            reverse=True,
+        )
+
+        return UserDataSummaryResponse(
+            user_id=str(user_id),
+            total_data_points=sum(provider_data_points.values()),
+            total_workouts=sum(provider_workouts.values()),
+            total_sleep_events=sum(provider_sleep.values()),
+            series_type_counts=dict(sorted(series_type_totals.items(), key=lambda x: x[1], reverse=True)),
+            workout_type_counts=dict(sorted(workout_type_totals.items(), key=lambda x: x[1], reverse=True)),
+            by_provider=by_provider,
         )
 
 

--- a/backend/tests/services/test_user_data_summary.py
+++ b/backend/tests/services/test_user_data_summary.py
@@ -1,0 +1,138 @@
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from app.schemas.enums import ProviderName
+from app.services.system_info_service import system_info_service
+from tests.factories import (
+    DataPointSeriesFactory,
+    DataSourceFactory,
+    EventRecordFactory,
+    SeriesTypeDefinitionFactory,
+    UserFactory,
+)
+
+
+class TestGetUserDataSummary:
+    """Tests for SystemInfoService.get_user_data_summary."""
+
+    def test_empty_user(self, db: Session) -> None:
+        """User with no data returns all zeros."""
+        user = UserFactory()
+        result = system_info_service.get_user_data_summary(db, user.id)
+
+        assert result.user_id == str(user.id)
+        assert result.total_data_points == 0
+        assert result.total_workouts == 0
+        assert result.total_sleep_events == 0
+        assert result.series_type_counts == {}
+        assert result.workout_type_counts == {}
+        assert result.by_provider == []
+
+    def test_series_type_counts(self, db: Session) -> None:
+        """Counts data points grouped by series type."""
+        user = UserFactory()
+        ds = DataSourceFactory(user=user, provider=ProviderName.APPLE)
+        hr_type = SeriesTypeDefinitionFactory.get_or_create_heart_rate()
+        steps_type = SeriesTypeDefinitionFactory.get_or_create_steps()
+
+        for _ in range(3):
+            DataPointSeriesFactory(data_source=ds, series_type=hr_type)
+        for _ in range(2):
+            DataPointSeriesFactory(data_source=ds, series_type=steps_type)
+
+        result = system_info_service.get_user_data_summary(db, user.id)
+
+        assert result.total_data_points == 5
+        assert result.series_type_counts["heart_rate"] == 3
+        assert result.series_type_counts["steps"] == 2
+
+    def test_workout_and_sleep_counts(self, db: Session) -> None:
+        """Counts workouts and sleep events separately."""
+        user = UserFactory()
+        ds = DataSourceFactory(user=user, provider=ProviderName.GARMIN)
+
+        for _ in range(4):
+            EventRecordFactory(data_source=ds, category="workout", type="running")
+        for _ in range(2):
+            EventRecordFactory(data_source=ds, category="workout", type="cycling")
+        for _ in range(3):
+            EventRecordFactory(data_source=ds, category="sleep", type="sleep_session")
+
+        result = system_info_service.get_user_data_summary(db, user.id)
+
+        assert result.total_workouts == 6
+        assert result.total_sleep_events == 3
+        assert result.workout_type_counts["running"] == 4
+        assert result.workout_type_counts["cycling"] == 2
+
+    def test_multi_provider_breakdown(self, db: Session) -> None:
+        """Breaks down counts by provider."""
+        user = UserFactory()
+        apple_ds = DataSourceFactory(user=user, provider=ProviderName.APPLE)
+        garmin_ds = DataSourceFactory(user=user, provider=ProviderName.GARMIN)
+        hr_type = SeriesTypeDefinitionFactory.get_or_create_heart_rate()
+
+        for _ in range(5):
+            DataPointSeriesFactory(data_source=apple_ds, series_type=hr_type)
+        for _ in range(3):
+            DataPointSeriesFactory(data_source=garmin_ds, series_type=hr_type)
+
+        EventRecordFactory(data_source=apple_ds, category="workout", type="running")
+        EventRecordFactory(data_source=garmin_ds, category="sleep", type="sleep_session")
+
+        result = system_info_service.get_user_data_summary(db, user.id)
+
+        assert len(result.by_provider) == 2
+
+        providers_by_name = {p.provider: p for p in result.by_provider}
+        apple = providers_by_name[ProviderName.APPLE]
+        garmin = providers_by_name[ProviderName.GARMIN]
+
+        assert apple.data_points == 5
+        assert apple.series_counts["heart_rate"] == 5
+        assert apple.workout_count == 1
+        assert apple.sleep_count == 0
+
+        assert garmin.data_points == 3
+        assert garmin.series_counts["heart_rate"] == 3
+        assert garmin.workout_count == 0
+        assert garmin.sleep_count == 1
+
+    def test_does_not_include_other_users(self, db: Session) -> None:
+        """Only counts data belonging to the requested user."""
+        user_a = UserFactory()
+        user_b = UserFactory()
+        ds_a = DataSourceFactory(user=user_a, provider=ProviderName.APPLE)
+        ds_b = DataSourceFactory(user=user_b, provider=ProviderName.APPLE)
+        hr_type = SeriesTypeDefinitionFactory.get_or_create_heart_rate()
+
+        for _ in range(3):
+            DataPointSeriesFactory(data_source=ds_a, series_type=hr_type)
+        for _ in range(7):
+            DataPointSeriesFactory(data_source=ds_b, series_type=hr_type)
+
+        result = system_info_service.get_user_data_summary(db, user_a.id)
+        assert result.total_data_points == 3
+
+    def test_nonexistent_user(self, db: Session) -> None:
+        """Returns empty summary for a user ID with no data."""
+        result = system_info_service.get_user_data_summary(db, uuid4())
+        assert result.total_data_points == 0
+        assert result.by_provider == []
+
+    def test_providers_sorted_by_total_records(self, db: Session) -> None:
+        """Providers are sorted by total record count descending."""
+        user = UserFactory()
+        small_ds = DataSourceFactory(user=user, provider=ProviderName.OURA)
+        big_ds = DataSourceFactory(user=user, provider=ProviderName.APPLE)
+        hr_type = SeriesTypeDefinitionFactory.get_or_create_heart_rate()
+
+        DataPointSeriesFactory(data_source=small_ds, series_type=hr_type)
+        for _ in range(10):
+            DataPointSeriesFactory(data_source=big_ds, series_type=hr_type)
+
+        result = system_info_service.get_user_data_summary(db, user.id)
+
+        assert result.by_provider[0].provider == ProviderName.APPLE
+        assert result.by_provider[1].provider == ProviderName.OURA

--- a/frontend/src/components/user/data-summary-section.tsx
+++ b/frontend/src/components/user/data-summary-section.tsx
@@ -1,0 +1,257 @@
+import { Database, Dumbbell, Moon, ChevronDown, ChevronUp } from 'lucide-react';
+import { useState } from 'react';
+import { useUserDataSummary } from '@/hooks/api/use-health';
+import { formatNumber } from '@/lib/utils/format';
+import type { ProviderDataCount } from '@/lib/api/types';
+
+interface DataSummarySectionProps {
+  userId: string;
+}
+
+function formatSeriesType(code: string): string {
+  return code.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatProvider(provider: string): string {
+  return provider.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function StatCard({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  value: number;
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-zinc-800 bg-zinc-900/30 p-4">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-zinc-800">
+        <Icon className="h-4 w-4 text-zinc-400" />
+      </div>
+      <div>
+        <p className="text-xs text-zinc-500">{label}</p>
+        <p className="text-lg font-semibold text-white">
+          {formatNumber(value)}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function SeriesTypeTable({
+  counts,
+  limit,
+}: {
+  counts: Record<string, number>;
+  limit?: number;
+}) {
+  const entries = Object.entries(counts);
+  const displayed = limit ? entries.slice(0, limit) : entries;
+
+  if (displayed.length === 0) {
+    return <p className="text-sm text-zinc-500">No data points</p>;
+  }
+
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="border-b border-zinc-800 text-left">
+          <th className="pb-2 font-medium text-zinc-500">Type</th>
+          <th className="pb-2 text-right font-medium text-zinc-500">Count</th>
+        </tr>
+      </thead>
+      <tbody>
+        {displayed.map(([type, count]) => (
+          <tr key={type} className="border-b border-zinc-800/50">
+            <td className="py-1.5 text-zinc-300">{formatSeriesType(type)}</td>
+            <td className="py-1.5 text-right tabular-nums text-zinc-400">
+              {formatNumber(count)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function ProviderCard({ provider }: { provider: ProviderDataCount }) {
+  const [expanded, setExpanded] = useState(false);
+  const totalRecords =
+    provider.data_points + provider.workout_count + provider.sleep_count;
+  const seriesEntries = Object.entries(provider.series_counts);
+
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-900/30">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-zinc-800/30 transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-medium text-white">
+            {formatProvider(provider.provider)}
+          </span>
+          <span className="text-xs text-zinc-500">
+            {formatNumber(totalRecords)} records
+          </span>
+        </div>
+        {expanded ? (
+          <ChevronUp className="h-4 w-4 text-zinc-500" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-zinc-500" />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="border-t border-zinc-800 px-4 py-3 space-y-3">
+          <div className="grid grid-cols-3 gap-3 text-center">
+            <div>
+              <p className="text-xs text-zinc-500">Data Points</p>
+              <p className="text-sm font-medium text-zinc-300">
+                {formatNumber(provider.data_points)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-zinc-500">Workouts</p>
+              <p className="text-sm font-medium text-zinc-300">
+                {formatNumber(provider.workout_count)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-zinc-500">Sleep</p>
+              <p className="text-sm font-medium text-zinc-300">
+                {formatNumber(provider.sleep_count)}
+              </p>
+            </div>
+          </div>
+
+          {seriesEntries.length > 0 && (
+            <SeriesTypeTable counts={provider.series_counts} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-3 gap-4">
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-[72px] rounded-lg border border-zinc-800 bg-zinc-800/30 animate-pulse"
+          />
+        ))}
+      </div>
+      <div className="space-y-2">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-8 bg-zinc-800/30 rounded animate-pulse" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function DataSummarySection({ userId }: DataSummarySectionProps) {
+  const { data, isLoading } = useUserDataSummary(userId);
+  const [showAllTypes, setShowAllTypes] = useState(false);
+
+  const isEmpty =
+    data &&
+    data.total_data_points === 0 &&
+    data.total_workouts === 0 &&
+    data.total_sleep_events === 0;
+
+  return (
+    <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl overflow-hidden">
+      <div className="px-6 py-4 border-b border-zinc-800">
+        <h2 className="text-sm font-medium text-white">Data Summary</h2>
+        <p className="text-xs text-zinc-500 mt-1">
+          Overview of all health data collected for this user
+        </p>
+      </div>
+      <div className="p-6">
+        {isLoading ? (
+          <LoadingSkeleton />
+        ) : isEmpty ? (
+          <div className="text-center py-8">
+            <p className="text-zinc-500">No data collected yet</p>
+          </div>
+        ) : data ? (
+          <div className="space-y-6">
+            {/* Summary stats */}
+            <div className="grid grid-cols-3 gap-4">
+              <StatCard
+                icon={Database}
+                label="Data Points"
+                value={data.total_data_points}
+              />
+              <StatCard
+                icon={Dumbbell}
+                label="Workouts"
+                value={data.total_workouts}
+              />
+              <StatCard
+                icon={Moon}
+                label="Sleep Events"
+                value={data.total_sleep_events}
+              />
+            </div>
+
+            {/* Series types */}
+            {Object.keys(data.series_type_counts).length > 0 && (
+              <div>
+                <h3 className="text-xs font-medium text-zinc-500 mb-2">
+                  Series Types
+                </h3>
+                <SeriesTypeTable
+                  counts={data.series_type_counts}
+                  limit={showAllTypes ? undefined : 8}
+                />
+                {Object.keys(data.series_type_counts).length > 8 && (
+                  <button
+                    type="button"
+                    onClick={() => setShowAllTypes(!showAllTypes)}
+                    className="mt-2 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+                  >
+                    {showAllTypes
+                      ? 'Show less'
+                      : `Show all ${Object.keys(data.series_type_counts).length} types`}
+                  </button>
+                )}
+              </div>
+            )}
+
+            {/* Workout types */}
+            {Object.keys(data.workout_type_counts).length > 0 && (
+              <div>
+                <h3 className="text-xs font-medium text-zinc-500 mb-2">
+                  Workout Types
+                </h3>
+                <SeriesTypeTable counts={data.workout_type_counts} />
+              </div>
+            )}
+
+            {/* Provider breakdown */}
+            {data.by_provider.length > 0 && (
+              <div>
+                <h3 className="text-xs font-medium text-zinc-500 mb-2">
+                  By Provider
+                </h3>
+                <div className="space-y-2">
+                  {data.by_provider.map((provider) => (
+                    <ProviderCard key={provider.provider} provider={provider} />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/user/profile-section.tsx
+++ b/frontend/src/components/user/profile-section.tsx
@@ -16,6 +16,7 @@ import {
 import { formatDate, truncateId } from '@/lib/utils/format';
 import { copyToClipboard } from '@/lib/utils/clipboard';
 import { ConnectionCard } from '@/components/user/connection-card';
+import { DataSummarySection } from '@/components/user/data-summary-section';
 
 interface ProfileSectionProps {
   userId: string;
@@ -216,6 +217,9 @@ export function ProfileSection({ userId }: ProfileSectionProps) {
             )}
           </div>
         </div>
+
+        {/* Data Summary */}
+        <DataSummarySection userId={userId} />
       </div>
 
       {/* Edit User Dialog */}

--- a/frontend/src/hooks/api/use-health.ts
+++ b/frontend/src/hooks/api/use-health.ts
@@ -108,6 +108,19 @@ export function useActivitySummaries(userId: string, params: SummaryParams) {
 }
 
 /**
+ * Get per-user data summary with counts by type and provider
+ * Uses GET /api/v1/users/{user_id}/summaries/data
+ */
+export function useUserDataSummary(userId: string) {
+  return useQuery({
+    queryKey: queryKeys.health.dataSummary(userId),
+    queryFn: () => healthService.getUserDataSummary(userId),
+    enabled: !!userId,
+    staleTime: 2 * 60 * 1000,
+  });
+}
+
+/**
  * Get body summary for a user (static, averaged, latest metrics)
  * Uses GET /api/v1/users/{user_id}/summaries/body
  */

--- a/frontend/src/hooks/api/use-health.ts
+++ b/frontend/src/hooks/api/use-health.ts
@@ -173,6 +173,9 @@ export function useSynchronizeDataFromProvider(
         queryKey: queryKeys.health.bodySummary(userId),
       });
       queryClient.invalidateQueries({
+        queryKey: queryKeys.health.dataSummary(userId),
+      });
+      queryClient.invalidateQueries({
         queryKey: queryKeys.health.healthScores(userId),
       });
 

--- a/frontend/src/lib/api/config.ts
+++ b/frontend/src/lib/api/config.ts
@@ -72,6 +72,9 @@ export const API_ENDPOINTS = {
   // Accept invitation (public - no auth)
   acceptInvitation: '/api/v1/invitations/accept',
 
+  // Data summary endpoint
+  userDataSummary: (userId: string) => `/api/v1/users/${userId}/summaries/data`,
+
   // Summary endpoints (authenticated - requires user authorization)
   userActivitySummary: (userId: string) =>
     `/api/v1/users/${userId}/summaries/activity`,

--- a/frontend/src/lib/api/services/health.service.ts
+++ b/frontend/src/lib/api/services/health.service.ts
@@ -18,6 +18,7 @@ import type {
   RecoverySummary,
   SleepSession,
   SleepSessionsParams,
+  UserDataSummary,
 } from '../types';
 
 export interface WorkoutsParams {
@@ -256,6 +257,15 @@ export const healthService = {
     return apiClient.get<PaginatedResponse<SleepSession>>(
       API_ENDPOINTS.userSleepSessions(userId),
       { params }
+    );
+  },
+
+  /**
+   * Get per-user data summary with counts by type and provider
+   */
+  async getUserDataSummary(userId: string): Promise<UserDataSummary> {
+    return apiClient.get<UserDataSummary>(
+      API_ENDPOINTS.userDataSummary(userId)
     );
   },
 };

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -185,6 +185,24 @@ export interface DashboardStats {
   data_points: DataPointsInfo;
 }
 
+export interface ProviderDataCount {
+  provider: string;
+  data_points: number;
+  series_counts: Record<string, number>;
+  workout_count: number;
+  sleep_count: number;
+}
+
+export interface UserDataSummary {
+  user_id: string;
+  total_data_points: number;
+  total_workouts: number;
+  total_sleep_events: number;
+  series_type_counts: Record<string, number>;
+  workout_type_counts: Record<string, number>;
+  by_provider: ProviderDataCount[];
+}
+
 export interface Provider {
   provider: string;
   name: string;

--- a/frontend/src/lib/query/keys.ts
+++ b/frontend/src/lib/query/keys.ts
@@ -87,6 +87,8 @@ export const queryKeys = {
       [...queryKeys.health.all, 'workouts', userId, params] as const,
     timeseries: (userId: string, params?: unknown) =>
       [...queryKeys.health.all, 'timeseries', userId, params] as const,
+    dataSummary: (userId: string) =>
+      [...queryKeys.health.all, 'dataSummary', userId] as const,
   },
 
   connections: {


### PR DESCRIPTION
## Description

Adds a new `GET /users/{user_id}/summaries/data` endpoint that shows what data exists for a user - series type counts, workout/sleep event counts, and everything broken down by provider. The data is displayed in a new "Data Summary" section on the user profile tab, right below Connected Providers.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes

## Testing Instructions

**Steps to test:**
1. Navigate to any user's profile tab in the dashboard
2. Below "Connected Providers", you should see a new "Data Summary" card
3. Verify it shows total data points, workouts, and sleep events
4. Click on a provider card to expand and see per-provider breakdown with series type details
5. Test with a user that has no data - should show "No data collected yet" empty state

**Expected behavior:**
- Summary stats show correct totals matching the user's actual data
- Series types table lists all types the user has data for, sorted by count
- Provider breakdown is collapsible and shows per-provider counts
- The endpoint also works via API key auth for external consumers

## Screenshots 

General summary: 

<img width="1273" height="812" alt="image" src="https://github.com/user-attachments/assets/2f50257e-5470-4811-861c-3c8b8dfe18e4" />


Per provider breakdown: 

<img width="1312" height="852" alt="image" src="https://github.com/user-attachments/assets/b848c2d7-5bb6-406e-978c-c0ab9c2597df" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User Data Summary dashboard: aggregated totals for data points, workouts, and sleep with provider breakdowns and per-type tables.
  * Collapsible provider cards and toggled "show all" for series/workout type lists.
  * Frontend hook and API integration to fetch and refresh the summary.

* **Tests**
  * Added comprehensive tests validating aggregation, per-provider breakdown, scoping to the requested user, empty states, and ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->