### PR TITLE
fix: slow tests after adding lifespan with webhook event registration

### DIFF
--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -38,6 +38,7 @@ from app.schemas.utils import (
 from app.schemas.utils import (
     SourceMetadata as DataSourceSchema,
 )
+from app.services.outgoing_webhooks import svix as svix_service
 from app.services.outgoing_webhooks.events import on_sleep_created, on_workout_created
 from app.services.services import AppService
 from app.utils.exceptions import handle_exceptions
@@ -399,6 +400,8 @@ class EventRecordService(
         detail: EventRecordDetailCreate,
     ) -> None:
         """Fire the appropriate outgoing webhook for a newly created event record."""
+        if not svix_service.is_enabled():
+            return
         category = (record.category or "").lower()
         provider = str(data_source.provider)
         device = data_source.device_model

--- a/backend/app/services/timeseries_service.py
+++ b/backend/app/services/timeseries_service.py
@@ -29,6 +29,7 @@ from app.schemas.utils import (
     SourceMetadata,
     TimeseriesMetadata,
 )
+from app.services.outgoing_webhooks import svix as svix_service
 from app.services.outgoing_webhooks.events import on_timeseries_batch_saved
 from app.services.services import AppService
 from app.utils.exceptions import handle_exceptions
@@ -54,14 +55,12 @@ class TimeSeriesService(
         samples: (list[TimeSeriesSampleCreate] | list[HeartRateSampleCreate] | list[StepSampleCreate]),
     ) -> None:
         self.crud.bulk_create(db_session, samples)  # type: ignore[arg-type]
-        # Webhooks must fire AFTER the transaction commits so consumers can
-        # query the API and already find the data.  Register a one-shot
-        # after_commit listener on the session; the daemon thread is started
-        # only once the rows are durably written.  No callers need changing.
         samples_copy = list(samples)
 
         @sa_event.listens_for(db_session, "after_commit", once=True)
         def _start_webhook_thread(session: DbSession) -> None:  # noqa: ARG001
+            if not svix_service.is_enabled():
+                return
             threading.Thread(
                 target=self._emit_timeseries_webhooks,
                 args=(samples_copy,),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -205,6 +205,14 @@ def flush_redis(_redis_url: str) -> Generator[None, None, None]:
 # ============================================================================
 
 
+@pytest.fixture(scope="session", autouse=True)
+def mock_svix_lifespan() -> Generator[MagicMock, None, None]:
+    """Prevent register_event_types() from making ~170 HTTP calls to Svix on
+    every TestClient lifespan startup during tests."""
+    with patch("app.services.outgoing_webhooks.svix.register_event_types") as mock:
+        yield mock
+
+
 @pytest.fixture(autouse=True)
 def mock_webhook_dispatch() -> Generator[MagicMock, None, None]:
     """Prevent outgoing webhook tasks from attempting real Redis/Celery connections.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed webhook emission to properly respect service enablement status.

* **Tests**
  * Improved test isolation by preventing external service calls during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->