### PR TITLE
feat(frontend): display API base URL in credentials tab

### DIFF
--- a/frontend/src/routes/_authenticated/settings/credentials-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/credentials-tab.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Plus, Eye, EyeOff, Copy, Trash2, Key } from 'lucide-react';
+import { Plus, Eye, EyeOff, Copy, Trash2, Key, Globe } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   useApiKeys,
@@ -7,6 +7,7 @@ import {
   useDeleteApiKey,
 } from '@/hooks/api/use-credentials';
 import { copyToClipboard } from '@/lib/utils/clipboard';
+import { API_CONFIG } from '@/lib/api/config';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -110,6 +111,30 @@ export function CredentialsTab() {
           <Plus className="h-4 w-4" />
           Create API Key
         </Button>
+      </div>
+
+      {/* API Base URL */}
+      <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Globe className="h-4 w-4 text-zinc-500" />
+            <div>
+              <p className="text-xs text-zinc-500">API Base URL</p>
+              <code className="font-mono text-sm text-zinc-300">
+                {API_CONFIG.baseUrl}
+              </code>
+            </div>
+          </div>
+          <Button
+            variant="ghost-faded"
+            size="icon-sm"
+            onClick={() =>
+              copyToClipboard(API_CONFIG.baseUrl, 'API URL copied')
+            }
+          >
+            <Copy className="h-4 w-4" />
+          </Button>
+        </div>
       </div>
 
       {/* API Keys Table */}

--- a/frontend/src/routes/_authenticated/settings/credentials-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/credentials-tab.tsx
@@ -128,6 +128,7 @@ export function CredentialsTab() {
           <Button
             variant="ghost-faded"
             size="icon-sm"
+            aria-label="Copy API URL"
             onClick={() =>
               copyToClipboard(API_CONFIG.baseUrl, 'API URL copied')
             }


### PR DESCRIPTION
## Description

Show the backend API base URL with a copy-to-clipboard button in the credentials tab. Not the most ideal spot for it TBH, but it's better than nothing - developers need the URL right next to their API keys anyway, and the important thing is that it's easily copiable.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

### Frontend Changes

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds (pre-existing SSR build issue unrelated to this change)

## Testing Instructions

**Steps to test:**
1. Go to Settings > Credentials tab
2. See the API Base URL displayed between the header and the API Keys table
3. Click the copy button next to it

**Expected behavior:**
- URL is displayed in a monospace code block with a globe icon
- Clicking copy shows "API URL copied" toast and copies the URL to clipboard

## Screenshots 

<img width="1511" height="858" alt="image" src="https://github.com/user-attachments/assets/0ddc6bc1-e41b-4269-b95e-b72343d2f8fb" />

## Additional Notes

Location could be revisited later - maybe a dedicated "Quick Start" or "Getting Started" section would be better. For now, credentials tab works since it's where developers go to grab their connection details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credentials Tab now displays your API Base URL prominently with a globe icon for easy identification and quick reference.
  * One-click copy-to-clipboard control lets you copy the API Base URL instantly, with an accessible control and on-screen confirmation to streamline integration and setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->