### PR TITLE
feat(mcp): add get_timeseries tool for granular sample queries

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -8,6 +8,7 @@ MCP (Model Context Protocol) server for Open Wearables, enabling AI assistants l
 - **get_activity_summary**: Get daily activity data (steps, calories, heart rate, intensity minutes)
 - **get_sleep_summary**: Get sleep data for a user within a date range
 - **get_workout_events**: Get workout/exercise sessions for a user within a date range
+- **get_timeseries**: Get granular time-series samples (weight, SpO2, HRV, intraday heart rate, etc.)
 
 ## Prerequisites
 
@@ -188,7 +189,8 @@ mcp/
 │   │   ├── users.py      # get_users tool
 │   │   ├── activity.py   # get_activity_summary tool
 │   │   ├── sleep.py      # get_sleep_summary tool
-│   │   └── workouts.py   # get_workout_events tool
+│   │   ├── workouts.py   # get_workout_events tool
+│   │   └── timeseries.py # get_timeseries tool
 │   └── services/
 │       └── api_client.py # HTTP client for backend API
 ├── config/

--- a/mcp/app/main.py
+++ b/mcp/app/main.py
@@ -9,6 +9,7 @@ from app.config import settings
 from app.prompts import prompts_router
 from app.tools.activity import activity_router
 from app.tools.sleep import sleep_router
+from app.tools.timeseries import timeseries_router
 from app.tools.users import users_router
 from app.tools.workouts import workouts_router
 
@@ -35,6 +36,7 @@ mcp = FastMCP(
     - get_activity_summary: Get daily activity data (steps, calories, heart rate, intensity minutes)
     - get_sleep_summary: Get sleep data for a user over a specified time period
     - get_workout_events: Get workout/exercise data for a user over a specified time period
+    - get_timeseries: Get granular time-series samples (e.g. weight, SpO2, HRV, intraday heart rate)
 
     Available prompts:
     - present_health_data: Guidelines for formatting health data for human readability
@@ -115,6 +117,7 @@ mcp.mount(users_router)
 mcp.mount(activity_router)
 mcp.mount(sleep_router)
 mcp.mount(workouts_router)
+mcp.mount(timeseries_router)
 
 # Mount prompts
 mcp.mount(prompts_router)

--- a/mcp/app/services/api_client.py
+++ b/mcp/app/services/api_client.py
@@ -167,6 +167,42 @@ class OpenWearablesClient:
         }
         return await self._request("GET", f"/api/v1/users/{user_id}/summaries/activity", params=params)
 
+    async def get_timeseries(
+        self,
+        user_id: str,
+        start_time: str,
+        end_time: str,
+        types: list[str],
+        resolution: str = "raw",
+        limit: int = 100,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Get granular time-series samples for a user within a time range.
+
+        Args:
+            user_id: UUID of the user
+            start_time: Start of the window (ISO-8601, e.g. "2026-04-05T00:00:00Z")
+            end_time: End of the window (ISO-8601, e.g. "2026-04-05T23:59:59Z")
+            types: SeriesType codes to include (e.g. ["heart_rate", "oxygen_saturation"])
+            resolution: One of "raw", "1min", "5min", "15min", "1hour"
+            limit: Page size (1-100)
+            cursor: Opaque pagination cursor returned by a previous call
+
+        Returns:
+            Paginated response with time-series samples
+        """
+        params: dict[str, Any] = {
+            "start_time": start_time,
+            "end_time": end_time,
+            "types": types,
+            "resolution": resolution,
+            "limit": limit,
+        }
+        if cursor:
+            params["cursor"] = cursor
+        return await self._request("GET", f"/api/v1/users/{user_id}/timeseries", params=params)
+
 
 # Singleton instance
 client = OpenWearablesClient()

--- a/mcp/app/tools/timeseries.py
+++ b/mcp/app/tools/timeseries.py
@@ -129,7 +129,7 @@ async def get_timeseries(
                 resolution=resolution,
                 cursor=cursor,
             )
-            for sample in response.get("data", []) or []:
+            for sample in response.get("data", []):
                 source = sample.get("source", {})
                 records.append(
                     {

--- a/mcp/app/tools/timeseries.py
+++ b/mcp/app/tools/timeseries.py
@@ -1,0 +1,193 @@
+"""MCP tools for querying granular time-series samples."""
+
+import logging
+from typing import Any
+
+from fastmcp import FastMCP
+
+from app.services.api_client import client
+
+logger = logging.getLogger(__name__)
+
+# Create router for time-series tools
+timeseries_router = FastMCP(name="Timeseries Tools")
+
+# Hard ceiling on pages walked per tool call to protect the backend
+# and keep responses bounded. 100 pages * 100 samples = 10k samples.
+_MAX_PAGES = 100
+
+
+@timeseries_router.tool
+async def get_timeseries(
+    user_id: str,
+    start_time: str,
+    end_time: str,
+    types: list[str],
+    resolution: str = "raw",
+) -> dict:
+    """
+    Get granular time-series samples for a user within a time range.
+
+    Time-series data is the raw/downsampled sample stream underlying the
+    higher-level summaries (activity, sleep, workouts). Use this tool when
+    the user asks about a metric that does NOT have a dedicated summary
+    tool (e.g. weight, SpO2, blood glucose, respiratory rate, HRV), or
+    when they need finer-grained data than daily averages.
+
+    Args:
+        user_id: UUID of the user. Use get_users to discover available users.
+        start_time: Start of the window in ISO-8601 format.
+                    Example: "2026-04-05T00:00:00Z"
+        end_time: End of the window in ISO-8601 format.
+                  Example: "2026-04-05T23:59:59Z"
+        types: List of SeriesType codes to include. Common values:
+               - "heart_rate", "resting_heart_rate", "walking_heart_rate_average"
+               - "heart_rate_variability_sdnn", "heart_rate_variability_rmssd"
+               - "oxygen_saturation", "respiratory_rate"
+               - "blood_glucose", "blood_pressure_systolic", "blood_pressure_diastolic"
+               - "weight", "body_fat_percentage", "body_mass_index"
+               - "steps", "active_energy", "basal_energy", "distance"
+        resolution: One of "raw", "1min", "5min", "15min", "1hour".
+                    Default "raw" returns every sample as stored; higher
+                    resolutions downsample server-side. Prefer "1min" or
+                    coarser for multi-day windows to keep response size
+                    bounded.
+
+    Returns:
+        A dictionary containing:
+        - user: Information about the user (id, first_name, last_name)
+        - period: The time window queried (start, end, resolution)
+        - records: List of samples, each {timestamp, type, value, unit, source}
+        - summary: Per-type aggregates (count, avg, min, max)
+        - truncated: True if pagination hit the safety ceiling (rare)
+
+    Example response:
+        {
+            "user": {"id": "uuid-1", "first_name": "John", "last_name": "Doe"},
+            "period": {
+                "start": "2026-04-05T00:00:00Z",
+                "end": "2026-04-05T23:59:59Z",
+                "resolution": "1min"
+            },
+            "records": [
+                {
+                    "timestamp": "2026-04-05T08:15:00+00:00",
+                    "type": "heart_rate",
+                    "value": 68,
+                    "unit": "bpm",
+                    "source": "garmin"
+                }
+            ],
+            "summary": {
+                "total_samples": 1433,
+                "by_type": {
+                    "heart_rate": {"count": 1433, "avg": 98, "min": 48, "max": 167}
+                }
+            },
+            "truncated": false
+        }
+
+    Notes for LLMs:
+        - Call get_users first to get the user_id.
+        - `types` must be a list even for a single metric: ["heart_rate"].
+        - Multi-day queries at resolution="raw" can return tens of thousands
+          of samples. Prefer "1min" or coarser for anything longer than a
+          day unless the user explicitly asks for raw data.
+        - For a single day's heart-rate average, prefer get_activity_summary
+          when it's available — it's cheaper. Use this tool when:
+          (a) activity summary is missing or has null heart_rate, or
+          (b) the user wants intraday detail (peaks, zones, a specific hour).
+        - Values are returned in the unit the provider supplied (e.g.
+          heart_rate in "bpm", weight in "kg", oxygen_saturation in "%").
+          Do unit conversions client-side when presenting to the user.
+        - The `source` field indicates which wearable produced the sample
+          (garmin, whoop, apple_health, etc.) and may differ across samples
+          in the same response when a user has multiple connected devices.
+    """
+    try:
+        # Fetch user details
+        try:
+            user_data = await client.get_user(user_id)
+            user = {
+                "id": str(user_data.get("id")),
+                "first_name": user_data.get("first_name"),
+                "last_name": user_data.get("last_name"),
+            }
+        except ValueError as e:
+            return {"error": f"User not found: {user_id}", "details": str(e)}
+
+        # Walk cursor pagination until exhausted or safety ceiling hit.
+        records: list[dict[str, Any]] = []
+        cursor: str | None = None
+        truncated = False
+        for _ in range(_MAX_PAGES):
+            response = await client.get_timeseries(
+                user_id=user_id,
+                start_time=start_time,
+                end_time=end_time,
+                types=types,
+                resolution=resolution,
+                cursor=cursor,
+            )
+            for sample in response.get("data", []) or []:
+                source = sample.get("source", {})
+                records.append(
+                    {
+                        "timestamp": str(sample.get("timestamp")) if sample.get("timestamp") else None,
+                        "type": sample.get("type"),
+                        "value": sample.get("value"),
+                        "unit": sample.get("unit"),
+                        "source": source.get("provider") if isinstance(source, dict) else source,
+                    }
+                )
+            cursor = (response.get("pagination") or {}).get("next_cursor")
+            if not cursor:
+                break
+        else:
+            truncated = True
+
+        # Per-type aggregates
+        by_type: dict[str, dict[str, Any]] = {}
+        for rec in records:
+            series_type = rec["type"]
+            value = rec["value"]
+            if series_type is None or value is None:
+                continue
+            bucket = by_type.setdefault(
+                series_type,
+                {"count": 0, "sum": 0.0, "min": value, "max": value},
+            )
+            bucket["count"] += 1
+            bucket["sum"] += value
+            if value < bucket["min"]:
+                bucket["min"] = value
+            if value > bucket["max"]:
+                bucket["max"] = value
+
+        summary_by_type = {
+            series_type: {
+                "count": bucket["count"],
+                "avg": round(bucket["sum"] / bucket["count"], 2) if bucket["count"] else None,
+                "min": bucket["min"],
+                "max": bucket["max"],
+            }
+            for series_type, bucket in by_type.items()
+        }
+
+        return {
+            "user": user,
+            "period": {"start": start_time, "end": end_time, "resolution": resolution},
+            "records": records,
+            "summary": {
+                "total_samples": len(records),
+                "by_type": summary_by_type,
+            },
+            "truncated": truncated,
+        }
+
+    except ValueError as e:
+        logger.error(f"API error in get_timeseries: {e}")
+        return {"error": str(e)}
+    except Exception as e:
+        logger.exception(f"Unexpected error in get_timeseries: {e}")
+        return {"error": f"Failed to fetch time-series samples: {e}"}


### PR DESCRIPTION
Closes #881

## Summary

Adds a `get_timeseries` MCP tool that exposes `/api/v1/users/{user_id}/timeseries` to AI clients, alongside the matching `OpenWearablesClient.get_timeseries` method.

The existing tools cover daily summaries (activity / sleep / workouts) but there is no path into the raw sample stream, so metrics that do not have a dedicated summary — weight, SpO2, HRV, blood glucose, intraday heart rate, etc. — are invisible to an LLM client today.

## What it does

- **Client method** (`mcp/app/services/api_client.py`): async `get_timeseries(user_id, start_time, end_time, types, resolution="raw", limit=100, cursor=None)`. Mirrors the backend signature from `backend/app/api/routes/v1/timeseries.py` and returns the raw paginated payload.
- **MCP tool** (`mcp/app/tools/timeseries.py`): walks cursor pagination (ceiling at 100 pages / 10k samples, `truncated: true` flag when hit), returns `{user, period, records, summary, truncated}`. `summary` contains per-type aggregates (`count`, `avg`, `min`, `max`).
- **Router mount** (`mcp/app/main.py`): registered via `mcp.mount(timeseries_router)` and listed in the instructions block.
- **README** updated with the new tool in Features + the `tools/` layout.

## Design notes

- `resolution` is passed through as a `str` so the tool surface stays decoupled from the backend enum. The backend rejects anything outside `{"raw", "1min", "5min", "15min", "1hour"}` and surfaces a 422, which the existing `_request` path already translates into a `ValueError`.
- The "Notes for LLMs" section of the docstring explicitly steers the model toward `get_activity_summary` when a daily rollup is sufficient, and toward `get_timeseries` only for metrics without a dedicated summary or when the user needs intraday detail.
- Values are returned in the unit the provider supplied (`bpm`, `kg`, `%`, …); unit conversions stay client-side to match the existing convention.

## Testing

Smoke-tested end-to-end against a live backend with real wearable data:

| Scenario | Result |
|---|---|
| `heart_rate`, 1-day window, `resolution="1min"` | 1,433 samples, avg 97.57 bpm, pagination walked cleanly (`truncated: false`) |
| `weight`, 30-day window, `resolution="1hour"` | 19 samples across providers, avg 88.12 kg, sparse pagination handled correctly |
| Multi-type: `heart_rate` + `oxygen_saturation`, 1-day | Per-type split in `summary.by_type`; empty SpO2 confirmed as real data gap via direct curl |

Tooling checks:

- `uv run --frozen python -c "from app.tools.timeseries import timeseries_router; from app.main import mcp"` — imports cleanly, server initializes.
- `uv run --frozen --group code-quality ruff check app/` — all checks passed.
- `uv run --frozen --group code-quality ruff format --check app/` — 13 files already formatted.

No unit tests added: the `mcp/` package does not ship a `tests/` directory today and none of the existing tools (`users.py`, `activity.py`, `sleep.py`, `workouts.py`) have coverage. Happy to bolt on a test suite in a follow-up PR — let me know the preferred framework/layout.

## Checklist

- [x] Conventional commit title (scope `mcp`)
- [x] No new third-party dependencies
- [x] Backwards compatible (new tool, no changes to existing signatures)
- [x] `ruff check` + `ruff format --check` pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added time-series health metrics retrieval to query granular data (weight, SpO2, HRV, intraday heart rate) across flexible time periods.
  * Includes automatic pagination to fetch large datasets and a truncation indicator when results hit a hard cap.
  * Produces per-metric statistical summaries (count, average, minimum, maximum) and returns structured results with user and period context.
  * Returns clear error responses for user-lookup or fetch failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->