### PR TITLE
feat(frontend): mark webhooks as beta

### DIFF
--- a/frontend/src/components/layout/simple-sidebar.tsx
+++ b/frontend/src/components/layout/simple-sidebar.tsx
@@ -29,6 +29,7 @@ const menuItems = [
     title: 'Webhooks',
     url: ROUTES.webhooks,
     icon: Webhook,
+    badge: 'Beta',
   },
   {
     title: 'Settings',
@@ -93,6 +94,11 @@ export function SimpleSidebar() {
                 )}
               />
               <span>{item.title}</span>
+              {item.badge ? (
+                <span className="ml-auto rounded-full border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-300">
+                  {item.badge}
+                </span>
+              ) : null}
             </Link>
           );
         })}

--- a/frontend/src/routes/_authenticated/webhooks.tsx
+++ b/frontend/src/routes/_authenticated/webhooks.tsx
@@ -1,9 +1,25 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router';
+import { FlaskConical } from 'lucide-react';
 
 export const Route = createFileRoute('/_authenticated/webhooks')({
   component: WebhooksLayout,
 });
 
 function WebhooksLayout() {
-  return <Outlet />;
+  return (
+    <>
+      <div className="px-8 pt-8">
+        <div className="flex items-start gap-3 rounded-lg border border-amber-500/20 bg-amber-500/10 px-4 py-2.5 text-amber-300">
+          <FlaskConical className="h-4 w-4 shrink-0 mt-0.5 text-amber-400" />
+          <p className="text-xs font-medium leading-relaxed">
+            <span className="font-semibold text-amber-200">Beta</span>
+            {' - '}
+            Webhooks are in beta. The API and delivery behavior may change, and
+            we don't recommend relying on them for production workloads yet.
+          </p>
+        </div>
+      </div>
+      <Outlet />
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- added a small `Beta` badge next to the Webhooks item in the sidebar
- added an inline beta notice at the top of the webhooks pages so users know the feature isn't production-ready yet

## Test plan
- [x] sign in and confirm the sidebar shows a `Beta` pill next to Webhooks
- [x] open `/webhooks` and confirm the beta notice is visible above the page content
- [x] open a specific webhook endpoint detail page and confirm the notice is still shown

## Screenshots 

<img width="1511" height="860" alt="image" src="https://github.com/user-attachments/assets/2c824447-1b41-4a45-94a4-fa965eef1987" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Beta" badge to the Webhooks menu item in the navigation to surface status.
  * Added a visible "Beta" warning banner at the top of the Webhooks page with an icon and explanatory text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->