### PR TITLE
docs: document grace-period flag for historical sync on connect

### DIFF
--- a/backend/app/api/routes/v1/sync_data.py
+++ b/backend/app/api/routes/v1/sync_data.py
@@ -349,9 +349,19 @@ def sync_historical_data(
     webhook backfill, etc.). The ``days`` parameter may be ignored by
     providers that enforce their own limits.
 
-    Historical sync is not automatically triggered when a provider is
-    connected - it must be explicitly requested via this endpoint.
-    (Changed in v0.4.2.)
+    **Automatic historical sync on connect (grace period)**
+
+    As of v0.4.2, historical sync must be explicitly requested via this
+    endpoint. To ease migration, a grace-period flag
+    (``HISTORICAL_SYNC_ON_CONNECT``, default: ``true``) preserves the
+    pre-0.4.2 behaviour: a historical sync is auto-dispatched after a
+    successful OAuth callback (up to 90 days for pull-based providers,
+    full available history for providers that support async export such
+    as Garmin).
+
+    Set ``HISTORICAL_SYNC_ON_CONNECT=false`` once your integration calls
+    this endpoint explicitly. The flag will default to ``false`` in a
+    future release and is planned for removal afterwards.
     """
     strategy = factory.get_provider(provider.value)
 

--- a/backend/app/api/routes/v1/sync_data.py
+++ b/backend/app/api/routes/v1/sync_data.py
@@ -351,17 +351,20 @@ def sync_historical_data(
 
     **Automatic historical sync on connect (grace period)**
 
-    As of v0.4.2, historical sync must be explicitly requested via this
-    endpoint. To ease migration, a grace-period flag
-    (``HISTORICAL_SYNC_ON_CONNECT``, default: ``true``) preserves the
-    pre-0.4.2 behaviour: a historical sync is auto-dispatched after a
-    successful OAuth callback (up to 90 days for pull-based providers,
-    full available history for providers that support async export such
-    as Garmin).
+    v0.4.2 introduced this endpoint as the canonical, opt-in way to
+    backfill historical data - the long-term goal is that connecting a
+    provider only sets up live sync, and history is pulled on demand.
 
-    Set ``HISTORICAL_SYNC_ON_CONNECT=false`` once your integration calls
-    this endpoint explicitly. The flag will default to ``false`` in a
-    future release and is planned for removal afterwards.
+    To make migration painless, the pre-0.4.2 behaviour is kept for now
+    behind a grace-period flag (``HISTORICAL_SYNC_ON_CONNECT``, default:
+    ``true``): a historical sync is auto-dispatched after a successful
+    OAuth callback (up to 90 days for pull-based providers, full
+    available history for providers that support async export such as
+    Garmin).
+
+    Once your integration calls this endpoint explicitly, set
+    ``HISTORICAL_SYNC_ON_CONNECT=false``. The flag will default to
+    ``false`` in a future release and is planned for removal afterwards.
     """
     strategy = factory.get_provider(provider.value)
 


### PR DESCRIPTION
## Description

Updates the `POST /sync/historical` endpoint docstring to match the behaviour shipped in #850. The old docs claimed historical sync is never auto-triggered on connect, but the grace-period flag `HISTORICAL_SYNC_ON_CONNECT` (default `true`) actually does dispatch one after OAuth callback. This clears up the contradiction for integrators reading the public API reference.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. Regenerate/preview the OpenAPI-driven docs page for `POST /api/v1/providers/{provider}/users/{user_id}/sync/historical`.
2. Confirm the description now mentions the `HISTORICAL_SYNC_ON_CONNECT` flag and its default.

**Expected behavior:**
The docs page no longer claims historical sync is never auto-triggered on connect - it explains the grace-period flag, its default, and the planned flip to `false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified historical data sync behavior: a short "grace period" after connecting a provider may automatically trigger historical sync by default, with provider-specific ranges; instructions added for opting out via configuration; note that the default behavior will change in a future release and guidance updated for that transition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->