### PR TITLE
docs: add Health Scores documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -30,6 +30,13 @@
             ]
           },
           {
+            "group": "Scores",
+            "pages": [
+              "scores/sleep-score",
+              "scores/resilience-score"
+            ]
+          },
+          {
             "group": "Providers",
             "pages": [
               "providers/supported",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -30,8 +30,9 @@
             ]
           },
           {
-            "group": "Scores",
+            "group": "Health Scores",
             "pages": [
+              "scores/health-scores",
               "scores/sleep-score",
               "scores/resilience-score"
             ]

--- a/docs/scores/health-scores.mdx
+++ b/docs/scores/health-scores.mdx
@@ -1,0 +1,37 @@
+---
+title: Health Scores
+description: OW platform provides two custom health scores backed by science. The scores are designed to help users understand their habits and should not be treated as a clinical tool.
+---
+
+
+<CardGroup cols={2}>
+  <Card title="Sleep Score" icon="moon" href="/scores/sleep-score">
+    A nightly 0-100 score measuring sleep quality across four pillars: duration, stages, consistency, and interruptions.
+  </Card>
+  <Card title="Resilience Score" icon="heart-pulse" href="/scores/resilience-score">
+    A weekly 0-100 score measuring autonomic nervous system stability through Heart Rate Variability Coefficient of Variation.
+  </Card>
+</CardGroup>
+
+The scores have been developed by a team of scientists and ML engineers and interpret physiological data into actionable score metric.
+
+---
+
+## Interpreting the Scores
+
+Both scores use a 0-100 scale. A higher score indicates a better outcome.
+
+| Score            | Scale  | Higher score means        |
+|------------------|--------|---------------------------|
+| Sleep Score      | 0-100  | Better sleep quality      |
+| Resilience Score | 0-100  | Better HRV consistency    |
+
+Neither score is a diagnostic tool. They are intended to surface trends and patterns over time.
+
+---
+
+## Provider Scores vs. OW Native Scores
+
+In addition to the OW native scores described above, users may also see scores fetched directly from their connected device providers - for example, a sleep score from Garmin or a readiness score from Oura. These provider scores are always clearly labelled with their source and are kept separate from the OW computed scores. They do not influence each other.
+
+This means you can surface both in your application - the OW scores for a consistent cross-device baseline, and the provider scores for users who want to compare against what their device reports.

--- a/docs/scores/resilience-score.mdx
+++ b/docs/scores/resilience-score.mdx
@@ -1,21 +1,21 @@
 ---
 title: Resilience Score
-description: A weekly HRV-based score computed by Open Wearables that measures the stability of the body's autonomic nervous system during sleep.
+description: A HRV-CV computed by Open Wearables that measures the stability of the body's autonomic nervous system.
 ---
 
 ## Overview
 
-The Resilience Score is an **Open Wearables native score** that measures how stable a user's heart rate variability (HRV) is across nights of sleep. It is computed from raw overnight biometric data — not sourced from or influenced by any manufacturer's proprietary score.
+The Resilience Score is an **Open Wearables native score** that measures how stable a user's heart rate variability (HRV) is. It is computed from raw overnight biometric data - not sourced from or influenced by any manufacturer's proprietary score.
 
-HRV consistency during sleep is a well-established marker of autonomic nervous system resilience: the more stable the overnight HRV, the better the body is recovering and adapting to physiological stress.
+HRV-CV during sleep is an established marker of autonomic nervous system resilience: the more stable the overnight HRV, the better the body is recovering and adapting to physiological stress.
 
-| Property   | Value                                                   |
-|------------|---------------------------------------------------------|
-| Range      | Continuous (HRV coefficient of variation)               |
-| Frequency  | Weekly rolling window, updated daily                    |
-| Daily view | Per-night HRV value shown alongside the weekly score    |
-| Component  | Heart Rate Variability (overnight, sleep-filtered)      |
-| Source     | Computed by Open Wearables — not a provider-sourced score |
+| Property   | Value                                                     |
+|------------|-----------------------------------------------------------|
+| Range      | 0-100                                                     |
+| Frequency  | Weekly rolling window, updated daily                      |
+| Daily view | Per-night HRV value shown alongside the weekly score      |
+| Component  | Heart Rate Variability (overnight, sleep-filtered)        |
+| Source     | Computed by Open Wearables - not a provider-sourced score |
 
 ---
 
@@ -24,17 +24,17 @@ HRV consistency during sleep is a well-established marker of autonomic nervous s
 ### Data syncing
 
 - The user must have at least one connected provider that syncs **heart rate data** and **sleep data**.
-- The device must be **worn during sleep** — overnight HR samples outside of detected sleep windows are excluded from the calculation.
+- The device must be **worn during sleep** - overnight HR samples outside of detected sleep windows are excluded from the calculation.
 
 ### Minimum data threshold
 
 A Resilience Score is only computed when there is sufficient data to produce a statistically meaningful result:
 
-| Requirement                        | Value  |
-|------------------------------------|--------|
-| Lookback window                    | 7 nights |
-| Minimum nights with HRV data       | 5 nights |
-| Minimum HR samples per night       | 20 samples |
+| Requirement                  | Value    |
+|------------------------------|----------|
+| Lookback window              | 7 nights |
+| Minimum nights with HRV data | 5 nights |
+| Minimum HR samples per night | 20 samples |
 
 If fewer than 5 of the 7 nights have valid overnight HRV recordings, the score is returned as `null`. The daily breakdown is still returned so you can show users how many nights have been counted and encourage consistent device wear.
 
@@ -54,13 +54,9 @@ Only HR samples recorded during confirmed sleep are used. The algorithm:
 
 1. Fetches all sleep sessions in the lookback window.
 2. Extracts stage-level windows where the user was in any asleep stage (Light, Deep, REM, or generic Sleeping).
-3. Filters HR data points to those timestamps — excluding awake periods, sleep latency, and morning lie-in.
+3. Filters HR data points to those timestamps - excluding awake periods and sleep latency.
 
 If a sleep session has no stage-level data, the full session window is used as a conservative fallback.
-
-### Open Wearables overnight HRV (RMSSD_OW / SDNN_OW)
-
-In addition to device-reported HRV values, Open Wearables can recompute overnight RMSSD and SDNN directly from the raw HR time series via RR-interval conversion. These are referred to as **RMSSD_OW** and **SDNN_OW** (OW = Open Wearables). This gives full control over the filtering and thresholding logic, independently of what the manufacturer reports.
 
 ### Coefficient of variation (HRV-CV)
 
@@ -70,7 +66,7 @@ The weekly score is the **coefficient of variation** of nightly average HRV valu
 HRV-CV = standard deviation of nightly HRV averages / mean of nightly HRV averages
 ```
 
-A **lower HRV-CV means more consistent overnight HRV** — the body is recovering steadily night to night. A higher HRV-CV indicates more variability, which can reflect stress, illness, overtraining, or lifestyle disruption.
+A **lower HRV-CV means more consistent overnight HRV** - the body is recovering steadily night to night. A higher HRV-CV indicates more variability, which can reflect stress, illness, overtraining, or lifestyle disruption.
 
 ### Daily view
 

--- a/docs/scores/resilience-score.mdx
+++ b/docs/scores/resilience-score.mdx
@@ -1,0 +1,97 @@
+---
+title: Resilience Score
+description: A weekly HRV-based score computed by Open Wearables that measures the stability of the body's autonomic nervous system during sleep.
+---
+
+## Overview
+
+The Resilience Score is an **Open Wearables native score** that measures how stable a user's heart rate variability (HRV) is across nights of sleep. It is computed from raw overnight biometric data — not sourced from or influenced by any manufacturer's proprietary score.
+
+HRV consistency during sleep is a well-established marker of autonomic nervous system resilience: the more stable the overnight HRV, the better the body is recovering and adapting to physiological stress.
+
+| Property   | Value                                                   |
+|------------|---------------------------------------------------------|
+| Range      | Continuous (HRV coefficient of variation)               |
+| Frequency  | Weekly rolling window, updated daily                    |
+| Daily view | Per-night HRV value shown alongside the weekly score    |
+| Component  | Heart Rate Variability (overnight, sleep-filtered)      |
+| Source     | Computed by Open Wearables — not a provider-sourced score |
+
+---
+
+## Requirements
+
+### Data syncing
+
+- The user must have at least one connected provider that syncs **heart rate data** and **sleep data**.
+- The device must be **worn during sleep** — overnight HR samples outside of detected sleep windows are excluded from the calculation.
+
+### Minimum data threshold
+
+A Resilience Score is only computed when there is sufficient data to produce a statistically meaningful result:
+
+| Requirement                        | Value  |
+|------------------------------------|--------|
+| Lookback window                    | 7 nights |
+| Minimum nights with HRV data       | 5 nights |
+| Minimum HR samples per night       | 20 samples |
+
+If fewer than 5 of the 7 nights have valid overnight HRV recordings, the score is returned as `null`. The daily breakdown is still returned so you can show users how many nights have been counted and encourage consistent device wear.
+
+---
+
+## How It Works
+
+### HRV metric selection
+
+The score prefers **RMSSD** (Root Mean Square of Successive Differences) as the HRV metric, since it is the most widely available measure of short-term HRV and is reported by most consumer wearables. If no RMSSD data survives the sleep-window filter, the algorithm automatically falls back to **SDNN** (Standard Deviation of Normal-to-Normal intervals).
+
+The metric type used (RMSSD or SDNN) is returned in the score response so it can be surfaced in the UI where appropriate.
+
+### Sleep-window filtering
+
+Only HR samples recorded during confirmed sleep are used. The algorithm:
+
+1. Fetches all sleep sessions in the lookback window.
+2. Extracts stage-level windows where the user was in any asleep stage (Light, Deep, REM, or generic Sleeping).
+3. Filters HR data points to those timestamps — excluding awake periods, sleep latency, and morning lie-in.
+
+If a sleep session has no stage-level data, the full session window is used as a conservative fallback.
+
+### Open Wearables overnight HRV (RMSSD_OW / SDNN_OW)
+
+In addition to device-reported HRV values, Open Wearables can recompute overnight RMSSD and SDNN directly from the raw HR time series via RR-interval conversion. These are referred to as **RMSSD_OW** and **SDNN_OW** (OW = Open Wearables). This gives full control over the filtering and thresholding logic, independently of what the manufacturer reports.
+
+### Coefficient of variation (HRV-CV)
+
+The weekly score is the **coefficient of variation** of nightly average HRV values across the lookback window:
+
+```
+HRV-CV = standard deviation of nightly HRV averages / mean of nightly HRV averages
+```
+
+A **lower HRV-CV means more consistent overnight HRV** — the body is recovering steadily night to night. A higher HRV-CV indicates more variability, which can reflect stress, illness, overtraining, or lifestyle disruption.
+
+### Daily view
+
+Each score response includes a day-by-day breakdown of overnight HRV values for the lookback window:
+
+```json
+{
+  "hrv_cv": 0.087,
+  "metric_type": "RMSSD",
+  "days_counted": 6,
+  "lookback_days": 7,
+  "daily_scores": [
+    { "date": "2025-04-09", "hrv_value_ms": 42.1, "has_data": true },
+    { "date": "2025-04-10", "hrv_value_ms": null, "has_data": false },
+    { "date": "2025-04-11", "hrv_value_ms": 39.8, "has_data": true },
+    { "date": "2025-04-12", "hrv_value_ms": 44.3, "has_data": true },
+    { "date": "2025-04-13", "hrv_value_ms": 40.5, "has_data": true },
+    { "date": "2025-04-14", "hrv_value_ms": 38.9, "has_data": true },
+    { "date": "2025-04-15", "hrv_value_ms": 43.7, "has_data": true }
+  ]
+}
+```
+
+Days where the device was not worn during sleep or where insufficient samples were recorded will have `has_data: false`.

--- a/docs/scores/sleep-score.mdx
+++ b/docs/scores/sleep-score.mdx
@@ -1,0 +1,135 @@
+---
+title: Sleep Score
+description: A nightly 0–100 score computed by Open Wearables from raw wearable data using a four-pillar model.
+---
+
+## Overview
+
+The Sleep Score is an **Open Wearables native score** — it is computed directly from the raw sensor data synced through the platform, independently of any manufacturer score. The same algorithm runs regardless of the device or provider the user wears, giving you a consistent, comparable score across your entire user base.
+
+| Property   | Value                                                              |
+|------------|--------------------------------------------------------------------|
+| Range      | 0 – 100                                                            |
+| Frequency  | Daily (one score per night)                                        |
+| Components | Sleep Duration, Sleep Stages, Sleep Consistency, Interruptions     |
+| Source     | Computed by Open Wearables — not a provider-sourced score          |
+
+---
+
+## Requirements
+
+For a Sleep Score to be generated, the following conditions must be met:
+
+**Data syncing**
+- The user must have at least one connected provider that syncs sleep data.
+- The provider must report total sleep duration (net sleep time, awake periods excluded).
+
+**Device and provider requirements by component**
+
+| Component        | Required data                                          | Notes                                                        |
+|------------------|--------------------------------------------------------|--------------------------------------------------------------|
+| Duration         | Total net sleep duration                               | Available from all sleep-tracking providers                  |
+| Stages           | Deep sleep minutes, REM sleep minutes                  | Requires a provider with stage-level sleep breakdown         |
+| Consistency      | Bedtime (session start timestamp) for prior nights     | Requires at least one historical night; best after 14+ nights|
+| Interruptions    | Wake-after-sleep-onset (WASO) data or sleep stage timeline | Stage timeline preferred; falls back to reported awake minutes|
+
+If a provider does not supply stage data, the Stages component will score 0. Scores are still computed and returned — missing components do not block the overall score.
+
+---
+
+## Score Components
+
+The overall Sleep Score is a weighted average of four independently-scored pillars.
+
+### Duration
+
+Scores how long the user actually slept (net sleep time, after subtracting awake periods).
+
+| Sleep duration  | Score behaviour                                             |
+|-----------------|-------------------------------------------------------------|
+| 7 – 9 hours     | 100 (perfect range)                                        |
+| Below 7 hours   | Steep sigmoid drop, centred at 5 h midpoint                |
+| Above 9 hours   | Gentle sigmoid drop, floor at 50 — oversleeping is penalised lightly |
+
+### Stages
+
+Scores the quality of sleep architecture by comparing Deep and REM stage durations against targets. Each stage is scored independently and combined with equal weighting.
+
+| Stage | Target        | Scoring                                           |
+|-------|---------------|---------------------------------------------------|
+| Deep  | 90 minutes    | Linear: 0 pts at 0 min, 100 pts at ≥ 90 min      |
+| REM   | 90 minutes    | Linear: 0 pts at 0 min, 100 pts at ≥ 90 min      |
+
+The two stage scores are combined at 50 / 50 to produce the Stages component score.
+
+### Consistency
+
+Scores how closely the user's bedtime matched their own historical routine — not against a fixed clock time. This encourages habit stability rather than conforming to an external schedule.
+
+- A **14-night rolling median** bedtime is computed from prior nights.
+- A **15-minute grace period** is applied symmetrically — minor variation is not penalised.
+- **Going to bed late** incurs a linear penalty up to 100 points across a 105-minute window past the grace period.
+- **Going to bed early** incurs a softer penalty, capped at 20 points — early nights are penalised less than late ones.
+
+No historical data means no consistency score can be computed (returns 0). The score becomes meaningful after a few nights and stabilises after ~14.
+
+### Interruptions
+
+Scores sleep continuity based on wake-after-sleep-onset (WASO) — time spent awake between falling asleep and the final wake-up, excluding sleep latency and morning lying-in-bed.
+
+The component has two sub-scores that are summed:
+
+**WASO duration (80 points available)**
+
+| WASO          | Score behaviour                                               |
+|---------------|---------------------------------------------------------------|
+| ≤ 20 minutes  | Full 80 points (grace period)                                 |
+| 20 – 90 min   | Linear penalty across a 70-minute window                      |
+| > 90 minutes  | 0 points                                                      |
+
+**Awakening frequency (20 points available)**
+
+| Significant awakenings (> 5 min each) | Points |
+|---------------------------------------|--------|
+| 0 or 1                                | 20     |
+| 2                                     | 15     |
+| 3                                     | 10     |
+| 4 or more                             | 0      |
+
+---
+
+## Weights
+
+The four pillars are combined into the overall score using a weighted average. The default weights reflect clinical research on the relative importance of each factor to sleep quality.
+
+| Component      | Default weight |
+|----------------|----------------|
+| Duration       | 40%            |
+| Stages         | 20%            |
+| Consistency    | 20%            |
+| Interruptions  | 20%            |
+
+**Weights are adjustable.** If your application has different priorities — for example, a focus on athletic recovery where sleep stages matter more, or a longevity use case where consistency is paramount — the pillar weights can be customised. The only constraint is that they must sum to 100%.
+
+Contact us or refer to the configuration reference to adjust weights for your deployment.
+
+---
+
+## Score Breakdown
+
+Every Sleep Score response includes a full breakdown payload so you can surface the component scores in your UI:
+
+```json
+{
+  "overall_score": 78,
+  "metrics": {
+    "duration_hours": 7.25
+  },
+  "breakdown": {
+    "duration":      { "score": 100 },
+    "stages":        { "score": 61 },
+    "consistency":   { "score": 85 },
+    "interruptions": { "score": 55 }
+  }
+}
+```

--- a/docs/scores/sleep-score.mdx
+++ b/docs/scores/sleep-score.mdx
@@ -1,18 +1,18 @@
 ---
 title: Sleep Score
-description: A nightly 0–100 score computed by Open Wearables from raw wearable data using a four-pillar model.
+description: A nightly 0-100 score computed by Open Wearables from raw wearable data using a four-pillar model.
 ---
 
 ## Overview
 
-The Sleep Score is an **Open Wearables native score** — it is computed directly from the raw sensor data synced through the platform, independently of any manufacturer score. The same algorithm runs regardless of the device or provider the user wears, giving you a consistent, comparable score across your entire user base.
+The Sleep Score is an **Open Wearables native score** - it is computed directly from the raw sensor data synced through the platform, independently of any manufacturer score. The same algorithm runs regardless of the device or provider the user wears, giving you a consistent, comparable score across your entire user base.
 
-| Property   | Value                                                              |
-|------------|--------------------------------------------------------------------|
-| Range      | 0 – 100                                                            |
-| Frequency  | Daily (one score per night)                                        |
-| Components | Sleep Duration, Sleep Stages, Sleep Consistency, Interruptions     |
-| Source     | Computed by Open Wearables — not a provider-sourced score          |
+| Property   | Value                                                          |
+|------------|----------------------------------------------------------------|
+| Range      | 0-100                                                          |
+| Frequency  | Daily (one score per night)                                    |
+| Components | Sleep Duration, Sleep Stages, Sleep Consistency, Sleep Interruptions |
+| Source     | Computed by Open Wearables - not a provider-sourced score      |
 
 ---
 
@@ -26,14 +26,13 @@ For a Sleep Score to be generated, the following conditions must be met:
 
 **Device and provider requirements by component**
 
-| Component        | Required data                                          | Notes                                                        |
-|------------------|--------------------------------------------------------|--------------------------------------------------------------|
-| Duration         | Total net sleep duration                               | Available from all sleep-tracking providers                  |
-| Stages           | Deep sleep minutes, REM sleep minutes                  | Requires a provider with stage-level sleep breakdown         |
-| Consistency      | Bedtime (session start timestamp) for prior nights     | Requires at least one historical night; best after 14+ nights|
-| Interruptions    | Wake-after-sleep-onset (WASO) data or sleep stage timeline | Stage timeline preferred; falls back to reported awake minutes|
+| Component     | Required data                                              | Notes                                                         |
+|---------------|------------------------------------------------------------|---------------------------------------------------------------|
+| Duration      | Total net sleep duration                                   | Available from all sleep-tracking providers                   |
+| Stages        | Deep sleep minutes, REM sleep minutes                      | Requires a provider with stage-level sleep breakdown          |
+| Consistency   | Bedtime (session start timestamp) for prior nights         | Requires at least one historical night; best after 14 nights |
+| Interruptions | Wake-after-sleep-onset (WASO) data or sleep stage timeline | Stage timeline preferred; falls back to reported awake minutes |
 
-If a provider does not supply stage data, the Stages component will score 0. Scores are still computed and returned — missing components do not block the overall score.
 
 ---
 
@@ -45,47 +44,47 @@ The overall Sleep Score is a weighted average of four independently-scored pilla
 
 Scores how long the user actually slept (net sleep time, after subtracting awake periods).
 
-| Sleep duration  | Score behaviour                                             |
-|-----------------|-------------------------------------------------------------|
-| 7 – 9 hours     | 100 (perfect range)                                        |
-| Below 7 hours   | Steep sigmoid drop, centred at 5 h midpoint                |
-| Above 9 hours   | Gentle sigmoid drop, floor at 50 — oversleeping is penalised lightly |
+| Sleep duration | Score behaviour                                                      |
+|----------------|----------------------------------------------------------------------|
+| 7-9 hours      | 100 (perfect range)                                                  |
+| Below 7 hours  | Steep sigmoid drop, centred at 5 h midpoint                          |
+| Above 9 hours  | Gentle sigmoid drop, floor at 50 - oversleeping is penalised lightly |
 
 ### Stages
 
 Scores the quality of sleep architecture by comparing Deep and REM stage durations against targets. Each stage is scored independently and combined with equal weighting.
 
-| Stage | Target        | Scoring                                           |
-|-------|---------------|---------------------------------------------------|
-| Deep  | 90 minutes    | Linear: 0 pts at 0 min, 100 pts at ≥ 90 min      |
-| REM   | 90 minutes    | Linear: 0 pts at 0 min, 100 pts at ≥ 90 min      |
+| Stage | Target     | Scoring                                      |
+|-------|------------|----------------------------------------------|
+| Deep  | 90 minutes | Linear: 0 pts at 0 min, 100 pts at 90+ min |
+| REM   | 90 minutes | Linear: 0 pts at 0 min, 100 pts at 90+ min |
 
-The two stage scores are combined at 50 / 50 to produce the Stages component score.
+The two stage scores are combined at 50/50 to produce the Stages component score.
 
 ### Consistency
 
-Scores how closely the user's bedtime matched their own historical routine — not against a fixed clock time. This encourages habit stability rather than conforming to an external schedule.
+Scores how closely the user's bedtime matched their own historical routine - not against a fixed clock time. This encourages habit stability rather than conforming to an external schedule.
 
 - A **14-night rolling median** bedtime is computed from prior nights.
-- A **15-minute grace period** is applied symmetrically — minor variation is not penalised.
+- A **15-minute grace period** is applied symmetrically - minor variation is not penalised.
 - **Going to bed late** incurs a linear penalty up to 100 points across a 105-minute window past the grace period.
-- **Going to bed early** incurs a softer penalty, capped at 20 points — early nights are penalised less than late ones.
+- **Going to bed early** incurs a softer penalty, capped at 20 points - early nights are penalised less than late ones.
 
 No historical data means no consistency score can be computed (returns 0). The score becomes meaningful after a few nights and stabilises after ~14.
 
 ### Interruptions
 
-Scores sleep continuity based on wake-after-sleep-onset (WASO) — time spent awake between falling asleep and the final wake-up, excluding sleep latency and morning lying-in-bed.
+Scores sleep continuity based on wake-after-sleep-onset (WASO) - time spent awake between falling asleep and the final wake-up, excluding sleep latency.
 
 The component has two sub-scores that are summed:
 
 **WASO duration (80 points available)**
 
-| WASO          | Score behaviour                                               |
-|---------------|---------------------------------------------------------------|
-| ≤ 20 minutes  | Full 80 points (grace period)                                 |
-| 20 – 90 min   | Linear penalty across a 70-minute window                      |
-| > 90 minutes  | 0 points                                                      |
+| WASO          | Score behaviour                               |
+|---------------|-----------------------------------------------|
+| Up to 20 min  | Full 80 points (grace period)                 |
+| 20-90 min     | Linear penalty across a 70-minute window      |
+| > 90 minutes  | 0 points                                      |
 
 **Awakening frequency (20 points available)**
 
@@ -102,14 +101,14 @@ The component has two sub-scores that are summed:
 
 The four pillars are combined into the overall score using a weighted average. The default weights reflect clinical research on the relative importance of each factor to sleep quality.
 
-| Component      | Default weight |
-|----------------|----------------|
-| Duration       | 40%            |
-| Stages         | 20%            |
-| Consistency    | 20%            |
-| Interruptions  | 20%            |
+| Component     | Default weight |
+|---------------|----------------|
+| Duration      | 40%            |
+| Stages        | 20%            |
+| Consistency   | 20%            |
+| Interruptions | 20%            |
 
-**Weights are adjustable.** If your application has different priorities — for example, a focus on athletic recovery where sleep stages matter more, or a longevity use case where consistency is paramount — the pillar weights can be customised. The only constraint is that they must sum to 100%.
+**Weights are adjustable.** If your application has different priorities - the pillar weights can be customised. The only constraint is that they must sum to 100%.
 
 Contact us or refer to the configuration reference to adjust weights for your deployment.
 


### PR DESCRIPTION
## Summary

- Adds a **Health Scores** navigation group with three pages:
  - `scores/health-scores` — landing page with intro, interpretation table, and provider scores note
  - `scores/sleep-score` — four-pillar model (Duration 40%, Stages 20%, Consistency 20%, Interruptions 20%), requirements, adjustable weights, and score breakdown payload
  - `scores/resilience-score` — HRV-CV methodology, sleep-window filtering, minimum data requirements (5 of 7 nights), and daily view

Both scores are Open Wearables native — not provider-sourced. Provider scores are documented as separate and non-interfering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new Health Scores documentation section in Guides tab
  * Sleep Score guide explains daily 0–100 metric based on duration, sleep stages, consistency, and interruptions
  * Resilience Score guide details weekly 0–100 metric measuring heart rate variability stability
  * Both pages include score interpretation guidance and data requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->