### PR TITLE
fix(dashboard): align sleep session date label with sleep score date

### DIFF
--- a/frontend/src/components/user/sleep-section.tsx
+++ b/frontend/src/components/user/sleep-section.tsx
@@ -214,11 +214,11 @@ function SleepSessionRow({
           </div>
           <div className="flex items-center gap-2">
             <p className="text-sm font-medium text-white">
-              {format(new Date(session.end_time), 'EEE, MMM d')}
+              {format(new Date(session.start_time), 'EEE, MMM d')}
             </p>
           </div>
           <p className="text-xs text-zinc-500">
-            {format(new Date(session.end_time), 'yyyy')}
+            {format(new Date(session.start_time), 'yyyy')}
           </p>
         </div>
 


### PR DESCRIPTION
Sleep session row header was showing wake-up date (end_time) while the sleep score card showed bedtime date (recorded_at), causing a 1-day UI drift. Session header now uses start_time so both surfaces show the same bedtime date.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the date displayed for sleep sessions to show the start time rather than the end time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->