### PR TITLE
fix: svix-server railway deployment

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from app.schemas.enums import ProviderName
 
-from pydantic import AnyHttpUrl, Field, SecretStr, ValidationInfo, field_validator
+from pydantic import AnyHttpUrl, Field, SecretStr, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from app.utils.config_utils import (
@@ -181,6 +181,12 @@ class Settings(BaseSettings):
     svix_jwt_secret: SecretStr | None = None
     # Bearer token for the Svix API.  If unset, auto-generated from svix_jwt_secret at startup.
     svix_auth_token: SecretStr | None = None
+
+    @model_validator(mode="after")
+    def derive_svix_jwt_secret(self) -> "Settings":
+        if self.svix_jwt_secret is None:
+            self.svix_jwt_secret = SecretStr(self.secret_key)
+        return self
 
     @field_validator("cors_origins", mode="after")
     @classmethod

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -184,7 +184,7 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def derive_svix_jwt_secret(self) -> "Settings":
-        if self.svix_jwt_secret is None:
+        if self.svix_jwt_secret is None or self.svix_jwt_secret.get_secret_value() == "":
             self.svix_jwt_secret = SecretStr(self.secret_key)
         return self
 

--- a/backend/app/services/outgoing_webhooks/svix.py
+++ b/backend/app/services/outgoing_webhooks/svix.py
@@ -112,9 +112,7 @@ def register_event_types() -> None:
     for evt in WebhookEventType:
         description = EVENT_TYPE_DESCRIPTIONS.get(evt, "")
         try:
-            _client.event_type.create(
-                EventTypeIn(name=evt.value, description=description),
-            )
+            _client.event_type.create(EventTypeIn(name=evt.value, description=description))
             logger.info("Registered event type: %s", evt.value)
         except Exception:
             try:

--- a/backend/scripts/init/create_svix_db.py
+++ b/backend/scripts/init/create_svix_db.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Ensure the 'svix' database exists, creating it if necessary.
+
+Runs before migrations so that svix-server can connect on first deploy.
+Uses autocommit because CREATE DATABASE cannot run inside a transaction.
+"""
+
+import psycopg
+
+from app.config import settings
+
+
+def create_svix_db() -> None:
+    dsn = (
+        f"host={settings.db_host} "
+        f"port={settings.db_port} "
+        f"dbname={settings.db_name} "
+        f"user={settings.db_user} "
+        f"password={settings.db_password.get_secret_value()}"
+    )
+    with psycopg.connect(dsn, autocommit=True) as conn:
+        exists = conn.execute("SELECT 1 FROM pg_database WHERE datname = 'svix'").fetchone()
+        if exists:
+            print("Svix database already exists, skipping.")
+            return
+        conn.execute("CREATE DATABASE svix")
+        print("✓ Created 'svix' database.")
+
+
+if __name__ == "__main__":
+    create_svix_db()

--- a/backend/scripts/init/create_svix_db.py
+++ b/backend/scripts/init/create_svix_db.py
@@ -6,6 +6,7 @@ Uses autocommit because CREATE DATABASE cannot run inside a transaction.
 """
 
 import psycopg
+import psycopg.errors
 
 from app.config import settings
 
@@ -19,12 +20,11 @@ def create_svix_db() -> None:
         f"password={settings.db_password.get_secret_value()}"
     )
     with psycopg.connect(dsn, autocommit=True) as conn:
-        exists = conn.execute("SELECT 1 FROM pg_database WHERE datname = 'svix'").fetchone()
-        if exists:
+        try:
+            conn.execute("CREATE DATABASE svix")
+            print("✓ Created 'svix' database.")
+        except psycopg.errors.DuplicateDatabase:
             print("Svix database already exists, skipping.")
-            return
-        conn.execute("CREATE DATABASE svix")
-        print("✓ Created 'svix' database.")
 
 
 if __name__ == "__main__":

--- a/backend/scripts/start/app.sh
+++ b/backend/scripts/start/app.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 set -e -x
 
-# Load auto-generated Svix JWT secret from the shared Docker volume (if present)
-if [ -f /run/svix-secrets/jwt_secret ]; then
-    SVIX_JWT_SECRET=$(cat /run/svix-secrets/jwt_secret)
-    export SVIX_JWT_SECRET
-fi
+# Ensure svix database exists (idempotent)
+echo 'Ensuring svix database...'
+uv run python scripts/init/create_svix_db.py
 
 # Init database
 echo 'Applying migrations...'

--- a/backend/scripts/start/worker.sh
+++ b/backend/scripts/start/worker.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
 set -e -x
 
-if [ -f /run/svix-secrets/jwt_secret ]; then
-    SVIX_JWT_SECRET=$(cat /run/svix-secrets/jwt_secret)
-    export SVIX_JWT_SECRET
-fi
-
 uv run celery -A app.main:celery_app worker --loglevel=info --pool=threads -Q default,sdk_sync,garmin_sync

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,27 +17,6 @@ services:
       - postgres_data:/var/lib/postgresql
     restart: unless-stopped
 
-  db-svix-init:
-    image: postgres:18
-    environment:
-      PGPASSWORD: ${DB_PASSWORD:-open-wearables}
-    command:
-      - bash
-      - -c
-      - |
-        createdb -h ${DB_HOST:-db} -U ${DB_USER:-open-wearables} svix || \
-          psql -h ${DB_HOST:-db} -U ${DB_USER:-open-wearables} -d svix -c 'SELECT 1'
-        if [ ! -f /run/svix-secrets/jwt_secret ]; then
-          openssl rand -hex 32 > /run/svix-secrets/jwt_secret
-          chmod 644 /run/svix-secrets/jwt_secret
-        fi
-    volumes:
-      - svix_secrets:/run/svix-secrets
-    depends_on:
-      db:
-        condition: service_healthy
-    restart: on-failure
-
   app:
     build:
         context: ./backend
@@ -51,8 +30,6 @@ services:
     environment:
       - DB_HOST=db
       - REDIS_HOST=redis
-    volumes:
-      - svix_secrets:/run/svix-secrets:ro
     ports:
       - "8000:8000"
     depends_on:
@@ -60,8 +37,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-      svix-server:
-        condition: service_healthy
     restart: unless-stopped
 
   celery-worker:
@@ -74,8 +49,6 @@ services:
     environment:
       - DB_HOST=db
       - REDIS_HOST=redis
-    volumes:
-      - svix_secrets:/run/svix-secrets:ro
     depends_on:
       - redis
       - db
@@ -132,23 +105,26 @@ services:
       - sh
       - -c
       - |
-        export SVIX_JWT_SECRET=$(cat /run/svix-secrets/jwt_secret)
-        exec /usr/local/bin/svix-server "$@"
+        : "$${SVIX_JWT_SECRET:=$$SECRET_KEY}"
+        export SVIX_JWT_SECRET
+        exec svix-server "$$@"
       - --
     command: ["--run-migrations"]
+    env_file:
+      - ./backend/config/.env
     environment:
       SVIX_DB_DSN: "postgresql://${DB_USER:-open-wearables}:${DB_PASSWORD:-open-wearables}@${DB_HOST:-db}:${DB_PORT:-5432}/svix"
       SVIX_QUEUE_TYPE: "redis"
       SVIX_REDIS_DSN: "redis://redis:6379/1"
       SVIX_CACHE_TYPE: "redis"
-    volumes:
-      - svix_secrets:/run/svix-secrets
     expose:
       - "8071"
     depends_on:
-      db-svix-init:
-        condition: service_completed_successfully
+      db:
+        condition: service_healthy
       redis:
+        condition: service_started
+      app:
         condition: service_started
     healthcheck:
       test: ["CMD", "svix-server", "healthcheck", "http://localhost:8071"]
@@ -176,4 +152,3 @@ services:
 volumes:
   postgres_data:
   redis_data:
-  svix_secrets:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,27 +16,6 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql
 
-  db-svix-init:
-    image: postgres:18
-    environment:
-      PGPASSWORD: ${DB_PASSWORD:-open-wearables}
-    command:
-      - bash
-      - -c
-      - |
-        createdb -h ${DB_HOST:-db} -U ${DB_USER:-open-wearables} svix || \
-          psql -h ${DB_HOST:-db} -U ${DB_USER:-open-wearables} -d svix -c 'SELECT 1'
-        if [ ! -f /run/svix-secrets/jwt_secret ]; then
-          openssl rand -hex 32 > /run/svix-secrets/jwt_secret
-          chmod 644 /run/svix-secrets/jwt_secret
-        fi
-    volumes:
-      - svix_secrets:/run/svix-secrets
-    depends_on:
-      db:
-        condition: service_healthy
-    restart: on-failure
-
   app:
     build:
         context: ./backend
@@ -50,8 +29,6 @@ services:
     environment:
       - DB_HOST=db
       - REDIS_HOST=redis
-    volumes:
-      - svix_secrets:/run/svix-secrets:ro
     ports:
       - "8000:8000"
     depends_on:
@@ -59,8 +36,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-      svix-server:
-        condition: service_healthy
     develop:
       watch:
         - action: sync
@@ -92,8 +67,6 @@ services:
     environment:
       - DB_HOST=db
       - REDIS_HOST=redis
-    volumes:
-      - svix_secrets:/run/svix-secrets:ro
     depends_on:
       - redis
       - db
@@ -169,23 +142,26 @@ services:
       - sh
       - -c
       - |
-        export SVIX_JWT_SECRET=$(cat /run/svix-secrets/jwt_secret)
-        exec /usr/local/bin/svix-server "$@"
+        : "$${SVIX_JWT_SECRET:=$$SECRET_KEY}"
+        export SVIX_JWT_SECRET
+        exec svix-server "$$@"
       - --
     command: ["--run-migrations"]
+    env_file:
+      - ./backend/config/.env
     environment:
       SVIX_DB_DSN: "postgresql://${DB_USER:-open-wearables}:${DB_PASSWORD:-open-wearables}@${DB_HOST:-db}:${DB_PORT:-5432}/svix"
       SVIX_QUEUE_TYPE: "redis"
       SVIX_REDIS_DSN: "redis://redis:6379/1"
       SVIX_CACHE_TYPE: "redis"
-    volumes:
-      - svix_secrets:/run/svix-secrets
     ports:
       - "8071:8071"
     depends_on:
-      db-svix-init:
-        condition: service_completed_successfully
+      db:
+        condition: service_healthy
       redis:
+        condition: service_started
+      app:
         condition: service_started
     healthcheck:
       test: ["CMD", "svix-server", "healthcheck", "http://localhost:8071"]
@@ -225,4 +201,3 @@ services:
 volumes:
   postgres_data:
   redis_data:
-  svix_secrets:


### PR DESCRIPTION
Adjust svix config to deploy it both from docker compose and railway templates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Svix JWT secret now derives automatically from the main application secret when not explicitly set.

* **Chores**
  * Consolidated Svix database creation into startup to ensure idempotent initialization.
  * Switched deployment to environment-based secret handling (removed file-based secret provisioning and related init service).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->