### PR TITLE
feat(backend): add created_at to BaseDbModel for all tables

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from fastapi import Depends
 from sqlalchemy import UUID as SQL_UUID
-from sqlalchemy import Date, DateTime, Engine, String, Text, create_engine, inspect
+from sqlalchemy import Date, DateTime, Engine, String, Text, create_engine, func, inspect
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -14,8 +14,10 @@ from sqlalchemy.ext.asyncio import (
 )
 from sqlalchemy.orm import (
     DeclarativeBase,
+    Mapped,
     Session,
     declared_attr,
+    mapped_column,
     sessionmaker,
 )
 
@@ -45,6 +47,8 @@ def _prepare_async_sessionmaker(engine: AsyncEngine) -> async_sessionmaker:
 
 
 class BaseDbModel(DeclarativeBase, metaclass=AutoRelMeta):
+    created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+
     @declared_attr.directive
     def __tablename__(self) -> str:
         return self.__name__.lower()

--- a/backend/app/models/api_key.py
+++ b/backend/app/models/api_key.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from sqlalchemy.orm import Mapped
 
 from app.database import BaseDbModel
@@ -14,4 +12,3 @@ class ApiKey(BaseDbModel):
     id: Mapped[PrimaryKey[str_64]]  # The actual key value (sk-...)
     name: Mapped[str]
     created_by: Mapped[FKDeveloper | None]
-    created_at: Mapped[datetime]

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -15,5 +15,4 @@ class Application(BaseDbModel):
     app_secret_hash: Mapped[str]  # bcrypt hashed secret
     name: Mapped[str_100]  # Display name
     developer_id: Mapped[FKDeveloper]  # Owner developer
-    created_at: Mapped[datetime]
     updated_at: Mapped[datetime]

--- a/backend/app/models/developer.py
+++ b/backend/app/models/developer.py
@@ -11,7 +11,6 @@ class Developer(BaseDbModel):
     """Admin of the portal model"""
 
     id: Mapped[PrimaryKey[UUID]]
-    created_at: Mapped[datetime]
     updated_at: Mapped[datetime]
 
     first_name: Mapped[str_100 | None]

--- a/backend/app/models/device_type_priority.py
+++ b/backend/app/models/device_type_priority.py
@@ -22,5 +22,4 @@ class DeviceTypePriority(BaseDbModel):
     id: Mapped[PrimaryKey[UUID]]
     device_type: Mapped[Unique[DeviceType]]  # Uses DeviceType enum
     priority: Mapped[Indexed[int]]  # 1 = highest priority (watch), 99 = lowest (unknown)
-    created_at: Mapped[datetime]
     updated_at: Mapped[datetime]

--- a/backend/app/models/invitation.py
+++ b/backend/app/models/invitation.py
@@ -17,7 +17,6 @@ class Invitation(BaseDbModel):
     token: Mapped[Unique[str_255]]
     status: Mapped[InvitationStatus]
     expires_at: Mapped[datetime]
-    created_at: Mapped[datetime]
 
     invited_by_id: Mapped[FKDeveloper | None]
     invited_by: Mapped[ManyToOne["Developer"] | None] = relationship(

--- a/backend/app/models/provider_priority.py
+++ b/backend/app/models/provider_priority.py
@@ -23,5 +23,4 @@ class ProviderPriority(BaseDbModel):
     id: Mapped[PrimaryKey[UUID]]
     provider: Mapped[Unique[ProviderName]]  # Uses ProviderName enum
     priority: Mapped[Indexed[int]]  # 1 = highest priority
-    created_at: Mapped[datetime]
     updated_at: Mapped[datetime]

--- a/backend/app/models/refresh_token.py
+++ b/backend/app/models/refresh_token.py
@@ -26,6 +26,5 @@ class RefreshToken(BaseDbModel):
     # For Developer tokens
     developer_id: Mapped[Indexed[FKDeveloper] | None]
 
-    created_at: Mapped[datetime]
     last_used_at: Mapped[datetime | None]
     revoked_at: Mapped[datetime | None]

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -11,7 +11,6 @@ class User(BaseDbModel):
     """Data owner model"""
 
     id: Mapped[PrimaryKey[UUID]]
-    created_at: Mapped[datetime]
 
     first_name: Mapped[str_100 | None]
     last_name: Mapped[str_100 | None]

--- a/backend/app/models/user_connection.py
+++ b/backend/app/models/user_connection.py
@@ -39,5 +39,4 @@ class UserConnection(BaseDbModel):
     # Metadata
     status: Mapped[ConnectionStatus]
     last_synced_at: Mapped[datetime | None]
-    created_at: Mapped[datetime]
     updated_at: Mapped[datetime]

--- a/backend/app/models/user_invitation_code.py
+++ b/backend/app/models/user_invitation_code.py
@@ -23,4 +23,3 @@ class UserInvitationCode(BaseDbModel):
     expires_at: Mapped[datetime]
     redeemed_at: Mapped[datetime | None]
     revoked_at: Mapped[datetime | None]
-    created_at: Mapped[datetime]

--- a/backend/migrations/versions/2026_04_14_1200-4bd01c907050_base_model_created_at.py
+++ b/backend/migrations/versions/2026_04_14_1200-4bd01c907050_base_model_created_at.py
@@ -46,12 +46,22 @@ TABLES_WITHOUT_CREATED_AT = [
     "workout_details",
 ]
 
+EPOCH_SENTINEL = sa.text("'1970-01-01 00:00:00+00'")
+
 
 def upgrade() -> None:
     for table in TABLES_WITHOUT_CREATED_AT:
+        # Backfill existing rows with epoch sentinel, then switch default to now() for new rows.
         op.add_column(
             table,
-            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=EPOCH_SENTINEL, nullable=False),
+        )
+        op.alter_column(
+            table,
+            "created_at",
+            existing_type=sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            existing_nullable=False,
         )
 
     for table in TABLES_WITH_CREATED_AT:

--- a/backend/migrations/versions/2026_04_14_1200-4bd01c907050_base_model_created_at.py
+++ b/backend/migrations/versions/2026_04_14_1200-4bd01c907050_base_model_created_at.py
@@ -1,0 +1,78 @@
+"""base model created_at
+
+Revision ID: 4bd01c907050
+Revises: cdac07b15b04
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "4bd01c907050"
+down_revision: Union[str, None] = "cdac07b15b04"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Tables that already have created_at (just need server_default)
+TABLES_WITH_CREATED_AT = [
+    "api_key",
+    "application",
+    "developer",
+    "device_type_priority",
+    "invitation",
+    "provider_priority",
+    "refresh_token",
+    "user",
+    "user_connection",
+    "user_invitation_code",
+]
+
+# Tables that need the column added
+TABLES_WITHOUT_CREATED_AT = [
+    "archival_settings",
+    "data_point_series",
+    "data_point_series_archive",
+    "data_source",
+    "event_record",
+    "event_record_detail",
+    "health_score",
+    "personal_record",
+    "provider_settings",
+    "series_type_definition",
+    "sleep_details",
+    "workout_details",
+]
+
+
+def upgrade() -> None:
+    for table in TABLES_WITHOUT_CREATED_AT:
+        op.add_column(
+            table,
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        )
+
+    for table in TABLES_WITH_CREATED_AT:
+        op.alter_column(
+            table,
+            "created_at",
+            existing_type=sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    for table in TABLES_WITHOUT_CREATED_AT:
+        op.drop_column(table, "created_at")
+
+    for table in TABLES_WITH_CREATED_AT:
+        op.alter_column(
+            table,
+            "created_at",
+            existing_type=sa.DateTime(timezone=True),
+            server_default=None,
+            existing_nullable=False,
+        )

--- a/backend/migrations/versions/2026_04_24_1500-4bd01c907050_base_model_created_at.py
+++ b/backend/migrations/versions/2026_04_24_1500-4bd01c907050_base_model_created_at.py
@@ -1,7 +1,7 @@
 """base model created_at
 
 Revision ID: 4bd01c907050
-Revises: cdac07b15b04
+Revises: e4f7a2c8b390
 
 """
 
@@ -12,7 +12,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "4bd01c907050"
-down_revision: Union[str, None] = "cdac07b15b04"
+down_revision: Union[str, None] = "e4f7a2c8b390"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/migrations/versions/2026_04_24_1500-4bd01c907050_base_model_created_at.py
+++ b/backend/migrations/versions/2026_04_24_1500-4bd01c907050_base_model_created_at.py
@@ -30,7 +30,9 @@ TABLES_WITH_CREATED_AT = [
     "user_invitation_code",
 ]
 
-# Tables that need the column added
+# Tables that need the column added.
+# sleep_details and workout_details are polymorphic joined-table children of
+# event_record_detail; created_at lives on the parent table, not on the children.
 TABLES_WITHOUT_CREATED_AT = [
     "archival_settings",
     "data_point_series",
@@ -42,8 +44,6 @@ TABLES_WITHOUT_CREATED_AT = [
     "personal_record",
     "provider_settings",
     "series_type_definition",
-    "sleep_details",
-    "workout_details",
 ]
 
 EPOCH_SENTINEL = sa.text("'1970-01-01 00:00:00+00'")


### PR DESCRIPTION
## Description

Moves `created_at` from individual model declarations into `BaseDbModel` with `server_default=func.now()`, so every table gets it automatically. No more forgetting to add it to new models.

> **Warning:** The migration sets `created_at = NOW()` (migration time) for all existing rows in the 12 tables that didn't have the column before. This needs confirmation/discussion before running on production - we might want a different backfill strategy.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally (1580/1580)

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. Run migration: `alembic upgrade head`
2. Verify `created_at` column exists on all tables
3. Create new records (e.g. health scores) and verify `created_at` is auto-populated

**Expected behavior:**
Every table has a `created_at` column with `server_default=now()`. New records get the timestamp automatically without explicit assignment.

## Additional Notes

- 10 models already had `created_at` declared individually - removed in favor of inheritance from `BaseDbModel`, plus `server_default` added
- 12 tables get the new column via migration: `archival_settings`, `data_point_series`, `data_point_series_archive`, `data_source`, `event_record`, `event_record_detail`, `health_score`, `personal_record`, `provider_settings`, `series_type_definition`, `sleep_details`, `workout_details`
- Existing repo code that sets `created_at` explicitly still works (explicit values override server defaults)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized creation timestamp handling so all models now use a single, consistent server-managed created_at field.
* **Chores**
  * Added a migration to apply and normalize automatic creation timestamps across the database, ensuring new records receive server-side creation times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->