### PR TITLE
docs: note cloud_only flag for web integration flows

### DIFF
--- a/docs/dev-guides/integration-guide.mdx
+++ b/docs/dev-guides/integration-guide.mdx
@@ -341,7 +341,7 @@ async def get_providers(enabled_only: bool = True, cloud_only: bool = True) -> l
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `enabled_only` | `false` | Return only providers enabled in your instance |
-| `cloud_only` | `false` | Return only cloud-based (OAuth) providers, excludes SDK-only providers like Apple Health |
+| `cloud_only` | `false` | Return only cloud-based (OAuth) providers, excludes SDK-only providers like Apple Health. If you're implementing an integration flow on web, you likely want to enable this flag. |
 
 **Response:**
 


### PR DESCRIPTION
## Description

Small doc tweak - the `cloud_only` query param description now hints that web integration flows probably want to enable it (since SDK-only providers like Apple Health aren't usable from the browser).

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated integration guide documentation to clarify the behavior of the `cloud_only` query parameter and provide guidance on when to enable it for web integration flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->