### PR TITLE
feat(frontend): add webhooks management UI

### DIFF
--- a/frontend/src/components/layout/simple-sidebar.tsx
+++ b/frontend/src/components/layout/simple-sidebar.tsx
@@ -6,6 +6,7 @@ import {
   LogOut,
   Settings,
   ExternalLink,
+  Webhook,
 } from 'lucide-react';
 import logotype from '@/logotype.svg';
 import { cn } from '@/lib/utils';
@@ -23,6 +24,11 @@ const menuItems = [
     title: 'Users',
     url: ROUTES.users,
     icon: Users,
+  },
+  {
+    title: 'Webhooks',
+    url: ROUTES.webhooks,
+    icon: Webhook,
   },
   {
     title: 'Settings',

--- a/frontend/src/components/webhooks/webhook-attempts-table.tsx
+++ b/frontend/src/components/webhooks/webhook-attempts-table.tsx
@@ -1,0 +1,211 @@
+import { useState } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+
+import { Badge } from '@/components/ui/badge';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { WebhookMessageAttempt } from '@/lib/api/types';
+
+interface WebhookAttemptsTableProps {
+  attempts: WebhookMessageAttempt[];
+  isLoading?: boolean;
+}
+
+const SUCCESS_STATUSES = new Set([0, 'success', 'Success']);
+const PENDING_STATUSES = new Set([1, 3, 'pending', 'sending']);
+
+function statusBadge(status: number | string) {
+  if (SUCCESS_STATUSES.has(status)) {
+    return (
+      <Badge className="bg-emerald-500/15 text-emerald-300 border border-emerald-500/30">
+        Success
+      </Badge>
+    );
+  }
+  if (PENDING_STATUSES.has(status)) {
+    return (
+      <Badge className="bg-amber-500/15 text-amber-300 border border-amber-500/30">
+        Pending
+      </Badge>
+    );
+  }
+  return (
+    <Badge className="bg-red-500/15 text-red-300 border border-red-500/30">
+      Failed
+    </Badge>
+  );
+}
+
+function statusCodeColor(code: number) {
+  if (code >= 200 && code < 300) return 'text-emerald-300';
+  if (code >= 300 && code < 400) return 'text-amber-300';
+  return 'text-red-300';
+}
+
+export function WebhookAttemptsTable({
+  attempts,
+  isLoading,
+}: WebhookAttemptsTableProps) {
+  const [selected, setSelected] = useState<WebhookMessageAttempt | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-6 animate-pulse space-y-3">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="h-12 bg-zinc-800/50 rounded-md" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!attempts.length) {
+    return (
+      <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-12 text-center">
+        <p className="text-sm text-zinc-500">No deliveries yet.</p>
+        <p className="text-xs text-zinc-600 mt-1">
+          Send a test event or wait for real activity to see delivery attempts
+          here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-zinc-800 hover:bg-transparent">
+              <TableHead className="text-zinc-400">Status</TableHead>
+              <TableHead className="text-zinc-400">Code</TableHead>
+              <TableHead className="text-zinc-400">Event</TableHead>
+              <TableHead className="text-zinc-400">Duration</TableHead>
+              <TableHead className="text-zinc-400">When</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {attempts.map((a) => (
+              <TableRow
+                key={a.id}
+                className="border-zinc-800 cursor-pointer hover:bg-zinc-900"
+                onClick={() => setSelected(a)}
+              >
+                <TableCell>{statusBadge(a.status)}</TableCell>
+                <TableCell
+                  className={`font-mono text-xs ${statusCodeColor(a.response_status_code)}`}
+                >
+                  {a.response_status_code || '-'}
+                </TableCell>
+                <TableCell className="text-xs text-zinc-300">
+                  {a.msg?.event_type ?? a.msg_id}
+                </TableCell>
+                <TableCell className="text-xs text-zinc-400">
+                  {a.response_duration_ms} ms
+                </TableCell>
+                <TableCell className="text-xs text-zinc-400">
+                  {a.timestamp
+                    ? formatDistanceToNow(new Date(a.timestamp), {
+                        addSuffix: true,
+                      })
+                    : '-'}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <Sheet
+        open={!!selected}
+        onOpenChange={(open) => !open && setSelected(null)}
+      >
+        <SheetContent className="w-full sm:max-w-xl bg-zinc-950 border-zinc-800 overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle className="text-white">Delivery attempt</SheetTitle>
+            <SheetDescription>
+              {selected?.id && (
+                <code className="font-mono text-[10px] text-zinc-500 break-all">
+                  {selected.id}
+                </code>
+              )}
+            </SheetDescription>
+          </SheetHeader>
+          {selected && (
+            <div className="px-4 space-y-4 text-sm">
+              <div className="grid grid-cols-2 gap-3">
+                <Field label="Status">{statusBadge(selected.status)}</Field>
+                <Field label="HTTP code">
+                  <span
+                    className={`font-mono ${statusCodeColor(selected.response_status_code)}`}
+                  >
+                    {selected.response_status_code}
+                  </span>
+                </Field>
+                <Field label="Duration">
+                  {selected.response_duration_ms} ms
+                </Field>
+                <Field label="When">
+                  {selected.timestamp
+                    ? new Date(selected.timestamp).toLocaleString()
+                    : '-'}
+                </Field>
+              </div>
+              <Field label="URL">
+                <code className="font-mono text-xs text-zinc-300 break-all">
+                  {selected.url}
+                </code>
+              </Field>
+              <Field label="Event type">
+                <code className="font-mono text-xs text-zinc-300">
+                  {selected.msg?.event_type ?? '-'}
+                </code>
+              </Field>
+              <Field label="Response body">
+                <pre className="text-xs text-zinc-300 bg-zinc-900 border border-zinc-800 rounded-md p-3 overflow-x-auto whitespace-pre-wrap break-all">
+                  {selected.response || '(empty)'}
+                </pre>
+              </Field>
+              {selected.msg?.payload && (
+                <Field label="Payload">
+                  <pre className="text-xs text-zinc-300 bg-zinc-900 border border-zinc-800 rounded-md p-3 overflow-x-auto">
+                    {JSON.stringify(selected.msg.payload, null, 2)}
+                  </pre>
+                </Field>
+              )}
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <p className="text-[10px] uppercase tracking-wide text-zinc-500">
+        {label}
+      </p>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/webhooks/webhook-create-dialog.tsx
+++ b/frontend/src/components/webhooks/webhook-create-dialog.tsx
@@ -1,0 +1,61 @@
+import { useNavigate } from '@tanstack/react-router';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useCreateWebhookEndpoint } from '@/hooks/api/use-webhooks';
+import { WebhookForm } from './webhook-form';
+
+interface WebhookCreateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function WebhookCreateDialog({
+  open,
+  onOpenChange,
+}: WebhookCreateDialogProps) {
+  const create = useCreateWebhookEndpoint();
+  const navigate = useNavigate();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Create webhook endpoint</DialogTitle>
+          <DialogDescription>
+            We'll deliver subscribed events to this URL with a signed payload.
+          </DialogDescription>
+        </DialogHeader>
+        <WebhookForm
+          submitLabel="Create webhook"
+          isSubmitting={create.isPending}
+          onCancel={() => onOpenChange(false)}
+          onSubmit={(data) => {
+            create.mutate(
+              {
+                url: data.url,
+                description: data.description ?? null,
+                filter_types: data.filter_types ?? null,
+                user_id: data.user_id ?? null,
+              },
+              {
+                onSuccess: (created) => {
+                  onOpenChange(false);
+                  navigate({
+                    to: '/webhooks/$endpointId',
+                    params: { endpointId: created.id },
+                  });
+                },
+              }
+            );
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/webhooks/webhook-delete-dialog.tsx
+++ b/frontend/src/components/webhooks/webhook-delete-dialog.tsx
@@ -1,0 +1,68 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useDeleteWebhookEndpoint } from '@/hooks/api/use-webhooks';
+
+interface WebhookDeleteDialogProps {
+  endpointId: string | null;
+  url?: string;
+  onClose: () => void;
+  onDeleted?: () => void;
+}
+
+export function WebhookDeleteDialog({
+  endpointId,
+  url,
+  onClose,
+  onDeleted,
+}: WebhookDeleteDialogProps) {
+  const remove = useDeleteWebhookEndpoint();
+
+  return (
+    <Dialog open={!!endpointId} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Delete webhook?</DialogTitle>
+          <DialogDescription>
+            Future events will no longer be delivered to this endpoint. This
+            cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        {url && (
+          <div className="p-3 bg-zinc-800 rounded-md">
+            <p className="text-xs text-zinc-500">URL:</p>
+            <code className="font-mono text-xs text-zinc-300 break-all">
+              {url}
+            </code>
+          </div>
+        )}
+        <DialogFooter className="gap-3">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={remove.isPending}
+            onClick={() => {
+              if (!endpointId) return;
+              remove.mutate(endpointId, {
+                onSuccess: () => {
+                  onClose();
+                  onDeleted?.();
+                },
+              });
+            }}
+          >
+            {remove.isPending ? 'Deleting...' : 'Delete webhook'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/webhooks/webhook-form.tsx
+++ b/frontend/src/components/webhooks/webhook-form.tsx
@@ -1,0 +1,226 @@
+import { useEffect, useState } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useWebhookEventTypes } from '@/hooks/api/use-webhooks';
+import {
+  webhookEndpointFormSchema,
+  type WebhookEndpointFormData,
+} from '@/lib/validation/webhooks.schemas';
+import type { WebhookEndpoint } from '@/lib/api/types';
+
+interface WebhookFormProps {
+  initial?: WebhookEndpoint;
+  isSubmitting?: boolean;
+  submitLabel: string;
+  onSubmit: (data: WebhookEndpointFormData) => void;
+  onCancel?: () => void;
+}
+
+export function WebhookForm({
+  initial,
+  isSubmitting,
+  submitLabel,
+  onSubmit,
+  onCancel,
+}: WebhookFormProps) {
+  const eventTypes = useWebhookEventTypes();
+  const [eventFilter, setEventFilter] = useState('');
+
+  const form = useForm<WebhookEndpointFormData>({
+    resolver: zodResolver(webhookEndpointFormSchema),
+    defaultValues: {
+      url: initial?.url ?? '',
+      description: initial?.description ?? '',
+      filter_types: initial?.filter_types ?? [],
+      user_id: initial?.user_id ?? '',
+    },
+  });
+
+  useEffect(() => {
+    if (initial) {
+      form.reset({
+        url: initial.url,
+        description: initial.description ?? '',
+        filter_types: initial.filter_types ?? [],
+        user_id: initial.user_id ?? '',
+      });
+    }
+  }, [initial, form]);
+
+  const handleFormSubmit = form.handleSubmit((data) => {
+    onSubmit({
+      url: data.url.trim(),
+      description: data.description?.trim() || undefined,
+      filter_types: data.filter_types?.length ? data.filter_types : undefined,
+      user_id: data.user_id?.trim() || undefined,
+    });
+  });
+
+  const filtered = eventTypes.data?.filter((t) =>
+    t.name.toLowerCase().includes(eventFilter.toLowerCase())
+  );
+
+  return (
+    <form onSubmit={handleFormSubmit} className="space-y-4">
+      <div className="space-y-1.5">
+        <Label htmlFor="webhook-url" className="text-zinc-300">
+          Endpoint URL
+        </Label>
+        <Input
+          id="webhook-url"
+          type="url"
+          placeholder="https://example.com/webhooks/openwearables"
+          {...form.register('url')}
+          className="bg-zinc-800 border-zinc-700"
+        />
+        {form.formState.errors.url && (
+          <p className="text-xs text-red-500">
+            {form.formState.errors.url.message}
+          </p>
+        )}
+        <p className="text-[10px] text-zinc-600">Must use HTTPS.</p>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="webhook-description" className="text-zinc-300">
+          Description{' '}
+          <span className="text-zinc-600 font-normal">(optional)</span>
+        </Label>
+        <Input
+          id="webhook-description"
+          type="text"
+          placeholder="Production ingestion pipeline"
+          maxLength={500}
+          {...form.register('description')}
+          className="bg-zinc-800 border-zinc-700"
+        />
+        {form.formState.errors.description && (
+          <p className="text-xs text-red-500">
+            {form.formState.errors.description.message}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="webhook-user-id" className="text-zinc-300">
+          User filter{' '}
+          <span className="text-zinc-600 font-normal">(optional)</span>
+        </Label>
+        <Input
+          id="webhook-user-id"
+          type="text"
+          placeholder="UUID - leave empty to receive events for all users"
+          {...form.register('user_id')}
+          className="bg-zinc-800 border-zinc-700 font-mono text-xs"
+        />
+        {form.formState.errors.user_id && (
+          <p className="text-xs text-red-500">
+            {form.formState.errors.user_id.message}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="text-zinc-300">
+          Event types{' '}
+          <span className="text-zinc-600 font-normal">
+            (leave none selected to receive all)
+          </span>
+        </Label>
+        {eventTypes.isLoading ? (
+          <div className="flex items-center gap-2 text-xs text-zinc-500 py-2">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Loading event types...
+          </div>
+        ) : eventTypes.error ? (
+          <p className="text-xs text-red-500">Failed to load event types.</p>
+        ) : (
+          <Controller
+            control={form.control}
+            name="filter_types"
+            render={({ field }) => {
+              const selected = new Set(field.value ?? []);
+              const toggle = (name: string) => {
+                const next = new Set(selected);
+                if (next.has(name)) next.delete(name);
+                else next.add(name);
+                field.onChange(Array.from(next));
+              };
+              return (
+                <div className="space-y-2">
+                  <Input
+                    type="text"
+                    placeholder="Filter event types..."
+                    value={eventFilter}
+                    onChange={(e) => setEventFilter(e.target.value)}
+                    className="bg-zinc-800 border-zinc-700 h-8 text-xs"
+                  />
+                  <div className="flex flex-wrap gap-1.5 max-h-40 overflow-y-auto rounded-md border border-zinc-800 bg-zinc-900/50 p-2">
+                    {filtered?.length ? (
+                      filtered.map((t) => {
+                        const isOn = selected.has(t.name);
+                        return (
+                          <button
+                            type="button"
+                            key={t.name}
+                            onClick={() => toggle(t.name)}
+                            title={t.description}
+                            className="focus:outline-none"
+                          >
+                            <Badge
+                              variant={isOn ? 'default' : 'outline'}
+                              className={
+                                isOn
+                                  ? 'cursor-pointer bg-white text-black hover:bg-zinc-200'
+                                  : 'cursor-pointer border-zinc-700 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200'
+                              }
+                            >
+                              {t.name}
+                            </Badge>
+                          </button>
+                        );
+                      })
+                    ) : (
+                      <p className="text-xs text-zinc-600 px-1 py-2">
+                        No matching event types.
+                      </p>
+                    )}
+                  </div>
+                  {selected.size > 0 && (
+                    <p className="text-[10px] text-zinc-600">
+                      {selected.size} selected
+                    </p>
+                  )}
+                </div>
+              );
+            }}
+          />
+        )}
+      </div>
+
+      <div className="flex justify-end gap-3 pt-2">
+        {onCancel && (
+          <Button type="button" variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+        )}
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            submitLabel
+          )}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/webhooks/webhook-secret-reveal.tsx
+++ b/frontend/src/components/webhooks/webhook-secret-reveal.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { Check, Copy, Eye, EyeOff, Loader2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { useWebhookSecret } from '@/hooks/api/use-webhooks';
+import { copyToClipboard } from '@/lib/utils/clipboard';
+
+interface WebhookSecretRevealProps {
+  endpointId: string;
+}
+
+export function WebhookSecretReveal({ endpointId }: WebhookSecretRevealProps) {
+  const [revealed, setRevealed] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const { data, isLoading, error } = useWebhookSecret(endpointId, {
+    enabled: revealed,
+  });
+
+  const handleCopy = async () => {
+    if (!data?.key) return;
+    const ok = await copyToClipboard(data.key);
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }
+  };
+
+  return (
+    <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-5 space-y-3">
+      <div>
+        <h3 className="text-sm font-medium text-white">Signing secret</h3>
+        <p className="text-xs text-zinc-500 mt-0.5">
+          Use this secret to verify the <code>svix-signature</code> header on
+          incoming webhook requests.
+        </p>
+      </div>
+
+      {!revealed && (
+        <Button variant="outline" size="sm" onClick={() => setRevealed(true)}>
+          <Eye className="h-4 w-4" />
+          Reveal secret
+        </Button>
+      )}
+
+      {revealed && isLoading && (
+        <div className="flex items-center gap-2 text-xs text-zinc-500 py-2">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          Loading secret...
+        </div>
+      )}
+
+      {revealed && error && (
+        <p className="text-xs text-red-500">Failed to load secret.</p>
+      )}
+
+      {revealed && data && (
+        <div className="flex items-center gap-2">
+          <code className="flex-1 font-mono text-xs text-zinc-200 bg-zinc-800 px-3 py-2 rounded-md break-all">
+            {data.key}
+          </code>
+          <Button variant="outline" size="sm" onClick={handleCopy}>
+            {copied ? (
+              <>
+                <Check className="h-4 w-4" />
+                Copied
+              </>
+            ) : (
+              <>
+                <Copy className="h-4 w-4" />
+                Copy
+              </>
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setRevealed(false)}
+            title="Hide secret"
+          >
+            <EyeOff className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/webhooks/webhook-test-event-dialog.tsx
+++ b/frontend/src/components/webhooks/webhook-test-event-dialog.tsx
@@ -1,0 +1,107 @@
+import { useState, useEffect } from 'react';
+import { Loader2, Send } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  useSendTestWebhook,
+  useWebhookEventTypes,
+} from '@/hooks/api/use-webhooks';
+
+interface WebhookTestEventDialogProps {
+  endpointId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialEventType?: string;
+}
+
+const FALLBACK_EVENT = 'workout.created';
+
+export function WebhookTestEventDialog({
+  endpointId,
+  open,
+  onOpenChange,
+  initialEventType,
+}: WebhookTestEventDialogProps) {
+  const eventTypes = useWebhookEventTypes();
+  const send = useSendTestWebhook();
+  const [eventType, setEventType] = useState(
+    initialEventType ?? FALLBACK_EVENT
+  );
+
+  useEffect(() => {
+    if (open && initialEventType) setEventType(initialEventType);
+  }, [open, initialEventType]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Send test event</DialogTitle>
+          <DialogDescription>
+            Dispatches a sample payload to this endpoint so you can verify the
+            integration end-to-end.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-1.5">
+          <Label htmlFor="test-event-type" className="text-zinc-300">
+            Event type
+          </Label>
+          <select
+            id="test-event-type"
+            value={eventType}
+            onChange={(e) => setEventType(e.target.value)}
+            className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-200"
+          >
+            {eventTypes.data?.map((t) => (
+              <option key={t.name} value={t.name}>
+                {t.name}
+              </option>
+            ))}
+          </select>
+          <p className="text-[10px] text-zinc-600">
+            {eventTypes.data?.find((t) => t.name === eventType)?.description}
+          </p>
+        </div>
+
+        <DialogFooter className="gap-3">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            disabled={send.isPending || !eventType}
+            onClick={() =>
+              send.mutate(
+                { id: endpointId, eventType },
+                {
+                  onSuccess: () => onOpenChange(false),
+                }
+              )
+            }
+          >
+            {send.isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Sending...
+              </>
+            ) : (
+              <>
+                <Send className="h-4 w-4" />
+                Send test
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/webhooks/webhooks-table.tsx
+++ b/frontend/src/components/webhooks/webhooks-table.tsx
@@ -1,0 +1,132 @@
+import { useNavigate } from '@tanstack/react-router';
+import { Trash2, Settings as SettingsIcon } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type { WebhookEndpoint } from '@/lib/api/types';
+
+interface WebhooksTableProps {
+  data: WebhookEndpoint[];
+  onDelete: (id: string) => void;
+}
+
+export function WebhooksTable({ data, onDelete }: WebhooksTableProps) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl overflow-hidden">
+      <Table>
+        <TableHeader>
+          <TableRow className="border-zinc-800 hover:bg-transparent">
+            <TableHead className="text-zinc-400">URL</TableHead>
+            <TableHead className="text-zinc-400">Description</TableHead>
+            <TableHead className="text-zinc-400">Events</TableHead>
+            <TableHead className="text-zinc-400">User filter</TableHead>
+            <TableHead className="text-zinc-400 text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {data.map((endpoint) => {
+            const goToDetail = () =>
+              navigate({
+                to: '/webhooks/$endpointId',
+                params: { endpointId: endpoint.id },
+              });
+            return (
+              <TableRow
+                key={endpoint.id}
+                className="border-zinc-800 cursor-pointer hover:bg-zinc-900"
+                onClick={goToDetail}
+              >
+                <TableCell className="font-mono text-xs text-zinc-200 max-w-[280px] truncate">
+                  {endpoint.url}
+                </TableCell>
+                <TableCell className="text-sm text-zinc-300 max-w-[220px] truncate">
+                  {endpoint.description ?? (
+                    <span className="text-zinc-600">-</span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  {endpoint.filter_types?.length ? (
+                    <div className="flex flex-wrap gap-1 max-w-[280px]">
+                      {endpoint.filter_types.slice(0, 3).map((t) => (
+                        <Badge
+                          key={t}
+                          variant="outline"
+                          className="border-zinc-700 text-zinc-300 text-[10px]"
+                        >
+                          {t}
+                        </Badge>
+                      ))}
+                      {endpoint.filter_types.length > 3 && (
+                        <Badge
+                          variant="outline"
+                          className="border-zinc-700 text-zinc-500 text-[10px]"
+                        >
+                          +{endpoint.filter_types.length - 3}
+                        </Badge>
+                      )}
+                    </div>
+                  ) : (
+                    <Badge
+                      variant="outline"
+                      className="border-zinc-700 text-zinc-400 text-[10px]"
+                    >
+                      All events
+                    </Badge>
+                  )}
+                </TableCell>
+                <TableCell>
+                  {endpoint.user_id ? (
+                    <code className="font-mono text-xs text-zinc-300">
+                      {endpoint.user_id.slice(0, 8)}...
+                    </code>
+                  ) : (
+                    <span className="text-xs text-zinc-600">All users</span>
+                  )}
+                </TableCell>
+                <TableCell
+                  className="text-right"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <div className="flex justify-end gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={goToDetail}
+                      title="Manage"
+                    >
+                      <SettingsIcon className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onDelete(endpoint.id)}
+                      title="Delete"
+                      className="text-zinc-400 hover:text-red-400"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+      {data.length === 0 && (
+        <div className="p-12 text-center">
+          <p className="text-sm text-zinc-500">No webhooks configured.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/api/use-webhooks.ts
+++ b/frontend/src/hooks/api/use-webhooks.ts
@@ -1,0 +1,120 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { webhooksService } from '@/lib/api';
+import { getErrorMessage } from '@/lib/errors/handler';
+import { queryKeys } from '@/lib/query/keys';
+import type {
+  WebhookEndpointCreate,
+  WebhookEndpointUpdate,
+} from '@/lib/api/types';
+
+export function useWebhookEventTypes() {
+  return useQuery({
+    queryKey: queryKeys.webhooks.eventTypes(),
+    queryFn: () => webhooksService.listEventTypes(),
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+}
+
+export function useWebhookEndpoints() {
+  return useQuery({
+    queryKey: queryKeys.webhooks.list(),
+    queryFn: () => webhooksService.list(),
+    retry: false,
+  });
+}
+
+export function useWebhookEndpoint(id: string) {
+  return useQuery({
+    queryKey: queryKeys.webhooks.detail(id),
+    queryFn: () => webhooksService.getById(id),
+    enabled: !!id,
+  });
+}
+
+export function useCreateWebhookEndpoint() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: WebhookEndpointCreate) => webhooksService.create(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.webhooks.lists() });
+      toast.success('Webhook created');
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error));
+    },
+  });
+}
+
+export function useUpdateWebhookEndpoint() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: WebhookEndpointUpdate }) =>
+      webhooksService.update(id, data),
+    onSuccess: (updated, { id }) => {
+      queryClient.setQueryData(queryKeys.webhooks.detail(id), updated);
+      queryClient.invalidateQueries({ queryKey: queryKeys.webhooks.lists() });
+      toast.success('Webhook updated');
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error));
+    },
+  });
+}
+
+export function useDeleteWebhookEndpoint() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => webhooksService.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.webhooks.lists() });
+      toast.success('Webhook deleted');
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error));
+    },
+  });
+}
+
+export function useWebhookSecret(id: string, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: queryKeys.webhooks.secret(id),
+    queryFn: () => webhooksService.getSecret(id),
+    enabled: !!id && (options?.enabled ?? false),
+    staleTime: Infinity,
+  });
+}
+
+export function useSendTestWebhook() {
+  return useMutation({
+    mutationFn: ({ id, eventType }: { id: string; eventType?: string }) =>
+      webhooksService.sendTest(id, eventType),
+    onSuccess: (data) => {
+      toast.success(`Test event sent (id: ${data.message_id})`);
+    },
+    onError: (error) => {
+      toast.error(getErrorMessage(error));
+    },
+  });
+}
+
+export function useWebhookMessages(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: queryKeys.webhooks.messages(),
+    queryFn: () => webhooksService.listMessages(),
+    enabled: options?.enabled ?? true,
+    retry: false,
+  });
+}
+
+export function useWebhookAttempts(id: string) {
+  return useQuery({
+    queryKey: queryKeys.webhooks.attempts(id),
+    queryFn: () => webhooksService.listAttempts(id),
+    enabled: !!id,
+  });
+}

--- a/frontend/src/lib/api/config.ts
+++ b/frontend/src/lib/api/config.ts
@@ -94,4 +94,15 @@ export const API_ENDPOINTS = {
   seedGenerate: '/api/v1/settings/seed',
   seedPresets: '/api/v1/settings/seed/presets',
   seedSleepProfiles: '/api/v1/settings/seed/sleep-profiles',
+
+  // Webhooks endpoints
+  webhookEventTypes: '/api/v1/webhooks/event-types',
+  webhookEndpoints: '/api/v1/webhooks/endpoints',
+  webhookEndpointDetail: (id: string) => `/api/v1/webhooks/endpoints/${id}`,
+  webhookEndpointSecret: (id: string) =>
+    `/api/v1/webhooks/endpoints/${id}/secret`,
+  webhookEndpointTest: (id: string) => `/api/v1/webhooks/endpoints/${id}/test`,
+  webhookEndpointAttempts: (id: string) =>
+    `/api/v1/webhooks/endpoints/${id}/attempts`,
+  webhookMessages: '/api/v1/webhooks/messages',
 } as const;

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -7,3 +7,4 @@ export * from './types';
 export { authService } from './services/auth.service';
 export { usersService } from './services/users.service';
 export { dashboardService } from './services/dashboard.service';
+export { webhooksService } from './services/webhooks.service';

--- a/frontend/src/lib/api/services/webhooks.service.ts
+++ b/frontend/src/lib/api/services/webhooks.service.ts
@@ -1,0 +1,80 @@
+import { apiClient } from '../client';
+import { API_ENDPOINTS } from '../config';
+import type {
+  WebhookEndpoint,
+  WebhookEndpointCreate,
+  WebhookEndpointSecret,
+  WebhookEndpointUpdate,
+  WebhookEventType,
+  WebhookListResponse,
+  WebhookMessage,
+  WebhookMessageAttempt,
+  WebhookTestEventResponse,
+} from '../types';
+
+export const webhooksService = {
+  async listEventTypes(): Promise<WebhookEventType[]> {
+    return apiClient.get<WebhookEventType[]>(API_ENDPOINTS.webhookEventTypes);
+  },
+
+  async list(): Promise<WebhookEndpoint[]> {
+    return apiClient.get<WebhookEndpoint[]>(API_ENDPOINTS.webhookEndpoints);
+  },
+
+  async getById(id: string): Promise<WebhookEndpoint> {
+    return apiClient.get<WebhookEndpoint>(
+      API_ENDPOINTS.webhookEndpointDetail(id)
+    );
+  },
+
+  async create(data: WebhookEndpointCreate): Promise<WebhookEndpoint> {
+    return apiClient.post<WebhookEndpoint>(
+      API_ENDPOINTS.webhookEndpoints,
+      data
+    );
+  },
+
+  async update(
+    id: string,
+    data: WebhookEndpointUpdate
+  ): Promise<WebhookEndpoint> {
+    return apiClient.patch<WebhookEndpoint>(
+      API_ENDPOINTS.webhookEndpointDetail(id),
+      data
+    );
+  },
+
+  async delete(id: string): Promise<void> {
+    return apiClient.delete<void>(API_ENDPOINTS.webhookEndpointDetail(id));
+  },
+
+  async getSecret(id: string): Promise<WebhookEndpointSecret> {
+    return apiClient.get<WebhookEndpointSecret>(
+      API_ENDPOINTS.webhookEndpointSecret(id)
+    );
+  },
+
+  async sendTest(
+    id: string,
+    eventType?: string
+  ): Promise<WebhookTestEventResponse> {
+    return apiClient.post<WebhookTestEventResponse>(
+      API_ENDPOINTS.webhookEndpointTest(id),
+      eventType ? { event_type: eventType } : null
+    );
+  },
+
+  async listMessages(): Promise<WebhookListResponse<WebhookMessage>> {
+    return apiClient.get<WebhookListResponse<WebhookMessage>>(
+      API_ENDPOINTS.webhookMessages
+    );
+  },
+
+  async listAttempts(
+    id: string
+  ): Promise<WebhookListResponse<WebhookMessageAttempt>> {
+    return apiClient.get<WebhookListResponse<WebhookMessageAttempt>>(
+      API_ENDPOINTS.webhookEndpointAttempts(id)
+    );
+  },
+};

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -671,3 +671,71 @@ export interface GarminBackfillStatus {
   max_attempts: number;
   permanently_failed: boolean;
 }
+
+export interface WebhookEventType {
+  name: string;
+  description: string;
+}
+
+export interface WebhookEndpoint {
+  id: string;
+  url: string;
+  description: string | null;
+  filter_types: string[] | null;
+  user_id: string | null;
+}
+
+export interface WebhookEndpointCreate {
+  url: string;
+  description?: string | null;
+  filter_types?: string[] | null;
+  user_id?: string | null;
+}
+
+export interface WebhookEndpointUpdate {
+  url?: string | null;
+  description?: string | null;
+  filter_types?: string[] | null;
+  user_id?: string | null;
+}
+
+export interface WebhookEndpointSecret {
+  key: string;
+}
+
+export interface WebhookTestEventResponse {
+  message: string;
+  message_id: string;
+}
+
+export interface WebhookMessage {
+  id: string;
+  event_type: string;
+  event_id: string | null;
+  timestamp: string;
+  channels: string[] | null;
+  tags: string[] | null;
+  payload: Record<string, unknown>;
+}
+
+export interface WebhookMessageAttempt {
+  id: string;
+  endpoint_id: string;
+  msg_id: string;
+  url: string;
+  response: string;
+  response_status_code: number;
+  response_duration_ms: number;
+  status: number | string;
+  status_text?: string;
+  trigger_type: number | string;
+  timestamp: string;
+  msg?: WebhookMessage | null;
+}
+
+export interface WebhookListResponse<T> {
+  data: T[];
+  done: boolean;
+  iterator: string | null;
+  prev_iterator: string | null;
+}

--- a/frontend/src/lib/constants/routes.ts
+++ b/frontend/src/lib/constants/routes.ts
@@ -9,6 +9,7 @@ export const ROUTES = {
   // Authenticated routes
   dashboard: '/dashboard',
   users: '/users',
+  webhooks: '/webhooks',
   settings: '/settings',
 
   // Widget routes

--- a/frontend/src/lib/query/keys.ts
+++ b/frontend/src/lib/query/keys.ts
@@ -162,4 +162,18 @@ export const queryKeys = {
     presets: () => [...queryKeys.seedData.all, 'presets'] as const,
     sleepProfiles: () => [...queryKeys.seedData.all, 'sleepProfiles'] as const,
   },
+
+  webhooks: {
+    all: ['webhooks'] as const,
+    eventTypes: () => [...queryKeys.webhooks.all, 'eventTypes'] as const,
+    lists: () => [...queryKeys.webhooks.all, 'list'] as const,
+    list: () => [...queryKeys.webhooks.lists()] as const,
+    details: () => [...queryKeys.webhooks.all, 'detail'] as const,
+    detail: (id: string) => [...queryKeys.webhooks.details(), id] as const,
+    secret: (id: string) =>
+      [...queryKeys.webhooks.detail(id), 'secret'] as const,
+    messages: () => [...queryKeys.webhooks.all, 'messages'] as const,
+    attempts: (id: string) =>
+      [...queryKeys.webhooks.detail(id), 'attempts'] as const,
+  },
 } as const;

--- a/frontend/src/lib/validation/webhooks.schemas.ts
+++ b/frontend/src/lib/validation/webhooks.schemas.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const httpsUrl = z
+  .string()
+  .min(1, 'URL is required')
+  .url('Please enter a valid URL')
+  .refine((val) => val.startsWith('https://'), {
+    message: 'Webhook URL must use HTTPS',
+  });
+
+const optionalUuid = z
+  .string()
+  .trim()
+  .optional()
+  .refine((val) => !val || uuidPattern.test(val), {
+    message: 'Must be a valid UUID',
+  });
+
+const filterTypes = z.array(z.string()).optional();
+
+const optionalDescription = z
+  .string()
+  .max(500, 'Description must be 500 characters or fewer')
+  .optional();
+
+export const webhookEndpointFormSchema = z.object({
+  url: httpsUrl,
+  description: optionalDescription,
+  filter_types: filterTypes,
+  user_id: optionalUuid,
+});
+
+export type WebhookEndpointFormData = z.infer<typeof webhookEndpointFormSchema>;

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -17,11 +17,14 @@ import { Route as AcceptInviteRouteImport } from './routes/accept-invite'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as WidgetConnectRouteImport } from './routes/widget.connect'
+import { Route as AuthenticatedWebhooksRouteImport } from './routes/_authenticated/webhooks'
 import { Route as AuthenticatedUsersRouteImport } from './routes/_authenticated/users'
 import { Route as AuthenticatedSettingsRouteImport } from './routes/_authenticated/settings'
 import { Route as AuthenticatedDashboardRouteImport } from './routes/_authenticated/dashboard'
+import { Route as AuthenticatedWebhooksIndexRouteImport } from './routes/_authenticated/webhooks/index'
 import { Route as AuthenticatedUsersIndexRouteImport } from './routes/_authenticated/users/index'
 import { Route as UsersUserIdPairRouteImport } from './routes/users/$userId/pair'
+import { Route as AuthenticatedWebhooksEndpointIdRouteImport } from './routes/_authenticated/webhooks/$endpointId'
 import { Route as AuthenticatedUsersUserIdRouteImport } from './routes/_authenticated/users/$userId'
 import { Route as UsersUserIdPairIndexRouteImport } from './routes/users/$userId/pair.index'
 import { Route as UsersUserIdPairSuccessRouteImport } from './routes/users/$userId/pair.success'
@@ -66,6 +69,11 @@ const WidgetConnectRoute = WidgetConnectRouteImport.update({
   path: '/widget/connect',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthenticatedWebhooksRoute = AuthenticatedWebhooksRouteImport.update({
+  id: '/webhooks',
+  path: '/webhooks',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
 const AuthenticatedUsersRoute = AuthenticatedUsersRouteImport.update({
   id: '/users',
   path: '/users',
@@ -81,6 +89,12 @@ const AuthenticatedDashboardRoute = AuthenticatedDashboardRouteImport.update({
   path: '/dashboard',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedWebhooksIndexRoute =
+  AuthenticatedWebhooksIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthenticatedWebhooksRoute,
+  } as any)
 const AuthenticatedUsersIndexRoute = AuthenticatedUsersIndexRouteImport.update({
   id: '/',
   path: '/',
@@ -91,6 +105,12 @@ const UsersUserIdPairRoute = UsersUserIdPairRouteImport.update({
   path: '/users/$userId/pair',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthenticatedWebhooksEndpointIdRoute =
+  AuthenticatedWebhooksEndpointIdRouteImport.update({
+    id: '/$endpointId',
+    path: '/$endpointId',
+    getParentRoute: () => AuthenticatedWebhooksRoute,
+  } as any)
 const AuthenticatedUsersUserIdRoute =
   AuthenticatedUsersUserIdRouteImport.update({
     id: '/$userId',
@@ -123,10 +143,13 @@ export interface FileRoutesByFullPath {
   '/dashboard': typeof AuthenticatedDashboardRoute
   '/settings': typeof AuthenticatedSettingsRoute
   '/users': typeof AuthenticatedUsersRouteWithChildren
+  '/webhooks': typeof AuthenticatedWebhooksRouteWithChildren
   '/widget/connect': typeof WidgetConnectRoute
   '/users/$userId': typeof AuthenticatedUsersUserIdRoute
+  '/webhooks/$endpointId': typeof AuthenticatedWebhooksEndpointIdRoute
   '/users/$userId/pair': typeof UsersUserIdPairRouteWithChildren
   '/users/': typeof AuthenticatedUsersIndexRoute
+  '/webhooks/': typeof AuthenticatedWebhooksIndexRoute
   '/users/$userId/pair/error': typeof UsersUserIdPairErrorRoute
   '/users/$userId/pair/success': typeof UsersUserIdPairSuccessRoute
   '/users/$userId/pair/': typeof UsersUserIdPairIndexRoute
@@ -142,7 +165,9 @@ export interface FileRoutesByTo {
   '/settings': typeof AuthenticatedSettingsRoute
   '/widget/connect': typeof WidgetConnectRoute
   '/users/$userId': typeof AuthenticatedUsersUserIdRoute
+  '/webhooks/$endpointId': typeof AuthenticatedWebhooksEndpointIdRoute
   '/users': typeof AuthenticatedUsersIndexRoute
+  '/webhooks': typeof AuthenticatedWebhooksIndexRoute
   '/users/$userId/pair/error': typeof UsersUserIdPairErrorRoute
   '/users/$userId/pair/success': typeof UsersUserIdPairSuccessRoute
   '/users/$userId/pair': typeof UsersUserIdPairIndexRoute
@@ -159,10 +184,13 @@ export interface FileRoutesById {
   '/_authenticated/dashboard': typeof AuthenticatedDashboardRoute
   '/_authenticated/settings': typeof AuthenticatedSettingsRoute
   '/_authenticated/users': typeof AuthenticatedUsersRouteWithChildren
+  '/_authenticated/webhooks': typeof AuthenticatedWebhooksRouteWithChildren
   '/widget/connect': typeof WidgetConnectRoute
   '/_authenticated/users/$userId': typeof AuthenticatedUsersUserIdRoute
+  '/_authenticated/webhooks/$endpointId': typeof AuthenticatedWebhooksEndpointIdRoute
   '/users/$userId/pair': typeof UsersUserIdPairRouteWithChildren
   '/_authenticated/users/': typeof AuthenticatedUsersIndexRoute
+  '/_authenticated/webhooks/': typeof AuthenticatedWebhooksIndexRoute
   '/users/$userId/pair/error': typeof UsersUserIdPairErrorRoute
   '/users/$userId/pair/success': typeof UsersUserIdPairSuccessRoute
   '/users/$userId/pair/': typeof UsersUserIdPairIndexRoute
@@ -179,10 +207,13 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/settings'
     | '/users'
+    | '/webhooks'
     | '/widget/connect'
     | '/users/$userId'
+    | '/webhooks/$endpointId'
     | '/users/$userId/pair'
     | '/users/'
+    | '/webhooks/'
     | '/users/$userId/pair/error'
     | '/users/$userId/pair/success'
     | '/users/$userId/pair/'
@@ -198,7 +229,9 @@ export interface FileRouteTypes {
     | '/settings'
     | '/widget/connect'
     | '/users/$userId'
+    | '/webhooks/$endpointId'
     | '/users'
+    | '/webhooks'
     | '/users/$userId/pair/error'
     | '/users/$userId/pair/success'
     | '/users/$userId/pair'
@@ -214,10 +247,13 @@ export interface FileRouteTypes {
     | '/_authenticated/dashboard'
     | '/_authenticated/settings'
     | '/_authenticated/users'
+    | '/_authenticated/webhooks'
     | '/widget/connect'
     | '/_authenticated/users/$userId'
+    | '/_authenticated/webhooks/$endpointId'
     | '/users/$userId/pair'
     | '/_authenticated/users/'
+    | '/_authenticated/webhooks/'
     | '/users/$userId/pair/error'
     | '/users/$userId/pair/success'
     | '/users/$userId/pair/'
@@ -293,6 +329,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WidgetConnectRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_authenticated/webhooks': {
+      id: '/_authenticated/webhooks'
+      path: '/webhooks'
+      fullPath: '/webhooks'
+      preLoaderRoute: typeof AuthenticatedWebhooksRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/users': {
       id: '/_authenticated/users'
       path: '/users'
@@ -314,6 +357,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedDashboardRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/webhooks/': {
+      id: '/_authenticated/webhooks/'
+      path: '/'
+      fullPath: '/webhooks/'
+      preLoaderRoute: typeof AuthenticatedWebhooksIndexRouteImport
+      parentRoute: typeof AuthenticatedWebhooksRoute
+    }
     '/_authenticated/users/': {
       id: '/_authenticated/users/'
       path: '/'
@@ -327,6 +377,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/users/$userId/pair'
       preLoaderRoute: typeof UsersUserIdPairRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/_authenticated/webhooks/$endpointId': {
+      id: '/_authenticated/webhooks/$endpointId'
+      path: '/$endpointId'
+      fullPath: '/webhooks/$endpointId'
+      preLoaderRoute: typeof AuthenticatedWebhooksEndpointIdRouteImport
+      parentRoute: typeof AuthenticatedWebhooksRoute
     }
     '/_authenticated/users/$userId': {
       id: '/_authenticated/users/$userId'
@@ -372,16 +429,33 @@ const AuthenticatedUsersRouteChildren: AuthenticatedUsersRouteChildren = {
 const AuthenticatedUsersRouteWithChildren =
   AuthenticatedUsersRoute._addFileChildren(AuthenticatedUsersRouteChildren)
 
+interface AuthenticatedWebhooksRouteChildren {
+  AuthenticatedWebhooksEndpointIdRoute: typeof AuthenticatedWebhooksEndpointIdRoute
+  AuthenticatedWebhooksIndexRoute: typeof AuthenticatedWebhooksIndexRoute
+}
+
+const AuthenticatedWebhooksRouteChildren: AuthenticatedWebhooksRouteChildren = {
+  AuthenticatedWebhooksEndpointIdRoute: AuthenticatedWebhooksEndpointIdRoute,
+  AuthenticatedWebhooksIndexRoute: AuthenticatedWebhooksIndexRoute,
+}
+
+const AuthenticatedWebhooksRouteWithChildren =
+  AuthenticatedWebhooksRoute._addFileChildren(
+    AuthenticatedWebhooksRouteChildren,
+  )
+
 interface AuthenticatedRouteChildren {
   AuthenticatedDashboardRoute: typeof AuthenticatedDashboardRoute
   AuthenticatedSettingsRoute: typeof AuthenticatedSettingsRoute
   AuthenticatedUsersRoute: typeof AuthenticatedUsersRouteWithChildren
+  AuthenticatedWebhooksRoute: typeof AuthenticatedWebhooksRouteWithChildren
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedDashboardRoute: AuthenticatedDashboardRoute,
   AuthenticatedSettingsRoute: AuthenticatedSettingsRoute,
   AuthenticatedUsersRoute: AuthenticatedUsersRouteWithChildren,
+  AuthenticatedWebhooksRoute: AuthenticatedWebhooksRouteWithChildren,
 }
 
 const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(

--- a/frontend/src/routes/_authenticated/webhooks.tsx
+++ b/frontend/src/routes/_authenticated/webhooks.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_authenticated/webhooks')({
+  component: WebhooksLayout,
+});
+
+function WebhooksLayout() {
+  return <Outlet />;
+}

--- a/frontend/src/routes/_authenticated/webhooks/$endpointId.tsx
+++ b/frontend/src/routes/_authenticated/webhooks/$endpointId.tsx
@@ -1,0 +1,153 @@
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
+import { ArrowLeft, Send, Trash2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { WebhookForm } from '@/components/webhooks/webhook-form';
+import { WebhookSecretReveal } from '@/components/webhooks/webhook-secret-reveal';
+import { WebhookTestEventDialog } from '@/components/webhooks/webhook-test-event-dialog';
+import { WebhookDeleteDialog } from '@/components/webhooks/webhook-delete-dialog';
+import { WebhookAttemptsTable } from '@/components/webhooks/webhook-attempts-table';
+import {
+  useUpdateWebhookEndpoint,
+  useWebhookAttempts,
+  useWebhookEndpoint,
+} from '@/hooks/api/use-webhooks';
+import { ROUTES } from '@/lib/constants/routes';
+
+export const Route = createFileRoute('/_authenticated/webhooks/$endpointId')({
+  component: WebhookDetailPage,
+});
+
+function WebhookDetailPage() {
+  const { endpointId } = Route.useParams();
+  const navigate = useNavigate();
+  const endpoint = useWebhookEndpoint(endpointId);
+  const update = useUpdateWebhookEndpoint();
+  const attempts = useWebhookAttempts(endpointId);
+
+  const [tab, setTab] = useState<'overview' | 'deliveries'>('overview');
+  const [isTestOpen, setIsTestOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+
+  if (endpoint.isLoading) {
+    return (
+      <div className="p-8">
+        <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-6 animate-pulse space-y-3">
+          <div className="h-6 w-1/3 bg-zinc-800 rounded" />
+          <div className="h-32 bg-zinc-800/50 rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  if (endpoint.error || !endpoint.data) {
+    return (
+      <div className="p-8">
+        <Link to={ROUTES.webhooks}>
+          <Button variant="ghost" size="sm" className="mb-4">
+            <ArrowLeft className="h-4 w-4" />
+            Back
+          </Button>
+        </Link>
+        <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-8 text-center">
+          <p className="text-zinc-400">Webhook not found or failed to load.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const ep = endpoint.data;
+
+  return (
+    <div className="p-8">
+      <Link to={ROUTES.webhooks}>
+        <Button variant="ghost" size="sm" className="mb-4 -ml-2">
+          <ArrowLeft className="h-4 w-4" />
+          Back to webhooks
+        </Button>
+      </Link>
+
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
+        <div className="min-w-0">
+          <h1 className="text-xl font-medium text-white truncate">
+            {ep.description || 'Webhook endpoint'}
+          </h1>
+          <code className="font-mono text-xs text-zinc-500 break-all">
+            {ep.url}
+          </code>
+        </div>
+        <div className="flex gap-2 shrink-0">
+          <Button variant="outline" onClick={() => setIsTestOpen(true)}>
+            <Send className="h-4 w-4" />
+            Send test
+          </Button>
+          <Button
+            variant="outline"
+            className="text-red-400 border-red-500/30 hover:bg-red-500/10"
+            onClick={() => setIsDeleteOpen(true)}
+          >
+            <Trash2 className="h-4 w-4" />
+            Delete
+          </Button>
+        </div>
+      </div>
+
+      <Tabs
+        value={tab}
+        onValueChange={(v) => setTab(v as 'overview' | 'deliveries')}
+      >
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="deliveries">Deliveries</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="space-y-6">
+          <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-5">
+            <h3 className="text-sm font-medium text-white mb-4">
+              Configuration
+            </h3>
+            <WebhookForm
+              initial={ep}
+              submitLabel="Save changes"
+              isSubmitting={update.isPending}
+              onSubmit={(data) =>
+                update.mutate({
+                  id: ep.id,
+                  data: {
+                    url: data.url,
+                    description: data.description ?? null,
+                    filter_types: data.filter_types ?? null,
+                    user_id: data.user_id ?? null,
+                  },
+                })
+              }
+            />
+          </div>
+
+          <WebhookSecretReveal endpointId={ep.id} />
+        </TabsContent>
+
+        <TabsContent value="deliveries">
+          <WebhookAttemptsTable
+            attempts={attempts.data?.data ?? []}
+            isLoading={attempts.isLoading}
+          />
+        </TabsContent>
+      </Tabs>
+
+      <WebhookTestEventDialog
+        endpointId={ep.id}
+        open={isTestOpen}
+        onOpenChange={setIsTestOpen}
+      />
+      <WebhookDeleteDialog
+        endpointId={isDeleteOpen ? ep.id : null}
+        url={ep.url}
+        onClose={() => setIsDeleteOpen(false)}
+        onDeleted={() => navigate({ to: ROUTES.webhooks })}
+      />
+    </div>
+  );
+}

--- a/frontend/src/routes/_authenticated/webhooks/index.tsx
+++ b/frontend/src/routes/_authenticated/webhooks/index.tsx
@@ -1,0 +1,112 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { useMemo, useState } from 'react';
+import { Plus, Webhook as WebhookIcon, ExternalLink } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { WebhooksTable } from '@/components/webhooks/webhooks-table';
+import { WebhookCreateDialog } from '@/components/webhooks/webhook-create-dialog';
+import { WebhookDeleteDialog } from '@/components/webhooks/webhook-delete-dialog';
+import { useWebhookEndpoints } from '@/hooks/api/use-webhooks';
+import { ApiError } from '@/lib/errors/api-error';
+
+export const Route = createFileRoute('/_authenticated/webhooks/')({
+  component: WebhooksPage,
+});
+
+function WebhooksPage() {
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+
+  const endpoints = useWebhookEndpoints();
+
+  const deleteUrl = useMemo(
+    () => endpoints.data?.find((e) => e.id === deleteId)?.url,
+    [endpoints.data, deleteId]
+  );
+
+  const isSvixDisabled =
+    endpoints.error instanceof ApiError && endpoints.error.statusCode === 503;
+
+  return (
+    <div className="p-8">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-medium text-white">Webhooks</h1>
+          <p className="text-sm text-zinc-500 mt-1">
+            Receive real-time events when wearable data is ingested.
+          </p>
+        </div>
+        <Button onClick={() => setIsCreateOpen(true)} disabled={isSvixDisabled}>
+          <Plus className="h-4 w-4" />
+          Add webhook
+        </Button>
+      </div>
+
+      {isSvixDisabled ? (
+        <div className="bg-amber-500/10 border border-amber-500/30 rounded-xl p-6">
+          <p className="text-sm text-amber-200 font-medium">
+            Webhooks are not enabled on this instance.
+          </p>
+          <p className="text-xs text-amber-200/70 mt-1">
+            Configure <code>SVIX_AUTH_TOKEN</code> or{' '}
+            <code>SVIX_JWT_SECRET</code> in the backend environment to enable
+            outgoing webhook delivery.
+          </p>
+        </div>
+      ) : endpoints.isLoading ? (
+        <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-6 animate-pulse space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-12 bg-zinc-800/50 rounded-md" />
+          ))}
+        </div>
+      ) : endpoints.error ? (
+        <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-8 text-center">
+          <p className="text-zinc-400 mb-4">
+            Failed to load webhooks. Please try again.
+          </p>
+          <Button onClick={() => endpoints.refetch()}>Retry</Button>
+        </div>
+      ) : endpoints.data && endpoints.data.length > 0 ? (
+        <WebhooksTable data={endpoints.data} onDelete={setDeleteId} />
+      ) : (
+        <EmptyState onCreate={() => setIsCreateOpen(true)} />
+      )}
+
+      <WebhookCreateDialog open={isCreateOpen} onOpenChange={setIsCreateOpen} />
+      <WebhookDeleteDialog
+        endpointId={deleteId}
+        url={deleteUrl}
+        onClose={() => setDeleteId(null)}
+      />
+    </div>
+  );
+}
+
+function EmptyState({ onCreate }: { onCreate: () => void }) {
+  return (
+    <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-12 text-center">
+      <WebhookIcon className="h-12 w-12 text-zinc-700 mx-auto mb-4" />
+      <p className="text-zinc-300 font-medium">No webhooks configured</p>
+      <p className="text-sm text-zinc-500 mt-1 max-w-md mx-auto">
+        Subscribe to events like <code>workout.created</code> or{' '}
+        <code>sleep.created</code> and we'll POST signed payloads to your URL.
+      </p>
+      <div className="mt-5 flex justify-center gap-3">
+        <Button onClick={onCreate}>
+          <Plus className="h-4 w-4" />
+          Create your first webhook
+        </Button>
+        <a
+          href="https://openwearables.io/docs"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Button variant="outline">
+            Read the docs
+            <ExternalLink className="h-3 w-3" />
+          </Button>
+        </a>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Adds a /webhooks section to the dashboard so devs can manage outgoing webhooks from the UI instead of curling the API. Wires up the existing `External: Webhooks` endpoints - list/create/edit/delete, reveal signing secret, send a test event, and inspect delivery attempts per endpoint.

- New sidebar entry between Users and Settings
- List page + detail page with Overview / Deliveries tabs
- Recognises 503 from the backend and shows a friendly banner when SVIX env vars are missing instead of a generic error

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Frontend Changes

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds

> Note: `pnpm run build` fails on `main` already due to the recent vite 7→8 bump (#870) - `createRawStreamRPCPlugin` is missing from `@tanstack/router-core`. Unrelated to this PR. `pnpm dev` works fine.

## Testing Instructions

**Steps to test:**
1. Make sure the backend has `SVIX_AUTH_TOKEN` (or `SVIX_JWT_SECRET`) configured - default docker-compose already runs a local Svix server.
2. `docker compose up -d` and `cd frontend && pnpm dev`.
3. Log in, click "Webhooks" in the sidebar.
4. Create an endpoint pointing to e.g. https://webhook.site/<your-id>, optionally select event types.
5. Open the endpoint, reveal the signing secret, copy it.
6. Click "Send test", pick an event type - confirm the payload arrives at webhook.site.
7. Switch to "Deliveries" tab and verify the attempt shows up with a 2xx code.
8. Edit and delete to verify the rest of the flow.

**Expected behavior:**

CRUD works end-to-end, secret can be revealed and copied, test events deliver, delivery history populates with status badges and a side sheet for response/payload inspection. With Svix not configured, the page shows an amber "Webhooks are not enabled" banner instead of crashing.

## Additional Notes

- Backend untouched - all endpoints already existed under `/api/v1/webhooks/*`.
- No unit tests added in this PR - happy to follow up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhooks management UI with sidebar navigation link
  * Create, configure, update, and delete webhook endpoints
  * Filter endpoints by event types and user targeting
  * View delivery history, delivery attempts, and per-attempt details (response, payload, timing)
  * Reveal and copy endpoint signing secrets
  * Send test webhook events from the UI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->