### PR TITLE
docs: fix e2e guide pagination field + provider list endpoint

### DIFF
--- a/docs/dev-guides/backend-e2e-integration.mdx
+++ b/docs/dev-guides/backend-e2e-integration.mdx
@@ -314,6 +314,62 @@ Connect users to their wearable devices via OAuth.
 | **Suunto** | ✅ | Workouts, 24/7 data (sleep, recovery) |
 | **Apple Health** | SDK only | All health data |
 
+### List Available Providers (Optional)
+
+If you want to build a dynamic provider selection screen (instead of hardcoding provider names), you can fetch the list of available providers:
+
+<CodeGroup>
+
+```bash cURL
+curl "http://localhost:8000/api/v1/oauth/providers?enabled_only=true&cloud_only=true" \
+  -H "X-Open-Wearables-API-Key: YOUR_API_KEY"
+```
+
+```python Python
+async def get_providers(enabled_only: bool = True, cloud_only: bool = True) -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            f"{OPEN_WEARABLES_API_URL}/api/v1/oauth/providers",
+            headers={"X-Open-Wearables-API-Key": API_KEY},
+            params={"enabled_only": enabled_only, "cloud_only": cloud_only}
+        )
+        return response.json()
+```
+
+</CodeGroup>
+
+**Query parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `enabled_only` | `false` | Return only providers enabled in your instance |
+| `cloud_only` | `false` | Return only cloud-based (OAuth) providers, excludes SDK-only providers like Apple Health |
+
+**Response:**
+
+```json
+[
+  {
+    "provider": "garmin",
+    "name": "Garmin",
+    "has_cloud_api": true,
+    "is_enabled": true,
+    "icon_url": "/static/provider-icons/garmin.svg"
+  },
+  {
+    "provider": "polar",
+    "name": "Polar",
+    "has_cloud_api": true,
+    "is_enabled": true,
+    "icon_url": "/static/provider-icons/polar.svg"
+  }
+]
+```
+
+<Warning>
+`icon_url` is a **relative path**. To render the provider icon, prepend your API base URL: `{OPEN_WEARABLES_API_URL}{icon_url}`.
+</Warning>
+
 ### Get Authorization URL
 
 <Warning>
@@ -520,7 +576,7 @@ curl "http://localhost:8000/api/v1/users/USER_ID/events/workouts?start_date=2025
     }
   ],
   "pagination": {
-    "cursor": null,
+    "next_cursor": null,
     "has_more": false
   }
 }
@@ -557,7 +613,7 @@ curl "http://localhost:8000/api/v1/users/USER_ID/events/sleep?start_date=2025-01
     }
   ],
   "pagination": {
-    "cursor": null,
+    "next_cursor": null,
     "has_more": false
   }
 }


### PR DESCRIPTION
## Summary

- **Fix pagination field name**: workout and sleep response examples showed `"cursor"` but the actual API returns `"next_cursor"` (matching the `Pagination` schema in `backend/app/schemas/utils/pagination.py`). This caused integration bugs when developers followed the guide.
- **Add provider list endpoint docs**: `GET /api/v1/oauth/providers` was listed in the API reference table but had no documented response format, query parameters, or `icon_url` handling. Added an optional section with cURL + Python examples, query param table, response shape, and a warning about `icon_url` being a relative path.

Found while preparing workshop materials for Ring Roast hackathon integration.

## Test plan

- [ ] Verify docs render correctly on openwearables.io after deploy
- [ ] Confirm `next_cursor` matches actual API response for workouts and sleep endpoints
- [ ] Confirm provider list response format matches `ProviderSettingRead` schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for discovering available wearable providers with example API calls
  * Updated pagination field naming in API documentation for workout and sleep event endpoints
  * Added clarification on icon URL formatting requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->