### PR TITLE
feat: add resilience score celery task

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -90,7 +90,9 @@ class Settings(BaseSettings):
     # SCORE SETTINGS
     score_backfill_days: int = 30  # How far back the missing-score query looks
     sleep_score_interval_seconds: int = 600  # How often to run the fill-missing-scores task (default: 10 min)
-    resilience_score_interval_seconds: int = 600  # How often to run the fill-missing-resilience-scores task (default: 10 min)
+    resilience_score_interval_seconds: int = (
+        600  # How often to run the fill-missing-resilience-scores task (default: 10 min)
+    )
 
     # API SETTINGS
     api_base_url: str = "http://localhost:8000"

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -90,6 +90,7 @@ class Settings(BaseSettings):
     # SCORE SETTINGS
     score_backfill_days: int = 30  # How far back the missing-score query looks
     sleep_score_interval_seconds: int = 600  # How often to run the fill-missing-scores task (default: 10 min)
+    resilience_score_interval_seconds: int = 600  # How often to run the fill-missing-resilience-scores task (default: 10 min)
 
     # API SETTINGS
     api_base_url: str = "http://localhost:8000"

--- a/backend/app/integrations/celery/core.py
+++ b/backend/app/integrations/celery/core.py
@@ -111,6 +111,12 @@ def create_celery() -> Celery:
             "args": (),
             "kwargs": {},
         },
+        "fill-missing-resilience-scores": {
+            "task": "app.integrations.celery.tasks.fill_missing_resilience_scores_task.fill_missing_resilience_scores",
+            "schedule": float(settings.resilience_score_interval_seconds),
+            "args": (),
+            "kwargs": {},
+        },
     }
 
     return celery_app

--- a/backend/app/integrations/celery/tasks/__init__.py
+++ b/backend/app/integrations/celery/tasks/__init__.py
@@ -19,6 +19,7 @@ from app.services.providers.garmin.backfill_state import (
 
 from .archival_task import run_daily_archival
 from .emit_webhook_event_task import emit_webhook_event
+from .fill_missing_resilience_scores_task import fill_missing_resilience_scores
 from .fill_missing_sleep_scores_task import fill_missing_sleep_scores
 from .finalize_stale_sleep_task import finalize_stale_sleeps
 from .garmin_backfill_task import (
@@ -60,6 +61,8 @@ __all__ = [
     "run_daily_archival",
     # Sleep score calculation
     "fill_missing_sleep_scores",
+    # Resilience score calculation
+    "fill_missing_resilience_scores",
     # Other tasks
     "finalize_stale_sleeps",
     "process_sdk_upload",

--- a/backend/app/integrations/celery/tasks/fill_missing_resilience_scores_task.py
+++ b/backend/app/integrations/celery/tasks/fill_missing_resilience_scores_task.py
@@ -1,0 +1,157 @@
+from collections import defaultdict
+from datetime import date, datetime, timezone
+from logging import getLogger
+from uuid import UUID, uuid4
+
+from sqlalchemy import text
+
+from app.algorithms.config_algorithms import resilience_config
+from app.config import settings
+from app.database import SessionLocal
+from app.schemas.enums import HealthScoreCategory, ProviderName, SeriesType, get_series_type_id
+from app.schemas.model_crud.activities.health_score import HealthScoreCreate, ScoreComponent
+from app.services.health_score_service import health_score_service
+from app.services.scores.resilience_service import resilience_score_service
+from app.utils.sentry_helpers import log_and_capture_error
+from app.utils.structured_logging import log_structured
+from celery import shared_task
+
+logger = getLogger(__name__)
+
+_RMSSD_TYPE_ID = get_series_type_id(SeriesType.heart_rate_variability_rmssd)
+_SDNN_TYPE_ID = get_series_type_id(SeriesType.heart_rate_variability_sdnn)
+
+# Find all (user, reference_date) pairs that are missing an OW resilience score.
+# active_users: users who have any RMSSD or SDNN data in the extended lookback window.
+# We cross-join with a date series covering the backfill window and filter out any
+# dates that already have a score, ensuring idempotency.
+_MISSING_RESILIENCE_SCORES_QUERY = text("""
+    SELECT DISTINCT
+        active_users.user_id,
+        gs.target_date::date AS reference_date
+    FROM generate_series(
+        CURRENT_DATE - :backfill_days * INTERVAL '1 day',
+        CURRENT_DATE,
+        INTERVAL '1 day'
+    ) AS gs(target_date)
+    CROSS JOIN (
+        SELECT DISTINCT ds.user_id
+        FROM data_point_series dp
+        JOIN data_source ds ON ds.id = dp.data_source_id
+        WHERE dp.series_type_definition_id IN (:rmssd_id, :sdnn_id)
+          AND dp.recorded_at >= CURRENT_DATE - :data_lookback_days * INTERVAL '1 day'
+    ) AS active_users
+    LEFT JOIN health_score hs
+           ON hs.user_id  = active_users.user_id
+          AND hs.category = 'resilience'
+          AND hs.provider = 'internal'
+          AND hs.recorded_at::date = gs.target_date::date
+    WHERE hs.id IS NULL
+    ORDER BY active_users.user_id, reference_date DESC
+""")
+
+
+@shared_task
+def fill_missing_resilience_scores() -> dict:
+    """Find (user, date) pairs without an OW resilience score and calculate them.
+
+    Runs frequently so scores appear shortly after any sync path that delivers
+    HRV data. Uses a LEFT JOIN against generate_series to guarantee idempotency
+    — already-scored dates are never re-processed.
+
+    Only dates where the service returns a non-null hrv_cv are persisted.
+    Dates where there is insufficient HRV data remain unscored so they are
+    retried on the next run once more data arrives.
+    """
+    with SessionLocal() as db:
+        rows = db.execute(
+            _MISSING_RESILIENCE_SCORES_QUERY,
+            {
+                "backfill_days": settings.score_backfill_days,
+                "rmssd_id": _RMSSD_TYPE_ID,
+                "sdnn_id": _SDNN_TYPE_ID,
+                "data_lookback_days": settings.score_backfill_days + resilience_config.lookback_days,
+            },
+        ).fetchall()
+
+        if not rows:
+            return {"saved": 0, "skipped": 0}
+
+        # Group reference dates per user
+        dates_by_user: dict[UUID, list[date]] = defaultdict(list)
+        for user_id, reference_date in rows:
+            dates_by_user[UUID(str(user_id))].append(reference_date)
+
+        log_structured(
+            logger,
+            "info",
+            f"Found {len(rows)} resilience score(s) missing across {len(dates_by_user)} user(s)",
+            task="fill_missing_resilience_scores",
+        )
+
+        total_saved = 0
+        total_skipped = 0
+
+        for uid, reference_dates in dates_by_user.items():
+            try:
+                scores_by_date = resilience_score_service.get_hrv_cv_scores_for_date_range(
+                    db, uid, reference_dates
+                )
+            except Exception as e:
+                total_skipped += len(reference_dates)
+                log_and_capture_error(
+                    e,
+                    logger,
+                    f"Failed to fetch HRV data for user {uid}",
+                    extra={"user_id": str(uid), "task": "fill_missing_resilience_scores"},
+                )
+                continue
+
+            scores_to_save = [
+                HealthScoreCreate(
+                    id=uuid4(),
+                    user_id=uid,
+                    data_source_id=None,
+                    provider=ProviderName.INTERNAL,
+                    category=HealthScoreCategory.RESILIENCE,
+                    value=result.hrv_cv,
+                    recorded_at=datetime(ref_date.year, ref_date.month, ref_date.day, tzinfo=timezone.utc),
+                    components={
+                        "days_counted": ScoreComponent(value=result.days_counted),
+                        "metric_type": ScoreComponent(qualifier=result.metric_type),
+                    },
+                )
+                for ref_date, result in scores_by_date.items()
+                if result.hrv_cv is not None
+            ]
+
+            # Dates with hrv_cv=None have insufficient data — leave unscored for retry.
+            total_skipped += len(reference_dates) - len(scores_to_save)
+
+            if not scores_to_save:
+                continue
+
+            try:
+                health_score_service.bulk_create(db, scores_to_save)
+                db.commit()
+                total_saved += len(scores_to_save)
+            except Exception as e:
+                db.rollback()
+                total_skipped += len(scores_to_save)
+                log_and_capture_error(
+                    e,
+                    logger,
+                    f"Failed to save resilience scores for user {uid}",
+                    extra={"user_id": str(uid), "task": "fill_missing_resilience_scores"},
+                )
+
+        log_structured(
+            logger,
+            "info",
+            f"Resilience score fill complete: {total_saved} saved, {total_skipped} skipped",
+            task="fill_missing_resilience_scores",
+            saved=total_saved,
+            skipped=total_skipped,
+        )
+
+        return {"saved": total_saved, "skipped": total_skipped}

--- a/backend/app/integrations/celery/tasks/fill_missing_resilience_scores_task.py
+++ b/backend/app/integrations/celery/tasks/fill_missing_resilience_scores_task.py
@@ -94,9 +94,7 @@ def fill_missing_resilience_scores() -> dict:
 
         for uid, reference_dates in dates_by_user.items():
             try:
-                scores_by_date = resilience_score_service.get_hrv_cv_scores_for_date_range(
-                    db, uid, reference_dates
-                )
+                scores_by_date = resilience_score_service.get_hrv_cv_scores_for_date_range(db, uid, reference_dates)
             except Exception as e:
                 total_skipped += len(reference_dates)
                 log_and_capture_error(

--- a/backend/app/services/scores/resilience_service.py
+++ b/backend/app/services/scores/resilience_service.py
@@ -352,7 +352,6 @@ class ResilienceScoreService:
         result = calculate_sdnn([v for _, v in filtered])
         return None if math.isnan(result) else result
 
-
     def get_hrv_cv_scores_for_date_range(
         self,
         db_session: DbSession,

--- a/backend/app/services/scores/resilience_service.py
+++ b/backend/app/services/scores/resilience_service.py
@@ -353,4 +353,84 @@ class ResilienceScoreService:
         return None if math.isnan(result) else result
 
 
+    def get_hrv_cv_scores_for_date_range(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        reference_dates: list[date],
+    ) -> dict[date, HrvCvScoreResult]:
+        """Calculate HRV-CV scores for multiple reference dates with a single DB fetch.
+
+        Fetches the full combined window (min reference_date - lookback_days to
+        max reference_date) once for sleep windows and HRV data, then computes
+        per-date CV in memory — avoiding the repeated overlapping queries that
+        individual get_hrv_cv_score calls would incur.
+
+        The metric type (RMSSD vs SDNN) is determined once across the full window:
+        RMSSD is preferred; SDNN is used only when no RMSSD data survives the
+        sleep-window filter.
+
+        Returns a dict mapping each reference_date to its HrvCvScoreResult.
+        Dates with insufficient data have hrv_cv=None in the result.
+        """
+        if not reference_dates:
+            return {}
+
+        earliest = min(reference_dates)
+        latest = max(reference_dates)
+
+        start_dt = datetime.combine(
+            earliest - timedelta(days=resilience_config.lookback_days),
+            time.min,
+            tzinfo=timezone.utc,
+        )
+        end_dt = datetime.combine(latest, time.min, tzinfo=timezone.utc)
+
+        # Fetch sleep windows and HRV data once for the full combined window.
+        windows = self._extract_asleep_windows(db_session, user_id, start_dt, end_dt, _ASLEEP_STAGES)
+
+        rmssd_type_id = get_series_type_id(SeriesType.heart_rate_variability_rmssd)
+        hrv_pts = self._query_data_series(db_session, user_id, rmssd_type_id, start_dt, end_dt)
+        filtered_hrv = self._filter_points_to_windows(hrv_pts, windows)
+        metric_type: str = "RMSSD"
+
+        if not filtered_hrv:
+            sdnn_type_id = get_series_type_id(SeriesType.heart_rate_variability_sdnn)
+            sdnn_pts = self._query_data_series(db_session, user_id, sdnn_type_id, start_dt, end_dt)
+            filtered_hrv = self._filter_points_to_windows(sdnn_pts, windows)
+            metric_type = "SDNN"
+
+        # Group all filtered points by UTC date once; reused for every reference_date.
+        by_day = self._group_by_day(filtered_hrv)
+
+        results: dict[date, HrvCvScoreResult] = {}
+        for ref_date in reference_dates:
+            all_days = [ref_date - timedelta(days=i) for i in range(resilience_config.lookback_days, 0, -1)]
+
+            daily_scores: list[DailyHrvScore] = []
+            for d in all_days:
+                vals = by_day.get(d, [])
+                avg = sum(vals) / len(vals) if vals else None
+                daily_scores.append(DailyHrvScore(date=d, hrv_value_ms=avg, has_data=(avg is not None)))
+
+            days_counted = sum(1 for ds in daily_scores if ds.has_data)
+            hrv_cv: float | None = None
+
+            if days_counted >= resilience_config.min_days_required:
+                valid_avgs = [ds.hrv_value_ms for ds in daily_scores if ds.hrv_value_ms is not None]
+                raw_cv = calculate_hrv_cv(valid_avgs)
+                if not math.isnan(raw_cv):
+                    hrv_cv = raw_cv
+
+            results[ref_date] = HrvCvScoreResult(
+                hrv_cv=hrv_cv,
+                metric_type=metric_type if filtered_hrv else None,
+                days_counted=days_counted,
+                lookback_days=resilience_config.lookback_days,
+                daily_scores=daily_scores,
+            )
+
+        return results
+
+
 resilience_score_service = ResilienceScoreService(log=getLogger(__name__))

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -59,6 +59,8 @@ AWS_SNS_TOPIC_ARN=arn:aws:sns:eu-north-1:123456789012:owear
 
 #--- SYNC SETTINGS ---#
 SYNC_INTERVAL_SECONDS=3600  # How often to run automatic sync (default: 1 hour)
+SLEEP_SCORE_INTERVAL_SECONDS=600  # How often to run the fill-missing-sleep-scores task (default: 10 min)
+RESILIENCE_SCORE_INTERVAL_SECONDS=600  # How often to run the fill-missing-resilience-scores task (default: 10 min)
 # Automatically dispatch a historical sync after a successful OAuth callback.
 # Set to false once your integration calls POST /sync/{provider}/users/{user_id}/sync/historical explicitly.
 # Will default to false in a future release.


### PR DESCRIPTION
## Description

Add daily celery task for calculating resilience scores that runs a query collecting backfill days' worth of sleeps without a healht score, then dispattches internal resilience score calculation in bulk

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated, configurable scheduled backfill for resilience scores (default: every 10 minutes).
  * Batched HRV-based score computation that processes multiple dates per user for efficiency.

* **Bug Fixes / Reliability**
  * Backfill is idempotent, skips insufficient-data dates, logs progress/errors, and reports saved vs skipped; failures per-user or on save are captured and handled.

* **Configuration**
  * Added environment/config option to adjust the resilience-score scheduling interval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->