### PR TITLE
fix: prevent sleep duration duplication during merge and log skips

### DIFF
--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -205,6 +205,11 @@ class EventRecordService(
             # retry, score update).  Replace the detail with fresh values instead
             # of accumulating them on top of the existing ones.
             if record.external_id is not None and adjacent.external_id == record.external_id:
+                for field in ("start_datetime", "end_datetime", "duration_seconds", "zone_offset"):
+                    new_val = getattr(record, field, None)
+                    if new_val is not None:
+                        setattr(adjacent, field, new_val)
+                db_session.flush()
                 self.event_record_detail_repo.delete_by_record_id(db_session, adjacent.id)
                 self.event_record_detail_repo.create_and_flush(
                     db_session,

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -201,6 +201,19 @@ class EventRecordService(
         )
 
         if adjacent is not None:
+            # Same external_id → re-ingestion of the same session (e.g. webhook
+            # retry, score update).  Replace the detail with fresh values instead
+            # of accumulating them on top of the existing ones.
+            if record.external_id is not None and adjacent.external_id == record.external_id:
+                self.event_record_detail_repo.delete_by_record_id(db_session, adjacent.id)
+                self.event_record_detail_repo.create_and_flush(
+                    db_session,
+                    detail.model_copy(update={"record_id": adjacent.id}),
+                    detail_type="sleep",
+                )
+                db_session.commit()
+                return adjacent
+
             adj_detail: SleepDetails | None = adjacent.detail if isinstance(adjacent.detail, SleepDetails) else None
 
             def _adj_int(attr: str) -> int:

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -205,10 +205,11 @@ class EventRecordService(
             # retry, score update).  Replace the detail with fresh values instead
             # of accumulating them on top of the existing ones.
             if record.external_id is not None and adjacent.external_id == record.external_id:
-                for field in ("start_datetime", "end_datetime", "duration_seconds", "zone_offset"):
+                for field in ("start_datetime", "end_datetime", "zone_offset"):
                     new_val = getattr(record, field, None)
                     if new_val is not None:
                         setattr(adjacent, field, new_val)
+                adjacent.duration_seconds = int((adjacent.end_datetime - adjacent.start_datetime).total_seconds())
                 db_session.flush()
                 self.event_record_detail_repo.delete_by_record_id(db_session, adjacent.id)
                 self.event_record_detail_repo.create_and_flush(
@@ -217,7 +218,7 @@ class EventRecordService(
                     detail_type="sleep",
                 )
                 db_session.commit()
-                return adjacent
+                return adjacent, False, detail
 
             adj_detail: SleepDetails | None = adjacent.detail if isinstance(adjacent.detail, SleepDetails) else None
 

--- a/backend/app/services/scores/sleep_service.py
+++ b/backend/app/services/scores/sleep_service.py
@@ -8,7 +8,6 @@ four-pillar algorithm (duration, stages, consistency, interruptions):
 - SleepScoreService.get_sleep_scores_for_date_range - DB-backed; multiple dates, one DB query
 """
 
-from contextlib import suppress
 from datetime import date, datetime, timedelta, timezone
 from logging import Logger, getLogger
 from uuid import UUID
@@ -24,6 +23,7 @@ from app.repositories.event_record_repository import EventRecordRepository
 from app.schemas.model_crud.activities import EventRecordQueryParams
 from app.schemas.model_crud.activities.sleep import SleepStage
 from app.utils.exceptions import ResourceNotFoundError, handle_exceptions
+from app.utils.structured_logging import log_structured
 
 
 class WasoData(BaseModel):
@@ -284,6 +284,7 @@ class SleepScoreService:
         target_dates = set(dates)
 
         results: dict[date, SleepScoreResult] = {}
+        skipped: list[tuple[date, str, str]] = []  # (date, record_id, reason)
         for i, sleep_date in enumerate(all_nights_asc):
             if sleep_date not in target_dates:
                 continue
@@ -304,7 +305,7 @@ class SleepScoreService:
             if detail.sleep_stages:
                 sleep_stages = [SleepStage(**s) for s in detail.sleep_stages]
 
-            with suppress(ValueError):
+            try:
                 results[sleep_date] = self.get_sleep_score(
                     total_sleep_duration_minutes=float(detail.sleep_total_duration_minutes or 0),
                     deep_minutes=float(detail.sleep_deep_minutes or 0),
@@ -314,6 +315,19 @@ class SleepScoreService:
                     historical_bedtimes=historical_bedtimes,
                     sleep_stages=sleep_stages,
                 )
+            except (ValueError, OverflowError) as exc:
+                skipped.append((sleep_date, str(record.id), str(exc)))
+
+        if skipped:
+            log_structured(
+                self.logger,
+                "warning",
+                f"Skipped sleep score for {len(skipped)} date(s): invalid session data",
+                skipped=[
+                    {"date": str(d), "record_id": rid, "reason": reason}
+                    for d, rid, reason in skipped
+                ],
+            )
 
         return results
 

--- a/backend/app/services/scores/sleep_service.py
+++ b/backend/app/services/scores/sleep_service.py
@@ -323,10 +323,7 @@ class SleepScoreService:
                 self.logger,
                 "warning",
                 f"Skipped sleep score for {len(skipped)} date(s): invalid session data",
-                skipped=[
-                    {"date": str(d), "record_id": rid, "reason": reason}
-                    for d, rid, reason in skipped
-                ],
+                skipped=[{"date": str(d), "record_id": rid, "reason": reason} for d, rid, reason in skipped],
             )
 
         return results


### PR DESCRIPTION
## Description

 prevent sleep duration duplication during merge and log skips

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * When duplicate sleep records with matching identifiers are detected, the system now refreshes the existing record’s core timestamps, recalculates duration, and replaces associated detail rows instead of proceeding with the previous merge flow.
  * Improved error handling for nightly sleep score computation: failing nights are skipped (not silently suppressed) and structured warnings are emitted with per-night metadata to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->