### PR TITLE
docs: add Apple Health integrations list

### DIFF
--- a/docs/providers/apple-health.mdx
+++ b/docs/providers/apple-health.mdx
@@ -85,3 +85,140 @@ Apple Health provides the widest range of health data types:
 
 See the [Flutter SDK documentation](/sdk/flutter#supported-health-data-types) for the complete list of supported types.
 
+## Apple Health as a Data Bridge
+
+Even if a provider is **not yet directly supported** by Open Wearables, its data can still be collected by syncing it into Apple Health first.
+
+<Warning>
+  **Data scope may differ.** Third-party providers often write a limited subset of their data to Apple Health compared to what's available through their native APIs. For example, a device might expose detailed HRV metrics in its own app but only sync basic heart rate samples to HealthKit. If you need the full data scope, prefer a direct provider integration when available.
+</Warning>
+
+Apple doesn't publish an official, exhaustive list of HealthKit-compatible apps. The tables below were compiled from internet research using Claude (as of April 2026).
+
+### Watches & Fitness Trackers
+
+| Device / Platform | Companion App |
+|---|---|
+| Garmin (full lineup) | Garmin Connect |
+| Polar | Polar Flow |
+| Suunto | Suunto App |
+| COROS | COROS App |
+| Amazfit | Zepp App |
+| Withings ScanWatch / Move | Health Mate |
+| Xiaomi Mi Watch | Zepp / Mi Fitness |
+| Huawei Watch | Huawei Health |
+| Myzone | Myzone App |
+| Biostrap | Biostrap App |
+| Wear OS (most watches) | Google Fit / Health Connect |
+
+### Rings & Bands
+
+| Device | Companion App |
+|---|---|
+| Oura Ring | Oura App |
+| Ultrahuman Ring | Ultrahuman App |
+| WHOOP | WHOOP App |
+| Luna Smart Ring | Luna App |
+
+### Sleep Monitors
+
+| Device | Companion App |
+|---|---|
+| Beddit Sleep Monitor | Beddit App |
+| Eight Sleep | Eight Sleep App |
+
+### CGM & Metabolism Monitors
+
+| Device | Companion App |
+|---|---|
+| Dexcom G6 / G7 | Dexcom App |
+| Freestyle Libre | LibreLink |
+| Lumen (breath analyzer) | Lumen App |
+| Keto-Mojo (glucose & ketones) | Keto-Mojo App |
+
+### Medical Devices (Blood Pressure, ECG, Body Composition)
+
+| Device | Companion App |
+|---|---|
+| Withings BPM Connect | Health Mate |
+| Omron (Connect series) | Omron Connect |
+| A&D Medical | A&D Heart Track |
+| KardiaMobile (AliveCor) | Kardia App |
+| InBody (body composition analyzers) | InBody App |
+| Renpho (smart scales) | Renpho App |
+| Hume Health | Hume App |
+| QardioBase 2 | Qardio App |
+| Withings Body Scan / Body Cardio | Health Mate |
+
+### Heart Rate Monitors & External Sensors
+
+| Device | Notes |
+|---|---|
+| Wahoo TICKR / TrackR | Chest strap, Bluetooth + ANT+ |
+| Polar H-series | Chest straps |
+| Moxy | Muscle oxygen saturation (SmO2) |
+| CORE | Core body temperature monitor |
+| Cardiomood | Medical heart health monitor |
+
+### Fitness & Workout Apps
+
+| App | Category |
+|---|---|
+| Strava | Running, cycling |
+| Nike Run Club | Running |
+| Peloton | Cycling, strength |
+| MapMyFitness / MapMyRun / MapMyRide / MapMyWalk | General activity |
+| Zwift | Virtual cycling |
+| TrainingPeaks | Training planning |
+| iFIT | Fitness equipment |
+| Wahoo SYSTM | Cycling |
+| Concept2 | Rowing |
+| Decathlon Coach | General activity |
+| Ride with GPS | Cycling navigation |
+| Komoot | Outdoor routes |
+| Rouvy | Cycling simulator |
+| Xert | Performance analysis |
+| Cycling Analytics | Cycling analysis |
+| Hammerhead Karoo | Cycling computer |
+| Lezyne GPS | Cycling navigation |
+| Outdooractive | Outdoor activities |
+
+### Wellness & Mindfulness Apps
+
+| App | Category |
+|---|---|
+| Headspace | Meditation, sleep |
+| Calm | Meditation, sleep |
+| Sleep Cycle | Sleep analysis |
+| AutoSleep | Sleep analysis (iOS) |
+| NaturalCycles | Reproductive health |
+
+### Nutrition Apps
+
+| App | Category |
+|---|---|
+| MyFitnessPal | Calories, macros |
+| Cronometer | Micronutrients, diet |
+| FatSecret | Diet tracking |
+| Nutracheck | Calories (UK) |
+| MacrosFirst | Macros |
+| My Macros+ | Macros |
+| Clue | Menstrual cycle |
+| Proov Insight | Hormones & fertility |
+
+### Other
+
+| App / Device | Notes |
+|---|---|
+| Healthify | Health app |
+| Gabit | Activity tracker |
+| HeyTap OHealth | OnePlus / OPPO |
+| Virtuagym | Workout management |
+
+### What Apple Health Does NOT Support Natively
+
+| Platform | Reason |
+|---|---|
+| Fitbit | No official HealthKit integration from Google/Fitbit |
+| Samsung Galaxy Watch / Samsung Health | Ecosystem designed exclusively for Android |
+


### PR DESCRIPTION
## Description

Adds a comprehensive "Apple Health as a Data Bridge" section to the Apple Health provider page - lists 70+ devices and apps that can sync data into HealthKit, so even providers not yet directly supported by OW can still feed data in. Includes a warning that data scope through Apple Health is often narrower than native APIs.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

## Testing Instructions

**Steps to test:**
1. Open the docs dev server or check the deployed preview
2. Navigate to `/providers/apple-health`
3. Scroll past "Supported Data Types" to see the new "Apple Health as a Data Bridge" section

**Expected behavior:**
- Warning box about data scope differences renders correctly
- All tables (watches, rings, CGMs, apps, etc.) display properly
- "What Apple Health Does NOT Support Natively" section at the bottom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Apple Health documentation with comprehensive reference tables for compatible companion apps and devices (watches, trackers, rings, sleep monitors, CGM devices, and fitness apps).
  * Added guidance on data scope limitations when syncing third-party sources through Apple Health.
  * Documented platforms not natively supported by Apple Health.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->