### PR TITLE
fix(sleep): group sleep summaries by local start date instead of UTC …

### DIFF
--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -458,6 +458,7 @@ class EventRecordRepository(
                 DataSource.user_id == user_id,
                 EventRecord.category == "sleep",
                 EventRecord.end_datetime >= start_date,
+                local_sleep_date >= cast(start_date, Date),
                 local_sleep_date < cast(end_date, Date),
             )
             .group_by(

--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from uuid import UUID
 
 from sqlalchemy import UUID as SQL_UUID
-from sqlalchemy import Date, Integer, String, and_, asc, case, cast, desc, func, text, tuple_
+from sqlalchemy import Date, Integer, Interval, String, and_, asc, case, cast, desc, func, text, tuple_
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Query, selectinload
@@ -400,12 +400,18 @@ class EventRecordRepository(
         # is_nap can be True, False, or NULL - we treat NULL as "not a nap"
         is_main_sleep = func.coalesce(SleepDetails.is_nap, False) == False  # noqa: E712
 
+        # Local calendar date the session started — mirrors score date logic in fill_missing_sleep_scores_task.
+        local_sleep_date = cast(
+            EventRecord.start_datetime + cast(func.coalesce(EventRecord.zone_offset, "+00:00"), Interval),
+            Date,
+        )
+
         # Build base aggregated query as subquery
         # Join with SleepDetails to get sleep stage data
         # Cast UUID to text for min() since PostgreSQL doesn't support min() on UUID directly
         subquery = (
             db_session.query(
-                cast(EventRecord.end_datetime, Date).label("sleep_date"),
+                local_sleep_date.label("sleep_date"),
                 # Main sleep times (exclude naps)
                 func.min(case((is_main_sleep, EventRecord.start_datetime), else_=None)).label("min_start_time"),
                 func.max(case((is_main_sleep, EventRecord.end_datetime), else_=None)).label("max_end_time"),
@@ -452,10 +458,10 @@ class EventRecordRepository(
                 DataSource.user_id == user_id,
                 EventRecord.category == "sleep",
                 EventRecord.end_datetime >= start_date,
-                cast(EventRecord.end_datetime, Date) < cast(end_date, Date),
+                local_sleep_date < cast(end_date, Date),
             )
             .group_by(
-                cast(EventRecord.end_datetime, Date),
+                local_sleep_date,
                 DataSource.source,
                 DataSource.device_model,
             )

--- a/backend/tests/api/v1/test_summaries.py
+++ b/backend/tests/api/v1/test_summaries.py
@@ -46,7 +46,7 @@ class TestSleepSummaryEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert len(data["data"]) == 1
-        assert data["data"][0]["date"] == "2025-12-26"
+        assert data["data"][0]["date"] == "2025-12-25"
         assert data["data"][0]["start_time"] == "2025-12-25T22:00:00Z"
         assert data["data"][0]["end_time"] == "2025-12-26T05:00:00Z"
         assert data["data"][0]["duration_minutes"] == 420  # 7 hours
@@ -91,7 +91,7 @@ class TestSleepSummaryEndpoint:
         assert len(data["data"]) == 1
 
         sleep_data = data["data"][0]
-        assert sleep_data["date"] == "2025-12-26"
+        assert sleep_data["date"] == "2025-12-25"
         assert sleep_data["duration_minutes"] == 480  # 8 hours
 
         # Verify sleep details are populated
@@ -256,25 +256,25 @@ class TestSleepSummaryEndpoint:
 
         assert response.status_code == 200
         data = response.json()
-        assert len(data["data"]) == 1
+        # Main sleep (local start Dec 25) and nap (local start Dec 26) land on separate dates.
+        assert len(data["data"]) == 2
 
-        sleep_data = data["data"][0]
-        assert sleep_data["date"] == "2025-12-26"
+        main_sleep_data = data["data"][0]
+        assert main_sleep_data["date"] == "2025-12-25"
+        assert main_sleep_data["start_time"] == "2025-12-25T22:00:00Z"
+        assert main_sleep_data["end_time"] == "2025-12-26T06:00:00Z"
+        assert main_sleep_data["duration_minutes"] == 480
+        assert main_sleep_data["time_in_bed_minutes"] == 480
+        assert main_sleep_data["efficiency_percent"] == 85.0
+        assert main_sleep_data["stages"]["deep_minutes"] == 90
+        assert main_sleep_data["stages"]["light_minutes"] == 210
+        assert main_sleep_data["nap_count"] == 0
+        assert main_sleep_data["nap_duration_minutes"] == 0
 
-        # Main sleep metrics should EXCLUDE nap
-        assert sleep_data["start_time"] == "2025-12-25T22:00:00Z"  # Main sleep start, not nap
-        assert sleep_data["end_time"] == "2025-12-26T06:00:00Z"  # Main sleep end, not nap
-        assert sleep_data["duration_minutes"] == 480  # Only main sleep (8 hours)
-        assert sleep_data["time_in_bed_minutes"] == 480  # Only main sleep time in bed
-        assert sleep_data["efficiency_percent"] == 85.0  # Only main sleep efficiency
-
-        # Sleep stages should be main sleep only
-        assert sleep_data["stages"]["deep_minutes"] == 90
-        assert sleep_data["stages"]["light_minutes"] == 210
-
-        # Nap tracking
-        assert sleep_data["nap_count"] == 1
-        assert sleep_data["nap_duration_minutes"] == 30
+        nap_data = data["data"][1]
+        assert nap_data["date"] == "2025-12-26"
+        assert nap_data["nap_count"] == 1
+        assert nap_data["nap_duration_minutes"] == 30
 
     def test_get_sleep_summary_no_naps(self, client: TestClient, db: Session) -> None:
         """Test sleep summary returns null for nap fields when no naps exist."""


### PR DESCRIPTION
Sleep tab was using cast(end_datetime, Date) while OW sleep scores use (start_datetime + zone_offset)::date, causing a date mismatch for sessions crossing midnight (e.g. bed at 11pm local → score on Apr 10, sleep shown on Apr 11). Now both use the local calendar date the session started on.

## Description

<!-- Provide a brief summary of your changes. What problem does this solve? -->

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sleep summaries now map events to the session's local calendar date, fixing incorrect date grouping.
  * Sleep and nap events are separated by local date instead of being combined into a single entry.

* **Tests**
  * Updated tests to reflect the corrected local-date behavior for sleep and nap summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->