### PR TITLE
fix: display sleep duration correctly via endpoint

### DIFF
--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -437,8 +437,23 @@ class EventRecordRepository(
                 # Main sleep times (exclude naps)
                 func.min(case((is_main_sleep, EventRecord.start_datetime), else_=None)).label("min_start_time"),
                 func.max(case((is_main_sleep, EventRecord.end_datetime), else_=None)).label("max_end_time"),
-                # Main sleep duration (exclude naps)
-                func.sum(case((is_main_sleep, EventRecord.duration_seconds), else_=0)).label("total_duration"),
+                # Main sleep duration (exclude naps) — prefer net sleep time over
+                # wall-clock duration.  Oura (and some other providers) store
+                # time_in_bed in duration_seconds; sleep_total_duration_minutes
+                # holds the actual sleep time and should be used when available.
+                func.sum(
+                    case(
+                        (
+                            is_main_sleep,
+                            func.coalesce(
+                                SleepDetails.sleep_total_duration_minutes * 60,
+                                EventRecord.duration_seconds,
+                                0,
+                            ),
+                        ),
+                        else_=0,
+                    )
+                ).label("total_duration"),
                 DataSource.source,
                 DataSource.device_model,
                 func.min(cast(EventRecord.id, String)).label("record_id_text"),

--- a/backend/app/services/scores/sleep_service.py
+++ b/backend/app/services/scores/sleep_service.py
@@ -323,7 +323,10 @@ class SleepScoreService:
                 self.logger,
                 "warning",
                 f"Skipped sleep score for {len(skipped)} date(s): invalid session data",
-                skipped=[{"date": str(d), "record_id": rid, "reason": reason} for d, rid, reason in skipped],
+                skipped=[
+                    {"date": str(d), "record_id": rid, "reason": reason}
+                    for d, rid, reason in skipped
+                ],
             )
 
         return results

--- a/backend/app/services/scores/sleep_service.py
+++ b/backend/app/services/scores/sleep_service.py
@@ -247,12 +247,15 @@ class SleepScoreService:
         earliest = min(dates)
         latest = max(dates)
 
-        # Extend one extra day on each side to accommodate UTC timezone offsets:
-        # a sleep session may start on the UTC-day before/after the local date.
+        # Extend the window on each side to accommodate UTC timezone offsets and
+        # the fact that sleep sessions end in the early morning hours of the next
+        # calendar day.  window_end must reach past the latest possible end_datetime
+        # (sleep starting at 23:59 local + 10 h = ~10:00 next day UTC) so we add
+        # 2 days instead of 1.
         window_start = datetime(earliest.year, earliest.month, earliest.day) - timedelta(
             days=sleep_config.rolling_window_nights + 2
         )
-        window_end = datetime(latest.year, latest.month, latest.day) + timedelta(days=1)
+        window_end = datetime(latest.year, latest.month, latest.day) + timedelta(days=2)
 
         all_records, _ = self.event_record_repo.get_records_with_filters(
             db_session,

--- a/backend/app/services/scores/sleep_service.py
+++ b/backend/app/services/scores/sleep_service.py
@@ -323,10 +323,7 @@ class SleepScoreService:
                 self.logger,
                 "warning",
                 f"Skipped sleep score for {len(skipped)} date(s): invalid session data",
-                skipped=[
-                    {"date": str(d), "record_id": rid, "reason": reason}
-                    for d, rid, reason in skipped
-                ],
+                skipped=[{"date": str(d), "record_id": rid, "reason": reason} for d, rid, reason in skipped],
             )
 
         return results

--- a/backend/tests/api/v1/test_summaries.py
+++ b/backend/tests/api/v1/test_summaries.py
@@ -92,7 +92,7 @@ class TestSleepSummaryEndpoint:
 
         sleep_data = data["data"][0]
         assert sleep_data["date"] == "2025-12-25"
-        assert sleep_data["duration_minutes"] == 480  # 8 hours
+        assert sleep_data["duration_minutes"] == 420  # net sleep (sleep_total_duration_minutes), not time_in_bed
 
         # Verify sleep details are populated
         assert sleep_data["time_in_bed_minutes"] == 480
@@ -156,7 +156,7 @@ class TestSleepSummaryEndpoint:
         sleep_data = data["data"][0]
 
         # Verify basic fields
-        assert sleep_data["duration_minutes"] == 480  # 8 hours
+        assert sleep_data["duration_minutes"] == 420  # net sleep (sleep_total_duration_minutes), not time_in_bed
         assert sleep_data["efficiency_percent"] == 85.0
         assert sleep_data["stages"] is not None
 


### PR DESCRIPTION
## Description

<!-- Provide a brief summary of your changes. What problem does this solve? -->

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Sleep duration metrics now accurately reflect net sleep time instead of total time in bed
* Improved sleep session detection by expanding the query window to capture sessions ending in early morning hours

<!-- end of auto-generated comment: release notes by coderabbit.ai -->