### PR TITLE
refactor(mcp): typed exception hierarchy + first test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,27 @@ jobs:
         working-directory: mcp
         run: uv run ty check
 
+  mcp-test:
+    needs: changes
+    if: ${{ needs.changes.outputs.mcp == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Add uv to PATH
+        run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        working-directory: mcp
+        run: uv sync --group dev
+      - name: Run tests
+        working-directory: mcp
+        run: uv run pytest -v
+
   frontend-setup:
     needs: changes
     if: ${{ needs.changes.outputs.frontend == 'true' }}

--- a/mcp/app/services/api_client.py
+++ b/mcp/app/services/api_client.py
@@ -6,6 +6,7 @@ from typing import Any
 import httpx
 
 from app.config import settings
+from app.services.exceptions import AuthenticationError, ConfigurationError, NotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +25,7 @@ class OpenWearablesClient:
             from app.config import Settings
 
             env_file = Settings.model_config.get("env_file")
-            raise ValueError(f"OPEN_WEARABLES_API_KEY is not configured. Please set it in: {env_file}")
+            raise ConfigurationError(f"OPEN_WEARABLES_API_KEY is not configured. Please set it in: {env_file}")
 
     @property
     def headers(self) -> dict[str, str]:
@@ -49,9 +50,9 @@ class OpenWearablesClient:
             )
 
             if response.status_code == 401:
-                raise ValueError("Invalid API key. Check your OPEN_WEARABLES_API_KEY configuration.")
+                raise AuthenticationError("Invalid API key. Check your OPEN_WEARABLES_API_KEY configuration.")
             if response.status_code == 404:
-                raise ValueError(f"Resource not found: {path}")
+                raise NotFoundError(f"Resource not found: {path}")
 
             response.raise_for_status()
             return response.json()

--- a/mcp/app/services/exceptions.py
+++ b/mcp/app/services/exceptions.py
@@ -1,0 +1,22 @@
+"""Exceptions raised by the Open Wearables MCP client.
+
+Mirrors the naming scheme used in `sdk/python/src/open_wearables/exceptions.py`
+so callers can reason about API failures without having to string-match on
+error messages.
+"""
+
+
+class OpenWearablesError(Exception):
+    """Base exception for MCP client errors talking to the Open Wearables API."""
+
+
+class AuthenticationError(OpenWearablesError):
+    """Raised when the API key is rejected (HTTP 401)."""
+
+
+class NotFoundError(OpenWearablesError):
+    """Raised when a requested resource does not exist (HTTP 404)."""
+
+
+class ConfigurationError(OpenWearablesError):
+    """Raised when the client is not configured (e.g. missing API key)."""

--- a/mcp/app/tools/activity.py
+++ b/mcp/app/tools/activity.py
@@ -5,6 +5,7 @@ import logging
 from fastmcp import FastMCP
 
 from app.services.api_client import client
+from app.services.exceptions import NotFoundError, OpenWearablesError
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +105,7 @@ async def get_activity_summary(
                 "first_name": user_data.get("first_name"),
                 "last_name": user_data.get("last_name"),
             }
-        except ValueError as e:
+        except NotFoundError as e:
             return {"error": f"User not found: {user_id}", "details": str(e)}
 
         # Fetch activity data
@@ -202,7 +203,7 @@ async def get_activity_summary(
             "summary": summary,
         }
 
-    except ValueError as e:
+    except OpenWearablesError as e:
         logger.error(f"API error in get_activity_summary: {e}")
         return {"error": str(e)}
     except Exception as e:

--- a/mcp/app/tools/sleep.py
+++ b/mcp/app/tools/sleep.py
@@ -5,6 +5,7 @@ import logging
 from fastmcp import FastMCP
 
 from app.services.api_client import client
+from app.services.exceptions import NotFoundError, OpenWearablesError
 from app.utils import normalize_datetime
 
 logger = logging.getLogger(__name__)
@@ -81,7 +82,7 @@ async def get_sleep_summary(
                 "first_name": user_data.get("first_name"),
                 "last_name": user_data.get("last_name"),
             }
-        except ValueError as e:
+        except NotFoundError as e:
             return {"error": f"User not found: {user_id}", "details": str(e)}
 
         # Fetch sleep data
@@ -139,7 +140,7 @@ async def get_sleep_summary(
             "summary": summary,
         }
 
-    except ValueError as e:
+    except OpenWearablesError as e:
         logger.error(f"API error in get_sleep_summary: {e}")
         return {"error": str(e)}
     except Exception as e:

--- a/mcp/app/tools/timeseries.py
+++ b/mcp/app/tools/timeseries.py
@@ -6,6 +6,7 @@ from typing import Any
 from fastmcp import FastMCP
 
 from app.services.api_client import client
+from app.services.exceptions import NotFoundError, OpenWearablesError
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +114,7 @@ async def get_timeseries(
                 "first_name": user_data.get("first_name"),
                 "last_name": user_data.get("last_name"),
             }
-        except ValueError as e:
+        except NotFoundError as e:
             return {"error": f"User not found: {user_id}", "details": str(e)}
 
         # Walk cursor pagination until exhausted or safety ceiling hit.
@@ -185,7 +186,7 @@ async def get_timeseries(
             "truncated": truncated,
         }
 
-    except ValueError as e:
+    except OpenWearablesError as e:
         logger.error(f"API error in get_timeseries: {e}")
         return {"error": str(e)}
     except Exception as e:

--- a/mcp/app/tools/users.py
+++ b/mcp/app/tools/users.py
@@ -5,6 +5,7 @@ import logging
 from fastmcp import FastMCP
 
 from app.services.api_client import client
+from app.services.exceptions import OpenWearablesError
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +70,7 @@ async def get_users(search: str | None = None, limit: int = 10) -> dict:
             "total": response.get("total", len(users)),
         }
 
-    except ValueError as e:
+    except OpenWearablesError as e:
         logger.error(f"API error in get_users: {e}")
         return {"error": str(e), "users": [], "total": 0}
     except Exception as e:

--- a/mcp/app/tools/workouts.py
+++ b/mcp/app/tools/workouts.py
@@ -5,6 +5,7 @@ import logging
 from fastmcp import FastMCP
 
 from app.services.api_client import client
+from app.services.exceptions import NotFoundError, OpenWearablesError
 from app.utils import normalize_datetime
 
 logger = logging.getLogger(__name__)
@@ -94,7 +95,7 @@ async def get_workout_events(
                 "first_name": user_data.get("first_name"),
                 "last_name": user_data.get("last_name"),
             }
-        except ValueError as e:
+        except NotFoundError as e:
             return {"error": f"User not found: {user_id}", "details": str(e)}
 
         # Fetch workout data
@@ -171,7 +172,7 @@ async def get_workout_events(
             "summary": summary,
         }
 
-    except ValueError as e:
+    except OpenWearablesError as e:
         logger.error(f"API error in get_workout_events: {e}")
         return {"error": str(e)}
     except Exception as e:

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -17,6 +17,11 @@ code-quality = [
     "ruff>=0.14.3",
     "ty>=0.0.1a25",
 ]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-httpx>=0.30.0",
+]
 
 [project.scripts]
 start = "app.main:main"
@@ -27,6 +32,10 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["app"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
 
 [tool.ruff]
 line-length = 120

--- a/mcp/tests/__init__.py
+++ b/mcp/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Open Wearables MCP server."""

--- a/mcp/tests/conftest.py
+++ b/mcp/tests/conftest.py
@@ -1,0 +1,29 @@
+"""Shared fixtures for MCP tests.
+
+The tool modules import a module-level `client` singleton from
+`app.services.api_client`. Tests configure that singleton with a
+predictable base URL + key so `pytest-httpx` can intercept requests,
+and restore the original values after each test.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+
+from app.services import api_client as api_client_module
+
+
+@pytest.fixture(autouse=True)
+def _configure_singleton_client() -> Iterator[None]:
+    """Point the singleton client at a predictable test host with a dummy key."""
+    client = api_client_module.client
+    original_key = client._api_key
+    original_url = client.base_url
+
+    client._api_key = "test_key"
+    client.base_url = "https://api.test.com"
+    try:
+        yield
+    finally:
+        client._api_key = original_key
+        client.base_url = original_url

--- a/mcp/tests/test_api_client.py
+++ b/mcp/tests/test_api_client.py
@@ -29,6 +29,7 @@ async def test_request_raises_authentication_error_on_401(
     api_client: OpenWearablesClient,
     httpx_mock: HTTPXMock,
 ) -> None:
+    """A 401 from the backend surfaces as `AuthenticationError`."""
     httpx_mock.add_response(
         method="GET",
         url="https://api.test.com/api/v1/users?limit=100",
@@ -43,6 +44,7 @@ async def test_request_raises_not_found_error_on_404(
     api_client: OpenWearablesClient,
     httpx_mock: HTTPXMock,
 ) -> None:
+    """A 404 from the backend surfaces as `NotFoundError`."""
     user_id = "00000000-0000-0000-0000-000000000000"
     httpx_mock.add_response(
         method="GET",
@@ -55,6 +57,7 @@ async def test_request_raises_not_found_error_on_404(
 
 
 async def test_request_raises_configuration_error_when_key_missing() -> None:
+    """A request with no API key raises `ConfigurationError` before hitting the network."""
     client = OpenWearablesClient()
     client._api_key = ""
 
@@ -63,6 +66,7 @@ async def test_request_raises_configuration_error_when_key_missing() -> None:
 
 
 def test_typed_errors_inherit_from_base() -> None:
+    """Every typed error is catchable via the `OpenWearablesError` base class."""
     assert issubclass(AuthenticationError, OpenWearablesError)
     assert issubclass(NotFoundError, OpenWearablesError)
     assert issubclass(ConfigurationError, OpenWearablesError)

--- a/mcp/tests/test_api_client.py
+++ b/mcp/tests/test_api_client.py
@@ -1,0 +1,68 @@
+"""Tests for the typed exception hierarchy raised by `OpenWearablesClient`.
+
+Mirrors the pattern used by `sdk/python/tests/`: `pytest` + `pytest-asyncio`
++ `pytest-httpx`, with mocked HTTP responses.
+"""
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from app.services.api_client import OpenWearablesClient
+from app.services.exceptions import (
+    AuthenticationError,
+    ConfigurationError,
+    NotFoundError,
+    OpenWearablesError,
+)
+
+
+@pytest.fixture
+def api_client() -> OpenWearablesClient:
+    """Fresh client wired to a predictable base URL + dummy key."""
+    client = OpenWearablesClient()
+    client._api_key = "test_key"
+    client.base_url = "https://api.test.com"
+    return client
+
+
+async def test_request_raises_authentication_error_on_401(
+    api_client: OpenWearablesClient,
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.test.com/api/v1/users?limit=100",
+        status_code=401,
+    )
+
+    with pytest.raises(AuthenticationError, match="Invalid API key"):
+        await api_client.get_users()
+
+
+async def test_request_raises_not_found_error_on_404(
+    api_client: OpenWearablesClient,
+    httpx_mock: HTTPXMock,
+) -> None:
+    user_id = "00000000-0000-0000-0000-000000000000"
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://api.test.com/api/v1/users/{user_id}",
+        status_code=404,
+    )
+
+    with pytest.raises(NotFoundError, match="Resource not found"):
+        await api_client.get_user(user_id)
+
+
+async def test_request_raises_configuration_error_when_key_missing() -> None:
+    client = OpenWearablesClient()
+    client._api_key = ""
+
+    with pytest.raises(ConfigurationError, match="OPEN_WEARABLES_API_KEY is not configured"):
+        await client.get_users()
+
+
+def test_typed_errors_inherit_from_base() -> None:
+    assert issubclass(AuthenticationError, OpenWearablesError)
+    assert issubclass(NotFoundError, OpenWearablesError)
+    assert issubclass(ConfigurationError, OpenWearablesError)

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -1,0 +1,112 @@
+"""Tests that MCP tool handlers translate typed client errors into the
+documented error-envelope shape instead of bubbling the exception up.
+
+Each tool has two error paths worth covering:
+- inner `NotFoundError` from the user-lookup block -> "User not found" envelope
+- outer `OpenWearablesError` from the downstream resource fetch -> generic error envelope
+"""
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from app.tools.activity import get_activity_summary
+from app.tools.sleep import get_sleep_summary
+from app.tools.timeseries import get_timeseries
+from app.tools.users import get_users
+from app.tools.workouts import get_workout_events
+
+USER_ID = "00000000-0000-0000-0000-000000000000"
+USER_PAYLOAD = {
+    "id": USER_ID,
+    "first_name": "Test",
+    "last_name": "User",
+    "email": "test@example.com",
+}
+
+
+async def test_get_users_returns_empty_envelope_on_auth_error(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="GET",
+        url="https://api.test.com/api/v1/users?limit=10",
+        status_code=401,
+    )
+
+    result = await get_users.fn()
+
+    assert result["users"] == []
+    assert result["total"] == 0
+    assert "error" in result
+
+
+@pytest.mark.parametrize(
+    "tool",
+    [
+        pytest.param(get_activity_summary, id="activity"),
+        pytest.param(get_sleep_summary, id="sleep"),
+        pytest.param(get_workout_events, id="workouts"),
+    ],
+)
+async def test_summary_tools_return_user_not_found_envelope_on_404(
+    tool: object,
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://api.test.com/api/v1/users/{USER_ID}",
+        status_code=404,
+    )
+
+    result = await tool.fn(
+        user_id=USER_ID,
+        start_date="2026-01-01",
+        end_date="2026-01-07",
+    )
+
+    assert result["error"] == f"User not found: {USER_ID}"
+    assert "details" in result
+
+
+async def test_get_timeseries_returns_user_not_found_envelope_on_404(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://api.test.com/api/v1/users/{USER_ID}",
+        status_code=404,
+    )
+
+    result = await get_timeseries.fn(
+        user_id=USER_ID,
+        start_time="2026-04-05T00:00:00Z",
+        end_time="2026-04-05T23:59:59Z",
+        types=["heart_rate"],
+    )
+
+    assert result["error"] == f"User not found: {USER_ID}"
+    assert "details" in result
+
+
+async def test_get_activity_summary_returns_generic_error_envelope_on_downstream_401(
+    httpx_mock: HTTPXMock,
+) -> None:
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://api.test.com/api/v1/users/{USER_ID}",
+        json=USER_PAYLOAD,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=(
+            f"https://api.test.com/api/v1/users/{USER_ID}/summaries/activity"
+            "?start_date=2026-01-01&end_date=2026-01-07&limit=100"
+        ),
+        status_code=401,
+    )
+
+    result = await get_activity_summary.fn(
+        user_id=USER_ID,
+        start_date="2026-01-01",
+        end_date="2026-01-07",
+    )
+
+    assert "error" in result
+    assert "Invalid API key" in result["error"]
+    assert not result["error"].startswith("User not found")

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -25,6 +25,7 @@ USER_PAYLOAD = {
 
 
 async def test_get_users_returns_empty_envelope_on_auth_error(httpx_mock: HTTPXMock) -> None:
+    """`get_users` translates a backend 401 into the documented empty-envelope shape."""
     httpx_mock.add_response(
         method="GET",
         url="https://api.test.com/api/v1/users?limit=10",
@@ -50,6 +51,7 @@ async def test_summary_tools_return_user_not_found_envelope_on_404(
     tool: object,
     httpx_mock: HTTPXMock,
 ) -> None:
+    """Summary tools turn a 404 on user lookup into the 'User not found' envelope (inner except block)."""
     httpx_mock.add_response(
         method="GET",
         url=f"https://api.test.com/api/v1/users/{USER_ID}",
@@ -67,6 +69,7 @@ async def test_summary_tools_return_user_not_found_envelope_on_404(
 
 
 async def test_get_timeseries_returns_user_not_found_envelope_on_404(httpx_mock: HTTPXMock) -> None:
+    """`get_timeseries` turns a 404 on user lookup into the 'User not found' envelope."""
     httpx_mock.add_response(
         method="GET",
         url=f"https://api.test.com/api/v1/users/{USER_ID}",
@@ -87,6 +90,7 @@ async def test_get_timeseries_returns_user_not_found_envelope_on_404(httpx_mock:
 async def test_get_activity_summary_returns_generic_error_envelope_on_downstream_401(
     httpx_mock: HTTPXMock,
 ) -> None:
+    """Downstream 401 (after user lookup succeeds) surfaces via the generic error envelope, not 'User not found'."""
     httpx_mock.add_response(
         method="GET",
         url=f"https://api.test.com/api/v1/users/{USER_ID}",

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -7,6 +7,7 @@ Each tool has two error paths worth covering:
 """
 
 import pytest
+from fastmcp.tools import FunctionTool
 from pytest_httpx import HTTPXMock
 
 from app.tools.activity import get_activity_summary
@@ -48,7 +49,7 @@ async def test_get_users_returns_empty_envelope_on_auth_error(httpx_mock: HTTPXM
     ],
 )
 async def test_summary_tools_return_user_not_found_envelope_on_404(
-    tool: object,
+    tool: FunctionTool,
     httpx_mock: HTTPXMock,
 ) -> None:
     """Summary tools turn a 404 on user lookup into the 'User not found' envelope (inner except block)."""

--- a/mcp/uv.lock
+++ b/mcp/uv.lock
@@ -465,6 +465,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -687,6 +696,11 @@ code-quality = [
     { name = "ruff" },
     { name = "ty" },
 ]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-httpx" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -701,6 +715,11 @@ code-quality = [
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "ruff", specifier = ">=0.14.3" },
     { name = "ty", specifier = ">=0.0.1a25" },
+]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23.0" },
+    { name = "pytest-httpx", specifier = ">=0.30.0" },
 ]
 
 [[package]]
@@ -818,6 +837,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -1035,6 +1063,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-httpx"
+version = "0.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/42/f53c58570e80d503ade9dd42ce57f2915d14bcbe25f6308138143950d1d6/pytest_httpx-0.36.2.tar.gz", hash = "sha256:05a56527484f7f4e8c856419ea379b8dc359c36801c4992fdb330f294c690356", size = 57683, upload-time = "2026-04-09T13:57:19.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/55/1fa65f8e4fceb19dd6daa867c162ad845d547f6058cd92b4b02384a44777/pytest_httpx-0.36.2-py3-none-any.whl", hash = "sha256:d42ebd5679442dc7bfb0c48e0767b6562e9bc4534d805127b0084171886a5e22", size = 20315, upload-time = "2026-04-09T13:57:18.587Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements #893.

Follow-up to review feedback on #882 where the maintainer flagged
`except ValueError` as an opportunity to introduce a proper exception
hierarchy across the MCP client.

## What changed

- New `mcp/app/services/exceptions.py` — `OpenWearablesError` base +
  `AuthenticationError` / `NotFoundError` / `ConfigurationError`,
  mirroring the SDK's naming at
  `sdk/python/src/open_wearables/exceptions.py`.
- `api_client.py`: `_request` raises the typed errors for 401 / 404;
  `_ensure_configured` raises `ConfigurationError` for missing key.
- All 6 tool handlers (`activity`, `sleep`, `workouts`, `timeseries`,
  `users`): inner user-lookup `except` catches `NotFoundError`, outer
  API-error `except` catches `OpenWearablesError`. Callers can now
  reason about failures by type instead of string-matching.
- First test infrastructure in `mcp/`: `pytest` + `pytest-asyncio` +
  `pytest-httpx` under `mcp/tests/`, `asyncio_mode = "auto"`,
  10 tests covering every exception path end-to-end.
- New `mcp-test` job in `.github/workflows/ci.yml` so the suite runs
  on every `mcp/**` PR. Mirrors `backend-test` minus the service
  containers (MCP is a stateless stdio wrapper).

Scope is deliberately narrow — see the linked issue for acceptance
criteria and the rationale for deferring 422 / 429 / 5xx wrapping to
a follow-up.

## Open question for reviewer

`mcp/` had no test infrastructure before this PR. I picked
`pytest-httpx` because `sdk/python/tests/` already uses that exact
stack and MCP is structurally the same shape (thin httpx wrapper) —
so it was the pattern with the most existing precedent in the repo.
Happy to pivot if you'd prefer something else:

- a different harness (FastMCP's own test utilities, respx, etc.)
- a different file layout
- splitting tests out into a separate follow-up PR and landing this
  one as refactor-only

One small sanity-check ask: tool tests call `tool.fn(...)` to reach
past the `FunctionTool` wrapper introduced by `@router.tool`. It
works, but if there's a more idiomatic way to drive a FastMCP tool
from a unit test I'd rather use that.

## Test plan

- [x] `cd mcp && uv run ruff check app/ tests/` — clean
- [x] `cd mcp && uv run ruff format --check app/ tests/` — clean
- [x] `cd mcp && uv run pytest -v` — 10 passed
- [x] Import smoke — every tool module loads cleanly with a dummy
      API key
- [ ] CI green on `mcp-build`, `mcp-code-quality`, `mcp-test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling: specific exception types for auth, not-found and configuration errors; tools now return consistent error envelopes.

* **Tests**
  * Added tests verifying typed exceptions and tools’ error-translation behavior; fixture ensures isolated test client configuration.

* **Chores**
  * Added CI job to run the MCP test suite and updated test dependencies and pytest configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->