### PR TITLE
feat(dashboard): add Oura as a seed data provider

### DIFF
--- a/backend/app/services/seed_data_service.py
+++ b/backend/app/services/seed_data_service.py
@@ -84,6 +84,12 @@ PROVIDER_CONFIGS: dict[ProviderName, dict] = {
         "devices": ["WHOOP 5.0", "WHOOP 4.0", "WHOOP 3.0"],
         "os_versions": ["5.0", "4.0", "3.0"],
     },
+    ProviderName.OURA: {
+        "source_name": "Oura",
+        "manufacturer": "Oura Health",
+        "devices": ["Oura Ring Gen 3", "Oura Ring Gen 4"],
+        "os_versions": ["2.0", "3.0"],
+    },
 }
 
 SEED_PROVIDERS = list(PROVIDER_CONFIGS.keys())

--- a/frontend/src/routes/_authenticated/settings/seed-data-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/seed-data-tab.tsx
@@ -113,6 +113,7 @@ const COMMON_WORKOUT_TYPES = [
 const PROVIDERS = [
   { id: 'apple', label: 'Apple Health' },
   { id: 'garmin', label: 'Garmin' },
+  { id: 'oura', label: 'Oura' },
   { id: 'polar', label: 'Polar' },
   { id: 'suunto', label: 'Suunto' },
   { id: 'whoop', label: 'WHOOP' },


### PR DESCRIPTION
Adds Oura Ring Gen 3/4 to PROVIDER_CONFIGS on the backend and exposes it as a selectable option in the seed data UI.

## Description

<!-- Provide a brief summary of your changes. What problem does this solve? -->

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Oura Ring as a supported data provider. Users can now select Oura from available providers in settings to sync data from Oura Ring Gen 3 and Gen 4 devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->