### PR TITLE
chore: regenerate routeTree.gen.ts with current router plugin

### DIFF
--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -275,7 +275,7 @@ declare module '@tanstack/react-router' {
     '/_authenticated': {
       id: '/_authenticated'
       path: ''
-      fullPath: ''
+      fullPath: '/'
       preLoaderRoute: typeof AuthenticatedRouteImport
       parentRoute: typeof rootRouteImport
     }


### PR DESCRIPTION
## Summary
- Regenerated `routeTree.gen.ts` to match output of installed `@tanstack/router-plugin@1.167.12`
- Fixes phantom git diff (`fullPath: ''` -> `fullPath: '/'` for `_authenticated` layout route) that kept reappearing on every dev server start

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed routing path resolution to ensure correct navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->