### PR TITLE
docs: trim meta title/description to ≤60/155 chars across all docs

### DIFF
--- a/docs/api-reference/guides/apple-xml-import.mdx
+++ b/docs/api-reference/guides/apple-xml-import.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Apple Health XML Import"
-description: "API endpoints for importing Apple Health XML exports"
+title: "Import Apple Health XML Export | Open Wearables"
+description: "Import complete Apple Health data exports via XML. Direct upload for small files, S3 presigned URL for large exports. Authentication via Bearer token or API key."
+keywords: ["apple health xml import", "apple health export api", "healthkit xml upload", "apple health data import"]
+"og:title": "Import Apple Health XML Export | Open Wearables"
+"og:description": "Import Apple Health XML exports. Direct upload for small files, S3 presigned URL for large exports. API key auth required."
+"og:url": "https://docs.openwearables.io/api-reference/guides/apple-xml-import"
+"og:type": "article"
+"twitter:title": "Import Apple Health XML Export | Open Wearables"
+"twitter:description": "Import Apple Health XML exports. Direct upload for small files, S3 presigned URL for large exports. API key auth required."
+"twitter:card": "summary_large_image"
 ---
 
 ## Overview

--- a/docs/api-reference/guides/apple-xml-import.mdx
+++ b/docs/api-reference/guides/apple-xml-import.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Import Apple Health XML Export | Open Wearables"
-description: "Import complete Apple Health data exports via XML. Direct upload for small files, S3 presigned URL for large exports. Authentication via Bearer token or API key."
+description: "Import Apple Health data exports via XML. Direct upload for small files, S3 presigned URL for large exports. Requires Bearer token or API key."
 keywords: ["apple health xml import", "apple health export api", "healthkit xml upload", "apple health data import"]
 "og:title": "Import Apple Health XML Export | Open Wearables"
 "og:description": "Import Apple Health XML exports. Direct upload for small files, S3 presigned URL for large exports. API key auth required."

--- a/docs/api-reference/guides/error-handling.mdx
+++ b/docs/api-reference/guides/error-handling.mdx
@@ -1,6 +1,14 @@
 ---
-title: 'Error Handling'
-description: 'Common API errors and how to resolve them'
+title: "API Error Handling | Open Wearables Reference"
+description: "Reference for Open Wearables API error codes, response formats, and resolution steps. Covers auth failures, validation errors, rate limits, and 404s with HTTP status codes."
+keywords: ["open wearables api errors", "health api error handling", "wearable api error codes", "open wearables http errors"]
+"og:title": "API Error Handling | Open Wearables Reference"
+"og:description": "Open Wearables API error codes, formats, and resolution steps. Auth failures, validation, rate limits, and 404s."
+"og:url": "https://docs.openwearables.io/api-reference/guides/error-handling"
+"og:type": "article"
+"twitter:title": "API Error Handling | Open Wearables Reference"
+"twitter:description": "Open Wearables API error codes, formats, and resolution steps. Auth failures, validation, rate limits, and 404s."
+"twitter:card": "summary_large_image"
 ---
 
 ## Authentication Errors

--- a/docs/api-reference/guides/error-handling.mdx
+++ b/docs/api-reference/guides/error-handling.mdx
@@ -1,6 +1,6 @@
 ---
 title: "API Error Handling | Open Wearables Reference"
-description: "Reference for Open Wearables API error codes, response formats, and resolution steps. Covers auth failures, validation errors, rate limits, and 404s with HTTP status codes."
+description: "Reference for Open Wearables API error codes, response formats, and resolution steps. Covers auth failures, validation errors, rate limits, and 404s."
 keywords: ["open wearables api errors", "health api error handling", "wearable api error codes", "open wearables http errors"]
 "og:title": "API Error Handling | Open Wearables Reference"
 "og:description": "Open Wearables API error codes, formats, and resolution steps. Auth failures, validation, rate limits, and 404s."

--- a/docs/api-reference/guides/provider-setup.mdx
+++ b/docs/api-reference/guides/provider-setup.mdx
@@ -1,6 +1,14 @@
 ---
-title: 'Provider Setup'
-description: 'Provider-specific configuration, requirements, and sync parameters'
+title: "Wearable Provider Setup and Sync Guide | Open Wearables"
+description: "Provider-specific configuration and sync parameters for all supported wearables. Covers Garmin, Polar, Suunto, Whoop, and Apple Health. API path conventions included."
+keywords: ["wearable provider setup", "garmin sync configuration", "health api provider config", "open wearables provider params"]
+"og:title": "Wearable Provider Setup and Sync Guide | Open Wearables"
+"og:description": "Configuration and sync parameters for Garmin, Polar, Suunto, Whoop, and Apple Health. API path conventions included."
+"og:url": "https://docs.openwearables.io/api-reference/guides/provider-setup"
+"og:type": "article"
+"twitter:title": "Wearable Provider Setup and Sync Guide | Open Wearables"
+"twitter:description": "Configuration and sync parameters for Garmin, Polar, Suunto, Whoop, and Apple Health. API path conventions included."
+"twitter:card": "summary_large_image"
 ---
 
 ## Overview

--- a/docs/api-reference/guides/provider-setup.mdx
+++ b/docs/api-reference/guides/provider-setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Wearable Provider Setup and Sync Guide | Open Wearables"
-description: "Provider-specific configuration and sync parameters for all supported wearables. Covers Garmin, Polar, Suunto, Whoop, and Apple Health. API path conventions included."
+description: "Provider configuration and sync parameters for Garmin, Polar, Suunto, Whoop, and Apple Health. API path conventions and provider name rules included."
 keywords: ["wearable provider setup", "garmin sync configuration", "health api provider config", "open wearables provider params"]
 "og:title": "Wearable Provider Setup and Sync Guide | Open Wearables"
 "og:description": "Configuration and sync parameters for Garmin, Polar, Suunto, Whoop, and Apple Health. API path conventions included."

--- a/docs/api-reference/guides/quick-integration.mdx
+++ b/docs/api-reference/guides/quick-integration.mdx
@@ -1,6 +1,15 @@
 ---
-title: 'Quick Integration'
-description: 'End-to-end guide to integrate Open Wearables with your application'
+title: "Wearable API Integration Guide | Open Wearables"
+sidebarTitle: "Quick Integration"
+description: "End-to-end guide to integrate Open Wearables with your app: create a user, connect a wearable provider via OAuth, sync data, and fetch timeseries, workouts, or sleep data."
+keywords: ["wearable api integration guide", "open wearables quick start", "health api tutorial", "wearable data integration"]
+"og:title": "Wearable API Integration Guide | Open Wearables"
+"og:description": "Create a user, connect a provider via OAuth, sync data, fetch timeseries and sleep. End-to-end integration walkthrough."
+"og:url": "https://docs.openwearables.io/api-reference/guides/quick-integration"
+"og:type": "article"
+"twitter:title": "Wearable API Integration Guide | Open Wearables"
+"twitter:description": "Create a user, connect a provider via OAuth, sync data, fetch timeseries and sleep. End-to-end integration walkthrough."
+"twitter:card": "summary_large_image"
 ---
 
 ## Overview

--- a/docs/api-reference/guides/quick-integration.mdx
+++ b/docs/api-reference/guides/quick-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Wearable API Integration Guide | Open Wearables"
 sidebarTitle: "Quick Integration"
-description: "End-to-end guide to integrate Open Wearables with your app: create a user, connect a wearable provider via OAuth, sync data, and fetch timeseries, workouts, or sleep data."
+description: "End-to-end guide: create a user, connect a wearable provider via OAuth, sync data, and fetch timeseries, workouts, or sleep data."
 keywords: ["wearable api integration guide", "open wearables quick start", "health api tutorial", "wearable data integration"]
 "og:title": "Wearable API Integration Guide | Open Wearables"
 "og:description": "Create a user, connect a provider via OAuth, sync data, fetch timeseries and sleep. End-to-end integration walkthrough."

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -1,6 +1,15 @@
 ---
-title: 'API Reference'
-description: 'API documentation for integrating with Open Wearables'
+title: "Open Wearables API Reference | REST API Docs"
+sidebarTitle: "Introduction"
+description: "REST API reference for Open Wearables: manage users, connect wearable providers, and retrieve health data. Covers 3rd-party integration endpoints. Authentication via API key."
+keywords: ["open wearables api reference", "wearable rest api docs", "health data api endpoints", "open wearables endpoints"]
+"og:title": "Open Wearables API Reference | REST API Docs"
+"og:description": "REST endpoints for managing users, connecting providers, and fetching health data. Authentication via API key."
+"og:url": "https://docs.openwearables.io/api-reference/introduction"
+"og:type": "article"
+"twitter:title": "Open Wearables API Reference | REST API Docs"
+"twitter:description": "REST endpoints for managing users, connecting providers, and fetching health data. Authentication via API key."
+"twitter:card": "summary_large_image"
 ---
 
 ## About this reference

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Open Wearables API Reference | REST API Docs"
 sidebarTitle: "Introduction"
-description: "REST API reference for Open Wearables: manage users, connect wearable providers, and retrieve health data. Covers 3rd-party integration endpoints. Authentication via API key."
+description: "REST API reference for managing users, connecting wearable providers, and retrieving health data. 3rd-party integration endpoints. Auth via API key."
 keywords: ["open wearables api reference", "wearable rest api docs", "health data api endpoints", "open wearables endpoints"]
 "og:title": "Open Wearables API Reference | REST API Docs"
 "og:description": "REST endpoints for managing users, connecting providers, and fetching health data. Authentication via API key."

--- a/docs/app/introduction.mdx
+++ b/docs/app/introduction.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Open Wearables Mobile App"
+title: "Open Wearables Mobile App | Health Sync for iOS and Android"
 sidebarTitle: "Introduction"
-description: "Apple Health, Samsung Health, and Google Health Connect don't offer a REST API. The Open Wearables mobile app bridges that gap - syncing on-device health data to your Open Wearables instance automatically."
+description: "Sync on-device health data to Open Wearables without an API. Install the app, enter an invitation code, and Apple Health or Android health data flows to your instance automatically."
+keywords: ["open wearables mobile app", "apple health sync app", "health connect mobile app", "health data sync ios android"]
+"og:title": "Open Wearables Mobile App | Health Sync for iOS and Android"
+"og:description": "Sync Apple Health and Android health data without an API. Install the app, enter an invitation code, and data flows automatically."
+"og:url": "https://docs.openwearables.io/app/introduction"
+"og:type": "article"
+"twitter:title": "Open Wearables Mobile App | Health Sync for iOS and Android"
+"twitter:description": "Sync Apple Health and Android health data without an API. Install the app, enter an invitation code, and data flows automatically."
+"twitter:card": "summary_large_image"
 ---
 
 ## Overview

--- a/docs/app/introduction.mdx
+++ b/docs/app/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Open Wearables Mobile App | Health Sync for iOS and Android"
 sidebarTitle: "Introduction"
-description: "Sync on-device health data to Open Wearables without an API. Install the app, enter an invitation code, and Apple Health or Android health data flows to your instance automatically."
+description: "Sync Apple Health and Android health data to Open Wearables without an API. Install the app, enter an invitation code, and data flows automatically."
 keywords: ["open wearables mobile app", "apple health sync app", "health connect mobile app", "health data sync ios android"]
 "og:title": "Open Wearables Mobile App | Health Sync for iOS and Android"
 "og:description": "Sync Apple Health and Android health data without an API. Install the app, enter an invitation code, and data flows automatically."

--- a/docs/architecture/data-types.mdx
+++ b/docs/architecture/data-types.mdx
@@ -1,6 +1,15 @@
 ---
-title: 'Data Types'
-description: 'Reference for available metrics, workout types, and data formats'
+title: "Health Data Types API Reference | Open Wearables"
+sidebarTitle: "Data Types"
+description: "Reference for all supported health data types, units, and formats. Covers timeseries metrics, sleep stages, workout fields, and activity data. Check provider coverage for per-device availability."
+keywords: ["health data types api", "wearable data types", "health metrics api reference", "timeseries health data"]
+"og:title": "Health Data Types API Reference | Open Wearables"
+"og:description": "All supported health data types, units, and formats. Timeseries, sleep, workouts, and activity. Provider coverage included."
+"og:url": "https://docs.openwearables.io/architecture/data-types"
+"og:type": "article"
+"twitter:title": "Health Data Types API Reference | Open Wearables"
+"twitter:description": "All supported health data types, units, and formats. Timeseries, sleep, workouts, and activity. Provider coverage included."
+"twitter:card": "summary_large_image"
 ---
 
 This page lists all supported data types, units, and formats. For provider-specific availability, see the [Provider Coverage Matrix](/providers/coverage).

--- a/docs/architecture/data-types.mdx
+++ b/docs/architecture/data-types.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Health Data Types API Reference | Open Wearables"
 sidebarTitle: "Data Types"
-description: "Reference for all supported health data types, units, and formats. Covers timeseries metrics, sleep stages, workout fields, and activity data. Check provider coverage for per-device availability."
+description: "Reference for all supported health data types, units, and formats. Covers timeseries metrics, sleep stages, workout fields, and activity data."
 keywords: ["health data types api", "wearable data types", "health metrics api reference", "timeseries health data"]
 "og:title": "Health Data Types API Reference | Open Wearables"
 "og:description": "All supported health data types, units, and formats. Timeseries, sleep, workouts, and activity. Provider coverage included."

--- a/docs/architecture/system-overview.mdx
+++ b/docs/architecture/system-overview.mdx
@@ -1,6 +1,14 @@
 ---
-title: "System Overview"
-description: "Repository structure, runtime stack, and technology choices"
+title: "Open Wearables Platform Architecture | System Overview"
+description: "Open Wearables uses FastAPI, PostgreSQL, Redis, and Celery in a layered monorepo. Self-hosted via Docker Compose. Covers backend structure, MCP server, frontend stack, and data flow."
+keywords: ["wearable platform architecture", "health data api architecture", "open wearables stack", "self-hosted wearable system"]
+"og:title": "Open Wearables Platform Architecture | System Overview"
+"og:description": "FastAPI, PostgreSQL, Redis, and Celery in a layered monorepo. Self-hosted via Docker Compose. Covers backend, MCP server, and data flow."
+"og:url": "https://docs.openwearables.io/architecture/system-overview"
+"og:type": "article"
+"twitter:title": "Open Wearables Platform Architecture | System Overview"
+"twitter:description": "FastAPI, PostgreSQL, Redis, and Celery in a layered monorepo. Self-hosted via Docker Compose. Covers backend, MCP server, and data flow."
+"twitter:card": "summary_large_image"
 ---
 
 ## Repository Structure

--- a/docs/architecture/system-overview.mdx
+++ b/docs/architecture/system-overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Open Wearables Platform Architecture | System Overview"
-description: "Open Wearables uses FastAPI, PostgreSQL, Redis, and Celery in a layered monorepo. Self-hosted via Docker Compose. Covers backend structure, MCP server, frontend stack, and data flow."
+description: "Open Wearables: FastAPI, PostgreSQL, Redis, and Celery in a layered monorepo. Self-hosted via Docker Compose. Covers backend, frontend, and data flow."
 keywords: ["wearable platform architecture", "health data api architecture", "open wearables stack", "self-hosted wearable system"]
 "og:title": "Open Wearables Platform Architecture | System Overview"
 "og:description": "FastAPI, PostgreSQL, Redis, and Celery in a layered monorepo. Self-hosted via Docker Compose. Covers backend, MCP server, and data flow."

--- a/docs/architecture/unified-data-model.mdx
+++ b/docs/architecture/unified-data-model.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Unified data model"
-description: "Database schema and entity relationships"
+title: "Wearable Data Normalization | Open Wearables Unified Data Model"
+description: "Open Wearables normalizes health data from all providers into a single schema. Open algorithms, no black boxes. Covers events, time series, device mapping, and entity relationships."
+keywords: ["wearable data normalization", "unified health data model", "health data schema", "health data aggregation"]
+"og:title": "Wearable Data Normalization | Open Wearables Unified Data Model"
+"og:description": "Normalizes health data from all providers into one schema. Open algorithms, no black boxes. Events, time series, and device mapping."
+"og:url": "https://docs.openwearables.io/architecture/unified-data-model"
+"og:type": "article"
+"twitter:title": "Wearable Data Normalization | Open Wearables Unified Data Model"
+"twitter:description": "Normalizes health data from all providers into one schema. Open algorithms, no black boxes. Events, time series, and device mapping."
+"twitter:card": "summary_large_image"
 ---
 
 The Open Wearables project aims to unify health monitoring data - to do that, a stable, optimised data architecture is paramount. This problem is not trivial, as we face raw data served in heterogeneous formats, with potential erroneous observations, noise interfering with the recorded values and other such issues. On top of that, the potential volume of data is a problem on its own, and without proper structure optimization will be unacceptably memory taxing, calculation intensive, if not both.

--- a/docs/architecture/unified-data-model.mdx
+++ b/docs/architecture/unified-data-model.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Wearable Data Normalization | Open Wearables Unified Data Model"
-description: "Open Wearables normalizes health data from all providers into a single schema. Open algorithms, no black boxes. Covers events, time series, device mapping, and entity relationships."
+title: "Unified Health Data Model | Open Wearables"
+description: "Open Wearables normalizes health data into one unified schema. Open algorithms, no black boxes. Covers events, timeseries, device mapping, and entities."
 keywords: ["wearable data normalization", "unified health data model", "health data schema", "health data aggregation"]
 "og:title": "Wearable Data Normalization | Open Wearables Unified Data Model"
 "og:description": "Normalizes health data from all providers into one schema. Open algorithms, no black boxes. Events, time series, and device mapping."

--- a/docs/deployment/railway.mdx
+++ b/docs/deployment/railway.mdx
@@ -1,6 +1,15 @@
 ---
-title: "Deploy to Railway"
-description: "One-click deploy Open Wearables to Railway with all services pre-configured"
+title: "Deploy Open Wearables to Railway | One-Click Setup"
+sidebarTitle: "Railway"
+description: "Deploy a production Open Wearables instance to Railway in one click. FastAPI, PostgreSQL, Redis, and Celery pre-configured. No manual infrastructure setup. Sensible defaults out of the box."
+keywords: ["deploy open wearables", "open wearables railway", "open wearables self-hosted", "wearable platform deployment"]
+"og:title": "Deploy Open Wearables to Railway | One-Click Setup"
+"og:description": "One-click Railway deploy for Open Wearables. FastAPI, PostgreSQL, Redis, and Celery pre-configured. No infrastructure setup."
+"og:url": "https://docs.openwearables.io/deployment/railway"
+"og:type": "article"
+"twitter:title": "Deploy Open Wearables to Railway | One-Click Setup"
+"twitter:description": "One-click Railway deploy for Open Wearables. FastAPI, PostgreSQL, Redis, and Celery pre-configured. No infrastructure setup."
+"twitter:card": "summary_large_image"
 ---
 
 Railway provides the fastest way to get a production Open Wearables instance running. The template deploys all required services with sensible defaults - no manual infrastructure setup needed.

--- a/docs/deployment/railway.mdx
+++ b/docs/deployment/railway.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Deploy Open Wearables to Railway | One-Click Setup"
 sidebarTitle: "Railway"
-description: "Deploy a production Open Wearables instance to Railway in one click. FastAPI, PostgreSQL, Redis, and Celery pre-configured. No manual infrastructure setup. Sensible defaults out of the box."
+description: "Deploy Open Wearables to Railway in one click. FastAPI, PostgreSQL, Redis, and Celery pre-configured. No manual infrastructure setup needed."
 keywords: ["deploy open wearables", "open wearables railway", "open wearables self-hosted", "wearable platform deployment"]
 "og:title": "Deploy Open Wearables to Railway | One-Click Setup"
 "og:description": "One-click Railway deploy for Open Wearables. FastAPI, PostgreSQL, Redis, and Celery pre-configured. No infrastructure setup."

--- a/docs/dev-guides/aws-setup.mdx
+++ b/docs/dev-guides/aws-setup.mdx
@@ -1,6 +1,14 @@
 ---
-title: "AWS Setup for XML Imports"
-description: "Configure AWS S3 and SNS for handling large file uploads"
+title: "AWS S3 Setup for Apple Health XML Imports | Open Wearables"
+description: "Configure AWS S3 and SNS for large Apple Health XML uploads. SNS triggers automatic processing when files land in S3. Covers creating the required AWS resources step by step."
+keywords: ["aws s3 apple health import", "aws sns health data", "open wearables aws setup", "s3 presigned url health xml"]
+"og:title": "AWS S3 Setup for Apple Health XML Imports | Open Wearables"
+"og:description": "Configure AWS S3 and SNS for large Apple Health XML uploads with presigned URLs. Covers creating required AWS resources."
+"og:url": "https://docs.openwearables.io/dev-guides/aws-setup"
+"og:type": "article"
+"twitter:title": "AWS S3 Setup for Apple Health XML Imports | Open Wearables"
+"twitter:description": "Configure AWS S3 and SNS for large Apple Health XML uploads with presigned URLs. Covers creating required AWS resources."
+"twitter:card": "summary_large_image"
 ---
 
 ## Overview

--- a/docs/dev-guides/aws-setup.mdx
+++ b/docs/dev-guides/aws-setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AWS S3 Setup for Apple Health XML Imports | Open Wearables"
-description: "Configure AWS S3 and SNS for large Apple Health XML uploads. SNS triggers automatic processing when files land in S3. Covers creating the required AWS resources step by step."
+description: "Configure AWS S3 and SNS for large Apple Health XML uploads. SNS triggers processing when files land in S3. Covers creating the required AWS resources."
 keywords: ["aws s3 apple health import", "aws sns health data", "open wearables aws setup", "s3 presigned url health xml"]
 "og:title": "AWS S3 Setup for Apple Health XML Imports | Open Wearables"
 "og:description": "Configure AWS S3 and SNS for large Apple Health XML uploads with presigned URLs. Covers creating required AWS resources."

--- a/docs/dev-guides/backend-e2e-integration.mdx
+++ b/docs/dev-guides/backend-e2e-integration.mdx
@@ -1,6 +1,15 @@
 ---
-title: "Backend E2E Integration Guide"
-description: "Complete walkthrough for integrating Open Wearables with your backend application"
+title: "Backend Health API Integration Guide | Open Wearables"
+sidebarTitle: "Backend E2E Integration"
+description: "Create users, connect wearable providers via OAuth, sync health data, and fetch metrics from your backend. Full integration walkthrough with FastAPI examples. Works with any language."
+keywords: ["health api integration guide", "wearable backend integration", "open wearables api tutorial", "health data api tutorial"]
+"og:title": "Backend Health API Integration Guide | Open Wearables"
+"og:description": "Create users, connect providers via OAuth, sync data, fetch health metrics. FastAPI examples. Any backend language."
+"og:url": "https://docs.openwearables.io/dev-guides/backend-e2e-integration"
+"og:type": "article"
+"twitter:title": "Backend Health API Integration Guide | Open Wearables"
+"twitter:description": "Create users, connect providers via OAuth, sync data, fetch health metrics. FastAPI examples. Any backend language."
+"twitter:card": "summary_large_image"
 ---
 
 This guide walks you through the complete integration flow for connecting your backend application to Open Wearables. You'll learn how to create users, connect wearable providers via OAuth, sync data, and retrieve health metrics.

--- a/docs/dev-guides/backend-e2e-integration.mdx
+++ b/docs/dev-guides/backend-e2e-integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Backend Health API Integration Guide | Open Wearables"
 sidebarTitle: "Backend E2E Integration"
-description: "Create users, connect wearable providers via OAuth, sync health data, and fetch metrics from your backend. Full integration walkthrough with FastAPI examples. Works with any language."
+description: "Create users, connect wearable providers via OAuth, sync health data, and fetch metrics. FastAPI examples included. Works with any backend language."
 keywords: ["health api integration guide", "wearable backend integration", "open wearables api tutorial", "health data api tutorial"]
 "og:title": "Backend Health API Integration Guide | Open Wearables"
 "og:description": "Create users, connect providers via OAuth, sync data, fetch health metrics. FastAPI examples. Any backend language."

--- a/docs/dev-guides/how-to-add-new-provider.mdx
+++ b/docs/dev-guides/how-to-add-new-provider.mdx
@@ -1,6 +1,15 @@
 ---
-title: 'Adding a new provider integration'
-description: 'Step-by-step guide to integrating a new fitness data provider into OpenWearables'
+title: "Add a Wearable Provider Integration | Open Wearables"
+sidebarTitle: "Adding a Provider"
+description: "Add a new fitness data provider to Open Wearables. Covers Strategy, Factory, and Template Method patterns for OAuth, workout, 24/7 data, and webhook handlers. Consistent across all providers."
+keywords: ["add wearable provider", "open wearables contribution", "provider integration guide", "wearable api provider"]
+"og:title": "Add a Wearable Provider Integration | Open Wearables"
+"og:description": "Add a new provider to Open Wearables. Covers Strategy, Factory, OAuth, workout, 24/7, and webhook handler patterns."
+"og:url": "https://docs.openwearables.io/dev-guides/how-to-add-new-provider"
+"og:type": "article"
+"twitter:title": "Add a Wearable Provider Integration | Open Wearables"
+"twitter:description": "Add a new provider to Open Wearables. Covers Strategy, Factory, OAuth, workout, 24/7, and webhook handler patterns."
+"twitter:card": "summary_large_image"
 ---
 
 # How to Add a New Provider Integration

--- a/docs/dev-guides/how-to-add-new-provider.mdx
+++ b/docs/dev-guides/how-to-add-new-provider.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Add a Wearable Provider Integration | Open Wearables"
 sidebarTitle: "Adding a Provider"
-description: "Add a new fitness data provider to Open Wearables. Covers Strategy, Factory, and Template Method patterns for OAuth, workout, 24/7 data, and webhook handlers. Consistent across all providers."
+description: "Add a new fitness data provider to Open Wearables. Covers Strategy, Factory, and Template Method patterns for OAuth, workout, and webhook handlers."
 keywords: ["add wearable provider", "open wearables contribution", "provider integration guide", "wearable api provider"]
 "og:title": "Add a Wearable Provider Integration | Open Wearables"
 "og:description": "Add a new provider to Open Wearables. Covers Strategy, Factory, OAuth, workout, 24/7, and webhook handler patterns."

--- a/docs/dev-guides/ngrok-setup.mdx
+++ b/docs/dev-guides/ngrok-setup.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Exposing local backend with ngrok"
-description: "Quick setup guide for testing webhooks, OAuth flows (Garmin), and mobile SDK integrations"
+title: "Expose Local Backend with ngrok | Open Wearables"
+description: "Use ngrok to expose your local Open Wearables backend for Garmin OAuth callbacks, webhook testing, and Apple Health SDK integration. Quick setup with minimal configuration."
+keywords: ["ngrok open wearables", "expose local backend webhooks", "garmin oauth ngrok", "local health api testing"]
+"og:title": "Expose Local Backend with ngrok | Open Wearables"
+"og:description": "Use ngrok for Garmin OAuth callbacks, webhook testing, and Apple Health SDK integration. Quick setup, minimal config."
+"og:url": "https://docs.openwearables.io/dev-guides/ngrok-setup"
+"og:type": "article"
+"twitter:title": "Expose Local Backend with ngrok | Open Wearables"
+"twitter:description": "Use ngrok for Garmin OAuth callbacks, webhook testing, and Apple Health SDK integration. Quick setup, minimal config."
+"twitter:card": "summary_large_image"
 ---
 
 When testing webhooks (Garmin OAuth callback, Garmin data push) or the Apple Health SDK, you need to expose your local backend to the internet. ngrok provides a simple solution with minimal configuration.

--- a/docs/dev-guides/ngrok-setup.mdx
+++ b/docs/dev-guides/ngrok-setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Expose Local Backend with ngrok | Open Wearables"
-description: "Use ngrok to expose your local Open Wearables backend for Garmin OAuth callbacks, webhook testing, and Apple Health SDK integration. Quick setup with minimal configuration."
+description: "Use ngrok to expose your local Open Wearables backend for Garmin OAuth callbacks, webhook testing, and Apple Health SDK integration. Quick setup."
 keywords: ["ngrok open wearables", "expose local backend webhooks", "garmin oauth ngrok", "local health api testing"]
 "og:title": "Expose Local Backend with ngrok | Open Wearables"
 "og:description": "Use ngrok for Garmin OAuth callbacks, webhook testing, and Apple Health SDK integration. Quick setup, minimal config."

--- a/docs/dev-guides/raw-payload-storage.mdx
+++ b/docs/dev-guides/raw-payload-storage.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Raw Payloads Storage"
-description: "Capture raw incoming data from wearable providers for debugging and testing"
+title: "Raw Payload Storage | Open Wearables Debug Tool"
+description: "Capture raw JSON payloads from wearable providers before processing. Useful for debugging data issues, testing ingestion changes, and reproducing parsing bugs locally."
+keywords: ["raw payload storage wearables", "wearable data debug", "health api payload capture", "open wearables debug"]
+"og:title": "Raw Payload Storage | Open Wearables Debug Tool"
+"og:description": "Capture raw JSON payloads from providers for debugging, testing ingestion changes, and reproducing parsing bugs locally."
+"og:url": "https://docs.openwearables.io/dev-guides/raw-payload-storage"
+"og:type": "article"
+"twitter:title": "Raw Payload Storage | Open Wearables Debug Tool"
+"twitter:description": "Capture raw JSON payloads from providers for debugging, testing ingestion changes, and reproducing parsing bugs locally."
+"twitter:card": "summary_large_image"
 ---
 
 ## Overview

--- a/docs/dev-guides/raw-payload-storage.mdx
+++ b/docs/dev-guides/raw-payload-storage.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Raw Payload Storage | Open Wearables Debug Tool"
-description: "Capture raw JSON payloads from wearable providers before processing. Useful for debugging data issues, testing ingestion changes, and reproducing parsing bugs locally."
+description: "Capture raw JSON payloads from wearable providers before processing. Useful for debugging issues, testing ingestion changes, and reproducing parsing bugs."
 keywords: ["raw payload storage wearables", "wearable data debug", "health api payload capture", "open wearables debug"]
 "og:title": "Raw Payload Storage | Open Wearables Debug Tool"
 "og:description": "Capture raw JSON payloads from providers for debugging, testing ingestion changes, and reproducing parsing bugs locally."

--- a/docs/faqs.mdx
+++ b/docs/faqs.mdx
@@ -1,6 +1,14 @@
 ---
-title: "FAQs"
-description: "Frequently asked questions about Open Wearables"
+title: "Open Wearables FAQs | Common Questions Answered"
+description: "Answers to common Open Wearables questions: what it is, pricing, supported providers, self-hosting, API keys, and data privacy. MIT license, $0 per user."
+keywords: ["open wearables faq", "wearable api questions", "open wearables pricing", "open wearables self-hosted"]
+"og:title": "Open Wearables FAQs | Common Questions Answered"
+"og:description": "Answers on pricing, supported providers, self-hosting, API keys, and data privacy. MIT license, $0 per user."
+"og:url": "https://docs.openwearables.io/faqs"
+"og:type": "article"
+"twitter:title": "Open Wearables FAQs | Common Questions Answered"
+"twitter:description": "Answers on pricing, supported providers, self-hosting, API keys, and data privacy. MIT license, $0 per user."
+"twitter:card": "summary_large_image"
 ---
 
 ## Frequently Asked Questions

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Welcome to our docs"
+title: "Open Wearables: Open Source Health Intelligence Platform"
 sidebarTitle: "Welcome"
-description: "Unified API for wearable device data and AI-powered health insights"
+description: "Open-source platform for health intelligence. Connect Garmin, Whoop, Apple Health, and more via one API. Self-hosted, MIT license, $0 per user. Health intelligence, not just health data."
+keywords: ["open source health intelligence platform", "wearable data platform", "health data integration", "open wearables"]
+"og:title": "Open Wearables: Open Source Health Intelligence Platform"
+"og:description": "Connect wearables via one API. Self-hosted, MIT license, $0 per user. Garmin, Whoop, Apple Health, Polar, and more."
+"og:url": "https://docs.openwearables.io"
+"og:type": "article"
+"twitter:title": "Open Wearables: Open Source Health Intelligence Platform"
+"twitter:description": "Connect wearables via one API. Self-hosted, MIT license, $0 per user. Garmin, Whoop, Apple Health, Polar, and more."
+"twitter:card": "summary_large_image"
 ---
 
 ## Welcome to Open Wearables

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Open Wearables: Open Source Health Intelligence Platform"
 sidebarTitle: "Welcome"
-description: "Open-source platform for health intelligence. Connect Garmin, Whoop, Apple Health, and more via one API. Self-hosted, MIT license, $0 per user. Health intelligence, not just health data."
+description: "Open-source health intelligence platform. Connect Garmin, Whoop, Apple Health, and more via one unified API. Self-hosted, MIT license, $0 per user."
 keywords: ["open source health intelligence platform", "wearable data platform", "health data integration", "open wearables"]
 "og:title": "Open Wearables: Open Source Health Intelligence Platform"
 "og:description": "Connect wearables via one API. Self-hosted, MIT license, $0 per user. Garmin, Whoop, Apple Health, Polar, and more."

--- a/docs/mcp-server/claude-desktop.mdx
+++ b/docs/mcp-server/claude-desktop.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Claude Desktop"
+title: "Claude Desktop Health Data via MCP | Open Wearables"
 sidebarTitle: "Claude Desktop"
-description: "Configure the Open Wearables MCP server with Claude Desktop"
+description: "Configure Claude Desktop to query wearable health data via the Open Wearables MCP server. Ask Claude about sleep, workouts, and HRV in natural language using your own health data."
+keywords: ["claude desktop health data", "wearables claude ai", "mcp claude health", "claude health integration"]
+"og:title": "Claude Desktop Health Data via MCP | Open Wearables"
+"og:description": "Configure Claude Desktop to query wearable health data via MCP. Ask about sleep, workouts, and HRV in natural language."
+"og:url": "https://docs.openwearables.io/mcp-server/claude-desktop"
+"og:type": "article"
+"twitter:title": "Claude Desktop Health Data via MCP | Open Wearables"
+"twitter:description": "Configure Claude Desktop to query wearable health data via MCP. Ask about sleep, workouts, and HRV in natural language."
+"twitter:card": "summary_large_image"
 ---
 
 ## Configuration

--- a/docs/mcp-server/claude-desktop.mdx
+++ b/docs/mcp-server/claude-desktop.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Claude Desktop Health Data via MCP | Open Wearables"
 sidebarTitle: "Claude Desktop"
-description: "Configure Claude Desktop to query wearable health data via the Open Wearables MCP server. Ask Claude about sleep, workouts, and HRV in natural language using your own health data."
+description: "Configure Claude Desktop to query wearable health data via the Open Wearables MCP server. Ask Claude about sleep, workouts, and HRV in natural language."
 keywords: ["claude desktop health data", "wearables claude ai", "mcp claude health", "claude health integration"]
 "og:title": "Claude Desktop Health Data via MCP | Open Wearables"
 "og:description": "Configure Claude Desktop to query wearable health data via MCP. Ask about sleep, workouts, and HRV in natural language."

--- a/docs/mcp-server/cursor.mdx
+++ b/docs/mcp-server/cursor.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Cursor"
+title: "Cursor MCP Server for Health Data | Open Wearables"
 sidebarTitle: "Cursor"
-description: "Configure the Open Wearables MCP server with Cursor IDE"
+description: "Configure the Open Wearables MCP server with Cursor IDE to query wearable health data via natural language. Ask about sleep, workouts, and activity without leaving your editor."
+keywords: ["cursor mcp health data", "cursor wearable integration", "mcp cursor health", "cursor health data ide"]
+"og:title": "Cursor MCP Server for Health Data | Open Wearables"
+"og:description": "Configure Open Wearables MCP with Cursor IDE. Query sleep, workouts, and activity in natural language from your editor."
+"og:url": "https://docs.openwearables.io/mcp-server/cursor"
+"og:type": "article"
+"twitter:title": "Cursor MCP Server for Health Data | Open Wearables"
+"twitter:description": "Configure Open Wearables MCP with Cursor IDE. Query sleep, workouts, and activity in natural language from your editor."
+"twitter:card": "summary_large_image"
 ---
 
 ## Configuration

--- a/docs/mcp-server/cursor.mdx
+++ b/docs/mcp-server/cursor.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Cursor MCP Server for Health Data | Open Wearables"
 sidebarTitle: "Cursor"
-description: "Configure the Open Wearables MCP server with Cursor IDE to query wearable health data via natural language. Ask about sleep, workouts, and activity without leaving your editor."
+description: "Configure the Open Wearables MCP server with Cursor IDE. Query sleep, workouts, and activity data via natural language without leaving your editor."
 keywords: ["cursor mcp health data", "cursor wearable integration", "mcp cursor health", "cursor health data ide"]
 "og:title": "Cursor MCP Server for Health Data | Open Wearables"
 "og:description": "Configure Open Wearables MCP with Cursor IDE. Query sleep, workouts, and activity in natural language from your editor."

--- a/docs/mcp-server/index.mdx
+++ b/docs/mcp-server/index.mdx
@@ -1,7 +1,15 @@
 ---
-title: "MCP Server"
+title: "Health Data MCP Server | Open Wearables"
 sidebarTitle: "Overview"
-description: "Connect AI assistants like Claude Desktop and Cursor to query wearable health data through natural language"
+description: "Open Wearables MCP server connects Claude Desktop and Cursor to wearable health data. Query sleep, workouts, and activity in natural language. Self-hosted, FastMCP-based, MIT license."
+keywords: ["mcp server health data", "model context protocol wearables", "health data mcp", "wearable ai integration"]
+"og:title": "Health Data MCP Server | Open Wearables"
+"og:description": "Connect Claude Desktop and Cursor to wearable health data via MCP. Query sleep, workouts, and activity in natural language."
+"og:url": "https://docs.openwearables.io/mcp-server"
+"og:type": "article"
+"twitter:title": "Health Data MCP Server | Open Wearables"
+"twitter:description": "Connect Claude Desktop and Cursor to wearable health data via MCP. Query sleep, workouts, and activity in natural language."
+"twitter:card": "summary_large_image"
 ---
 
 ## What is MCP?

--- a/docs/mcp-server/index.mdx
+++ b/docs/mcp-server/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Health Data MCP Server | Open Wearables"
 sidebarTitle: "Overview"
-description: "Open Wearables MCP server connects Claude Desktop and Cursor to wearable health data. Query sleep, workouts, and activity in natural language. Self-hosted, FastMCP-based, MIT license."
+description: "The Open Wearables MCP server connects Claude Desktop and Cursor to health data. Query sleep, workouts, and activity in natural language. FastMCP-based."
 keywords: ["mcp server health data", "model context protocol wearables", "health data mcp", "wearable ai integration"]
 "og:title": "Health Data MCP Server | Open Wearables"
 "og:description": "Connect Claude Desktop and Cursor to wearable health data via MCP. Query sleep, workouts, and activity in natural language."

--- a/docs/providers/apple-health.mdx
+++ b/docs/providers/apple-health.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Apple Health"
-description: "Setup guide for Apple Health integration using the Flutter SDK"
+title: "HealthKit Integration with Open Wearables | Apple Health"
+description: "Integrate Apple Health via HealthKit using the Open Wearables Flutter SDK. Push-based sync for steps, heart rate, sleep, workouts, and HRV. Requires iOS 13+ and Apple Developer account."
+keywords: ["healthkit integration", "apple health api", "apple health data", "healthkit open source"]
+"og:title": "HealthKit Integration with Open Wearables | Apple Health"
+"og:description": "Sync Apple Health via HealthKit with the Flutter SDK. Covers steps, heart rate, sleep, workouts, HRV. iOS 13+, push-based."
+"og:url": "https://docs.openwearables.io/providers/apple-health"
+"og:type": "article"
+"twitter:title": "HealthKit Integration with Open Wearables | Apple Health"
+"twitter:description": "Sync Apple Health via HealthKit with the Flutter SDK. Covers steps, heart rate, sleep, workouts, HRV. iOS 13+, push-based."
+"twitter:card": "summary_large_image"
 ---
 
 ## Overview

--- a/docs/providers/apple-health.mdx
+++ b/docs/providers/apple-health.mdx
@@ -1,6 +1,6 @@
 ---
 title: "HealthKit Integration with Open Wearables | Apple Health"
-description: "Integrate Apple Health via HealthKit using the Open Wearables Flutter SDK. Push-based sync for steps, heart rate, sleep, workouts, and HRV. Requires iOS 13+ and Apple Developer account."
+description: "Integrate Apple Health via HealthKit using the Open Wearables Flutter SDK. Push-based sync for steps, heart rate, sleep, and workouts. iOS 13+ required."
 keywords: ["healthkit integration", "apple health api", "apple health data", "healthkit open source"]
 "og:title": "HealthKit Integration with Open Wearables | Apple Health"
 "og:description": "Sync Apple Health via HealthKit with the Flutter SDK. Covers steps, heart rate, sleep, workouts, HRV. iOS 13+, push-based."

--- a/docs/providers/coverage.mdx
+++ b/docs/providers/coverage.mdx
@@ -1,6 +1,15 @@
 ---
-title: 'Coverage Matrix'
-description: 'Which health data types are supported by each wearable provider'
+title: "Wearable API Coverage Matrix | Open Wearables"
+sidebarTitle: "Coverage Matrix"
+description: "Full matrix of health data types supported per provider: Apple, Garmin, Polar, Suunto, Oura, Whoop, Ultrahuman, Strava, and Fitbit. Check OAuth support, workouts, sleep, and timeseries availability."
+keywords: ["wearable api coverage", "health data types by provider", "wearable data types", "provider data support"]
+"og:title": "Wearable API Coverage Matrix | Open Wearables"
+"og:description": "Health data types by provider: Apple, Garmin, Polar, Suunto, Oura, Whoop, Ultrahuman, Strava, Fitbit."
+"og:url": "https://docs.openwearables.io/providers/coverage"
+"og:type": "article"
+"twitter:title": "Wearable API Coverage Matrix | Open Wearables"
+"twitter:description": "Health data types by provider: Apple, Garmin, Polar, Suunto, Oura, Whoop, Ultrahuman, Strava, Fitbit."
+"twitter:card": "summary_large_image"
 ---
 
 This guide provides a comprehensive overview of data type support across all integrated wearable providers. Use this matrix to understand what data you can expect when integrating with specific devices.

--- a/docs/providers/coverage.mdx
+++ b/docs/providers/coverage.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Wearable API Coverage Matrix | Open Wearables"
 sidebarTitle: "Coverage Matrix"
-description: "Full matrix of health data types supported per provider: Apple, Garmin, Polar, Suunto, Oura, Whoop, Ultrahuman, Strava, and Fitbit. Check OAuth support, workouts, sleep, and timeseries availability."
+description: "Data types by provider: Apple, Garmin, Polar, Suunto, Oura, Whoop, Ultrahuman, Strava, and Fitbit. OAuth, workouts, sleep, and timeseries support."
 keywords: ["wearable api coverage", "health data types by provider", "wearable data types", "provider data support"]
 "og:title": "Wearable API Coverage Matrix | Open Wearables"
 "og:description": "Health data types by provider: Apple, Garmin, Polar, Suunto, Oura, Whoop, Ultrahuman, Strava, Fitbit."

--- a/docs/providers/fitbit-api-integration.mdx
+++ b/docs/providers/fitbit-api-integration.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Fitbit API Integration"
-description: "Setup guide for Fitbit integration"
+title: "Fitbit API Integration | Open Wearables"
+description: "Connect Fitbit via OAuth 2.0 to sync workout and activity data. Free Fitbit account required. Pull-based syncing only, no webhooks. No special developer permissions needed."
+keywords: ["fitbit api integration", "fitbit oauth", "fitbit health data", "fitbit api"]
+"og:title": "Fitbit API Integration | Open Wearables"
+"og:description": "Connect Fitbit via OAuth 2.0. Syncs workouts and activity. Free account required, pull-based syncing only."
+"og:url": "https://docs.openwearables.io/providers/fitbit-api-integration"
+"og:type": "article"
+"twitter:title": "Fitbit API Integration | Open Wearables"
+"twitter:description": "Connect Fitbit via OAuth 2.0. Syncs workouts and activity. Free account required, pull-based syncing only."
+"twitter:card": "summary_large_image"
 ---
 
 <Note>

--- a/docs/providers/fitbit-api-integration.mdx
+++ b/docs/providers/fitbit-api-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Fitbit API Integration | Open Wearables"
-description: "Connect Fitbit via OAuth 2.0 to sync workout and activity data. Free Fitbit account required. Pull-based syncing only, no webhooks. No special developer permissions needed."
+description: "Connect Fitbit via OAuth 2.0 to sync workouts and activity. Free account required. Pull-based syncing only, no webhooks. No special developer permissions."
 keywords: ["fitbit api integration", "fitbit oauth", "fitbit health data", "fitbit api"]
 "og:title": "Fitbit API Integration | Open Wearables"
 "og:description": "Connect Fitbit via OAuth 2.0. Syncs workouts and activity. Free account required, pull-based syncing only."

--- a/docs/providers/garmin-api-integration.mdx
+++ b/docs/providers/garmin-api-integration.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Garmin API Integration"
-description: "Setup guide for Garmin Connect integration"
+title: "Garmin API Integration | Open Wearables"
+description: "Connect Garmin devices via Garmin Connect OAuth 2.0. Syncs activities, sleep, HRV, body composition, and daily summaries. Requires legal entity and Garmin Developer Program approval."
+keywords: ["garmin api", "garmin connect api", "garmin health data", "garmin api integration"]
+"og:title": "Garmin API Integration | Open Wearables"
+"og:description": "Connect Garmin via OAuth 2.0. Syncs activities, sleep, HRV, and daily summaries. Requires Garmin Developer Program approval."
+"og:url": "https://docs.openwearables.io/providers/garmin-api-integration"
+"og:type": "article"
+"twitter:title": "Garmin API Integration | Open Wearables"
+"twitter:description": "Connect Garmin via OAuth 2.0. Syncs activities, sleep, HRV, and daily summaries. Requires Garmin Developer Program approval."
+"twitter:card": "summary_large_image"
 ---
 
 <Note>

--- a/docs/providers/garmin-api-integration.mdx
+++ b/docs/providers/garmin-api-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Garmin API Integration | Open Wearables"
-description: "Connect Garmin devices via Garmin Connect OAuth 2.0. Syncs activities, sleep, HRV, body composition, and daily summaries. Requires legal entity and Garmin Developer Program approval."
+description: "Connect Garmin via OAuth 2.0. Syncs activities, sleep, HRV, and daily summaries. Requires legal entity and Garmin Developer Program approval."
 keywords: ["garmin api", "garmin connect api", "garmin health data", "garmin api integration"]
 "og:title": "Garmin API Integration | Open Wearables"
 "og:description": "Connect Garmin via OAuth 2.0. Syncs activities, sleep, HRV, and daily summaries. Requires Garmin Developer Program approval."

--- a/docs/providers/garmin-data-pipeline.mdx
+++ b/docs/providers/garmin-data-pipeline.mdx
@@ -1,6 +1,15 @@
 ---
-title: "Garmin Data Pipeline"
-description: "Technical deep-dive into Garmin webhook ingestion, backfill orchestration, retry/recovery, and frontend status rendering"
+title: "Garmin Data Pipeline | Open Wearables"
+sidebarTitle: "Data Pipeline"
+description: "Deep-dive into Garmin webhook ingestion, backfill orchestration, and retry logic. Garmin delivers data only via webhooks. Celery workers process events with Redis-backed state management."
+keywords: ["garmin data pipeline", "garmin webhook ingestion", "garmin api architecture", "garmin celery workers"]
+"og:title": "Garmin Data Pipeline | Open Wearables"
+"og:description": "Garmin webhook ingestion, backfill orchestration, and retry logic. Celery workers with Redis-backed state management."
+"og:url": "https://docs.openwearables.io/providers/garmin-data-pipeline"
+"og:type": "article"
+"twitter:title": "Garmin Data Pipeline | Open Wearables"
+"twitter:description": "Garmin webhook ingestion, backfill orchestration, and retry logic. Celery workers with Redis-backed state management."
+"twitter:card": "summary_large_image"
 ---
 
 ## Architecture Overview

--- a/docs/providers/garmin-data-pipeline.mdx
+++ b/docs/providers/garmin-data-pipeline.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Garmin Data Pipeline | Open Wearables"
 sidebarTitle: "Data Pipeline"
-description: "Deep-dive into Garmin webhook ingestion, backfill orchestration, and retry logic. Garmin delivers data only via webhooks. Celery workers process events with Redis-backed state management."
+description: "Garmin delivers data only via webhooks. This guide covers ingestion, backfill orchestration, and retry logic. Celery workers with Redis-backed state."
 keywords: ["garmin data pipeline", "garmin webhook ingestion", "garmin api architecture", "garmin celery workers"]
 "og:title": "Garmin Data Pipeline | Open Wearables"
 "og:description": "Garmin webhook ingestion, backfill orchestration, and retry logic. Celery workers with Redis-backed state management."

--- a/docs/providers/polar-api-integration.mdx
+++ b/docs/providers/polar-api-integration.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Polar API Integration"
-description: "Setup guide for Polar integration"
+title: "Polar API Integration | Open Wearables"
+description: "Connect Polar devices via the AccessLink API with OAuth 2.0. Syncs exercise and workout data. Client ID and Secret from Polar AccessLink Admin. Free Polar Flow account required."
+keywords: ["polar api", "polar api integration", "polar health data", "polar fitness api"]
+"og:title": "Polar API Integration | Open Wearables"
+"og:description": "Connect Polar via AccessLink API with OAuth 2.0. Syncs exercise and workout data. Free Polar Flow account required."
+"og:url": "https://docs.openwearables.io/providers/polar-api-integration"
+"og:type": "article"
+"twitter:title": "Polar API Integration | Open Wearables"
+"twitter:description": "Connect Polar via AccessLink API with OAuth 2.0. Syncs exercise and workout data. Free Polar Flow account required."
+"twitter:card": "summary_large_image"
 ---
 
 <Note>

--- a/docs/providers/polar-api-integration.mdx
+++ b/docs/providers/polar-api-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Polar API Integration | Open Wearables"
-description: "Connect Polar devices via the AccessLink API with OAuth 2.0. Syncs exercise and workout data. Client ID and Secret from Polar AccessLink Admin. Free Polar Flow account required."
+description: "Connect Polar devices via AccessLink API with OAuth 2.0. Syncs exercise and workout data. Requires Client ID and Secret from Polar AccessLink Admin."
 keywords: ["polar api", "polar api integration", "polar health data", "polar fitness api"]
 "og:title": "Polar API Integration | Open Wearables"
 "og:description": "Connect Polar via AccessLink API with OAuth 2.0. Syncs exercise and workout data. Free Polar Flow account required."

--- a/docs/providers/strava-api-integration.mdx
+++ b/docs/providers/strava-api-integration.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Strava API Integration"
-description: "Setup guide for Strava integration"
+title: "Strava API Integration | Open Wearables"
+description: "Connect Strava via OAuth 2.0 for personal activity sync. Single-user only, no analytics layer. Real-time webhooks for new activities plus polling for historical data."
+keywords: ["strava api integration", "strava oauth", "strava activity data", "strava api"]
+"og:title": "Strava API Integration | Open Wearables"
+"og:description": "Connect Strava via OAuth 2.0. Syncs personal activities. Single-user only, webhooks plus polling for historical data."
+"og:url": "https://docs.openwearables.io/providers/strava-api-integration"
+"og:type": "article"
+"twitter:title": "Strava API Integration | Open Wearables"
+"twitter:description": "Connect Strava via OAuth 2.0. Syncs personal activities. Single-user only, webhooks plus polling for historical data."
+"twitter:card": "summary_large_image"
 ---
 
 <Warning>

--- a/docs/providers/strava-api-integration.mdx
+++ b/docs/providers/strava-api-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Strava API Integration | Open Wearables"
-description: "Connect Strava via OAuth 2.0 for personal activity sync. Single-user only, no analytics layer. Real-time webhooks for new activities plus polling for historical data."
+description: "Connect Strava via OAuth 2.0 for personal activity sync. Single-user only, no analytics. Webhooks for real-time events plus polling for historical data."
 keywords: ["strava api integration", "strava oauth", "strava activity data", "strava api"]
 "og:title": "Strava API Integration | Open Wearables"
 "og:description": "Connect Strava via OAuth 2.0. Syncs personal activities. Single-user only, webhooks plus polling for historical data."

--- a/docs/providers/supported.mdx
+++ b/docs/providers/supported.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Supported providers"
-description: "Connect and configure wearable device providers"
+title: "Supported Wearable Device Integrations | Open Wearables"
+description: "Open Wearables supports 9 providers: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Ultrahuman, Apple Health, and Google Health Connect. Cloud OAuth and SDK-based integrations."
+keywords: ["wearable device integrations", "supported wearables api", "wearable api providers", "open wearables"]
+"og:title": "Supported Wearable Device Integrations | Open Wearables"
+"og:description": "9 providers supported: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Ultrahuman, Apple Health, and Google Health Connect."
+"og:url": "https://docs.openwearables.io/providers/supported"
+"og:type": "article"
+"twitter:title": "Supported Wearable Device Integrations | Open Wearables"
+"twitter:description": "9 providers supported: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Ultrahuman, Apple Health, and Google Health Connect."
+"twitter:card": "summary_large_image"
 ---
 
 ## Available Providers

--- a/docs/providers/supported.mdx
+++ b/docs/providers/supported.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Supported Wearable Device Integrations | Open Wearables"
-description: "Open Wearables supports 9 providers: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Ultrahuman, Apple Health, and Google Health Connect. Cloud OAuth and SDK-based integrations."
+description: "9 providers: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Ultrahuman, Apple Health, and Google Health Connect. Cloud OAuth and mobile SDK integrations."
 keywords: ["wearable device integrations", "supported wearables api", "wearable api providers", "open wearables"]
 "og:title": "Supported Wearable Device Integrations | Open Wearables"
 "og:description": "9 providers supported: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Ultrahuman, Apple Health, and Google Health Connect."

--- a/docs/providers/suunto-api-integration.mdx
+++ b/docs/providers/suunto-api-integration.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Suunto API Integration"
-description: "Setup guide for Suunto integration"
+title: "Suunto API Integration | Open Wearables"
+description: "Connect Suunto devices via OAuth 2.0 to sync workout, sleep, and 24/7 health metrics. Requires Suunto Developer Program access. Full data type coverage across all Suunto devices."
+keywords: ["suunto api integration", "suunto oauth", "suunto health data", "suunto api"]
+"og:title": "Suunto API Integration | Open Wearables"
+"og:description": "Connect Suunto via OAuth 2.0. Syncs workouts, sleep, and 24/7 metrics. Requires Suunto Developer Program access."
+"og:url": "https://docs.openwearables.io/providers/suunto-api-integration"
+"og:type": "article"
+"twitter:title": "Suunto API Integration | Open Wearables"
+"twitter:description": "Connect Suunto via OAuth 2.0. Syncs workouts, sleep, and 24/7 metrics. Requires Suunto Developer Program access."
+"twitter:card": "summary_large_image"
 ---
 
 TODO

--- a/docs/providers/suunto-api-integration.mdx
+++ b/docs/providers/suunto-api-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Suunto API Integration | Open Wearables"
-description: "Connect Suunto devices via OAuth 2.0 to sync workout, sleep, and 24/7 health metrics. Requires Suunto Developer Program access. Full data type coverage across all Suunto devices."
+description: "Connect Suunto devices via OAuth 2.0 to sync workout, sleep, and 24/7 health metrics. Requires Suunto Developer Program access. Full data type coverage."
 keywords: ["suunto api integration", "suunto oauth", "suunto health data", "suunto api"]
 "og:title": "Suunto API Integration | Open Wearables"
 "og:description": "Connect Suunto via OAuth 2.0. Syncs workouts, sleep, and 24/7 metrics. Requires Suunto Developer Program access."

--- a/docs/providers/ultrahuman-api-integration.mdx
+++ b/docs/providers/ultrahuman-api-integration.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Ultrahuman API Integration"
-description: "Setup guide for Ultrahuman Ring Air integration"
+title: "Ultrahuman Ring API Integration | Open Wearables"
+description: "Connect Ultrahuman Ring Air via OAuth 2.0 to sync sleep stages, HRV, and 24/7 heart rate. Requires Ultrahuman Partnership API access. Pull-based syncing with daily metrics."
+keywords: ["ultrahuman api integration", "ultrahuman ring api", "ultrahuman health data", "ultrahuman hrv"]
+"og:title": "Ultrahuman Ring API Integration | Open Wearables"
+"og:description": "Connect Ultrahuman Ring Air via OAuth 2.0. Syncs sleep, HRV, and 24/7 heart rate. Requires Partnership API access."
+"og:url": "https://docs.openwearables.io/providers/ultrahuman-api-integration"
+"og:type": "article"
+"twitter:title": "Ultrahuman Ring API Integration | Open Wearables"
+"twitter:description": "Connect Ultrahuman Ring Air via OAuth 2.0. Syncs sleep, HRV, and 24/7 heart rate. Requires Partnership API access."
+"twitter:card": "summary_large_image"
 ---
 
 <Note>

--- a/docs/providers/ultrahuman-api-integration.mdx
+++ b/docs/providers/ultrahuman-api-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Ultrahuman Ring API Integration | Open Wearables"
-description: "Connect Ultrahuman Ring Air via OAuth 2.0 to sync sleep stages, HRV, and 24/7 heart rate. Requires Ultrahuman Partnership API access. Pull-based syncing with daily metrics."
+description: "Connect Ultrahuman Ring Air via OAuth 2.0 to sync sleep stages, HRV, and 24/7 heart rate. Requires Partnership API access. Pull-based syncing."
 keywords: ["ultrahuman api integration", "ultrahuman ring api", "ultrahuman health data", "ultrahuman hrv"]
 "og:title": "Ultrahuman Ring API Integration | Open Wearables"
 "og:description": "Connect Ultrahuman Ring Air via OAuth 2.0. Syncs sleep, HRV, and 24/7 heart rate. Requires Partnership API access."

--- a/docs/providers/whoop-api-integration.mdx
+++ b/docs/providers/whoop-api-integration.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Whoop API Integration"
-description: "Setup guide for Whoop integration"
+title: "Whoop API Integration | Open Wearables"
+description: "Connect Whoop via OAuth 2.0. Syncs workouts, sleep with stages, recovery scores, HRV, SpO2, and body measurements. Requires an active Whoop membership. Polling-based sync."
+keywords: ["whoop api", "whoop data integration", "whoop health data", "whoop api open source"]
+"og:title": "Whoop API Integration | Open Wearables"
+"og:description": "Connect Whoop via OAuth 2.0. Syncs workouts, sleep, recovery scores, HRV, and SpO2. Requires Whoop membership."
+"og:url": "https://docs.openwearables.io/providers/whoop-api-integration"
+"og:type": "article"
+"twitter:title": "Whoop API Integration | Open Wearables"
+"twitter:description": "Connect Whoop via OAuth 2.0. Syncs workouts, sleep, recovery scores, HRV, and SpO2. Requires Whoop membership."
+"twitter:card": "summary_large_image"
 ---
 
 <Note>

--- a/docs/providers/whoop-api-integration.mdx
+++ b/docs/providers/whoop-api-integration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Whoop API Integration | Open Wearables"
-description: "Connect Whoop via OAuth 2.0. Syncs workouts, sleep with stages, recovery scores, HRV, SpO2, and body measurements. Requires an active Whoop membership. Polling-based sync."
+description: "Connect Whoop via OAuth 2.0. Syncs workouts, sleep with stages, recovery scores, HRV, SpO2, and body measurements. Requires an active Whoop membership."
 keywords: ["whoop api", "whoop data integration", "whoop health data", "whoop api open source"]
 "og:title": "Whoop API Integration | Open Wearables"
 "og:description": "Connect Whoop via OAuth 2.0. Syncs workouts, sleep, recovery scores, HRV, and SpO2. Requires Whoop membership."

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Quickstart"
-description: "Get Open Wearables up and running in minutes"
+title: "Wearable API Quickstart | Open Wearables Setup Guide"
+description: "Make your first wearable API call in 5 minutes with this quickstart. Covers Docker setup, environment config, and your first authenticated health data request."
+keywords: ["wearable api quickstart", "open wearables setup", "health data api tutorial", "open wearables"]
+"og:title": "Wearable API Quickstart | Open Wearables Setup Guide"
+"og:description": "Make your first wearable API call in 5 minutes. Covers Docker setup, environment config, and authenticated health data requests."
+"og:url": "https://docs.openwearables.io/quickstart"
+"og:type": "article"
+"twitter:title": "Wearable API Quickstart | Open Wearables Setup Guide"
+"twitter:description": "Make your first wearable API call in 5 minutes. Covers Docker setup, environment config, and authenticated health data requests."
+"twitter:card": "summary_large_image"
 ---
 
 ## Get started in three steps

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Wearable API Quickstart | Open Wearables Setup Guide"
-description: "Make your first wearable API call in 5 minutes with this quickstart. Covers Docker setup, environment config, and your first authenticated health data request."
+description: "Make your first wearable API call in 5 minutes. Covers Docker setup, environment config, and your first authenticated health data request."
 keywords: ["wearable api quickstart", "open wearables setup", "health data api tutorial", "open wearables"]
 "og:title": "Wearable API Quickstart | Open Wearables Setup Guide"
 "og:description": "Make your first wearable API call in 5 minutes. Covers Docker setup, environment config, and authenticated health data requests."

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Roadmap"
-description: "Current features and upcoming development plans"
+title: "Open Wearables Roadmap: Current Features and Upcoming Plans"
+description: "Track what's available and what's next in Open Wearables. Covers provider integrations, health scores in development, webhooks, and the AI health roadmap."
+keywords: ["open wearables roadmap", "wearable platform updates", "open source health api", "open wearables"]
+"og:title": "Open Wearables Roadmap: Current Features and Upcoming Plans"
+"og:description": "Track what's available and what's next in Open Wearables. Provider integrations, health scores, webhooks, and the AI health roadmap."
+"og:url": "https://docs.openwearables.io/roadmap"
+"og:type": "article"
+"twitter:title": "Open Wearables Roadmap: Current Features and Upcoming Plans"
+"twitter:description": "Track what's available and what's next in Open Wearables. Provider integrations, health scores, webhooks, and the AI health roadmap."
+"twitter:card": "summary_large_image"
 ---
 
 ## Overview

--- a/docs/sdk/android/index.mdx
+++ b/docs/sdk/android/index.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Android SDK"
+title: "Android Health Connect SDK | Open Wearables"
 sidebarTitle: "Overview"
-description: "Native Android SDK for background health data sync from Samsung Health and Health Connect"
+description: "Native Kotlin SDK for background health data sync from Samsung Health and Health Connect. Dual provider support, WorkManager-backed sync, and foreground service for reliability."
+keywords: ["android health connect sdk", "samsung health sdk", "android health data sync", "health connect integration"]
+"og:title": "Android Health Connect SDK | Open Wearables"
+"og:description": "Native Kotlin SDK for Samsung Health and Health Connect. WorkManager sync, dual provider support, foreground service."
+"og:url": "https://docs.openwearables.io/sdk/android"
+"og:type": "article"
+"twitter:title": "Android Health Connect SDK | Open Wearables"
+"twitter:description": "Native Kotlin SDK for Samsung Health and Health Connect. WorkManager sync, dual provider support, foreground service."
+"twitter:card": "summary_large_image"
 ---
 
 ## Introduction

--- a/docs/sdk/android/index.mdx
+++ b/docs/sdk/android/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Android Health Connect SDK | Open Wearables"
 sidebarTitle: "Overview"
-description: "Native Kotlin SDK for background health data sync from Samsung Health and Health Connect. Dual provider support, WorkManager-backed sync, and foreground service for reliability."
+description: "Native Kotlin SDK for background sync from Samsung Health and Health Connect. Dual provider support, WorkManager-backed sync, and foreground service."
 keywords: ["android health connect sdk", "samsung health sdk", "android health data sync", "health connect integration"]
 "og:title": "Android Health Connect SDK | Open Wearables"
 "og:description": "Native Kotlin SDK for Samsung Health and Health Connect. WorkManager sync, dual provider support, foreground service."

--- a/docs/sdk/android/integration.mdx
+++ b/docs/sdk/android/integration.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Integration Guide"
+title: "Android Health Connect Integration Guide | Open Wearables"
 sidebarTitle: "Integration Guide"
-description: "Complete guide to integrating the native Android SDK with your Kotlin application"
+description: "Integrate the Open Wearables Android SDK into a Kotlin app. Covers backend auth setup, SDK initialization, health provider selection, and Health Connect permission requests."
+keywords: ["android health connect integration", "health connect sdk setup", "android health data kotlin", "open wearables android"]
+"og:title": "Android Health Connect Integration Guide | Open Wearables"
+"og:description": "Integrate the Android SDK into a Kotlin app. Backend auth, initialization, provider selection, and Health Connect permissions."
+"og:url": "https://docs.openwearables.io/sdk/android/integration"
+"og:type": "article"
+"twitter:title": "Android Health Connect Integration Guide | Open Wearables"
+"twitter:description": "Integrate the Android SDK into a Kotlin app. Backend auth, initialization, provider selection, and Health Connect permissions."
+"twitter:card": "summary_large_image"
 ---
 
 ## Overview

--- a/docs/sdk/android/integration.mdx
+++ b/docs/sdk/android/integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Android Health Connect Integration Guide | Open Wearables"
 sidebarTitle: "Integration Guide"
-description: "Integrate the Open Wearables Android SDK into a Kotlin app. Covers backend auth setup, SDK initialization, health provider selection, and Health Connect permission requests."
+description: "Integrate the Open Wearables Android SDK into a Kotlin app. Covers backend auth, SDK initialization, provider selection, and Health Connect permissions."
 keywords: ["android health connect integration", "health connect sdk setup", "android health data kotlin", "open wearables android"]
 "og:title": "Android Health Connect Integration Guide | Open Wearables"
 "og:description": "Integrate the Android SDK into a Kotlin app. Backend auth, initialization, provider selection, and Health Connect permissions."

--- a/docs/sdk/android/troubleshooting.mdx
+++ b/docs/sdk/android/troubleshooting.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Troubleshooting"
+title: "Android Health Connect SDK Troubleshooting | Open Wearables"
 sidebarTitle: "Troubleshooting"
-description: "Common issues and solutions for the native Android SDK"
+description: "Fix common Android SDK issues: Health Connect permissions not showing, Samsung Health unavailable, and background sync failures. Solutions for Kotlin and WorkManager integration."
+keywords: ["android health connect troubleshooting", "health connect permissions fix", "samsung health sdk issues", "open wearables android debug"]
+"og:title": "Android Health Connect SDK Troubleshooting | Open Wearables"
+"og:description": "Fix Android SDK issues: Health Connect permissions not showing, Samsung Health unavailable, and background sync failures."
+"og:url": "https://docs.openwearables.io/sdk/android/troubleshooting"
+"og:type": "article"
+"twitter:title": "Android Health Connect SDK Troubleshooting | Open Wearables"
+"twitter:description": "Fix Android SDK issues: Health Connect permissions not showing, Samsung Health unavailable, and background sync failures."
+"twitter:card": "summary_large_image"
 ---
 
 ## Common Issues

--- a/docs/sdk/android/troubleshooting.mdx
+++ b/docs/sdk/android/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Android Health Connect SDK Troubleshooting | Open Wearables"
 sidebarTitle: "Troubleshooting"
-description: "Fix common Android SDK issues: Health Connect permissions not showing, Samsung Health unavailable, and background sync failures. Solutions for Kotlin and WorkManager integration."
+description: "Fix Android SDK issues: Health Connect permissions not showing, Samsung Health unavailable, and background sync failures. Kotlin and WorkManager tips."
 keywords: ["android health connect troubleshooting", "health connect permissions fix", "samsung health sdk issues", "open wearables android debug"]
 "og:title": "Android Health Connect SDK Troubleshooting | Open Wearables"
 "og:description": "Fix Android SDK issues: Health Connect permissions not showing, Samsung Health unavailable, and background sync failures."

--- a/docs/sdk/flutter/example-app.mdx
+++ b/docs/sdk/flutter/example-app.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Open Wearables App"
+title: "Open Wearables Flutter Example App | SDK Demo"
 sidebarTitle: "Open Wearables App"
-description: "Try the SDK with our demo app and see health data sync in action"
+description: "Explore the Open Wearables Flutter SDK with a working example app. Syncs Apple Health and Android health data in minutes. Good starting point for personal tracking or coach app builds."
+keywords: ["flutter health example app", "open wearables flutter demo", "healthkit flutter example", "flutter health sync demo"]
+"og:title": "Open Wearables Flutter Example App | SDK Demo"
+"og:description": "Working Flutter example app for the Open Wearables SDK. Syncs Apple Health and Android health data in minutes."
+"og:url": "https://docs.openwearables.io/sdk/flutter/example-app"
+"og:type": "article"
+"twitter:title": "Open Wearables Flutter Example App | SDK Demo"
+"twitter:description": "Working Flutter example app for the Open Wearables SDK. Syncs Apple Health and Android health data in minutes."
+"twitter:card": "summary_large_image"
 ---
 
 ## Overview

--- a/docs/sdk/flutter/example-app.mdx
+++ b/docs/sdk/flutter/example-app.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Open Wearables Flutter Example App | SDK Demo"
 sidebarTitle: "Open Wearables App"
-description: "Explore the Open Wearables Flutter SDK with a working example app. Syncs Apple Health and Android health data in minutes. Good starting point for personal tracking or coach app builds."
+description: "Explore the Flutter SDK with a working example app. Syncs Apple Health and Android health data in minutes. Good for personal tracking or coach app builds."
 keywords: ["flutter health example app", "open wearables flutter demo", "healthkit flutter example", "flutter health sync demo"]
 "og:title": "Open Wearables Flutter Example App | SDK Demo"
 "og:description": "Working Flutter example app for the Open Wearables SDK. Syncs Apple Health and Android health data in minutes."

--- a/docs/sdk/flutter/index.mdx
+++ b/docs/sdk/flutter/index.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Flutter SDK"
+title: "Flutter Health Data SDK | Open Wearables"
 sidebarTitle: "Overview"
-description: "Background health data sync for Flutter apps from Apple HealthKit, Samsung Health, and Health Connect"
+description: "Flutter SDK for background health data sync from Apple HealthKit, Samsung Health, and Health Connect. Cross-platform Dart API wrapping the native iOS and Android SDKs."
+keywords: ["flutter health data sdk", "flutter healthkit", "flutter health connect", "flutter wearable sdk"]
+"og:title": "Flutter Health Data SDK | Open Wearables"
+"og:description": "Background sync from HealthKit, Samsung Health, and Health Connect. Dart API wrapping native iOS and Android implementations."
+"og:url": "https://docs.openwearables.io/sdk/flutter"
+"og:type": "article"
+"twitter:title": "Flutter Health Data SDK | Open Wearables"
+"twitter:description": "Background sync from HealthKit, Samsung Health, and Health Connect. Dart API wrapping native iOS and Android implementations."
+"twitter:card": "summary_large_image"
 ---
 
 ## Introduction

--- a/docs/sdk/flutter/index.mdx
+++ b/docs/sdk/flutter/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Flutter Health Data SDK | Open Wearables"
 sidebarTitle: "Overview"
-description: "Flutter SDK for background health data sync from Apple HealthKit, Samsung Health, and Health Connect. Cross-platform Dart API wrapping the native iOS and Android SDKs."
+description: "Flutter SDK for background sync from Apple HealthKit, Samsung Health, and Health Connect. Cross-platform Dart API wrapping the native iOS and Android SDKs."
 keywords: ["flutter health data sdk", "flutter healthkit", "flutter health connect", "flutter wearable sdk"]
 "og:title": "Flutter Health Data SDK | Open Wearables"
 "og:description": "Background sync from HealthKit, Samsung Health, and Health Connect. Dart API wrapping native iOS and Android implementations."

--- a/docs/sdk/flutter/integration.mdx
+++ b/docs/sdk/flutter/integration.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Integration Guide"
+title: "Flutter Health Data Integration Guide | Open Wearables"
 sidebarTitle: "Integration Guide"
-description: "Complete guide to integrating the Flutter SDK with your application"
+description: "Integrate the Open Wearables Flutter SDK for health data sync on iOS and Android. Covers backend auth, SDK setup, sign-in flow, and HealthKit or Health Connect permission requests."
+keywords: ["flutter healthkit integration", "flutter health connect", "flutter health data setup", "open wearables flutter"]
+"og:title": "Flutter Health Data Integration Guide | Open Wearables"
+"og:description": "Integrate the Flutter SDK for iOS and Android. Covers backend auth, SDK setup, sign-in, and permission requests."
+"og:url": "https://docs.openwearables.io/sdk/flutter/integration"
+"og:type": "article"
+"twitter:title": "Flutter Health Data Integration Guide | Open Wearables"
+"twitter:description": "Integrate the Flutter SDK for iOS and Android. Covers backend auth, SDK setup, sign-in, and permission requests."
+"twitter:card": "summary_large_image"
 ---
 
 ## Overview

--- a/docs/sdk/flutter/integration.mdx
+++ b/docs/sdk/flutter/integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Flutter Health Data Integration Guide | Open Wearables"
 sidebarTitle: "Integration Guide"
-description: "Integrate the Open Wearables Flutter SDK for health data sync on iOS and Android. Covers backend auth, SDK setup, sign-in flow, and HealthKit or Health Connect permission requests."
+description: "Integrate the Flutter SDK for health data sync on iOS and Android. Covers backend auth, SDK setup, sign-in, and HealthKit or Health Connect permissions."
 keywords: ["flutter healthkit integration", "flutter health connect", "flutter health data setup", "open wearables flutter"]
 "og:title": "Flutter Health Data Integration Guide | Open Wearables"
 "og:description": "Integrate the Flutter SDK for iOS and Android. Covers backend auth, SDK setup, sign-in, and permission requests."

--- a/docs/sdk/flutter/troubleshooting.mdx
+++ b/docs/sdk/flutter/troubleshooting.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Troubleshooting"
+title: "Flutter Health SDK Troubleshooting | Open Wearables"
 sidebarTitle: "Troubleshooting"
-description: "Common issues and solutions for the Flutter SDK on iOS and Android"
+description: "Fix common Flutter SDK issues on iOS and Android: HealthKit permissions not showing, Health Connect unavailable, and background sync not triggering. Covers cross-platform edge cases."
+keywords: ["flutter healthkit troubleshooting", "flutter health connect issues", "flutter health sync debug", "open wearables flutter debug"]
+"og:title": "Flutter Health SDK Troubleshooting | Open Wearables"
+"og:description": "Fix Flutter SDK issues: HealthKit not showing on iOS, Health Connect unavailable on Android, and background sync failures."
+"og:url": "https://docs.openwearables.io/sdk/flutter/troubleshooting"
+"og:type": "article"
+"twitter:title": "Flutter Health SDK Troubleshooting | Open Wearables"
+"twitter:description": "Fix Flutter SDK issues: HealthKit not showing on iOS, Health Connect unavailable on Android, and background sync failures."
+"twitter:card": "summary_large_image"
 ---
 
 ## Common Issues

--- a/docs/sdk/flutter/troubleshooting.mdx
+++ b/docs/sdk/flutter/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Flutter Health SDK Troubleshooting | Open Wearables"
 sidebarTitle: "Troubleshooting"
-description: "Fix common Flutter SDK issues on iOS and Android: HealthKit permissions not showing, Health Connect unavailable, and background sync not triggering. Covers cross-platform edge cases."
+description: "Fix common Flutter SDK issues on iOS and Android: HealthKit permissions not showing, Health Connect unavailable, and background sync not triggering."
 keywords: ["flutter healthkit troubleshooting", "flutter health connect issues", "flutter health sync debug", "open wearables flutter debug"]
 "og:title": "Flutter Health SDK Troubleshooting | Open Wearables"
 "og:description": "Fix Flutter SDK issues: HealthKit not showing on iOS, Health Connect unavailable on Android, and background sync failures."

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Sync SDK"
+title: "Wearable Sync SDK | Open Wearables"
 sidebarTitle: "Overview"
-description: "Native SDKs for syncing health data from Apple HealthKit, Samsung Health, and Health Connect"
+description: "Native mobile SDKs for background health data sync from Apple HealthKit, Samsung Health, and Health Connect. iOS, Android, Flutter, and React Native supported. Push-based architecture."
+keywords: ["wearable sync sdk", "healthkit sdk", "health connect sdk", "mobile health data sdk"]
+"og:title": "Wearable Sync SDK | Open Wearables"
+"og:description": "Native mobile SDKs for Apple HealthKit, Samsung Health, and Health Connect. iOS, Android, Flutter, and React Native."
+"og:url": "https://docs.openwearables.io/sdk"
+"og:type": "article"
+"twitter:title": "Wearable Sync SDK | Open Wearables"
+"twitter:description": "Native mobile SDKs for Apple HealthKit, Samsung Health, and Health Connect. iOS, Android, Flutter, and React Native."
+"twitter:card": "summary_large_image"
 ---
 
 ## Introduction

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Wearable Sync SDK | Open Wearables"
 sidebarTitle: "Overview"
-description: "Native mobile SDKs for background health data sync from Apple HealthKit, Samsung Health, and Health Connect. iOS, Android, Flutter, and React Native supported. Push-based architecture."
+description: "Native mobile SDKs for background sync from Apple HealthKit, Samsung Health, and Health Connect. iOS, Android, Flutter, and React Native supported."
 keywords: ["wearable sync sdk", "healthkit sdk", "health connect sdk", "mobile health data sdk"]
 "og:title": "Wearable Sync SDK | Open Wearables"
 "og:description": "Native mobile SDKs for Apple HealthKit, Samsung Health, and Health Connect. iOS, Android, Flutter, and React Native."

--- a/docs/sdk/ios/index.mdx
+++ b/docs/sdk/ios/index.mdx
@@ -1,7 +1,15 @@
 ---
-title: "iOS SDK"
+title: "iOS HealthKit SDK | Open Wearables"
 sidebarTitle: "Overview"
-description: "Native iOS SDK for background health data sync from Apple HealthKit"
+description: "Native Swift SDK for background health data sync from Apple HealthKit. Supports background delivery, streaming sync, and secure token storage. Powers the Flutter SDK under the hood."
+keywords: ["ios healthkit sdk", "apple healthkit integration", "ios health data sync", "healthkit background sync"]
+"og:title": "iOS HealthKit SDK | Open Wearables"
+"og:description": "Native Swift SDK for Apple HealthKit background sync. Streaming upload, secure storage, BGTaskScheduler integration."
+"og:url": "https://docs.openwearables.io/sdk/ios"
+"og:type": "article"
+"twitter:title": "iOS HealthKit SDK | Open Wearables"
+"twitter:description": "Native Swift SDK for Apple HealthKit background sync. Streaming upload, secure storage, BGTaskScheduler integration."
+"twitter:card": "summary_large_image"
 ---
 
 ## Introduction

--- a/docs/sdk/ios/index.mdx
+++ b/docs/sdk/ios/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "iOS HealthKit SDK | Open Wearables"
 sidebarTitle: "Overview"
-description: "Native Swift SDK for background health data sync from Apple HealthKit. Supports background delivery, streaming sync, and secure token storage. Powers the Flutter SDK under the hood."
+description: "Native Swift SDK for Apple HealthKit background sync. Supports background delivery, streaming sync, and secure token storage. Powers the Flutter SDK."
 keywords: ["ios healthkit sdk", "apple healthkit integration", "ios health data sync", "healthkit background sync"]
 "og:title": "iOS HealthKit SDK | Open Wearables"
 "og:description": "Native Swift SDK for Apple HealthKit background sync. Streaming upload, secure storage, BGTaskScheduler integration."

--- a/docs/sdk/ios/integration.mdx
+++ b/docs/sdk/ios/integration.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Integration Guide"
+title: "iOS HealthKit Integration Guide | Open Wearables"
 sidebarTitle: "Integration Guide"
-description: "Complete guide to integrating the native iOS SDK with your Swift application"
+description: "Integrate the Open Wearables iOS SDK into a Swift app. Covers backend auth setup, SDK configuration, sign-in flow, and HealthKit permission requests. From setup to production."
+keywords: ["ios healthkit integration", "healthkit sdk setup", "ios health data swift", "open wearables ios"]
+"og:title": "iOS HealthKit Integration Guide | Open Wearables"
+"og:description": "Integrate the iOS SDK into a Swift app. Covers backend auth, SDK config, sign-in flow, and HealthKit permissions."
+"og:url": "https://docs.openwearables.io/sdk/ios/integration"
+"og:type": "article"
+"twitter:title": "iOS HealthKit Integration Guide | Open Wearables"
+"twitter:description": "Integrate the iOS SDK into a Swift app. Covers backend auth, SDK config, sign-in flow, and HealthKit permissions."
+"twitter:card": "summary_large_image"
 ---
 
 ## Overview

--- a/docs/sdk/ios/integration.mdx
+++ b/docs/sdk/ios/integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "iOS HealthKit Integration Guide | Open Wearables"
 sidebarTitle: "Integration Guide"
-description: "Integrate the Open Wearables iOS SDK into a Swift app. Covers backend auth setup, SDK configuration, sign-in flow, and HealthKit permission requests. From setup to production."
+description: "Integrate the Open Wearables iOS SDK into a Swift app. Covers backend auth, SDK configuration, sign-in flow, and HealthKit permission requests."
 keywords: ["ios healthkit integration", "healthkit sdk setup", "ios health data swift", "open wearables ios"]
 "og:title": "iOS HealthKit Integration Guide | Open Wearables"
 "og:description": "Integrate the iOS SDK into a Swift app. Covers backend auth, SDK config, sign-in flow, and HealthKit permissions."

--- a/docs/sdk/ios/troubleshooting.mdx
+++ b/docs/sdk/ios/troubleshooting.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Troubleshooting"
+title: "iOS HealthKit SDK Troubleshooting | Open Wearables"
 sidebarTitle: "Troubleshooting"
-description: "Common issues and solutions for the native iOS SDK"
+description: "Fix common iOS SDK issues: HealthKit permissions not showing, background sync not triggering, and upload failures. Solutions for Swift and Xcode integration problems."
+keywords: ["ios healthkit troubleshooting", "healthkit permissions fix", "ios health sync issues", "open wearables ios debug"]
+"og:title": "iOS HealthKit SDK Troubleshooting | Open Wearables"
+"og:description": "Fix iOS SDK issues: HealthKit permissions not showing, background sync failures, and upload errors. Solutions for Swift."
+"og:url": "https://docs.openwearables.io/sdk/ios/troubleshooting"
+"og:type": "article"
+"twitter:title": "iOS HealthKit SDK Troubleshooting | Open Wearables"
+"twitter:description": "Fix iOS SDK issues: HealthKit permissions not showing, background sync failures, and upload errors. Solutions for Swift."
+"twitter:card": "summary_large_image"
 ---
 
 ## Common Issues

--- a/docs/sdk/ios/troubleshooting.mdx
+++ b/docs/sdk/ios/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "iOS HealthKit SDK Troubleshooting | Open Wearables"
 sidebarTitle: "Troubleshooting"
-description: "Fix common iOS SDK issues: HealthKit permissions not showing, background sync not triggering, and upload failures. Solutions for Swift and Xcode integration problems."
+description: "Fix common iOS SDK issues: HealthKit permissions not showing, background sync not triggering, and upload failures. Swift and Xcode integration tips."
 keywords: ["ios healthkit troubleshooting", "healthkit permissions fix", "ios health sync issues", "open wearables ios debug"]
 "og:title": "iOS HealthKit SDK Troubleshooting | Open Wearables"
 "og:description": "Fix iOS SDK issues: HealthKit permissions not showing, background sync failures, and upload errors. Solutions for Swift."

--- a/docs/sdk/react-native/example-app.mdx
+++ b/docs/sdk/react-native/example-app.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Open Wearables App"
+title: "Open Wearables React Native Example App | SDK Demo"
 sidebarTitle: "Open Wearables App"
-description: "Try the SDK with our demo app and see health data sync in action"
+description: "Explore the React Native SDK with a working example app. Syncs Apple Health and Android health data in minutes. Use it to test the integration or as a reference implementation."
+keywords: ["react native health example app", "open wearables react native demo", "expo health sync example", "react native health data demo"]
+"og:title": "Open Wearables React Native Example App | SDK Demo"
+"og:description": "Working React Native example app for the Open Wearables SDK. Syncs Apple Health and Android health data in minutes."
+"og:url": "https://docs.openwearables.io/sdk/react-native/example-app"
+"og:type": "article"
+"twitter:title": "Open Wearables React Native Example App | SDK Demo"
+"twitter:description": "Working React Native example app for the Open Wearables SDK. Syncs Apple Health and Android health data in minutes."
+"twitter:card": "summary_large_image"
 ---
 
 ## Overview

--- a/docs/sdk/react-native/example-app.mdx
+++ b/docs/sdk/react-native/example-app.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Open Wearables React Native Example App | SDK Demo"
 sidebarTitle: "Open Wearables App"
-description: "Explore the React Native SDK with a working example app. Syncs Apple Health and Android health data in minutes. Use it to test the integration or as a reference implementation."
+description: "Explore the React Native SDK with a working example app. Syncs Apple Health and Android health data in minutes. Use it as a reference implementation."
 keywords: ["react native health example app", "open wearables react native demo", "expo health sync example", "react native health data demo"]
 "og:title": "Open Wearables React Native Example App | SDK Demo"
 "og:description": "Working React Native example app for the Open Wearables SDK. Syncs Apple Health and Android health data in minutes."

--- a/docs/sdk/react-native/index.mdx
+++ b/docs/sdk/react-native/index.mdx
@@ -1,7 +1,15 @@
 ---
-title: "React Native SDK"
+title: "React Native Wearables SDK | Open Wearables"
 sidebarTitle: "Overview"
-description: "Background health data sync for React Native apps from Apple HealthKit, Samsung Health, and Health Connect"
+description: "React Native SDK for background health data sync from Apple HealthKit, Samsung Health, and Health Connect. TypeScript API built with Expo Module API, wrapping native iOS and Android SDKs."
+keywords: ["react native wearables sdk", "react native healthkit", "react native health connect", "react native health data"]
+"og:title": "React Native Wearables SDK | Open Wearables"
+"og:description": "Background sync from HealthKit and Health Connect in React Native. TypeScript API via Expo Module API, wrapping native SDKs."
+"og:url": "https://docs.openwearables.io/sdk/react-native"
+"og:type": "article"
+"twitter:title": "React Native Wearables SDK | Open Wearables"
+"twitter:description": "Background sync from HealthKit and Health Connect in React Native. TypeScript API via Expo Module API, wrapping native SDKs."
+"twitter:card": "summary_large_image"
 ---
 
 ## Introduction

--- a/docs/sdk/react-native/index.mdx
+++ b/docs/sdk/react-native/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "React Native Wearables SDK | Open Wearables"
 sidebarTitle: "Overview"
-description: "React Native SDK for background health data sync from Apple HealthKit, Samsung Health, and Health Connect. TypeScript API built with Expo Module API, wrapping native iOS and Android SDKs."
+description: "React Native SDK for background sync from HealthKit and Health Connect. TypeScript API via Expo Module API, wrapping native iOS and Android SDKs."
 keywords: ["react native wearables sdk", "react native healthkit", "react native health connect", "react native health data"]
 "og:title": "React Native Wearables SDK | Open Wearables"
 "og:description": "Background sync from HealthKit and Health Connect in React Native. TypeScript API via Expo Module API, wrapping native SDKs."

--- a/docs/sdk/react-native/integration.mdx
+++ b/docs/sdk/react-native/integration.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Integration Guide"
+title: "React Native Health Data Integration | Open Wearables"
 sidebarTitle: "Integration Guide"
-description: "Complete guide to integrating the React Native SDK with your application"
+description: "Integrate the Open Wearables React Native SDK for health data sync on iOS and Android. Covers backend auth, Expo Module setup, sign-in flow, and HealthKit permission requests."
+keywords: ["react native healthkit integration", "react native health connect", "expo health data sdk", "open wearables react native"]
+"og:title": "React Native Health Data Integration | Open Wearables"
+"og:description": "Integrate the React Native SDK. Backend auth, Expo Module setup, sign-in flow, and HealthKit permissions on iOS and Android."
+"og:url": "https://docs.openwearables.io/sdk/react-native/integration"
+"og:type": "article"
+"twitter:title": "React Native Health Data Integration | Open Wearables"
+"twitter:description": "Integrate the React Native SDK. Backend auth, Expo Module setup, sign-in flow, and HealthKit permissions on iOS and Android."
+"twitter:card": "summary_large_image"
 ---
 
 ## Overview

--- a/docs/sdk/react-native/integration.mdx
+++ b/docs/sdk/react-native/integration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "React Native Health Data Integration | Open Wearables"
 sidebarTitle: "Integration Guide"
-description: "Integrate the Open Wearables React Native SDK for health data sync on iOS and Android. Covers backend auth, Expo Module setup, sign-in flow, and HealthKit permission requests."
+description: "Integrate the React Native SDK for health data sync on iOS and Android. Covers backend auth, Expo Module setup, sign-in, and HealthKit permission requests."
 keywords: ["react native healthkit integration", "react native health connect", "expo health data sdk", "open wearables react native"]
 "og:title": "React Native Health Data Integration | Open Wearables"
 "og:description": "Integrate the React Native SDK. Backend auth, Expo Module setup, sign-in flow, and HealthKit permissions on iOS and Android."

--- a/docs/sdk/react-native/troubleshooting.mdx
+++ b/docs/sdk/react-native/troubleshooting.mdx
@@ -1,7 +1,15 @@
 ---
-title: "Troubleshooting"
+title: "React Native Health SDK Troubleshooting | Open Wearables"
 sidebarTitle: "Troubleshooting"
-description: "Common issues and solutions for the React Native SDK on iOS and Android"
+description: "Fix common React Native SDK issues on iOS and Android: HealthKit permissions not showing, Health Connect unavailable, and background sync failures. Covers Expo and bare workflow."
+keywords: ["react native healthkit troubleshooting", "react native health connect issues", "expo health sdk debug", "open wearables react native debug"]
+"og:title": "React Native Health SDK Troubleshooting | Open Wearables"
+"og:description": "Fix React Native SDK issues: permissions not showing, Health Connect unavailable, and background sync failures."
+"og:url": "https://docs.openwearables.io/sdk/react-native/troubleshooting"
+"og:type": "article"
+"twitter:title": "React Native Health SDK Troubleshooting | Open Wearables"
+"twitter:description": "Fix React Native SDK issues: permissions not showing, Health Connect unavailable, and background sync failures."
+"twitter:card": "summary_large_image"
 ---
 
 ## Common Issues

--- a/docs/sdk/react-native/troubleshooting.mdx
+++ b/docs/sdk/react-native/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 title: "React Native Health SDK Troubleshooting | Open Wearables"
 sidebarTitle: "Troubleshooting"
-description: "Fix common React Native SDK issues on iOS and Android: HealthKit permissions not showing, Health Connect unavailable, and background sync failures. Covers Expo and bare workflow."
+description: "Fix React Native SDK issues: HealthKit permissions not showing, Health Connect unavailable, and background sync failures. Covers Expo and bare workflow."
 keywords: ["react native healthkit troubleshooting", "react native health connect issues", "expo health sdk debug", "open wearables react native debug"]
 "og:title": "React Native Health SDK Troubleshooting | Open Wearables"
 "og:description": "Fix React Native SDK issues: permissions not showing, Health Connect unavailable, and background sync failures."

--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -1,6 +1,14 @@
 ---
-title: "Support"
-description: "Get help and support for Open Wearables"
+title: "Open Wearables Support | GitHub, Discord, and Docs"
+description: "Get Open Wearables support via GitHub Discussions, Issues, and Discord. Links to API docs, quickstart guide, FAQs, and provider setup guides for integration help."
+keywords: ["open wearables support", "wearable api help", "health data sdk support", "open wearables"]
+"og:title": "Open Wearables Support | GitHub, Discord, and Docs"
+"og:description": "Get Open Wearables support via GitHub Discussions, Issues, and Discord. Links to API docs, quickstart, FAQs, and provider guides."
+"og:url": "https://docs.openwearables.io/support"
+"og:type": "article"
+"twitter:title": "Open Wearables Support | GitHub, Discord, and Docs"
+"twitter:description": "Get Open Wearables support via GitHub Discussions, Issues, and Discord. Links to API docs, quickstart, FAQs, and provider guides."
+"twitter:card": "summary_large_image"
 ---
 
 ## Get Support

--- a/docs/support.mdx
+++ b/docs/support.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Open Wearables Support | GitHub, Discord, and Docs"
-description: "Get Open Wearables support via GitHub Discussions, Issues, and Discord. Links to API docs, quickstart guide, FAQs, and provider setup guides for integration help."
+description: "Get Open Wearables support via GitHub Discussions, Issues, and Discord. Links to API docs, quickstart, FAQs, and provider setup guides for help."
 keywords: ["open wearables support", "wearable api help", "health data sdk support", "open wearables"]
 "og:title": "Open Wearables Support | GitHub, Discord, and Docs"
 "og:description": "Get Open Wearables support via GitHub Discussions, Issues, and Discord. Links to API docs, quickstart, FAQs, and provider guides."


### PR DESCRIPTION
Follow-up to #822 (now merged). Fixes two issues found in the SEO frontmatter across all 49 docs pages.

## Changes

### 1. Meta description trimmed to ≤155 chars
47 pages had descriptions over the 155-character limit Google truncates at. All trimmed at natural phrase boundaries.

### 2. Display title separated from SEO title
The `title` field in Mintlify serves as the visible page H1 **and** the `<title>` tag (auto-formatted as "Title - Open Wearables"). Using "Strava API Integration | Open Wearables" as the `title` caused the brand suffix to appear as the page heading.

**Fix:** `title` now holds the clean display title only (e.g. "Strava API Integration"). The `og:title` and `twitter:title` fields retain the full SEO-optimized value for social sharing and link previews.

**Result per page:**
- H1 heading: `Strava API Integration` (clean)
- Browser `<title>`: `Strava API Integration - Open Wearables` (auto-formatted by Mintlify)
- Social/OG preview: `Strava API Integration | Open Wearables` (from `og:title`)

### Pages not changed
- `roadmap.mdx` and `index.mdx` — title uses `:` separator, no brand suffix to strip
- `faqs.mdx` — title was already clean