### PR TITLE
docs: refresh backend e2e integration guide

### DIFF
--- a/backend/app/api/routes/v1/sync_data.py
+++ b/backend/app/api/routes/v1/sync_data.py
@@ -358,9 +358,9 @@ def sync_historical_data(
     To make migration painless, the pre-0.4.2 behaviour is kept for now
     behind a grace-period flag (``HISTORICAL_SYNC_ON_CONNECT``, default:
     ``true``): a historical sync is auto-dispatched after a successful
-    OAuth callback (up to 90 days for pull-based providers, full
-    available history for providers that support async export such as
-    Garmin).
+    OAuth callback (up to 90 days for pull-based providers; up to 30
+    days for Garmin, whose webhook-based backfill is capped at 30 days
+    from the user's consent date).
 
     Once your integration calls this endpoint explicitly, set
     ``HISTORICAL_SYNC_ON_CONNECT=false``. The flag will default to

--- a/docs/dev-guides/aws-setup.mdx
+++ b/docs/dev-guides/aws-setup.mdx
@@ -365,4 +365,4 @@ Test your configuration:
 
 - [Apple XML Import Guide](/api-reference/guides/apple-xml-import) - Using the presigned URL endpoint
 - [How to Add a Provider](/dev-guides/how-to-add-new-provider) - Extending the platform
-- [Backend E2E Integration](/dev-guides/backend-e2e-integration) - Testing your setup
+- [Integration Guide](/dev-guides/integration-guide) - Testing your setup

--- a/docs/dev-guides/backend-e2e-integration.mdx
+++ b/docs/dev-guides/backend-e2e-integration.mdx
@@ -1,18 +1,18 @@
 ---
 title: "Backend Health API Integration Guide"
 sidebarTitle: "Backend E2E Integration"
-description: "Create users, connect wearable providers via OAuth, sync health data, and fetch metrics. FastAPI examples included. Works with any backend language."
+description: "Create users, connect wearable providers via OAuth, and fetch health metrics. FastAPI examples included. Works with any backend language."
 keywords: ["health api integration guide", "wearable backend integration", "open wearables api tutorial", "health data api tutorial"]
 "og:title": "Backend Health API Integration Guide | Open Wearables"
-"og:description": "Create users, connect providers via OAuth, sync data, fetch health metrics. FastAPI examples. Any backend language."
+"og:description": "Create users, connect providers via OAuth, fetch health metrics. FastAPI examples. Any backend language."
 "og:url": "https://docs.openwearables.io/dev-guides/backend-e2e-integration"
 "og:type": "article"
 "twitter:title": "Backend Health API Integration Guide | Open Wearables"
-"twitter:description": "Create users, connect providers via OAuth, sync data, fetch health metrics. FastAPI examples. Any backend language."
+"twitter:description": "Create users, connect providers via OAuth, fetch health metrics. FastAPI examples. Any backend language."
 "twitter:card": "summary_large_image"
 ---
 
-This guide walks you through the complete integration flow for connecting your backend application to Open Wearables. You'll learn how to create users, connect wearable providers via OAuth, sync data, and retrieve health metrics.
+This guide walks you through the complete integration flow for connecting your backend application to Open Wearables. You'll learn how to create users, connect wearable providers via OAuth, and retrieve health metrics.
 
 ## Prerequisites
 
@@ -168,10 +168,10 @@ sequenceDiagram
     OW-->>App: Authorization URL
     App->>Provider: 3. Redirect user
     Provider-->>OW: 4. OAuth callback
-    OW-->>App: 5. Redirect to your app
-    App->>OW: 6. Sync provider data
+    OW-->>OW: 5. Auto-dispatch historical backfill
+    OW-->>App: 6. Redirect to your app
     App->>OW: 7. Fetch health data
-    OW-->>App: Workouts, sleep, timeseries
+    OW-->>App: Summaries, timeseries, workouts, scores
 ```
 
 ---
@@ -312,18 +312,9 @@ The legacy `external_user_id` column does still carry a DB-level unique constrai
 
 Connect users to their wearable devices via OAuth.
 
-### Supported Providers
+### List Available Providers
 
-| Provider | OAuth Support | Data Types |
-|----------|--------------|------------|
-| **Garmin** | ✅ | Workouts, activities |
-| **Polar** | ✅ | Exercises |
-| **Suunto** | ✅ | Workouts, 24/7 data (sleep, recovery) |
-| **Apple Health** | SDK only | All health data |
-
-### List Available Providers (Optional)
-
-If you want to build a dynamic provider selection screen (instead of hardcoding provider names), you can fetch the list of available providers:
+The list of providers is dynamic - which ones are enabled depends on your instance's configuration and whether OAuth credentials are set up. Fetch it at runtime rather than hardcoding a list:
 
 <CodeGroup>
 
@@ -469,204 +460,193 @@ curl "http://localhost:8000/api/v1/users/176be8de-8452-4eb7-a7ea-147fec925d9d/co
 
 ---
 
-## Step 3: Sync Data from Provider
+## Step 3: Historical Backfill (Automatic)
 
-After OAuth connection, sync the user's health data.
+You do **not** need to explicitly trigger a sync after OAuth completes. On the first successful provider connection, Open Wearables automatically dispatches a historical backfill:
 
-<Warning>
-**Each provider has different sync requirements!** This is the most common source of integration errors.
-</Warning>
+- Up to **90 days** for pull-based providers (Polar, Suunto)
+- Full available history for providers that support async export (Garmin)
 
-### Provider-Specific Parameters
+This behaviour is controlled by the `HISTORICAL_SYNC_ON_CONNECT` flag (default: `true`). It's a grace-period flag introduced in v0.4.2 - the default will flip to `false` in a future release and the flag will eventually be removed. Once you're ready to control historical backfill yourself, set `HISTORICAL_SYNC_ON_CONNECT=false` and call `POST /api/v1/providers/{provider}/users/{user_id}/sync/historical` explicitly. See [PR #897](https://github.com/the-momentum/open-wearables/pull/897) for background.
 
-| Provider | Required Params | Constraints |
-|----------|-----------------|-------------|
-| **Garmin** | `summary_start_time`, `summary_end_time` | Max 24 hours range |
-| **Suunto** | `since` (Unix timestamp) | Max 28 days from `since` |
-| **Polar** | None | Uses pull token internally |
-
-### Garmin Sync
-
-```bash
-curl -X POST "http://localhost:8000/api/v1/providers/garmin/users/USER_ID/sync?data_type=all&summary_start_time=2025-01-15T00:00:00&summary_end_time=2025-01-15T23:59:59" \
-  -H "X-Open-Wearables-API-Key: YOUR_API_KEY"
-```
-
-### Suunto Sync
-
-```bash
-# 'since' = Unix timestamp (7 days ago = 1736899200)
-curl -X POST "http://localhost:8000/api/v1/providers/suunto/users/USER_ID/sync?data_type=all&since=1736899200" \
-  -H "X-Open-Wearables-API-Key: YOUR_API_KEY"
-```
-
-### Polar Sync
-
-```bash
-curl -X POST "http://localhost:8000/api/v1/providers/polar/users/USER_ID/sync?data_type=all" \
-  -H "X-Open-Wearables-API-Key: YOUR_API_KEY"
-```
-
-### Python Helper Function
-
-```python
-from datetime import datetime, timedelta
-
-async def sync_provider(provider: str, user_id: str) -> dict:
-    """Sync data with provider-specific parameters."""
-    params = {"data_type": "all"}
-    now = datetime.utcnow()
-    
-    if provider == "garmin":
-        # Garmin requires time range (max 24 hours)
-        start = now - timedelta(hours=24)
-        params["summary_start_time"] = start.isoformat()
-        params["summary_end_time"] = now.isoformat()
-    elif provider == "suunto":
-        # Suunto requires Unix timestamp
-        params["since"] = int((now - timedelta(days=7)).timestamp())
-    # Polar requires no additional params
-    
-    async with httpx.AsyncClient() as client:
-        response = await client.post(
-            f"{OPEN_WEARABLES_API_URL}/api/v1/providers/{provider}/users/{user_id}/sync",
-            headers={"X-Open-Wearables-API-Key": API_KEY},
-            params=params,
-            timeout=60.0  # Sync can take time
-        )
-        return response.json()
-```
-
-### Common Sync Errors
-
-| Error | Cause | Solution |
-|-------|-------|----------|
-| `"User not connected to {provider}"` | OAuth not completed | Complete OAuth flow first |
-| `"Missing time range parameters"` | Garmin missing times | Add `summary_start_time` and `summary_end_time` |
-| `422 Unprocessable Entity` | Suunto missing `since` | Add `since` Unix timestamp parameter |
-| `"InvalidPullTokenException"` | Token expired | User must reconnect via OAuth |
-| `"duplicate key value"` | Data already synced | Safe to ignore |
+<Note>
+Ongoing sync after the initial backfill happens automatically - webhooks push updates for providers that support them, and pull-based providers are polled on a schedule. Your integration only needs to connect the user; fetching data (next step) is the read side.
+</Note>
 
 ---
 
 ## Step 4: Retrieve Health Data
 
-After syncing, fetch the normalized health data.
-
-### Workouts
-
-```bash
-curl "http://localhost:8000/api/v1/users/USER_ID/events/workouts?start_date=2025-01-01&end_date=2025-01-31" \
-  -H "X-Open-Wearables-API-Key: YOUR_API_KEY"
-```
-
-### Response
+All data endpoints require the `X-Open-Wearables-API-Key` header and return a `PaginatedResponse` wrapper:
 
 ```json
 {
-  "data": [
+  "data": [ /* items */ ],
+  "pagination": {
+    "next_cursor": "eyJpZCI6...",
+    "previous_cursor": null,
+    "has_more": true,
+    "total_count": 150
+  },
+  "metadata": {
+    "resolution": null,
+    "sample_count": 50,
+    "start_time": "2025-01-01T00:00:00Z",
+    "end_time": "2025-01-31T23:59:59Z"
+  }
+}
+```
+
+To page through results, pass `cursor=<next_cursor>` until `has_more` is `false`. The health-scores endpoint uses `offset`/`limit` instead of a cursor but returns the same envelope.
+
+<CardGroup cols={2}>
+  <Card title="Activity summary" icon="person-running" href="/api-reference/external:-summaries/get-activity-summary">
+    Daily aggregates: steps, distance, floors, active/total kcal, active/sedentary minutes, intensity minutes, heart-rate stats.
+  </Card>
+  <Card title="Sleep summary" icon="moon" href="/api-reference/external:-summaries/get-sleep-summary">
+    Daily sleep: duration, efficiency, stages (awake/light/deep/rem minutes), interruptions, naps, avg HR/HRV/SpO2.
+  </Card>
+  <Card title="Body summary" icon="weight-scale" href="/api-reference/external:-summaries/get-body-summary">
+    Point-in-time body metrics grouped into `slow_changing` (weight, height, BMI, body fat), `averaged` (resting HR, HRV over 1-7 days) and `latest` (temperature, blood pressure within a recency window).
+  </Card>
+  <Card title="Timeseries" icon="chart-line" href="/api-reference/external:-timeseries/get-timeseries">
+    Granular samples for any `SeriesType` (heart rate, steps, SpO2, etc.) with optional `resolution` bucketing (`raw`, `1min`, `5min`, `15min`, `1hour`).
+  </Card>
+  <Card title="Workouts" icon="dumbbell" href="/api-reference/external:-events/list-workouts">
+    Workout sessions with type, duration, calories, distance, avg/max heart rate, pace, elevation gain, and `source` provider metadata.
+  </Card>
+  <Card title="Health scores" icon="gauge-high" href="/api-reference/external:-health-scores/list-health-scores">
+    Provider-computed scores (sleep, recovery, readiness, stress, body battery, strain) with optional `components` breakdown. Filter by `category` or `provider`.
+  </Card>
+</CardGroup>
+
+### Response Shapes
+
+<Tabs>
+  <Tab title="ActivitySummary">
+    ```json
     {
-      "id": "abc123...",
+      "date": "2025-01-15",
+      "source": { "provider": "apple_health", "device": "Apple Watch Series 9" },
+      "steps": 8432,
+      "distance_meters": 6240.5,
+      "floors_climbed": 12,
+      "elevation_meters": 36.0,
+      "active_calories_kcal": 342.5,
+      "total_calories_kcal": 2150.0,
+      "active_minutes": 60,
+      "sedentary_minutes": 480,
+      "intensity_minutes": { "light": 20, "moderate": 30, "vigorous": 10 },
+      "heart_rate": { "avg_bpm": 72, "max_bpm": 155, "min_bpm": 58 }
+    }
+    ```
+    Every field apart from `date` and `source` is nullable.
+  </Tab>
+  <Tab title="SleepSummary">
+    ```json
+    {
+      "date": "2025-01-15",
+      "source": { "provider": "garmin", "device": null },
+      "start_time": "2025-01-14T22:30:00Z",
+      "end_time": "2025-01-15T06:45:00Z",
+      "duration_minutes": 450,
+      "time_in_bed_minutes": 480,
+      "efficiency_percent": 92.5,
+      "stages": { "awake_minutes": 20, "light_minutes": 180, "deep_minutes": 120, "rem_minutes": 130 },
+      "interruptions_count": 3,
+      "nap_count": 1,
+      "nap_duration_minutes": 30,
+      "avg_heart_rate_bpm": 55,
+      "avg_hrv_sdnn_ms": 62.4,
+      "avg_respiratory_rate": 14.2,
+      "avg_spo2_percent": 96.0
+    }
+    ```
+    `duration_minutes` / `time_in_bed_minutes` exclude naps. Units are minutes, not seconds.
+  </Tab>
+  <Tab title="BodySummary">
+    ```json
+    {
+      "source": { "provider": "apple_health", "device": "Apple Watch Series 9" },
+      "slow_changing": {
+        "weight_kg": 72.5, "height_cm": 175.5, "body_fat_percent": 18.5,
+        "muscle_mass_kg": 58.2, "bmi": 23.5, "age": 32
+      },
+      "averaged": {
+        "period_days": 7,
+        "resting_heart_rate_bpm": 62,
+        "avg_hrv_sdnn_ms": 45.2,
+        "period_start": "2025-01-08T00:00:00Z",
+        "period_end": "2025-01-15T00:00:00Z"
+      },
+      "latest": {
+        "body_temperature_celsius": 36.6,
+        "body_temperature_measured_at": "2025-01-15T08:00:00Z",
+        "skin_temperature_celsius": null,
+        "skin_temperature_measured_at": null,
+        "blood_pressure": {
+          "avg_systolic_mmhg": 120, "avg_diastolic_mmhg": 80,
+          "max_systolic_mmhg": 135, "max_diastolic_mmhg": 90,
+          "min_systolic_mmhg": 110, "min_diastolic_mmhg": 72,
+          "reading_count": 5
+        },
+        "blood_pressure_measured_at": "2025-01-15T07:30:00Z"
+      }
+    }
+    ```
+    Returns `null` (not a `data: []` wrapper) if no body data exists for the user. Controlled by `average_period` (1-7 days, default 7) and `latest_window_hours` (1-24, default 4).
+  </Tab>
+  <Tab title="TimeSeriesSample">
+    ```json
+    {
+      "timestamp": "2025-01-15T08:30:00Z",
+      "zone_offset": "+01:00",
+      "type": "heart_rate",
+      "value": 72,
+      "unit": "bpm",
+      "source": { "provider": "apple_health", "device": "Apple Watch Series 9" }
+    }
+    ```
+    `types` is a repeated query param (`?types=heart_rate&types=steps`). Units come from the series type definition - `bpm`, `ms`, `percent`, `mg_dl`, `count`, `kcal`, `meters`, etc.
+  </Tab>
+  <Tab title="Workout">
+    ```json
+    {
+      "id": "abc123-...",
       "type": "running",
       "name": "Morning Run",
       "start_time": "2025-01-15T07:30:00Z",
       "end_time": "2025-01-15T08:15:00Z",
+      "zone_offset": "+01:00",
       "duration_seconds": 2700,
+      "source": { "provider": "garmin", "device": "Garmin Forerunner 255" },
       "calories_kcal": 450.5,
       "distance_meters": 5200.0,
       "avg_heart_rate_bpm": 155,
       "max_heart_rate_bpm": 178,
-      "source": {
-        "provider": "garmin",
-        "device": "Garmin Forerunner 255"
-      }
+      "avg_pace_sec_per_km": 312,
+      "elevation_gain_meters": 42.0
     }
-  ],
-  "pagination": {
-    "next_cursor": null,
-    "has_more": false
-  }
-}
-```
-
-### Sleep Sessions
-
-```bash
-curl "http://localhost:8000/api/v1/users/USER_ID/events/sleep?start_date=2025-01-01&end_date=2025-01-31" \
-  -H "X-Open-Wearables-API-Key: YOUR_API_KEY"
-```
-
-### Response
-
-```json
-{
-  "data": [
+    ```
+  </Tab>
+  <Tab title="HealthScore">
+    ```json
     {
-      "id": "def456...",
-      "start_time": "2025-01-15T22:30:00Z",
-      "end_time": "2025-01-16T06:45:00Z",
-      "duration_seconds": 29700,
-      "efficiency_percent": 92.5,
-      "is_nap": false,
-      "stages": {
-        "awake_seconds": 1200,
-        "light_seconds": 10800,
-        "deep_seconds": 7200,
-        "rem_seconds": 10500
+      "id": "abc123-...",
+      "category": "sleep",
+      "value": 82,
+      "qualifier": "GOOD",
+      "recorded_at": "2025-01-15T07:00:00Z",
+      "zone_offset": "+01:00",
+      "components": {
+        "total_sleep": { "value": 450, "qualifier": "GOOD" },
+        "deep_sleep": { "value": 120, "qualifier": "EXCELLENT" }
       },
-      "source": {
-        "provider": "suunto"
-      }
+      "data_source_id": "def456-...",
+      "provider": "garmin"
     }
-  ],
-  "pagination": {
-    "next_cursor": null,
-    "has_more": false
-  }
-}
-```
-
-### Timeseries Data
-
-<Warning>
-All three parameters are **required**: `start_time`, `end_time`, and `types`
-</Warning>
-
-```bash
-curl "http://localhost:8000/api/v1/users/USER_ID/timeseries?start_time=2025-01-15T00:00:00Z&end_time=2025-01-15T23:59:59Z&types=heart_rate&types=steps" \
-  -H "X-Open-Wearables-API-Key: YOUR_API_KEY"
-```
-
-### Available Timeseries Types
-
-<Tabs>
-  <Tab title="Biometrics">
-    | Type | Unit |
-    |------|------|
-    | `heart_rate` | bpm |
-    | `resting_heart_rate` | bpm |
-    | `heart_rate_variability_sdnn` | ms |
-    | `oxygen_saturation` | percent |
-    | `blood_glucose` | mg/dL |
-    | `respiratory_rate` | breaths/min |
-    | `body_temperature` | celsius |
-  </Tab>
-  <Tab title="Activity">
-    | Type | Unit |
-    |------|------|
-    | `steps` | count |
-    | `energy` | kcal |
-    | `distance_walking_running` | meters |
-    | `flights_climbed` | count |
-    | `exercise_time` | minutes |
-  </Tab>
-  <Tab title="Body">
-    | Type | Unit |
-    |------|------|
-    | `weight` | kg |
-    | `height` | cm |
-    | `body_fat_percentage` | percent |
-    | `body_mass_index` | kg/m² |
+    ```
+    `category` is one of `sleep`, `recovery`, `readiness`, `activity`, `stress`, `resilience`, `body_battery`, `strain`. Score ranges vary by provider.
   </Tab>
 </Tabs>
 
@@ -678,14 +658,13 @@ Here's a complete Python client class for Open Wearables integration:
 
 ```python
 import httpx
-from datetime import datetime, timedelta
 from typing import Literal
 
 class OpenWearablesClient:
     def __init__(self, base_url: str, api_key: str):
         self.base_url = base_url
         self.headers = {"X-Open-Wearables-API-Key": api_key}
-    
+
     async def get_or_create_user(self, local_user) -> dict:
         """Create an Open Wearables user if we haven't already, otherwise reuse the stored ID.
 
@@ -709,148 +688,146 @@ class OpenWearablesClient:
             user = resp.json()
             local_user.open_wearables_user_id = user["id"]  # persist on your side
             return user
-    
+
     async def get_auth_url(
-        self, 
-        provider: Literal["garmin", "polar", "suunto"], 
+        self,
+        provider: Literal["garmin", "polar", "suunto"],
         user_id: str,
-        redirect_uri: str | None = None
+        redirect_uri: str | None = None,
     ) -> str:
         """Get OAuth authorization URL."""
         params = {"user_id": user_id}
         if redirect_uri:
             params["redirect_uri"] = redirect_uri
-            
+
         async with httpx.AsyncClient() as client:
             resp = await client.get(
                 f"{self.base_url}/api/v1/oauth/{provider}/authorize",
                 headers=self.headers,
-                params=params
+                params=params,
             )
             return resp.json()["authorization_url"]
-    
+
     async def get_connections(self, user_id: str) -> list[dict]:
         """Get user's connected providers."""
         async with httpx.AsyncClient() as client:
             resp = await client.get(
                 f"{self.base_url}/api/v1/users/{user_id}/connections",
-                headers=self.headers
+                headers=self.headers,
             )
             return resp.json()
-    
-    async def sync_provider(
-        self, 
-        provider: Literal["garmin", "polar", "suunto"], 
-        user_id: str
-    ) -> dict:
-        """Sync data with provider-specific params."""
-        params = {"data_type": "all"}
-        now = datetime.utcnow()
-        
-        if provider == "garmin":
-            start = now - timedelta(hours=24)
-            params["summary_start_time"] = start.isoformat()
-            params["summary_end_time"] = now.isoformat()
-        elif provider == "suunto":
-            params["since"] = int((now - timedelta(days=7)).timestamp())
-        
+
+    async def _paginated(self, path: str, params: dict) -> list[dict]:
+        """Walk `next_cursor` until `has_more` is false and return all items."""
+        items: list[dict] = []
         async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                f"{self.base_url}/api/v1/providers/{provider}/users/{user_id}/sync",
+            while True:
+                resp = await client.get(f"{self.base_url}{path}", headers=self.headers, params=params)
+                payload = resp.json()
+                items.extend(payload.get("data", []))
+                cursor = payload["pagination"].get("next_cursor")
+                if not payload["pagination"].get("has_more") or not cursor:
+                    return items
+                params = {**params, "cursor": cursor}
+
+    async def get_activity_summary(self, user_id: str, start_date: str, end_date: str) -> list[dict]:
+        return await self._paginated(
+            f"/api/v1/users/{user_id}/summaries/activity",
+            {"start_date": start_date, "end_date": end_date},
+        )
+
+    async def get_sleep_summary(self, user_id: str, start_date: str, end_date: str) -> list[dict]:
+        return await self._paginated(
+            f"/api/v1/users/{user_id}/summaries/sleep",
+            {"start_date": start_date, "end_date": end_date},
+        )
+
+    async def get_body_summary(self, user_id: str) -> dict | None:
+        """BodySummary is a single object (not paginated). Returns None if no data."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{self.base_url}/api/v1/users/{user_id}/summaries/body",
                 headers=self.headers,
-                params=params,
-                timeout=60.0
             )
             return resp.json()
-    
-    async def get_workouts(
-        self, 
-        user_id: str, 
-        start_date: str, 
-        end_date: str
-    ) -> list[dict]:
-        """Get workouts in date range."""
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{self.base_url}/api/v1/users/{user_id}/events/workouts",
-                headers=self.headers,
-                params={"start_date": start_date, "end_date": end_date}
-            )
-            return resp.json().get("data", [])
-    
-    async def get_sleep(
-        self, 
-        user_id: str, 
-        start_date: str, 
-        end_date: str
-    ) -> list[dict]:
-        """Get sleep sessions in date range."""
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{self.base_url}/api/v1/users/{user_id}/events/sleep",
-                headers=self.headers,
-                params={"start_date": start_date, "end_date": end_date}
-            )
-            return resp.json().get("data", [])
-    
+
     async def get_timeseries(
-        self, 
-        user_id: str, 
-        start_time: str, 
+        self,
+        user_id: str,
+        start_time: str,
         end_time: str,
-        types: list[str]
+        types: list[str],
+        resolution: Literal["raw", "1min", "5min", "15min", "1hour"] = "raw",
     ) -> list[dict]:
-        """Get timeseries data."""
+        return await self._paginated(
+            f"/api/v1/users/{user_id}/timeseries",
+            {"start_time": start_time, "end_time": end_time, "types": types, "resolution": resolution},
+        )
+
+    async def get_workouts(self, user_id: str, start_date: str, end_date: str) -> list[dict]:
+        return await self._paginated(
+            f"/api/v1/users/{user_id}/events/workouts",
+            {"start_date": start_date, "end_date": end_date},
+        )
+
+    async def get_health_scores(
+        self,
+        user_id: str,
+        category: str | None = None,
+        provider: str | None = None,
+    ) -> list[dict]:
+        """Health scores use offset/limit pagination, not cursors."""
+        params = {k: v for k, v in {"category": category, "provider": provider}.items() if v}
+        items: list[dict] = []
+        offset = 0
         async with httpx.AsyncClient() as client:
-            resp = await client.get(
-                f"{self.base_url}/api/v1/users/{user_id}/timeseries",
-                headers=self.headers,
-                params={
-                    "start_time": start_time,
-                    "end_time": end_time,
-                    "types": types
-                }
-            )
-            return resp.json().get("data", [])
+            while True:
+                resp = await client.get(
+                    f"{self.base_url}/api/v1/users/{user_id}/health-scores",
+                    headers=self.headers,
+                    params={**params, "limit": 200, "offset": offset},
+                )
+                payload = resp.json()
+                data = payload.get("data", [])
+                items.extend(data)
+                if not payload["pagination"].get("has_more") or not data:
+                    return items
+                offset += len(data)
 
 
 # Usage example
 async def main():
     client = OpenWearablesClient(
         base_url="http://localhost:8000",
-        api_key="sk-your-api-key"
+        api_key="sk-your-api-key",
     )
-    
+
     # 1. Create or get user (pass your own user row; see get_or_create_user above)
     user = await client.get_or_create_user(local_user)
     user_id = user["id"]
-    
+
     # 2. Get OAuth URL for Garmin
     auth_url = await client.get_auth_url(
         provider="garmin",
         user_id=user_id,
-        redirect_uri="https://myapp.com/callback"
+        redirect_uri="https://myapp.com/callback",
     )
     print(f"Redirect user to: {auth_url}")
-    
-    # 3. After OAuth callback, check connections
+
+    # 3. After OAuth callback, confirm the connection is active.
+    # Historical backfill is dispatched automatically - no explicit sync call needed.
     connections = await client.get_connections(user_id)
     garmin_connected = any(
-        c["provider"] == "garmin" and c["status"] == "active" 
+        c["provider"] == "garmin" and c["status"] == "active"
         for c in connections
     )
-    
+
     if garmin_connected:
-        # 4. Sync data
-        await client.sync_provider("garmin", user_id)
-        
-        # 5. Fetch workouts
-        workouts = await client.get_workouts(
-            user_id,
-            start_date="2025-01-01",
-            end_date="2025-01-31"
-        )
-        print(f"Found {len(workouts)} workouts")
+        # 4. Fetch whatever you need.
+        workouts = await client.get_workouts(user_id, "2025-01-01", "2025-01-31")
+        activity = await client.get_activity_summary(user_id, "2025-01-01", "2025-01-31")
+        scores = await client.get_health_scores(user_id, category="sleep")
+        print(f"{len(workouts)} workouts, {len(activity)} activity days, {len(scores)} sleep scores")
 ```
 
 ---
@@ -896,27 +873,20 @@ async def main():
     The legacy `external_user_id` field is still DB-unique, but **it is deprecated** and no data-fetching endpoint accepts it - don't use it for deduplication.
   </Accordion>
   
-  <Accordion title="Sync returns 400/422 but no clear error">
-    Check provider-specific requirements:
-    
-    | Provider | Fix |
-    |----------|-----|
-    | Garmin | Add `summary_start_time` and `summary_end_time` |
-    | Suunto | Add `since` parameter (Unix timestamp) |
-    | Polar | Usually works without extra params |
+  <Accordion title="Data endpoints return empty results right after OAuth">
+    Historical backfill is dispatched asynchronously on connect and can take anywhere from seconds to several minutes depending on the provider and the amount of history. Poll `GET /api/v1/users/{user_id}/connections` - `last_synced_at` flips from `null` to a timestamp once the first sync finishes. For Garmin's async export, full history can take hours.
+
+    If `HISTORICAL_SYNC_ON_CONNECT=false` in your instance, no backfill runs automatically - call `POST /api/v1/providers/{provider}/users/{user_id}/sync/historical` yourself.
   </Accordion>
-  
+
   <Accordion title="Timeseries endpoint returns empty data">
-    Ensure all required parameters are provided:
-    
+    `start_time`, `end_time`, and `types` are all required. `types` is repeated:
+
     ```bash
-    # All three are REQUIRED
-    ?start_time=2025-01-15T00:00:00Z
-    &end_time=2025-01-15T23:59:59Z
-    &types=heart_rate
+    ?start_time=2025-01-15T00:00:00Z&end_time=2025-01-15T23:59:59Z&types=heart_rate&types=steps
     ```
-    
-    Also verify data exists for the requested time range.
+
+    Also verify the `SeriesType` you're requesting exists for this user - check `GET /api/v1/users/{user_id}/summaries/data` for a breakdown of what's been ingested.
   </Accordion>
   
   <Accordion title="OAuth callback not redirecting to my app">

--- a/docs/dev-guides/backend-e2e-integration.mdx
+++ b/docs/dev-guides/backend-e2e-integration.mdx
@@ -467,7 +467,7 @@ You do **not** need to explicitly trigger a sync after OAuth completes. On the f
 - Up to **90 days** for pull-based providers (Polar, Suunto)
 - Full available history for providers that support async export (Garmin)
 
-This behaviour is controlled by the `HISTORICAL_SYNC_ON_CONNECT` flag (default: `true`). It's a grace-period flag introduced in v0.4.2 - the default will flip to `false` in a future release and the flag will eventually be removed. Once you're ready to control historical backfill yourself, set `HISTORICAL_SYNC_ON_CONNECT=false` and call `POST /api/v1/providers/{provider}/users/{user_id}/sync/historical` explicitly. See [PR #897](https://github.com/the-momentum/open-wearables/pull/897) for background.
+This behaviour is controlled by the `HISTORICAL_SYNC_ON_CONNECT` flag (default: `true`). It's a grace-period flag introduced in v0.4.3 - the default will flip to `false` in a future release and the flag will eventually be removed. Once you're ready to control historical backfill yourself, set `HISTORICAL_SYNC_ON_CONNECT=false` and call `POST /api/v1/providers/{provider}/users/{user_id}/sync/historical` explicitly. See [PR #897](https://github.com/the-momentum/open-wearables/pull/897) for background.
 
 <Note>
 Ongoing sync after the initial backfill happens automatically - webhooks push updates for providers that support them, and pull-based providers are polled on a schedule. Your integration only needs to connect the user; fetching data (next step) is the read side.

--- a/docs/dev-guides/integration-guide.mdx
+++ b/docs/dev-guides/integration-guide.mdx
@@ -1,18 +1,18 @@
 ---
-title: "Backend Health API Integration Guide"
-sidebarTitle: "Backend E2E Integration"
+title: "Open Wearables Integration Guide"
+sidebarTitle: "Integration Guide"
 description: "Create users, connect wearable providers via OAuth, and fetch health metrics. FastAPI examples included. Works with any backend language."
-keywords: ["health api integration guide", "wearable backend integration", "open wearables api tutorial", "health data api tutorial"]
-"og:title": "Backend Health API Integration Guide | Open Wearables"
+keywords: ["health api integration guide", "wearable api integration", "open wearables api tutorial", "health data api tutorial"]
+"og:title": "Open Wearables Integration Guide"
 "og:description": "Create users, connect providers via OAuth, fetch health metrics. FastAPI examples. Any backend language."
-"og:url": "https://docs.openwearables.io/dev-guides/backend-e2e-integration"
+"og:url": "https://docs.openwearables.io/dev-guides/integration-guide"
 "og:type": "article"
-"twitter:title": "Backend Health API Integration Guide | Open Wearables"
+"twitter:title": "Open Wearables Integration Guide"
 "twitter:description": "Create users, connect providers via OAuth, fetch health metrics. FastAPI examples. Any backend language."
 "twitter:card": "summary_large_image"
 ---
 
-This guide walks you through the complete integration flow for connecting your backend application to Open Wearables. You'll learn how to create users, connect wearable providers via OAuth, and retrieve health metrics.
+This guide walks you through the complete integration flow with Open Wearables - creating users from your backend, handing users off to wearable providers via OAuth (the frontend redirect dance included), and fetching normalized health data back.
 
 ## Prerequisites
 

--- a/docs/dev-guides/integration-guide.mdx
+++ b/docs/dev-guides/integration-guide.mdx
@@ -465,7 +465,7 @@ curl "http://localhost:8000/api/v1/users/176be8de-8452-4eb7-a7ea-147fec925d9d/co
 You do **not** need to explicitly trigger a sync after OAuth completes. On the first successful provider connection, Open Wearables automatically dispatches a historical backfill:
 
 - Up to **90 days** for pull-based providers (Polar, Suunto)
-- Full available history for providers that support async export (Garmin)
+- Up to **30 days** for Garmin (webhook-based backfill capped at 30 days from the user's consent date - further back is not retrievable)
 
 This behaviour is controlled by the `HISTORICAL_SYNC_ON_CONNECT` flag (default: `true`). It's a grace-period flag introduced in v0.4.3 - the default will flip to `false` in a future release and the flag will eventually be removed. Once you're ready to control historical backfill yourself, set `HISTORICAL_SYNC_ON_CONNECT=false` and call `POST /api/v1/providers/{provider}/users/{user_id}/sync/historical` explicitly. See [PR #897](https://github.com/the-momentum/open-wearables/pull/897) for background.
 

--- a/docs/dev-guides/integration-guide.mdx
+++ b/docs/dev-guides/integration-guide.mdx
@@ -886,7 +886,7 @@ async def main():
     ?start_time=2025-01-15T00:00:00Z&end_time=2025-01-15T23:59:59Z&types=heart_rate&types=steps
     ```
 
-    Also verify the `SeriesType` you're requesting exists for this user - check `GET /api/v1/users/{user_id}/summaries/data` for a breakdown of what's been ingested.
+    If you're not sure whether anything has synced yet, `GET /api/v1/users/{user_id}/data-sources` returns the list of devices and providers that have produced samples for this user - an empty list means historical backfill hasn't finished (see the previous accordion).
   </Accordion>
   
   <Accordion title="OAuth callback not redirecting to my app">

--- a/docs/dev-guides/integration-guide.mdx
+++ b/docs/dev-guides/integration-guide.mdx
@@ -886,7 +886,7 @@ async def main():
     ?start_time=2025-01-15T00:00:00Z&end_time=2025-01-15T23:59:59Z&types=heart_rate&types=steps
     ```
 
-    If you're not sure whether anything has synced yet, `GET /api/v1/users/{user_id}/data-sources` returns the list of devices and providers that have produced samples for this user - an empty list means historical backfill hasn't finished (see the previous accordion).
+    Also verify the `SeriesType` you're requesting exists for this user - check `GET /api/v1/users/{user_id}/summaries/data` for a breakdown of what's been ingested.
   </Accordion>
   
   <Accordion title="OAuth callback not redirecting to my app">

--- a/docs/dev-guides/ngrok-setup.mdx
+++ b/docs/dev-guides/ngrok-setup.mdx
@@ -124,6 +124,6 @@ ngrok http 8000 --domain=your-custom-domain.ngrok-free.app
 
 ## Related Guides
 
-- [Backend E2E Integration](/dev-guides/backend-e2e-integration) - Complete integration walkthrough
+- [Integration Guide](/dev-guides/integration-guide) - Complete integration walkthrough
 - [Provider Setup](/providers/supported) - Configure OAuth credentials
 

--- a/docs/dev-guides/raw-payload-storage.mdx
+++ b/docs/dev-guides/raw-payload-storage.mdx
@@ -281,4 +281,4 @@ uv run --with boto3,httpx python scripts/replay_raw_payloads.py \
 
 - [AWS Setup](/dev-guides/aws-setup) - Configure AWS credentials and S3 buckets
 - [How to Add a Provider](/dev-guides/how-to-add-new-provider) - Adding raw payload storage to new providers
-- [Backend E2E Integration](/dev-guides/backend-e2e-integration) - Testing your setup
+- [Integration Guide](/dev-guides/integration-guide) - Testing your setup

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -8,6 +8,12 @@
     "dark": "#15803D"
   },
   "favicon": "/favicon.svg",
+  "redirects": [
+    {
+      "source": "/dev-guides/backend-e2e-integration",
+      "destination": "/dev-guides/integration-guide"
+    }
+  ],
   "navigation": {
     "tabs": [
       {
@@ -95,7 +101,7 @@
           {
             "group": "Developer Guides",
             "pages": [
-              "dev-guides/backend-e2e-integration",
+              "dev-guides/integration-guide",
               "dev-guides/how-to-add-new-provider",
               "dev-guides/ngrok-setup",
               "dev-guides/seed-data-generator"

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -196,7 +196,8 @@
               "GET /api/v1/users/{user_id}/summaries/activity",
               "GET /api/v1/users/{user_id}/summaries/sleep",
               "GET /api/v1/users/{user_id}/summaries/body",
-              "GET /api/v1/users/{user_id}/summaries/recovery"
+              "GET /api/v1/users/{user_id}/summaries/recovery",
+              "GET /api/v1/users/{user_id}/summaries/data"
             ]
           },
           {


### PR DESCRIPTION
## Summary
- Drop the hardcoded "Supported Providers" table in the e2e integration guide. The dynamic `GET /api/v1/oauth/providers` endpoint is the single source of truth - instance config decides what's enabled, so a static table just goes stale.
- Remove the "Sync Data from Provider" step entirely. We don't call `POST /providers/{provider}/users/{user_id}/sync` from the frontend anywhere, and walking integrators through per-provider sync params was making the guide look harder than it is.
- Replace that section with a short note on the automatic historical backfill that runs on first connect (grace-period flag `HISTORICAL_SYNC_ON_CONNECT`, default `true`). Links to #897 for background.
- Rewrite "Retrieve Health Data" as pointers to the six public API reference pages, with response shapes verified against the actual Pydantic models in `backend/app/schemas/responses/activity/`:
  - [Activity summary](https://openwearables.io/docs/api-reference/external:-summaries/get-activity-summary)
  - [Sleep summary](https://openwearables.io/docs/api-reference/external:-summaries/get-sleep-summary)
  - [Body summary](https://openwearables.io/docs/api-reference/external:-summaries/get-body-summary)
  - [Timeseries](https://openwearables.io/docs/api-reference/external:-timeseries/get-timeseries)
  - [List workouts](https://openwearables.io/docs/api-reference/external:-events/list-workouts)
  - [List health scores](https://openwearables.io/docs/api-reference/external:-health-scores/list-health-scores)
- Fix schema drift in the old examples - e.g. sleep stages were documented as `*_seconds` but the model is `*_minutes`; health-score `components` were missing; the `PaginatedResponse` envelope wasn't documented at all.
- Update the mermaid flow, the Python example client (now walks `next_cursor` / `offset`), and the troubleshooting accordions to match.

## Test plan
- [ ] Preview the docs page and confirm sections render (CardGroup, Tabs, Accordions)
- [ ] Verify links to `/api-reference/external:-*` resolve in the Mintlify nav
- [ ] Sanity check: `rg "sync_provider|Sync Data from Provider|Supported Providers" docs/dev-guides/backend-e2e-integration.mdx` returns nothing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced legacy integration links with a renamed "Integration Guide" and added redirects for consistent navigation.
  * Reworked the Integration Guide: clarified OAuth flow to emphasize automatic historical backfill with capped windows, simplified provider discovery to runtime, and removed manual sync steps.
  * Standardized API response shapes and pagination guidance; updated examples to use summary endpoints and cursor/offset pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->