### PR TITLE
chore: deprecate external_user_id in OpenAPI schema

### DIFF
--- a/backend/app/api/routes/v1/users.py
+++ b/backend/app/api/routes/v1/users.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Query, status
 
 from app.database import DbSession
 from app.schemas.model_crud.user_management import (
@@ -20,7 +20,7 @@ router = APIRouter()
 async def list_users(
     db: DbSession,
     _api_key: ApiKeyDep,
-    query_params: Annotated[UserQueryParams, Depends()],
+    query_params: Annotated[UserQueryParams, Query()],
 ):
     """List users with pagination, sorting, and search."""
     return user_service.get_users_paginated(db, query_params)

--- a/backend/app/schemas/model_crud/user_management/user.py
+++ b/backend/app/schemas/model_crud/user_management/user.py
@@ -7,6 +7,13 @@ from pydantic import BaseModel, ConfigDict, EmailStr, Field
 # Allowlist for user sort columns - keep in sync with Literal type below
 USER_SORT_COLUMNS: frozenset[str] = frozenset({"created_at", "email", "first_name", "last_name", "last_synced_at"})
 
+_EXTERNAL_USER_ID_DEPRECATION = (
+    "Deprecated: no data-fetching endpoint (timeseries, workouts, sleep, summaries, health-scores, etc.) "
+    "accepts external_user_id - they all require the Open Wearables UUID. This field was added early in the "
+    "project but never wired into those endpoints, so it only works as a filter on GET /users. Store the "
+    "UUID returned by POST /users in your own system instead."
+)
+
 
 class UserQueryParams(BaseModel):
     """Query parameters for filtering and searching users.
@@ -36,7 +43,11 @@ class UserQueryParams(BaseModel):
     )
 
     email: EmailStr | None = Field(None, description="Filter by exact email")
-    external_user_id: str | None = Field(None, description="Filter by external user ID")
+    external_user_id: str | None = Field(
+        None,
+        description=f"Filter by external user ID. {_EXTERNAL_USER_ID_DEPRECATION}",
+        deprecated=True,
+    )
 
 
 class UserRead(BaseModel):
@@ -47,7 +58,7 @@ class UserRead(BaseModel):
     first_name: str | None = None
     last_name: str | None = None
     email: EmailStr | None = None
-    external_user_id: str | None = None
+    external_user_id: str | None = Field(None, description=_EXTERNAL_USER_ID_DEPRECATION, deprecated=True)
     last_synced_at: datetime | None = None
     last_synced_provider: str | None = None
 
@@ -56,7 +67,7 @@ class UserCreate(BaseModel):
     first_name: str | None = Field(None, max_length=100)
     last_name: str | None = Field(None, max_length=100)
     email: EmailStr | None = None
-    external_user_id: str | None = None
+    external_user_id: str | None = Field(None, description=_EXTERNAL_USER_ID_DEPRECATION, deprecated=True)
 
 
 class UserCreateInternal(UserCreate):
@@ -68,7 +79,7 @@ class UserUpdate(BaseModel):
     first_name: str | None = Field(None, max_length=100)
     last_name: str | None = Field(None, max_length=100)
     email: EmailStr | None = None
-    external_user_id: str | None = None
+    external_user_id: str | None = Field(None, description=_EXTERNAL_USER_ID_DEPRECATION, deprecated=True)
 
 
 class UserUpdateInternal(UserUpdate):

--- a/docs/dev-guides/backend-e2e-integration.mdx
+++ b/docs/dev-guides/backend-e2e-integration.mdx
@@ -299,8 +299,12 @@ model User {
 </CodeGroup>
 
 <Note>
-Open Wearables does **not** enforce any uniqueness constraints on users - there's no unique index on `email` or any other field, so calling `POST /api/v1/users` twice will happily create two separate user records. Your backend is the source of truth for user identity and is responsible for ensuring you only create one Open Wearables user per user in your system (e.g. by storing `open_wearables_user_id` on your own user row and checking it before creating).
+Open Wearables does **not** enforce uniqueness on `email`, `first_name`, or `last_name` - calling `POST /api/v1/users` twice with the same email will happily create two separate user records. Your backend is the source of truth for user identity and is responsible for ensuring you only create one Open Wearables user per user in your system (e.g. by storing `open_wearables_user_id` on your own user row and checking it before creating).
 </Note>
+
+<Warning>
+The legacy `external_user_id` column does still carry a DB-level unique constraint, so sending a duplicate value there will fail with an integrity error. **The field is deprecated** and no data-fetching endpoint accepts it - do not rely on it for deduplication. Use the pattern above (store the Open Wearables UUID on your side) instead.
+</Warning>
 
 ---
 
@@ -880,7 +884,7 @@ async def main():
   </Accordion>
   
   <Accordion title="Multiple users created for the same email">
-    Open Wearables does not enforce uniqueness on any user field - calling `POST /api/v1/users` twice will create two separate records. Your backend is the source of truth for user identity, so store the Open Wearables `id` (UUID) on your own user row the first time you create it, and reuse that ID for every subsequent call:
+    `email` has no unique constraint in Open Wearables - calling `POST /api/v1/users` twice with the same email will create two separate records. Your backend is the source of truth for user identity, so store the Open Wearables `id` (UUID) on your own user row the first time you create it, and reuse that ID for every subsequent call:
 
     ```python
     if not local_user.open_wearables_user_id:
@@ -888,6 +892,8 @@ async def main():
         local_user.open_wearables_user_id = resp.json()["id"]
         # persist local_user
     ```
+
+    The legacy `external_user_id` field is still DB-unique, but **it is deprecated** and no data-fetching endpoint accepts it - don't use it for deduplication.
   </Accordion>
   
   <Accordion title="Sync returns 400/422 but no clear error">

--- a/docs/dev-guides/backend-e2e-integration.mdx
+++ b/docs/dev-guides/backend-e2e-integration.mdx
@@ -182,6 +182,14 @@ When a user registers in your application, create a corresponding user in Open W
 
 ### Create User
 
+All fields in the create-user payload are **optional** - you can even `POST` an empty body and get back a valid user.
+
+| Field        | Type     | Required | Notes                                                                                        |
+| ------------ | -------- | -------- | -------------------------------------------------------------------------------------------- |
+| `email`      | `string` | Optional | Must be a valid email if provided. Not enforced unique - see the note below.                 |
+| `first_name` | `string` | Optional | Max 100 characters. Useful for display in the Open Wearables dashboard.                      |
+| `last_name`  | `string` | Optional | Max 100 characters. Useful for display in the Open Wearables dashboard.                      |
+
 <CodeGroup>
 
 ```bash cURL
@@ -190,28 +198,44 @@ curl -X POST http://localhost:8000/api/v1/users \
   -H "Content-Type: application/json" \
   -d '{
     "email": "user@example.com",
-    "external_user_id": "your-internal-user-id"
+    "first_name": "Ada",
+    "last_name": "Lovelace"
   }'
 ```
 
 ```python Python
 import httpx
 
-async def create_user(email: str, external_id: str) -> dict:
+async def create_user(
+    email: str | None = None,
+    first_name: str | None = None,
+    last_name: str | None = None,
+) -> dict:
+    payload: dict = {}
+    if email:
+        payload["email"] = email
+    if first_name:
+        payload["first_name"] = first_name
+    if last_name:
+        payload["last_name"] = last_name
+
     async with httpx.AsyncClient() as client:
         response = await client.post(
             f"{OPEN_WEARABLES_API_URL}/api/v1/users",
             headers={"X-Open-Wearables-API-Key": API_KEY},
-            json={
-                "email": email,
-                "external_user_id": external_id  # e.g., Auth0 ID, your DB user ID
-            }
+            json=payload,
         )
         return response.json()
 ```
 
 ```typescript TypeScript
-async function createUser(email: string, externalId: string): Promise<User> {
+type CreateUserInput = {
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+};
+
+async function createUser(input: CreateUserInput): Promise<User> {
   const response = await fetch(`${OPEN_WEARABLES_API_URL}/api/v1/users`, {
     method: 'POST',
     headers: {
@@ -219,8 +243,9 @@ async function createUser(email: string, externalId: string): Promise<User> {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      email: email,
-      external_user_id: externalId,
+      email: input.email,
+      first_name: input.firstName,
+      last_name: input.lastName,
     }),
   });
   return response.json();
@@ -235,12 +260,13 @@ async function createUser(email: string, externalId: string): Promise<User> {
 {
   "id": "176be8de-8452-4eb7-a7ea-147fec925d9d",
   "email": "user@example.com",
-  "external_user_id": "your-internal-user-id",
-  "created_at": "2025-01-15T10:30:00Z",
-  "first_name": null,
-  "last_name": null
+  "first_name": "Ada",
+  "last_name": "Lovelace",
+  "created_at": "2025-01-15T10:30:00Z"
 }
 ```
+
+Any field you omit from the request will come back as `null`.
 
 <Warning>
 **Store the Open Wearables User ID!** You'll need this ID for all subsequent API calls.
@@ -272,32 +298,9 @@ model User {
 
 </CodeGroup>
 
-### Handling Duplicate Users
-
-Open Wearables allows multiple users with the same email. To prevent duplicates in concurrent requests (common in SPAs), implement a check-then-create pattern:
-
-```python
-async def get_or_create_user(email: str, external_id: str) -> dict:
-    async with httpx.AsyncClient() as client:
-        # Check if user exists by external_user_id
-        response = await client.get(
-            f"{OPEN_WEARABLES_API_URL}/api/v1/users",
-            headers={"X-Open-Wearables-API-Key": API_KEY},
-            params={"external_user_id": external_id, "limit": 1}
-        )
-        
-        users = response.json().get("items", [])
-        if users:
-            return users[0]
-        
-        # Create new user
-        response = await client.post(
-            f"{OPEN_WEARABLES_API_URL}/api/v1/users",
-            headers={"X-Open-Wearables-API-Key": API_KEY},
-            json={"email": email, "external_user_id": external_id}
-        )
-        return response.json()
-```
+<Note>
+Open Wearables does **not** enforce any uniqueness constraints on users - there's no unique index on `email` or any other field, so calling `POST /api/v1/users` twice will happily create two separate user records. Your backend is the source of truth for user identity and is responsible for ensuring you only create one Open Wearables user per user in your system (e.g. by storing `open_wearables_user_id` on your own user row and checking it before creating).
+</Note>
 
 ---
 
@@ -679,26 +682,29 @@ class OpenWearablesClient:
         self.base_url = base_url
         self.headers = {"X-Open-Wearables-API-Key": api_key}
     
-    async def get_or_create_user(self, email: str, external_id: str) -> dict:
-        """Create user or return existing."""
+    async def get_or_create_user(self, local_user) -> dict:
+        """Create an Open Wearables user if we haven't already, otherwise reuse the stored ID.
+
+        `local_user` is your own user row - it stores `open_wearables_user_id` once set
+        so we never create a second Open Wearables user for the same person.
+        """
         async with httpx.AsyncClient() as client:
-            # Check if exists
-            resp = await client.get(
-                f"{self.base_url}/api/v1/users",
-                headers=self.headers,
-                params={"external_user_id": external_id, "limit": 1}
-            )
-            users = resp.json().get("items", [])
-            if users:
-                return users[0]
-            
-            # Create new
+            if local_user.open_wearables_user_id:
+                resp = await client.get(
+                    f"{self.base_url}/api/v1/users/{local_user.open_wearables_user_id}",
+                    headers=self.headers,
+                )
+                if resp.status_code == 200:
+                    return resp.json()
+
             resp = await client.post(
                 f"{self.base_url}/api/v1/users",
                 headers=self.headers,
-                json={"email": email, "external_user_id": external_id}
+                json={"email": local_user.email},
             )
-            return resp.json()
+            user = resp.json()
+            local_user.open_wearables_user_id = user["id"]  # persist on your side
+            return user
     
     async def get_auth_url(
         self, 
@@ -811,11 +817,8 @@ async def main():
         api_key="sk-your-api-key"
     )
     
-    # 1. Create or get user
-    user = await client.get_or_create_user(
-        email="user@example.com",
-        external_id="auth0|123456"
-    )
+    # 1. Create or get user (pass your own user row; see get_or_create_user above)
+    user = await client.get_or_create_user(local_user)
     user_id = user["id"]
     
     # 2. Get OAuth URL for Garmin
@@ -877,14 +880,13 @@ async def main():
   </Accordion>
   
   <Accordion title="Multiple users created for the same email">
-    Open Wearables allows duplicate emails by design. Use `external_user_id` to identify users uniquely:
-    
+    Open Wearables does not enforce uniqueness on any user field - calling `POST /api/v1/users` twice will create two separate records. Your backend is the source of truth for user identity, so store the Open Wearables `id` (UUID) on your own user row the first time you create it, and reuse that ID for every subsequent call:
+
     ```python
-    # Always check by external_user_id before creating
-    existing = await client.get(
-        "/api/v1/users",
-        params={"external_user_id": your_user_id}
-    )
+    if not local_user.open_wearables_user_id:
+        resp = await client.post("/api/v1/users", json={"email": local_user.email})
+        local_user.open_wearables_user_id = resp.json()["id"]
+        # persist local_user
     ```
   </Accordion>
   


### PR DESCRIPTION
## What

Marks `external_user_id` as deprecated in the OpenAPI schema, across all places it shows up in the user API:

- `UserCreate` (request body on `POST /users`)
- `UserUpdate` (request body on `PATCH /users/{user_id}`)
- `UserRead` (response on every user endpoint)
- `UserQueryParams.external_user_id` (query param on `GET /users`)

Also switches the `GET /users` query binding from `Depends()` to `Query()` so Pydantic `Field(deprecated=True, description=...)` metadata actually propagates into the OpenAPI parameter - otherwise the flag was silently dropped for the query-param case.

Behavior is unchanged - the field still works everywhere it did before. This is purely a schema/docs signal.

## Why

The field was added early in the project as a way for integrators to map Open Wearables users back to users in their own system. In practice though, **no data-fetching endpoint accepts it**: timeseries, workouts, sleep events, summaries, health-scores, connections, data-sources, sync, backfill, SDK token exchange etc. all require the Open Wearables UUID in the path. The only place `external_user_id` is wired in is as a filter on `GET /users`, which means the best an integrator can do is a two-step dance (list → grab UUID → actual call).

We haven't had a single report or question about this attribute, so it's very likely nobody is actually relying on it. Rather than silently remove it, we're marking it deprecated first so anyone who *is* using it gets a clear signal in the generated docs/SDKs. We can plan full removal later.

Recommended alternative for integrators: store the `id` (UUID) returned by `POST /users` alongside your own user record and use that for all subsequent calls.

## Test plan

- [x] `pytest tests/api/v1/test_users.py tests/services/test_user_service.py tests/repositories/test_user_repository.py` - all 61 pass
- [x] Verified OpenAPI spec shows `"deprecated": true` on `external_user_id` in `UserCreate`, `UserUpdate`, `UserRead`, and on the `GET /users` query parameter
- [ ] Eyeball `/docs` in Swagger UI to confirm the "deprecated" badge renders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Marked external_user_id as deprecated across user APIs; migrate away from this field.
  * Adjusted user-list query parameter handling so query parameters are interpreted as request-supplied query values.

* **Documentation**
  * Updated integration guide: create-user payloads are optional and examples omit external_user_id.
  * SDK/examples now demonstrate using a stored open_wearables_user_id for reuse/deduplication instead of external_user_id.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->