### PR TITLE
fix(backend): scope x100 ratio->percent conversion to Apple provider only

### DIFF
--- a/backend/app/services/apple/healthkit/import_service.py
+++ b/backend/app/services/apple/healthkit/import_service.py
@@ -127,8 +127,14 @@ class ImportService:
 
             if not series_type:
                 continue
-            # Convert from meters to centimeters or ratio to percentage
-            if series_type in (SeriesType.height, SeriesType.body_fat_percentage):
+            # Convert meters -> centimeters for height (both HealthKit and Health Connect report meters)
+            # and ratio (0..1) -> percent for Apple body_fat_percentage (HealthKit HKUnit.percent()).
+            # Android Health Connect's BodyFatRecord.percentage is already in percent, so only scale
+            # body_fat_percentage for provider == "apple" — otherwise Google/Samsung values are stored
+            # ~100x too large.
+            if series_type == SeriesType.height or (
+                series_type == SeriesType.body_fat_percentage and provider == "apple"
+            ):
                 value = value * 100
 
             # Extract device info

--- a/backend/tests/integrations/test_apple_sdk_import.py
+++ b/backend/tests/integrations/test_apple_sdk_import.py
@@ -8,11 +8,14 @@ import logging
 from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pytest
 from sqlalchemy.orm import Session
 
 from app.models import EventRecord, WorkoutDetails
+from app.schemas.enums import SeriesType
+from app.schemas.providers.mobile_sdk import SyncRequest as SDKSyncRequest
 from app.services.apple.healthkit.import_service import ImportService
 from tests.factories import UserFactory
 
@@ -539,3 +542,121 @@ class TestAppleSDKImportEdgeCases:
         assert details.heart_rate_avg is None
         assert details.distance is None
         assert details.energy_burned is None
+
+
+class TestSDKImportUnitConversion:
+    """Unit conversions applied in `_build_statistic_bundles`.
+
+    Apple HealthKit reports `body_fat_percentage` via `HKUnit.percent()` as a 0..1 ratio,
+    while Android Health Connect's `BodyFatRecord.percentage` is already in percent.
+    Height in meters is consistent across both platforms and must always be converted to cm.
+    """
+
+    @pytest.fixture
+    def import_service(self) -> ImportService:
+        return ImportService(log=logging.getLogger("test"))
+
+    @staticmethod
+    def _record(metric_type: str, value: float) -> dict[str, Any]:
+        return {
+            "id": f"test-{metric_type}",
+            "type": metric_type,
+            "unit": "",
+            "value": value,
+            "startDate": "2025-04-10T12:00:00Z",
+            "endDate": "2025-04-10T12:00:00Z",
+            "source": {
+                "name": "Test Device",
+                "bundleIdentifier": "test",
+            },
+        }
+
+    def _build_request(self, provider: str, records: list[dict[str, Any]]) -> SDKSyncRequest:
+        return SDKSyncRequest(
+            **{
+                "provider": provider,
+                "sdkVersion": "1.0.0",
+                "syncTimestamp": "2025-04-10T12:00:00Z",
+                "data": {"records": records},
+            }
+        )
+
+    def test_apple_body_fat_percentage_scaled_by_100(
+        self,
+        import_service: ImportService,
+    ) -> None:
+        """Apple sends ratio 0.304 — must be stored as 30.4 (%)."""
+        user_id = str(uuid4())
+        request = self._build_request(
+            "apple",
+            [self._record("HKQuantityTypeIdentifierBodyFatPercentage", 0.304)],
+        )
+        samples = import_service._build_statistic_bundles(request, user_id)
+
+        assert len(samples) == 1
+        assert samples[0].series_type == SeriesType.body_fat_percentage
+        assert samples[0].value == Decimal("30.400")
+
+    def test_google_body_fat_percentage_not_scaled(
+        self,
+        import_service: ImportService,
+    ) -> None:
+        """Google/Health Connect sends already-percent 30.4 — must be stored as 30.4 (no x100)."""
+        user_id = str(uuid4())
+        request = self._build_request(
+            "google",
+            [self._record("BODY_FAT", 30.4)],
+        )
+        samples = import_service._build_statistic_bundles(request, user_id)
+
+        assert len(samples) == 1
+        assert samples[0].series_type == SeriesType.body_fat_percentage
+        assert samples[0].value == Decimal("30.4")
+
+    def test_samsung_body_fat_percentage_not_scaled(
+        self,
+        import_service: ImportService,
+    ) -> None:
+        """Samsung uses Health Connect semantics — already percent, must not be scaled."""
+        user_id = str(uuid4())
+        request = self._build_request(
+            "samsung",
+            [self._record("BODY_FAT", 18.5)],
+        )
+        samples = import_service._build_statistic_bundles(request, user_id)
+
+        assert len(samples) == 1
+        assert samples[0].series_type == SeriesType.body_fat_percentage
+        assert samples[0].value == Decimal("18.5")
+
+    def test_apple_height_converted_meters_to_centimeters(
+        self,
+        import_service: ImportService,
+    ) -> None:
+        """Height in meters 1.7526 — must be stored as 175.26 cm regardless of provider."""
+        user_id = str(uuid4())
+        request = self._build_request(
+            "apple",
+            [self._record("HKQuantityTypeIdentifierHeight", 1.7526)],
+        )
+        samples = import_service._build_statistic_bundles(request, user_id)
+
+        assert len(samples) == 1
+        assert samples[0].series_type == SeriesType.height
+        assert samples[0].value == Decimal("175.2600")
+
+    def test_google_height_converted_meters_to_centimeters(
+        self,
+        import_service: ImportService,
+    ) -> None:
+        """Health Connect also sends height in meters — the x100 conversion still applies."""
+        user_id = str(uuid4())
+        request = self._build_request(
+            "google",
+            [self._record("HEIGHT", 1.7526)],
+        )
+        samples = import_service._build_statistic_bundles(request, user_id)
+
+        assert len(samples) == 1
+        assert samples[0].series_type == SeriesType.height
+        assert samples[0].value == Decimal("175.2600")


### PR DESCRIPTION
## Summary

`ImportService` in `backend/app/services/apple/healthkit/import_service.py` is routed for Apple, Samsung, and Google SDK payloads (see `process_sdk_upload_task._get_import_service`), but `body_fat_percentage` was unconditionally multiplied by `100`. That ratio->percent conversion is correct only for Apple HealthKit, where `HKUnit.percent()` returns a `0..1` ratio. Android Health Connect's `BodyFatRecord.percentage.value` is already reported in percent, so Google/Samsung body-fat samples were stored ~100x too large.

## Why

On Android users, stored `body_fat_percentage` samples come back around `3040` (from an actual value like `30.4`). This made downstream summaries and charts meaningless for any provider using the SDK path on Android. Samsung is presumably also affected — Samsung's Health Connect export uses the same semantics — though I don't personally have Samsung data to confirm directly.

Height (`SeriesType.height`) is left unchanged: both HealthKit and Health Connect report height in meters, so the m -> cm conversion is correct for all providers.

## Changes

- `backend/app/services/apple/healthkit/import_service.py`: gate the `x100` for `body_fat_percentage` on `provider == "apple"`. Height conversion remains provider-agnostic.
- `backend/tests/integrations/test_apple_sdk_import.py`: new `TestSDKImportUnitConversion` class covering the provider-dispatched branches.

This is intentionally a minimal, targeted fix. A proper provider-dispatch refactor for ingestion (splitting the HealthKit service from a Health Connect service, or introducing an explicit provider adapter layer) is a larger change that this PR unblocks rather than attempts.

## Question for maintainers

This fix lands in `apple/healthkit/import_service.py` because that's where the bug lives today — but given that `ImportService` is actually the shared post-SDK-translation path for Apple, Samsung, and Google payloads, it's not obvious this is the right long-term home. Would you prefer:

- **(a)** keep the provider branch here, consistent with the rest of the file; or
- **(b)** start splitting Android/HC-specific handling into a separate module now, with this PR as the first move?

Happy to rework if you have a layout in mind. I've also opened **#916** proposing a broader refactor of this area; this PR is the narrow regression fix, but the two are tied.

## Test plan

- [x] `pytest tests/integrations/test_apple_sdk_import.py` — all 15 tests pass (10 existing + 5 new).
- [x] `pytest -k "body_fat or height or sdk_import or apple"` — 52 tests pass.
- [x] `ruff check` and `ruff format --check` on both modified files — clean.

New test cases:
- `provider="apple"`, `body_fat_percentage` input `0.304` -> stored `30.4`
- `provider="google"`, `body_fat_percentage` input `30.4` -> stored `30.4`
- `provider="samsung"`, `body_fat_percentage` input `18.5` -> stored `18.5`
- `provider="apple"`, `height` input `1.7526` -> stored `175.26`
- `provider="google"`, `height` input `1.7526` -> stored `175.26` (regression guard)

## Notes

No data backfill is included in this PR — existing incorrect rows will need a separate one-off correction, which is infra-specific to each deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected unit scaling for body fat percentage in health data imports. Apple provider measurements are now scaled by 100, while data from Google and Samsung providers remain unscaled.

* **Tests**
  * Added comprehensive test coverage for health metric unit conversions across different health data providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->