### PR TITLE
feat: Sleep score recalculation after sleep session merge

### DIFF
--- a/backend/app/repositories/health_score_repository.py
+++ b/backend/app/repositories/health_score_repository.py
@@ -1,3 +1,4 @@
+from datetime import date, datetime, timezone
 from uuid import UUID
 
 from sqlalchemy import and_, desc
@@ -67,6 +68,31 @@ class HealthScoreRepository(CrudRepository[HealthScore, HealthScoreCreate, Healt
             .filter(HealthScore.user_id == user_id, HealthScore.category == category)
             .order_by(desc(HealthScore.recorded_at))
             .first()
+        )
+
+    def delete_for_user_date(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        score_date: date,
+        category: HealthScoreCategory,
+        provider: str = "internal",
+    ) -> int:
+        """Delete health scores matching user/category/provider/date without loading objects.
+
+        Caller is responsible for commit. Returns deleted row count.
+        Sleep scores are stored with recorded_at = midnight UTC of the local sleep date.
+        """
+        midnight = datetime(score_date.year, score_date.month, score_date.day, tzinfo=timezone.utc)
+        return (
+            db_session.query(HealthScore)
+            .filter(
+                HealthScore.user_id == user_id,
+                HealthScore.provider == provider,
+                HealthScore.category == category,
+                HealthScore.recorded_at == midnight,
+            )
+            .delete(synchronize_session=False)
         )
 
     def get_latest_per_category(

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from logging import Logger, getLogger
 from uuid import UUID, uuid4
@@ -11,6 +11,7 @@ from app.models import (
     DataSource,
     EventRecord,
     EventRecordDetail,
+    HealthScore,
     SleepDetails,
     WorkoutDetails,
 )
@@ -19,14 +20,17 @@ from app.repositories import (
     DataSourceRepository,
     EventRecordDetailRepository,
     EventRecordRepository,
+    HealthScoreRepository,
 )
-from app.schemas.enums import WORKOUTS_WITH_PACE
+from app.schemas.enums import WORKOUTS_WITH_PACE, HealthScoreCategory, ProviderName
 from app.schemas.model_crud.activities import (
     EventRecordCreate,
     EventRecordDetailCreate,
     EventRecordQueryParams,
     EventRecordResponse,
     EventRecordUpdate,
+    HealthScoreCreate,
+    ScoreComponent,
 )
 from app.schemas.model_crud.activities.sleep import SleepStage
 from app.schemas.responses.activity import SleepSession, SleepStagesSummary, Workout, WorkoutDetailed
@@ -39,7 +43,8 @@ from app.schemas.utils import (
     SourceMetadata as DataSourceSchema,
 )
 from app.services.outgoing_webhooks import svix as svix_service
-from app.services.outgoing_webhooks.events import on_sleep_created, on_workout_created
+from app.services.outgoing_webhooks.events import on_activity_created, on_sleep_created, on_workout_created
+from app.services.scores.sleep_service import sleep_score_service
 from app.services.services import AppService
 from app.utils.exceptions import handle_exceptions
 from app.utils.pagination import encode_cursor
@@ -55,6 +60,7 @@ class EventRecordService(
         self.event_record_detail_repo = EventRecordDetailRepository(EventRecordDetail)
         self.data_source_repo = DataSourceRepository()
         self.data_point_series_repo = DataPointSeriesRepository(DataPointSeries)
+        self.health_score_repo = HealthScoreRepository(HealthScore)
 
     def _resolve_avg_hr(
         self,
@@ -121,6 +127,54 @@ class EventRecordService(
                     self._emit_event_record_webhook(_record, _data_source, _detail)
 
         return result  # type: ignore[return-value]
+
+    @staticmethod
+    def _local_sleep_date(start_datetime: datetime, zone_offset: str | None) -> date:
+        """Return the local calendar date of a sleep session start (mirrors SQL logic in fill task)."""
+        dt = start_datetime if start_datetime.tzinfo is not None else start_datetime.replace(tzinfo=timezone.utc)
+        if zone_offset is not None:
+            sign = 1 if zone_offset[0] == "+" else -1
+            hours, minutes = int(zone_offset[1:3]), int(zone_offset[4:6])
+            dt = dt.astimezone(timezone(timedelta(hours=sign * hours, minutes=sign * minutes)))
+        return dt.date()
+
+    def _recompute_sleep_score(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        sleep_date: date,
+    ) -> None:
+        """Delete any existing internal sleep score for sleep_date and recompute it immediately.
+
+        Called after merge/re-ingestion paths commit updated session data.  The
+        session data has already been flushed so sleep_score_service sees the
+        up-to-date detail rows within the same transaction.
+        """
+        self.health_score_repo.delete_for_user_date(
+            db_session, user_id, sleep_date, HealthScoreCategory.SLEEP
+        )
+        scores = sleep_score_service.get_sleep_scores_for_date_range(db_session, user_id, [sleep_date])
+        if not scores:
+            return
+        creators = [
+            HealthScoreCreate(
+                id=uuid4(),
+                user_id=user_id,
+                data_source_id=None,
+                provider=ProviderName.INTERNAL,
+                category=HealthScoreCategory.SLEEP,
+                value=result.overall_score,
+                recorded_at=datetime(d.year, d.month, d.day, tzinfo=timezone.utc),
+                components={
+                    "duration": ScoreComponent(value=result.breakdown.duration.score),
+                    "stages": ScoreComponent(value=result.breakdown.stages.score),
+                    "consistency": ScoreComponent(value=result.breakdown.consistency.score),
+                    "interruptions": ScoreComponent(value=result.breakdown.interruptions.score),
+                },
+            )
+            for d, result in scores.items()
+        ]
+        self.health_score_repo.bulk_create(db_session, creators)
 
     def find_adjacent_sleep_record(
         self,
@@ -224,6 +278,11 @@ class EventRecordService(
                     db_session,
                     detail.model_copy(update={"record_id": adjacent.id}),
                     detail_type="sleep",
+                )
+                self._recompute_sleep_score(
+                    db_session,
+                    user_id,
+                    self._local_sleep_date(adjacent.start_datetime, adjacent.zone_offset),
                 )
                 db_session.commit()
                 return adjacent, False, detail
@@ -348,6 +407,11 @@ class EventRecordService(
                     detail.model_copy(update={"record_id": adjacent.id, **merged_detail_fields}),
                     detail_type="sleep",
                 )
+                self._recompute_sleep_score(
+                    db_session,
+                    user_id,
+                    self._local_sleep_date(adjacent.start_datetime, adjacent.zone_offset),
+                )
                 db_session.commit()
                 return adjacent, False, detail
 
@@ -370,6 +434,11 @@ class EventRecordService(
                     detail.model_copy(update={"record_id": adjacent.id, **merged_detail_fields}),
                     detail_type="sleep",
                 )
+                self._recompute_sleep_score(
+                    db_session,
+                    user_id,
+                    self._local_sleep_date(adjacent.start_datetime, adjacent.zone_offset),
+                )
                 db_session.commit()
                 return adjacent, False, detail
 
@@ -380,6 +449,11 @@ class EventRecordService(
                 detail_type="sleep",
             )
             self.crud.delete_flush(db_session, adjacent)
+            self._recompute_sleep_score(
+                db_session,
+                user_id,
+                self._local_sleep_date(created_record.start_datetime, created_record.zone_offset),
+            )
             db_session.commit()
             return created_record, True, merged_final_detail
 

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -43,7 +43,7 @@ from app.schemas.utils import (
     SourceMetadata as DataSourceSchema,
 )
 from app.services.outgoing_webhooks import svix as svix_service
-from app.services.outgoing_webhooks.events import on_activity_created, on_sleep_created, on_workout_created
+from app.services.outgoing_webhooks.events import on_sleep_created, on_workout_created
 from app.services.scores.sleep_service import sleep_score_service
 from app.services.services import AppService
 from app.utils.exceptions import handle_exceptions

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -138,20 +138,22 @@ class EventRecordService(
             dt = dt.astimezone(timezone(timedelta(hours=sign * hours, minutes=sign * minutes)))
         return dt.date()
 
-    def _recompute_sleep_score(
+    def _recompute_sleep_scores(
         self,
         db_session: DbSession,
         user_id: UUID,
-        sleep_date: date,
+        sleep_dates: set[date],
     ) -> None:
-        """Delete any existing internal sleep score for sleep_date and recompute it immediately.
+        """Delete existing internal sleep scores for each date and recompute them immediately.
 
-        Called after merge/re-ingestion paths commit updated session data.  The
-        session data has already been flushed so sleep_score_service sees the
-        up-to-date detail rows within the same transaction.
+        Accepts multiple dates so callers can cover both the old and new local
+        date when a session shifts across midnight.  The session data has already
+        been flushed, so sleep_score_service sees up-to-date rows within the
+        same transaction.
         """
-        self.health_score_repo.delete_for_user_date(db_session, user_id, sleep_date, HealthScoreCategory.SLEEP)
-        scores = sleep_score_service.get_sleep_scores_for_date_range(db_session, user_id, [sleep_date])
+        for d in sleep_dates:
+            self.health_score_repo.delete_for_user_date(db_session, user_id, d, HealthScoreCategory.SLEEP)
+        scores = sleep_score_service.get_sleep_scores_for_date_range(db_session, user_id, list(sleep_dates))
         if not scores:
             return
         creators = [
@@ -265,6 +267,7 @@ class EventRecordService(
             # retry, score update).  Replace the detail with fresh values instead
             # of accumulating them on top of the existing ones.
             if record.external_id is not None and adjacent.external_id == record.external_id:
+                old_start, old_zone = adjacent.start_datetime, adjacent.zone_offset
                 for field in ("start_datetime", "end_datetime", "zone_offset"):
                     new_val = getattr(record, field, None)
                     if new_val is not None:
@@ -277,10 +280,13 @@ class EventRecordService(
                     detail.model_copy(update={"record_id": adjacent.id}),
                     detail_type="sleep",
                 )
-                self._recompute_sleep_score(
+                self._recompute_sleep_scores(
                     db_session,
                     user_id,
-                    self._local_sleep_date(adjacent.start_datetime, adjacent.zone_offset),
+                    {
+                        self._local_sleep_date(old_start, old_zone),
+                        self._local_sleep_date(adjacent.start_datetime, adjacent.zone_offset),
+                    },
                 )
                 db_session.commit()
                 return adjacent, False, detail
@@ -405,10 +411,10 @@ class EventRecordService(
                     detail.model_copy(update={"record_id": adjacent.id, **merged_detail_fields}),
                     detail_type="sleep",
                 )
-                self._recompute_sleep_score(
+                self._recompute_sleep_scores(
                     db_session,
                     user_id,
-                    self._local_sleep_date(adjacent.start_datetime, adjacent.zone_offset),
+                    {self._local_sleep_date(adjacent.start_datetime, adjacent.zone_offset)},
                 )
                 db_session.commit()
                 return adjacent, False, detail
@@ -432,10 +438,10 @@ class EventRecordService(
                     detail.model_copy(update={"record_id": adjacent.id, **merged_detail_fields}),
                     detail_type="sleep",
                 )
-                self._recompute_sleep_score(
+                self._recompute_sleep_scores(
                     db_session,
                     user_id,
-                    self._local_sleep_date(adjacent.start_datetime, adjacent.zone_offset),
+                    {self._local_sleep_date(adjacent.start_datetime, adjacent.zone_offset)},
                 )
                 db_session.commit()
                 return adjacent, False, detail
@@ -446,11 +452,15 @@ class EventRecordService(
                 merged_final_detail,
                 detail_type="sleep",
             )
+            adj_start, adj_zone = adjacent.start_datetime, adjacent.zone_offset
             self.crud.delete_flush(db_session, adjacent)
-            self._recompute_sleep_score(
+            self._recompute_sleep_scores(
                 db_session,
                 user_id,
-                self._local_sleep_date(created_record.start_datetime, created_record.zone_offset),
+                {
+                    self._local_sleep_date(adj_start, adj_zone),
+                    self._local_sleep_date(created_record.start_datetime, created_record.zone_offset),
+                },
             )
             db_session.commit()
             return created_record, True, merged_final_detail

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -150,9 +150,7 @@ class EventRecordService(
         session data has already been flushed so sleep_score_service sees the
         up-to-date detail rows within the same transaction.
         """
-        self.health_score_repo.delete_for_user_date(
-            db_session, user_id, sleep_date, HealthScoreCategory.SLEEP
-        )
+        self.health_score_repo.delete_for_user_date(db_session, user_id, sleep_date, HealthScoreCategory.SLEEP)
         scores = sleep_score_service.get_sleep_scores_for_date_range(db_session, user_id, [sleep_date])
         if not scores:
             return


### PR DESCRIPTION
## Description

When another sleep session is merged (or an incoming one), the sleep score stays the same (even if e.g. the sleep stages changed), and now it will be correctly recalculating afterwards

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sleep scores are now automatically recalculated whenever sleep records are created, updated, merged, or re-ingested.
  * Internal per-day sleep scores for affected dates are removed and repopulated to keep assessments accurate.
  * Edge cases around merged, replaced, or re-ingested sleep sessions are handled to ensure consistent, up-to-date health scoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->