### PR TITLE
feat(backend): grace-period feature flag for automatic historical sync

### DIFF
--- a/backend/app/api/routes/v1/oauth.py
+++ b/backend/app/api/routes/v1/oauth.py
@@ -1,9 +1,11 @@
+from datetime import datetime, timedelta, timezone
 from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, Query, status
 from fastapi.responses import RedirectResponse
 
+from app.config import settings
 from app.database import DbSession
 from app.schemas.enums import ProviderName
 from app.schemas.model_crud.credentials import AuthorizationURLResponse
@@ -89,10 +91,32 @@ def oauth_callback(
     assert strategy.oauth
     oauth_state = strategy.oauth.handle_callback(db, code, state)
 
-    # Stamp last_synced_at=now so the first periodic sync uses it as the
-    # live-sync cursor and won't pull all historical data.
-    # Historical data must be fetched explicitly via the /sync/historical endpoint.
+    # Stamp last_synced_at=now so the first periodic sync uses the connection
+    # timestamp as its live-sync cursor and won't attempt to pull all history.
     user_connection_service.stamp_last_synced_at(db, oauth_state.user_id, provider.value)
+
+    # Grace-period flag: automatically kick off a historical sync so integrators
+    # who haven't yet adopted the explicit /sync/historical call still get backfill.
+    # Controlled by HISTORICAL_SYNC_ON_CONNECT (default: true).
+    if settings.historical_sync_on_connect:
+        caps = strategy.capabilities
+        if caps.supports_async_export:
+            # this code is going to be removed later, so leave inner imports heres
+            from app.integrations.celery.tasks import start_garmin_full_backfill
+
+            start_garmin_full_backfill.delay(str(oauth_state.user_id))
+        elif caps.supports_pull:
+            from app.integrations.celery.tasks import sync_vendor_data
+
+            now = datetime.now(timezone.utc)
+            start_date = (now - timedelta(days=90)).isoformat()
+            sync_vendor_data.delay(
+                user_id=str(oauth_state.user_id),
+                start_date=start_date,
+                end_date=now.isoformat(),
+                providers=[provider.value],
+                is_historical=True,
+            )
 
     # If a specific redirect_uri was requested (e.g. by frontend), redirect there
     if oauth_state.redirect_uri:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -82,6 +82,10 @@ class Settings(BaseSettings):
     # SYNC SETTINGS
     sync_interval_seconds: int = 3600  # Default: 1 hour (3600 seconds)
     sleep_sync_interval_seconds: int = 3600  # Default: 1 hour (3600 seconds)
+    # Grace-period flag: auto-dispatch historical sync after OAuth connect (default: true).
+    # Pre-0.4.2 behaviour. Set to false once your integration calls /sync/historical explicitly.
+    # Will default to false in a future release.
+    historical_sync_on_connect: bool = True
 
     # SCORE SETTINGS
     score_backfill_days: int = 30  # How far back the missing-score query looks

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -59,6 +59,10 @@ AWS_SNS_TOPIC_ARN=arn:aws:sns:eu-north-1:123456789012:owear
 
 #--- SYNC SETTINGS ---#
 SYNC_INTERVAL_SECONDS=3600  # How often to run automatic sync (default: 1 hour)
+# Automatically dispatch a historical sync after a successful OAuth callback.
+# Set to false once your integration calls POST /sync/{provider}/users/{user_id}/sync/historical explicitly.
+# Will default to false in a future release.
+HISTORICAL_SYNC_ON_CONNECT=true
 
 #--- OUTGOING WEBHOOKS (Svix) ---#
 # Self-hosted Svix server URL (default matches docker-compose.yml)


### PR DESCRIPTION
Resolves #843 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly connected OAuth accounts now automatically synchronize available historical data, with sync methods intelligently optimized based on provider capabilities. Up to 90 days of historical records are retrieved where supported.

* **Chores**
  * Added a configuration flag to control whether automatic historical data synchronization occurs when new accounts are connected via OAuth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->