### PR TITLE
fix: emit webhooks from bulk_create_details for SDK imports

### DIFF
--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -466,8 +466,8 @@ class EventRecordService(
         records: list[EventRecordCreate],
     ) -> list[UUID]:
         """Bulk create event records with batch data source resolution."""
-        # Webhooks are not emitted for bulk-created records; they fire via
-        # create_detail() when individual details are added.
+        # Webhooks are not emitted for bulk-created records; they fire from
+        # bulk_create_details() when the matching details are inserted.
         return self.crud.bulk_create(db_session, records)
 
     def bulk_create_details(
@@ -476,8 +476,42 @@ class EventRecordService(
         details: list[EventRecordDetailCreate],
         detail_type: str = "workout",
     ) -> None:
-        """Bulk create event record details."""
+        """Bulk create event record details and fire one webhook per detail on commit."""
         self.event_record_detail_repo.bulk_create(db_session, details, detail_type=detail_type)  # type: ignore[arg-type]
+
+        if not details or not svix_service.is_enabled():
+            return
+
+        record_ids = [d.record_id for d in details if d.record_id is not None]
+        if not record_ids:
+            return
+
+        records = db_session.query(EventRecord).filter(EventRecord.id.in_(record_ids)).all()
+        records_by_id = {r.id: r for r in records}
+
+        data_source_ids = {r.data_source_id for r in records if r.data_source_id is not None}
+        data_sources = (
+            db_session.query(DataSource).filter(DataSource.id.in_(data_source_ids)).all() if data_source_ids else []
+        )
+        data_sources_by_id = {ds.id: ds for ds in data_sources}
+
+        dispatches: list[tuple[EventRecord, DataSource, EventRecordDetailCreate]] = []
+        for detail in details:
+            record = records_by_id.get(detail.record_id)
+            if record is None or record.data_source_id is None:
+                continue
+            data_source = data_sources_by_id.get(record.data_source_id)
+            if data_source is None:
+                continue
+            dispatches.append((record, data_source, detail))
+
+        if not dispatches:
+            return
+
+        @sa_event.listens_for(db_session, "after_commit", once=True)
+        def _dispatch_bulk_webhooks(session: DbSession) -> None:  # noqa: ARG001
+            for record, data_source, detail in dispatches:
+                self._emit_event_record_webhook(record, data_source, detail)
 
     @handle_exceptions
     def _get_records_with_filters(

--- a/backend/tests/services/test_event_record_service.py
+++ b/backend/tests/services/test_event_record_service.py
@@ -10,6 +10,7 @@ Tests cover:
 
 from datetime import datetime, timezone
 from decimal import Decimal
+from unittest.mock import patch
 from uuid import UUID, uuid4
 
 from sqlalchemy.orm import Session
@@ -102,6 +103,68 @@ class TestEventRecordServiceCreateDetail:
         # All optional fields should be None
         assert getattr(detail, "heart_rate_min", None) is None
         assert getattr(detail, "steps_count", None) is None
+
+
+class TestEventRecordServiceBulkCreateDetails:
+    """bulk_create_details must dispatch a webhook per detail on commit.
+
+    Before the fix, Apple/Google/Samsung SDK imports saved workouts through
+    bulk_create + bulk_create_details and no webhook was ever emitted.
+    """
+
+    def test_bulk_create_details_emits_workout_webhooks(self, db: Session) -> None:
+        data_source = DataSourceFactory(source="apple")
+        rec1 = EventRecordFactory(mapping=data_source, category="workout", type_="running")
+        rec2 = EventRecordFactory(mapping=data_source, category="workout", type_="cycling")
+
+        details = [
+            EventRecordDetailCreate(
+                record_id=rec1.id,
+                energy_burned=Decimal("300.0"),
+                distance=Decimal("5000.0"),
+            ),
+            EventRecordDetailCreate(
+                record_id=rec2.id,
+                energy_burned=Decimal("500.0"),
+                distance=Decimal("20000.0"),
+            ),
+        ]
+
+        with (
+            patch("app.services.event_record_service.svix_service.is_enabled", return_value=True),
+            patch("app.services.event_record_service.on_workout_created") as mock_workout,
+        ):
+            event_record_service.bulk_create_details(db, details, detail_type="workout")
+            db.commit()
+
+        assert mock_workout.call_count == 2
+        dispatched_ids = {c.kwargs["record_id"] for c in mock_workout.call_args_list}
+        assert dispatched_ids == {rec1.id, rec2.id}
+
+    def test_bulk_create_details_silent_when_svix_disabled(self, db: Session) -> None:
+        data_source = DataSourceFactory(source="apple")
+        rec = EventRecordFactory(mapping=data_source, category="workout", type_="running")
+
+        details = [EventRecordDetailCreate(record_id=rec.id, energy_burned=Decimal("250.0"))]
+
+        with (
+            patch("app.services.event_record_service.svix_service.is_enabled", return_value=False),
+            patch("app.services.event_record_service.on_workout_created") as mock_workout,
+        ):
+            event_record_service.bulk_create_details(db, details, detail_type="workout")
+            db.commit()
+
+        mock_workout.assert_not_called()
+
+    def test_bulk_create_details_empty_list_is_noop(self, db: Session) -> None:
+        with (
+            patch("app.services.event_record_service.svix_service.is_enabled", return_value=True),
+            patch("app.services.event_record_service.on_workout_created") as mock_workout,
+        ):
+            event_record_service.bulk_create_details(db, [], detail_type="workout")
+            db.commit()
+
+        mock_workout.assert_not_called()
 
 
 class TestEventRecordServiceGetRecordsResponse:


### PR DESCRIPTION
## Summary

- Apple/Google/Samsung SDK workouts silently skipped webhook emission because they go through `bulk_create` + `bulk_create_details`, and neither registered the `after_commit` listener that `create_detail` uses. Pull-based providers (Suunto, Garmin, Oura, Fitbit, Whoop, Polar, Strava) were unaffected.
- `bulk_create_details` now does the `(record, data_source, detail)` lookup in batch and registers one `after_commit` listener that fires one webhook per detail - same `_emit_event_record_webhook` path the single-item flow uses.

## Test plan

- [x] New tests in `tests/services/test_event_record_service.py::TestEventRecordServiceBulkCreateDetails` cover: webhook fires once per detail on commit, no-op when Svix is disabled, no-op for empty list
- [x] Full service + webhook + Garmin 24/7 + Apple SDK test suites (118 tests) green locally
- [ ] Monitor Svix dashboard after deploy for `workout.created` events from Apple/Google/Samsung SDK batches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bulk event record insertion now emits webhooks for each created item, ensuring proper event notifications for batch operations.

* **Tests**
  * Added test coverage for webhook dispatch behavior during bulk creation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->