### PR TITLE
feat(polar): daily activity + Sleep Plus Stages + continuous HR sync

### DIFF
--- a/backend/app/constants/series_types/polar/__init__.py
+++ b/backend/app/constants/series_types/polar/__init__.py
@@ -1,0 +1,3 @@
+from app.constants.series_types.polar.sleep_stage import POLAR_HYPNOGRAM_MAP
+
+__all__ = ["POLAR_HYPNOGRAM_MAP"]

--- a/backend/app/constants/series_types/polar/sleep_stage.py
+++ b/backend/app/constants/series_types/polar/sleep_stage.py
@@ -1,0 +1,26 @@
+"""Polar Sleep Plus Stages hypnogram code → unified SleepStageType.
+
+Polar's AccessLink v3 `sleep.hypnogram` is a mapping of ``"HH:MM"`` transition
+times to stage codes. Codes are documented as::
+
+    0 = WAKE
+    1 = REM
+    2 = LIGHTER NON-REM   (AASM N1)
+    3 = LIGHT NON-REM     (AASM N2)
+    4 = DEEP NON-REM      (AASM N3)
+    5 = UNKNOWN           (e.g. poor skin contact)
+
+OW's `SleepStageType` has a single ``LIGHT`` bucket, so 2 and 3 both map to it.
+Codes outside this range fall back to ``UNKNOWN`` at the call site.
+"""
+
+from app.constants.sleep import SleepStageType
+
+POLAR_HYPNOGRAM_MAP: dict[int, SleepStageType] = {
+    0: SleepStageType.AWAKE,
+    1: SleepStageType.REM,
+    2: SleepStageType.LIGHT,
+    3: SleepStageType.LIGHT,
+    4: SleepStageType.DEEP,
+    5: SleepStageType.UNKNOWN,
+}

--- a/backend/app/schemas/enums/series_types.py
+++ b/backend/app/schemas/enums/series_types.py
@@ -150,6 +150,13 @@ class SeriesType(str, Enum):
     garmin_body_battery = "garmin_body_battery"  # Garmin body battery (0-100)
 
     # =========================================================================
+    # POLAR-SPECIFIC METRICS (IDs 240-259)
+    # =========================================================================
+    polar_nightly_recharge_status = "polar_nightly_recharge_status"  # 1-5 ordinal
+    polar_ans_charge = "polar_ans_charge"                             # -10 to +10 signed
+    polar_ans_charge_status = "polar_ans_charge_status"               # 1-5 ordinal
+
+    # =========================================================================
     # OTHER (IDs 500-)
     # =========================================================================
 
@@ -285,6 +292,12 @@ SERIES_TYPE_DEFINITIONS: list[tuple[int, SeriesType, str]] = [
     (221, SeriesType.garmin_skin_temperature, "celsius"),  # kept for backwards compatibility
     (222, SeriesType.garmin_fitness_age, "years"),
     (223, SeriesType.garmin_body_battery, "percent"),
+    # -------------------------------------------------------------------------
+    # POLAR-SPECIFIC METRICS (IDs 240-259)
+    # -------------------------------------------------------------------------
+    (240, SeriesType.polar_nightly_recharge_status, "score"),
+    (241, SeriesType.polar_ans_charge, "score"),
+    (242, SeriesType.polar_ans_charge_status, "score"),
     # -------------------------------------------------------------------------
     # OTHER (IDs 500-)
     # -------------------------------------------------------------------------

--- a/backend/app/schemas/providers/polar/__init__.py
+++ b/backend/app/schemas/providers/polar/__init__.py
@@ -4,6 +4,8 @@ from .exercise_import import (
     HRSamplesJSON,
     HRZoneJSON,
 )
+from .heart_rate_import import PolarContinuousHRJSON, PolarContinuousHRSample
+from .sleep_import import PolarSleepJSON, PolarSleepNightsJSON
 
 __all__ = [
     # Activity import (daily summaries)
@@ -12,4 +14,10 @@ __all__ = [
     "HRSamplesJSON",
     "HRZoneJSON",
     "ExerciseJSON",
+    # Sleep Plus Stages
+    "PolarSleepJSON",
+    "PolarSleepNightsJSON",
+    # Continuous HR
+    "PolarContinuousHRJSON",
+    "PolarContinuousHRSample",
 ]

--- a/backend/app/schemas/providers/polar/__init__.py
+++ b/backend/app/schemas/providers/polar/__init__.py
@@ -1,3 +1,4 @@
+from .activity_import import PolarActivityJSON
 from .exercise_import import (
     ExerciseJSON,
     HRSamplesJSON,
@@ -5,6 +6,8 @@ from .exercise_import import (
 )
 
 __all__ = [
+    # Activity import (daily summaries)
+    "PolarActivityJSON",
     # Exercise import
     "HRSamplesJSON",
     "HRZoneJSON",

--- a/backend/app/schemas/providers/polar/__init__.py
+++ b/backend/app/schemas/providers/polar/__init__.py
@@ -5,6 +5,10 @@ from .exercise_import import (
     HRZoneJSON,
 )
 from .heart_rate_import import PolarContinuousHRJSON, PolarContinuousHRSample
+from .nightly_recharge_import import (
+    PolarNightlyRechargeEntryJSON,
+    PolarNightlyRechargeJSON,
+)
 from .sleep_import import PolarSleepJSON, PolarSleepNightsJSON
 
 __all__ = [
@@ -20,4 +24,7 @@ __all__ = [
     # Continuous HR
     "PolarContinuousHRJSON",
     "PolarContinuousHRSample",
+    # Nightly Recharge
+    "PolarNightlyRechargeEntryJSON",
+    "PolarNightlyRechargeJSON",
 ]

--- a/backend/app/schemas/providers/polar/activity_import.py
+++ b/backend/app/schemas/providers/polar/activity_import.py
@@ -1,0 +1,36 @@
+"""Polar AccessLink v3 daily activity response schemas.
+
+Source endpoint: GET /v3/users/activities and GET /v3/users/activities/{date}
+Docs: https://www.polar.com/accesslink-api/#daily-activity-summary
+
+Polar's v3 response fields are documented as snake_case, but older/related
+endpoints in the same API use hyphenated JSON keys (see HRSamplesJSON in
+exercise_import.py). We accept both via `populate_by_name=True` + explicit
+hyphen aliases, and tolerate unknown fields so new keys added upstream
+don't break parsing.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PolarActivityJSON(BaseModel):
+    """Single daily activity summary from Polar AccessLink v3."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    # --- Time window ---------------------------------------------------------
+    start_time: str | None = Field(default=None, validation_alias="start-time")
+    end_time: str | None = Field(default=None, validation_alias="end-time")
+    created: str | None = None
+
+    # --- Durations (ISO 8601 duration strings, e.g., "PT3H11M") -------------
+    active_duration: str | None = Field(default=None, validation_alias="active-duration")
+    inactive_duration: str | None = Field(default=None, validation_alias="inactive-duration")
+
+    # --- Metrics -------------------------------------------------------------
+    calories: int | None = None
+    active_calories: int | None = Field(default=None, validation_alias="active-calories")
+    steps: int | None = None
+    distance_from_steps: float | None = Field(default=None, validation_alias="distance-from-steps")
+    inactivity_alert_count: int | None = Field(default=None, validation_alias="inactivity-alert-count")
+    daily_activity: float | None = Field(default=None, validation_alias="daily-activity")

--- a/backend/app/schemas/providers/polar/heart_rate_import.py
+++ b/backend/app/schemas/providers/polar/heart_rate_import.py
@@ -1,0 +1,33 @@
+"""Polar AccessLink v3 Continuous Heart Rate response schemas.
+
+Source endpoints:
+- GET /v3/users/continuous-heart-rate/{date}
+- GET /v3/users/continuous-heart-rate?from=YYYY-MM-DD&to=YYYY-MM-DD
+
+Docs: https://www.polar.com/accesslink-api/#continuous-heart-rate
+
+Samples are 5-minute averages (some denser intervals). ``sample_time`` is
+wall-clock ``HH:MM:SS`` relative to ``date`` (no timezone on the wire — we
+combine as UTC-naive, matching the policy Phase 1 uses for daily activity).
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PolarContinuousHRSample(BaseModel):
+    """Single continuous-HR sample: bpm + wall-clock time-of-day."""
+
+    model_config = ConfigDict(extra="allow")
+
+    heart_rate: int
+    sample_time: str  # "HH:MM:SS"
+
+
+class PolarContinuousHRJSON(BaseModel):
+    """Response shape for per-date Continuous HR endpoint."""
+
+    model_config = ConfigDict(extra="allow")
+
+    polar_user: str | None = None
+    date: str  # "YYYY-MM-DD"
+    heart_rate_samples: list[PolarContinuousHRSample] = []

--- a/backend/app/schemas/providers/polar/nightly_recharge_import.py
+++ b/backend/app/schemas/providers/polar/nightly_recharge_import.py
@@ -1,0 +1,37 @@
+"""Polar AccessLink v3 Nightly Recharge response schemas.
+
+Source endpoints:
+- GET /v3/users/nightly-recharge            → {"recharges": [...]}
+- GET /v3/users/nightly-recharge/{date}     → either {"recharges": [entry]} or bare entry
+
+Docs: https://www.polar.com/accesslink-api/#nightly-recharge
+
+Persistence happens via DataPointSeries only (see
+20260418[DECISION]polar_nightly_recharge_schema). Derivable averages
+(heart_rate_avg, beat_to_beat_avg, heart_rate_variability_avg,
+breathing_rate_avg) are deliberately not parsed.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PolarNightlyRechargeEntryJSON(BaseModel):
+    """Single night of Nightly Recharge data."""
+
+    model_config = ConfigDict(extra="allow")
+
+    polar_user: str | None = None
+    date: str  # "YYYY-MM-DD"
+    nightly_recharge_status: int | None = None  # 1-5 ordinal
+    ans_charge: int | None = None                # -10..+10 signed
+    ans_charge_status: int | None = None         # 1-5 ordinal
+    hrv_samples: dict[str, float] | None = None       # "HH:MM" -> ms (int on wire, accept float for safety)
+    breathing_samples: dict[str, float] | None = None # "HH:MM" -> brpm
+
+
+class PolarNightlyRechargeJSON(BaseModel):
+    """Wrapper shape for the list endpoint."""
+
+    model_config = ConfigDict(extra="allow")
+
+    recharges: list[PolarNightlyRechargeEntryJSON] = []

--- a/backend/app/schemas/providers/polar/sleep_import.py
+++ b/backend/app/schemas/providers/polar/sleep_import.py
@@ -1,0 +1,67 @@
+"""Polar AccessLink v3 Sleep Plus Stages response schemas.
+
+Source endpoints:
+- GET /v3/users/sleep           — list of up to 28 recent nights.
+- GET /v3/users/sleep/{date}    — single night, identical element shape.
+
+Docs: https://www.polar.com/accesslink-api/#sleep
+
+Notes:
+- `hypnogram` is a dict of ``"HH:MM"`` transition-start → integer stage code.
+  The value is the stage entered at that wall-clock time, running until the
+  next key or until ``sleep_end_time`` for the last interval.
+- `heart_rate_samples` in the sleep payload is ``{"HH:MM": bpm_int}`` —
+  different shape from the continuous-HR endpoint which uses a list.
+- Polar tends to return snake_case for v3 but other endpoints in the same
+  surface use hyphenated keys; tolerate both via ``populate_by_name=True`` +
+  ``extra="allow"`` so upstream key drift doesn't break parsing.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PolarSleepJSON(BaseModel):
+    """Single night entry from ``/v3/users/sleep`` or ``/v3/users/sleep/{date}``."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    polar_user: str | None = None
+    date: str | None = None
+
+    sleep_start_time: str | None = Field(default=None, validation_alias="sleep-start-time")
+    sleep_end_time: str | None = Field(default=None, validation_alias="sleep-end-time")
+    device_id: str | None = Field(default=None, validation_alias="device-id")
+
+    # Durations in seconds
+    light_sleep: int | None = None
+    deep_sleep: int | None = None
+    rem_sleep: int | None = None
+    unrecognized_sleep_stage: int | None = None
+    total_interruption_duration: int | None = None
+    short_interruption_duration: int | None = None
+    long_interruption_duration: int | None = None
+    sleep_goal: int | None = None
+
+    # Scores and classifications (documented ranges: sleep_score 1-100, sleep_charge/sleep_rating 1-5)
+    sleep_score: int | None = None
+    sleep_charge: int | None = None
+    sleep_rating: int | None = None
+    sleep_cycles: int | None = None
+
+    continuity: float | None = None
+    continuity_class: int | None = None
+    group_duration_score: float | None = None
+    group_solidity_score: float | None = None
+    group_regeneration_score: float | None = None
+
+    # Time-series inside the night
+    hypnogram: dict[str, int] | None = None
+    heart_rate_samples: dict[str, int] | None = None
+
+
+class PolarSleepNightsJSON(BaseModel):
+    """Wrapper response shape for ``GET /v3/users/sleep``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    nights: list[PolarSleepJSON] = Field(default_factory=list)

--- a/backend/app/services/providers/polar/data_247.py
+++ b/backend/app/services/providers/polar/data_247.py
@@ -592,6 +592,43 @@ def _combine_date_time(day: datetime, sample_time: str | None) -> datetime | Non
     return day.replace(hour=h, minute=m, second=s, microsecond=0)
 
 
+def _hhmm_transitions_to_datetimes(
+    hhmm_map: dict[str, Any] | None,
+    base_date: datetime,
+) -> list[tuple[datetime, Any]]:
+    """Parse a ``{"HH:MM": value}`` transition map into ``(datetime, value)`` pairs.
+
+    Each key is anchored to ``base_date``'s calendar date (using its tzinfo).
+    Transitions are walked in HH:MM-sorted order; whenever a candidate
+    regresses past the previous transition (e.g. the night crosses midnight),
+    we bump it forward by one day. Malformed HH:MM keys are skipped.
+    """
+    if not hhmm_map:
+        return []
+
+    calendar_date = base_date.date()
+    tzinfo = base_date.tzinfo
+
+    pairs: list[tuple[datetime, Any]] = []
+    prev_dt: datetime | None = None
+    for hhmm, value in sorted(hhmm_map.items()):
+        try:
+            parts = hhmm.split(":")
+            h, m = int(parts[0]), int(parts[1])
+        except (ValueError, IndexError):
+            continue
+        candidate = datetime(
+            calendar_date.year, calendar_date.month, calendar_date.day,
+            h, m, tzinfo=tzinfo,
+        )
+        while prev_dt is not None and candidate <= prev_dt:
+            candidate += timedelta(days=1)
+        pairs.append((candidate, value))
+        prev_dt = candidate
+
+    return pairs
+
+
 def _hypnogram_to_stage_intervals(
     hypnogram: dict[str, int] | None,
     sleep_start: datetime,
@@ -600,29 +637,11 @@ def _hypnogram_to_stage_intervals(
     """Convert Polar's ``{"HH:MM": stage_code}`` transition map into intervals.
 
     Each key marks when that stage begins; duration runs until the next key,
-    or ``sleep_end`` for the final interval. Transitions are anchored to
-    ``sleep_start``'s calendar date and bumped by one day whenever they would
-    regress past the previous transition (e.g. nights that cross midnight).
+    or ``sleep_end`` for the final interval.
     """
-    if not hypnogram:
+    transitions = _hhmm_transitions_to_datetimes(hypnogram, sleep_start)
+    if not transitions:
         return []
-
-    base_date = sleep_start.date()
-    tzinfo = sleep_start.tzinfo
-
-    transitions: list[tuple[datetime, int]] = []
-    prev_dt: datetime | None = None
-    for hhmm, code in sorted(hypnogram.items()):
-        try:
-            parts = hhmm.split(":")
-            h, m = int(parts[0]), int(parts[1])
-        except (ValueError, IndexError):
-            continue
-        candidate = datetime(base_date.year, base_date.month, base_date.day, h, m, tzinfo=tzinfo)
-        while prev_dt is not None and candidate <= prev_dt:
-            candidate += timedelta(days=1)
-        transitions.append((candidate, code))
-        prev_dt = candidate
 
     intervals: list[SleepStage] = []
     for i, (start_dt, code) in enumerate(transitions):

--- a/backend/app/services/providers/polar/data_247.py
+++ b/backend/app/services/providers/polar/data_247.py
@@ -180,10 +180,12 @@ class PolarData247Template(Base247DataTemplate):
     ) -> int:
         """Persist normalized daily activity as EventRecord + detail pairs.
 
-        Each day is keyed by (source="polar", external_id=<YYYY-MM-DD>). When a
-        record already exists for the same day we replace only the detail
-        (the record itself is stable since duration/window are derived from
-        the Polar response, which is authoritative).
+        ``event_record_repository.create`` is idempotent on the
+        ``(data_source_id, start_datetime, end_datetime)`` unique index — on
+        collision it rolls back and returns the existing record — so we trust
+        its return value as the authoritative record id and attach the detail
+        to that id. Re-syncs of the same day therefore just refresh the detail
+        instead of duplicating a row.
         """
         saved = 0
         for item in normalized:
@@ -192,14 +194,8 @@ class PolarData247Template(Base247DataTemplate):
             record: EventRecordCreate = item["record"]
             detail: EventRecordDetailCreate = item["detail"]
 
-            existing = self.event_record_repo.get_by_external_id(
-                db, source="polar", external_id=item["external_id"], user_id=user_id,
-            ) if hasattr(self.event_record_repo, "get_by_external_id") else None
-
-            target_id = existing.id if existing else record.id
-            if not existing:
-                event_record_service.create(db, record)
-            detail_for_record = detail.model_copy(update={"record_id": target_id})
+            persisted = event_record_service.create(db, record)
+            detail_for_record = detail.model_copy(update={"record_id": persisted.id})
             event_record_service.create_detail(db, detail_for_record, detail_type="workout")
             saved += 1
         return saved
@@ -499,12 +495,18 @@ class PolarData247Template(Base247DataTemplate):
             "nightly_recharge_synced": 0,  # Phase 3
         }
 
+        # Each data type runs in its own try block and rolls back on failure
+        # so a DB error in one path doesn't poison the SQLAlchemy session for
+        # the next — tests for this session-isolation contract live in
+        # test_polar_247_sync_isolation.py.
+
         # Daily activity (Phase 1)
         try:
             raw_daily = self.get_daily_activity_statistics(db, user_id, start_dt, end_dt)
             normalized = [self.normalize_daily_activity(item, user_id) for item in raw_daily]
             results["daily_activity_synced"] = self.save_daily_activity_statistics(db, user_id, normalized)
         except Exception as e:
+            db.rollback()
             log_structured(
                 self.logger,
                 "error",
@@ -519,6 +521,7 @@ class PolarData247Template(Base247DataTemplate):
             normalized_sleep = [self.normalize_sleep(n, user_id) for n in raw_nights]
             results["sleep_sessions_synced"] = self.save_sleep_data(db, user_id, normalized_sleep)
         except Exception as e:
+            db.rollback()
             log_structured(
                 self.logger,
                 "error",
@@ -533,6 +536,7 @@ class PolarData247Template(Base247DataTemplate):
             samples = self.normalize_continuous_hr(raw_hr, user_id)
             results["continuous_hr_synced"] = self.save_continuous_hr(db, user_id, samples)
         except Exception as e:
+            db.rollback()
             log_structured(
                 self.logger,
                 "error",

--- a/backend/app/services/providers/polar/data_247.py
+++ b/backend/app/services/providers/polar/data_247.py
@@ -531,7 +531,8 @@ class PolarData247Template(Base247DataTemplate):
             )
             response = None
 
-        if isinstance(response, dict) and response.get("recharges"):
+        if isinstance(response, dict) and isinstance(response.get("recharges"), list):
+            # Empty list is a valid "no data" response — don't waste per-day calls
             return list(response["recharges"])
 
         # Per-day fallback
@@ -775,9 +776,10 @@ def _hhmm_transitions_to_datetimes(
     """Parse a ``{"HH:MM": value}`` transition map into ``(datetime, value)`` pairs.
 
     Each key is anchored to ``base_date``'s calendar date (using its tzinfo).
-    Transitions are walked in HH:MM-sorted order; whenever a candidate
-    regresses past the previous transition (e.g. the night crosses midnight),
-    we bump it forward by one day. Malformed HH:MM keys are skipped.
+    Transitions are walked in night-centric order (hours 12-23 sort before 0-11
+    via :func:`_sort_key`); whenever a candidate regresses past the previous
+    transition (e.g. the night crosses midnight), we bump it forward by one day.
+    Malformed HH:MM keys are skipped.
     """
     if not hhmm_map:
         return []

--- a/backend/app/services/providers/polar/data_247.py
+++ b/backend/app/services/providers/polar/data_247.py
@@ -32,6 +32,7 @@ from app.schemas.model_crud.activities import (
 from app.schemas.providers.polar import (
     PolarActivityJSON,
     PolarContinuousHRJSON,
+    PolarNightlyRechargeEntryJSON,
     PolarSleepJSON,
     PolarSleepNightsJSON,
 )
@@ -464,15 +465,175 @@ class PolarData247Template(Base247DataTemplate):
         db.commit()
         return len(samples)
 
+    def save_recovery_data(
+        self,
+        db: DbSession,
+        user_id: UUID,  # kept for signature symmetry with Oura/Suunto
+        samples: list[TimeSeriesSampleCreate],
+    ) -> int:
+        """Persist Nightly Recharge samples and commit.
+
+        ``bulk_create_samples`` only stages the INSERTs; the sync route
+        handler does not commit on our behalf, so we commit here — same
+        pattern as ``save_continuous_hr``. Idempotent via unique index
+        + on_conflict_do_update on (data_source_id, series_type_definition_id, recorded_at).
+        """
+        if not samples:
+            return 0
+        timeseries_service.bulk_create_samples(db, samples)
+        db.commit()
+        return len(samples)
+
+    def load_and_save_recovery(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> int:
+        """Orchestrate get → normalize → save for Nightly Recharge.
+
+        Returns total number of DataPointSeries samples persisted.
+        """
+        raw_nights = self.get_recovery_data(db, user_id, start_time, end_time)
+        all_samples: list[TimeSeriesSampleCreate] = []
+        for raw in raw_nights:
+            all_samples.extend(self.normalize_recovery(raw, user_id))
+        return self.save_recovery_data(db, user_id, all_samples)
+
     # -------------------------------------------------------------------------
     # Recovery / Activity Samples — Phase 3 stubs (base-class compatibility)
     # -------------------------------------------------------------------------
 
-    def get_recovery_data(self, db: DbSession, user_id: UUID, start_time: datetime, end_time: datetime) -> list[dict[str, Any]]:
-        return []
+    def get_recovery_data(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> list[dict[str, Any]]:
+        """Fetch Nightly Recharge entries across the window.
 
-    def normalize_recovery(self, raw_recovery: dict[str, Any], user_id: UUID) -> dict[str, Any]:
-        return {}
+        Primary path hits the list endpoint ``/v3/users/nightly-recharge``
+        (returns up to the last 28 nights in one shot). On failure, fall back
+        to per-day ``/v3/users/nightly-recharge/{date}`` — same shape the
+        daily-activity path uses and easier to recover day-by-day.
+        """
+        try:
+            response = self._make_api_request(db, user_id, "/v3/users/nightly-recharge")
+        except Exception as e:
+            log_structured(
+                self.logger,
+                "warning",
+                f"Polar nightly-recharge list fetch failed, falling back per-day: {e}",
+                provider="polar",
+                task="get_recovery_data",
+            )
+            response = None
+
+        if isinstance(response, dict) and response.get("recharges"):
+            return list(response["recharges"])
+
+        # Per-day fallback
+        results: list[dict[str, Any]] = []
+        current = start_time.date()
+        last = end_time.date()
+        while current <= last:
+            endpoint = f"/v3/users/nightly-recharge/{current.isoformat()}"
+            try:
+                per_day = self._make_api_request(db, user_id, endpoint)
+            except Exception as e:
+                log_structured(
+                    self.logger,
+                    "warning",
+                    f"Polar nightly-recharge fetch failed for {current}: {e}",
+                    provider="polar",
+                    task="get_recovery_data",
+                )
+                current += timedelta(days=1)
+                continue
+            if isinstance(per_day, dict):
+                if per_day.get("recharges"):
+                    results.extend(per_day["recharges"])
+                elif per_day.get("date"):
+                    results.append(per_day)
+            current += timedelta(days=1)
+        return results
+
+    def normalize_recovery(
+        self,
+        raw_recovery: dict[str, Any],
+        user_id: UUID,
+    ) -> list[TimeSeriesSampleCreate]:
+        """Convert a single Nightly Recharge entry into DataPointSeries samples.
+
+        Emits up to 5 sample streams per night:
+        - hrv_samples      -> SeriesType.heart_rate_variability_rmssd (one per HH:MM)
+        - breathing_samples -> SeriesType.respiratory_rate (one per HH:MM)
+        - nightly_recharge_status -> polar_nightly_recharge_status (single-point, midnight UTC of `date`)
+        - ans_charge -> polar_ans_charge (single-point)
+        - ans_charge_status -> polar_ans_charge_status (single-point)
+
+        Deliberately skips derivable averages (heart_rate_avg,
+        beat_to_beat_avg, heart_rate_variability_avg, breathing_rate_avg).
+        """
+        try:
+            entry = PolarNightlyRechargeEntryJSON.model_validate(raw_recovery)
+        except Exception as e:
+            log_structured(
+                self.logger,
+                "warning",
+                f"Polar nightly-recharge parse failed: {e}",
+                provider="polar",
+                task="normalize_recovery",
+            )
+            return []
+
+        try:
+            base_date = datetime.strptime(entry.date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            return []
+
+        samples: list[TimeSeriesSampleCreate] = []
+
+        # Intra-night sample streams
+        for hhmm_map, series_type in (
+            (entry.hrv_samples, SeriesType.heart_rate_variability_rmssd),
+            (entry.breathing_samples, SeriesType.respiratory_rate),
+        ):
+            for recorded_at, value in _hhmm_transitions_to_datetimes(hhmm_map, base_date):
+                samples.append(
+                    TimeSeriesSampleCreate(
+                        id=uuid4(),
+                        user_id=user_id,
+                        source=self.provider_name,
+                        recorded_at=recorded_at,
+                        value=Decimal(str(value)),
+                        series_type=series_type,
+                    )
+                )
+
+        # Single-point score fields at midnight UTC of the reported date
+        single_points = (
+            (entry.nightly_recharge_status, SeriesType.polar_nightly_recharge_status),
+            (entry.ans_charge, SeriesType.polar_ans_charge),
+            (entry.ans_charge_status, SeriesType.polar_ans_charge_status),
+        )
+        for value, series_type in single_points:
+            if value is None:
+                continue
+            samples.append(
+                TimeSeriesSampleCreate(
+                    id=uuid4(),
+                    user_id=user_id,
+                    source=self.provider_name,
+                    recorded_at=base_date,
+                    value=Decimal(str(value)),
+                    series_type=series_type,
+                )
+            )
+
+        return samples
 
     def get_activity_samples(self, db: DbSession, user_id: UUID, start_time: datetime, end_time: datetime) -> list[dict[str, Any]]:
         return []
@@ -553,6 +714,21 @@ class PolarData247Template(Base247DataTemplate):
                 task="load_and_save_all",
             )
 
+        # Nightly Recharge (Phase 3)
+        try:
+            results["nightly_recharge_synced"] = self.load_and_save_recovery(
+                db, user_id, start_dt, end_dt
+            )
+        except Exception as e:
+            db.rollback()
+            log_structured(
+                self.logger,
+                "error",
+                f"Polar nightly recharge sync failed: {e}",
+                provider="polar",
+                task="load_and_save_all",
+            )
+
         return results
 
 
@@ -609,18 +785,35 @@ def _hhmm_transitions_to_datetimes(
     calendar_date = base_date.date()
     tzinfo = base_date.tzinfo
 
+    def _sort_key(item: tuple[str, Any]) -> tuple[int, int]:
+        """Sort HH:MM keys for nightly data that can cross midnight.
+
+        Hours in [0, 11] are treated as hour+24 so they sort after evening
+        hours [12, 23].  This lets bump-on-regress handle midnight correctly
+        whether the night starts at 22:xx or 23:xx.  Malformed keys sort last.
+        """
+        try:
+            parts = item[0].split(":")
+            h, m = int(parts[0]), int(parts[1])
+            return (h + 24 if h < 12 else h, m)
+        except (ValueError, IndexError):
+            return (48, 0)
+
     pairs: list[tuple[datetime, Any]] = []
     prev_dt: datetime | None = None
-    for hhmm, value in sorted(hhmm_map.items()):
+    for hhmm, value in sorted(hhmm_map.items(), key=_sort_key):
         try:
             parts = hhmm.split(":")
             h, m = int(parts[0]), int(parts[1])
         except (ValueError, IndexError):
             continue
-        candidate = datetime(
-            calendar_date.year, calendar_date.month, calendar_date.day,
-            h, m, tzinfo=tzinfo,
-        )
+        try:
+            candidate = datetime(
+                calendar_date.year, calendar_date.month, calendar_date.day,
+                h, m, tzinfo=tzinfo,
+            )
+        except ValueError:
+            continue
         while prev_dt is not None and candidate <= prev_dt:
             candidate += timedelta(days=1)
         pairs.append((candidate, value))

--- a/backend/app/services/providers/polar/data_247.py
+++ b/backend/app/services/providers/polar/data_247.py
@@ -1,14 +1,12 @@
 """Polar AccessLink v3 247-data implementation.
 
-Phase 1 (this file): daily activity summaries — steps, calories, distance,
-active/inactive durations — one EventRecord per day under
-`category="daily_activity"`, source="polar".
+Phase 1: daily activity summaries — one ``EventRecord`` per day with
+``category="daily_activity"``, ``source="polar"``.
 
-Phase 2 (stubbed): sleep (Sleep Plus Stages), continuous heart rate samples,
-nightly recharge. Each returns `[]` / `{}` today; see vault SPEC
-`B.TEJO/devops/20260417[SPEC]polar_loop_activity_sleep.md` for Phase 2 scope.
+Phase 2 (this file now): Sleep Plus Stages and continuous heart rate.
+Nightly Recharge remains stubbed for Phase 3.
 
-Endpoint reference: https://www.polar.com/accesslink-api/#daily-activity-summary
+Endpoint reference: https://www.polar.com/accesslink-api/
 """
 
 from datetime import datetime, timedelta, timezone
@@ -18,18 +16,30 @@ from uuid import UUID, uuid4
 
 import isodate
 
+from app.config import settings
+from app.constants.series_types.polar import POLAR_HYPNOGRAM_MAP
+from app.constants.sleep import SleepStageType
 from app.database import DbSession
 from app.models import EventRecord
 from app.repositories import EventRecordRepository, UserConnectionRepository
+from app.schemas.enums import SeriesType
 from app.schemas.model_crud.activities import (
     EventRecordCreate,
     EventRecordDetailCreate,
+    SleepStage,
+    TimeSeriesSampleCreate,
 )
-from app.schemas.providers.polar import PolarActivityJSON
+from app.schemas.providers.polar import (
+    PolarActivityJSON,
+    PolarContinuousHRJSON,
+    PolarSleepJSON,
+    PolarSleepNightsJSON,
+)
 from app.services.event_record_service import event_record_service
 from app.services.providers.api_client import make_authenticated_request
 from app.services.providers.templates.base_247_data import Base247DataTemplate
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
+from app.services.timeseries_service import timeseries_service
 from app.utils.structured_logging import log_structured
 
 
@@ -195,14 +205,264 @@ class PolarData247Template(Base247DataTemplate):
         return saved
 
     # -------------------------------------------------------------------------
-    # Sleep / Recovery / Activity Samples — Phase 2 stubs
+    # Sleep — Phase 2a (Sleep Plus Stages)
     # -------------------------------------------------------------------------
 
-    def get_sleep_data(self, db: DbSession, user_id: UUID, start_time: datetime, end_time: datetime) -> list[dict[str, Any]]:
-        return []
+    def get_sleep_data(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> list[dict[str, Any]]:
+        """Fetch the last 28 days of sleep nights from Polar AccessLink.
 
-    def normalize_sleep(self, raw_sleep: dict[str, Any], user_id: UUID) -> dict[str, Any]:
-        return {}
+        Polar returns all nights in a single response under ``{"nights": [...]}``
+        — start/end times in the method signature exist for base-class
+        compatibility but are not used as query params; if a narrower window
+        is desired the caller can post-filter by ``date``.
+        """
+        try:
+            response = self._make_api_request(db, user_id, "/v3/users/sleep")
+        except Exception as e:
+            log_structured(
+                self.logger,
+                "warning",
+                f"Polar sleep fetch failed: {e}",
+                provider="polar",
+                task="get_sleep_data",
+            )
+            return []
+
+        if not isinstance(response, dict):
+            return []
+        nights = response.get("nights", [])
+        return nights if isinstance(nights, list) else []
+
+    def normalize_sleep(
+        self,
+        raw_sleep: dict[str, Any],
+        user_id: UUID,
+    ) -> dict[str, Any]:
+        """Normalise a Polar night payload into OW's internal sleep dict shape.
+
+        Mirrors the keys produced by Oura's ``normalize_sleeps`` so the save
+        path can stay provider-agnostic.
+        """
+        try:
+            parsed = PolarSleepJSON.model_validate(raw_sleep)
+        except Exception as e:
+            log_structured(
+                self.logger,
+                "warning",
+                f"Polar sleep parse failed: {e}",
+                provider="polar",
+                task="normalize_sleep",
+            )
+            return {}
+
+        start_dt = _parse_polar_datetime(parsed.sleep_start_time)
+        end_dt = _parse_polar_datetime(parsed.sleep_end_time)
+        if not (start_dt and end_dt):
+            log_structured(
+                self.logger,
+                "warning",
+                f"Polar sleep skipped: missing start/end time for date={parsed.date}",
+                provider="polar",
+                task="normalize_sleep",
+            )
+            return {}
+
+        duration_seconds = int((end_dt - start_dt).total_seconds())
+
+        stage_intervals = _hypnogram_to_stage_intervals(parsed.hypnogram, start_dt, end_dt)
+
+        return {
+            "id": uuid4(),
+            "user_id": user_id,
+            "provider": self.provider_name,
+            "external_id": parsed.date,
+            "polar_sleep_date": parsed.date,
+            "start_time": start_dt,
+            "end_time": end_dt,
+            "duration_seconds": duration_seconds,
+            "efficiency_percent": float(parsed.sleep_score) if parsed.sleep_score is not None else None,
+            "is_nap": False,  # Polar /v3/users/sleep reports primary nightly sleep only
+            "stages": {
+                "deep_seconds": parsed.deep_sleep or 0,
+                "light_seconds": parsed.light_sleep or 0,
+                "rem_seconds": parsed.rem_sleep or 0,
+                "awake_seconds": parsed.total_interruption_duration or 0,
+            },
+            "stage_timestamps": stage_intervals,
+        }
+
+    def save_sleep_data(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        normalized_items: list[dict[str, Any]],
+    ) -> int:
+        """Persist normalised sleep dicts as ``EventRecord`` + ``SleepDetails``.
+
+        Uses the same ``create_or_merge_sleep`` helper as Oura/Suunto so a
+        single night split across multiple devices (or re-syncs) collapses to
+        one record.
+        """
+        count = 0
+        for item in normalized_items:
+            if not item:
+                continue
+            sleep_id: UUID = item["id"]
+            start_dt: datetime = item["start_time"]
+            end_dt: datetime = item["end_time"]
+
+            stages = item.get("stages", {})
+            total_sleep_seconds = (
+                stages.get("deep_seconds", 0) + stages.get("light_seconds", 0) + stages.get("rem_seconds", 0)
+            )
+            total_sleep_minutes = total_sleep_seconds // 60
+            time_in_bed_minutes = (item.get("duration_seconds") or 0) // 60
+
+            record = EventRecordCreate(
+                id=sleep_id,
+                user_id=user_id,
+                category="sleep",
+                type="sleep_session",
+                source_name="Polar",
+                device_model=None,
+                duration_seconds=item.get("duration_seconds"),
+                start_datetime=start_dt,
+                end_datetime=end_dt,
+                zone_offset=None,
+                external_id=item.get("external_id"),
+                source=self.provider_name,
+            )
+
+            detail = EventRecordDetailCreate(
+                record_id=sleep_id,
+                sleep_total_duration_minutes=total_sleep_minutes,
+                sleep_time_in_bed_minutes=time_in_bed_minutes,
+                sleep_efficiency_score=(
+                    Decimal(str(item["efficiency_percent"]))
+                    if item.get("efficiency_percent") is not None
+                    else None
+                ),
+                sleep_deep_minutes=stages.get("deep_seconds", 0) // 60,
+                sleep_light_minutes=stages.get("light_seconds", 0) // 60,
+                sleep_rem_minutes=stages.get("rem_seconds", 0) // 60,
+                sleep_awake_minutes=stages.get("awake_seconds", 0) // 60,
+                is_nap=item.get("is_nap", False),
+                sleep_stages=item.get("stage_timestamps", []),
+            )
+
+            try:
+                event_record_service.create_or_merge_sleep(
+                    db, user_id, record, detail, settings.sleep_end_gap_minutes
+                )
+                count += 1
+            except Exception as e:
+                log_structured(
+                    self.logger,
+                    "error",
+                    f"Polar sleep save failed for {item.get('external_id')}: {e}",
+                    provider="polar",
+                    task="save_sleep_data",
+                )
+        return count
+
+    # -------------------------------------------------------------------------
+    # Continuous HR — Phase 2b
+    # -------------------------------------------------------------------------
+
+    def get_continuous_hr_data(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[dict[str, Any]]:
+        """Fetch per-date continuous-HR payloads across the window.
+
+        We iterate days rather than using ``/v3/users/continuous-heart-rate``
+        with ``from``/``to`` because the per-date endpoint has the same shape
+        the daily-activity path uses and is easier to recover day-by-day when
+        a single date fails.
+        """
+        results: list[dict[str, Any]] = []
+        current = start_date.date()
+        last = end_date.date()
+        while current <= last:
+            endpoint = f"/v3/users/continuous-heart-rate/{current.isoformat()}"
+            try:
+                response = self._make_api_request(db, user_id, endpoint)
+                if isinstance(response, dict) and response.get("heart_rate_samples"):
+                    results.append(response)
+            except Exception as e:
+                log_structured(
+                    self.logger,
+                    "warning",
+                    f"Polar continuous HR fetch failed for {current}: {e}",
+                    provider="polar",
+                    task="get_continuous_hr_data",
+                )
+            current += timedelta(days=1)
+        return results
+
+    def normalize_continuous_hr(
+        self,
+        raw_days: list[dict[str, Any]],
+        user_id: UUID,
+    ) -> list[TimeSeriesSampleCreate]:
+        """Convert per-date payloads into bulk-insertable timeseries samples."""
+        samples: list[TimeSeriesSampleCreate] = []
+        for raw in raw_days:
+            try:
+                parsed = PolarContinuousHRJSON.model_validate(raw)
+            except Exception as e:
+                log_structured(
+                    self.logger,
+                    "warning",
+                    f"Polar continuous HR parse failed: {e}",
+                    provider="polar",
+                    task="normalize_continuous_hr",
+                )
+                continue
+
+            try:
+                day = datetime.strptime(parsed.date, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            except (ValueError, TypeError):
+                continue
+
+            for s in parsed.heart_rate_samples:
+                recorded_at = _combine_date_time(day, s.sample_time)
+                if recorded_at is None:
+                    continue
+                samples.append(
+                    TimeSeriesSampleCreate(
+                        id=uuid4(),
+                        user_id=user_id,
+                        source=self.provider_name,
+                        recorded_at=recorded_at,
+                        value=Decimal(str(s.heart_rate)),
+                        series_type=SeriesType.heart_rate,
+                    )
+                )
+        return samples
+
+    def save_continuous_hr(
+        self,
+        db: DbSession,
+        user_id: UUID,  # kept for signature symmetry with Oura/Suunto
+        samples: list[TimeSeriesSampleCreate],
+    ) -> int:
+        if samples:
+            timeseries_service.bulk_create_samples(db, samples)
+        return len(samples)
+
+    # -------------------------------------------------------------------------
+    # Recovery / Activity Samples — Phase 3 stubs (base-class compatibility)
+    # -------------------------------------------------------------------------
 
     def get_recovery_data(self, db: DbSession, user_id: UUID, start_time: datetime, end_time: datetime) -> list[dict[str, Any]]:
         return []
@@ -228,17 +488,18 @@ class PolarData247Template(Base247DataTemplate):
         end_time: datetime | None = None,
         is_first_sync: bool = False,
     ) -> dict[str, int]:
-        """Phase 1: persist daily activity. Sleep/HR/recharge remain 0 until Phase 2."""
+        """Run all Phase 1 + Phase 2 Polar syncs in one pass."""
         end_dt = end_time or datetime.now(timezone.utc)
         start_dt = start_time or (end_dt - timedelta(days=28 if is_first_sync else 7))
 
         results: dict[str, int] = {
             "daily_activity_synced": 0,
-            "sleep_sessions_synced": 0,   # Phase 2
-            "continuous_hr_synced": 0,    # Phase 2
-            "nightly_recharge_synced": 0, # Phase 2
+            "sleep_sessions_synced": 0,
+            "continuous_hr_synced": 0,
+            "nightly_recharge_synced": 0,  # Phase 3
         }
 
+        # Daily activity (Phase 1)
         try:
             raw_daily = self.get_daily_activity_statistics(db, user_id, start_dt, end_dt)
             normalized = [self.normalize_daily_activity(item, user_id) for item in raw_daily]
@@ -248,6 +509,34 @@ class PolarData247Template(Base247DataTemplate):
                 self.logger,
                 "error",
                 f"Polar daily activity sync failed: {e}",
+                provider="polar",
+                task="load_and_save_all",
+            )
+
+        # Sleep (Phase 2a)
+        try:
+            raw_nights = self.get_sleep_data(db, user_id, start_dt, end_dt)
+            normalized_sleep = [self.normalize_sleep(n, user_id) for n in raw_nights]
+            results["sleep_sessions_synced"] = self.save_sleep_data(db, user_id, normalized_sleep)
+        except Exception as e:
+            log_structured(
+                self.logger,
+                "error",
+                f"Polar sleep sync failed: {e}",
+                provider="polar",
+                task="load_and_save_all",
+            )
+
+        # Continuous HR (Phase 2b)
+        try:
+            raw_hr = self.get_continuous_hr_data(db, user_id, start_dt, end_dt)
+            samples = self.normalize_continuous_hr(raw_hr, user_id)
+            results["continuous_hr_synced"] = self.save_continuous_hr(db, user_id, samples)
+        except Exception as e:
+            log_structured(
+                self.logger,
+                "error",
+                f"Polar continuous HR sync failed: {e}",
                 provider="polar",
                 task="load_and_save_all",
             )
@@ -275,3 +564,59 @@ def _parse_polar_datetime(value: str | None) -> datetime | None:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return dt
+
+
+def _combine_date_time(day: datetime, sample_time: str | None) -> datetime | None:
+    """Combine a ``YYYY-MM-DD`` day (as aware datetime) with ``HH:MM[:SS]``."""
+    if not sample_time:
+        return None
+    parts = sample_time.split(":")
+    try:
+        h = int(parts[0])
+        m = int(parts[1]) if len(parts) > 1 else 0
+        s = int(parts[2]) if len(parts) > 2 else 0
+    except (ValueError, IndexError):
+        return None
+    return day.replace(hour=h, minute=m, second=s, microsecond=0)
+
+
+def _hypnogram_to_stage_intervals(
+    hypnogram: dict[str, int] | None,
+    sleep_start: datetime,
+    sleep_end: datetime,
+) -> list[SleepStage]:
+    """Convert Polar's ``{"HH:MM": stage_code}`` transition map into intervals.
+
+    Each key marks when that stage begins; duration runs until the next key,
+    or ``sleep_end`` for the final interval. Transitions are anchored to
+    ``sleep_start``'s calendar date and bumped by one day whenever they would
+    regress past the previous transition (e.g. nights that cross midnight).
+    """
+    if not hypnogram:
+        return []
+
+    base_date = sleep_start.date()
+    tzinfo = sleep_start.tzinfo
+
+    transitions: list[tuple[datetime, int]] = []
+    prev_dt: datetime | None = None
+    for hhmm, code in sorted(hypnogram.items()):
+        try:
+            parts = hhmm.split(":")
+            h, m = int(parts[0]), int(parts[1])
+        except (ValueError, IndexError):
+            continue
+        candidate = datetime(base_date.year, base_date.month, base_date.day, h, m, tzinfo=tzinfo)
+        while prev_dt is not None and candidate <= prev_dt:
+            candidate += timedelta(days=1)
+        transitions.append((candidate, code))
+        prev_dt = candidate
+
+    intervals: list[SleepStage] = []
+    for i, (start_dt, code) in enumerate(transitions):
+        end_dt = transitions[i + 1][0] if i + 1 < len(transitions) else sleep_end
+        if end_dt <= start_dt:
+            continue
+        stage = POLAR_HYPNOGRAM_MAP.get(code, SleepStageType.UNKNOWN)
+        intervals.append(SleepStage(stage=stage, start_time=start_dt, end_time=end_dt))
+    return intervals

--- a/backend/app/services/providers/polar/data_247.py
+++ b/backend/app/services/providers/polar/data_247.py
@@ -1,0 +1,277 @@
+"""Polar AccessLink v3 247-data implementation.
+
+Phase 1 (this file): daily activity summaries — steps, calories, distance,
+active/inactive durations — one EventRecord per day under
+`category="daily_activity"`, source="polar".
+
+Phase 2 (stubbed): sleep (Sleep Plus Stages), continuous heart rate samples,
+nightly recharge. Each returns `[]` / `{}` today; see vault SPEC
+`B.TEJO/devops/20260417[SPEC]polar_loop_activity_sleep.md` for Phase 2 scope.
+
+Endpoint reference: https://www.polar.com/accesslink-api/#daily-activity-summary
+"""
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any
+from uuid import UUID, uuid4
+
+import isodate
+
+from app.database import DbSession
+from app.models import EventRecord
+from app.repositories import EventRecordRepository, UserConnectionRepository
+from app.schemas.model_crud.activities import (
+    EventRecordCreate,
+    EventRecordDetailCreate,
+)
+from app.schemas.providers.polar import PolarActivityJSON
+from app.services.event_record_service import event_record_service
+from app.services.providers.api_client import make_authenticated_request
+from app.services.providers.templates.base_247_data import Base247DataTemplate
+from app.services.providers.templates.base_oauth import BaseOAuthTemplate
+from app.utils.structured_logging import log_structured
+
+
+class PolarData247Template(Base247DataTemplate):
+    """Polar implementation for 247 data.
+
+    Phase 1 implements `daily_activity` end-to-end. Sleep, recovery, and
+    activity_samples are stubbed and return empty collections so the base
+    template's `load_all_247_data` remains safe to call.
+    """
+
+    def __init__(
+        self,
+        provider_name: str,
+        api_base_url: str,
+        oauth: BaseOAuthTemplate,
+    ):
+        super().__init__(provider_name, api_base_url, oauth)
+        self.event_record_repo = EventRecordRepository(EventRecord)
+        self.connection_repo = UserConnectionRepository()
+
+    # -------------------------------------------------------------------------
+    # HTTP
+    # -------------------------------------------------------------------------
+
+    def _make_api_request(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        endpoint: str,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        return make_authenticated_request(
+            db=db,
+            user_id=user_id,
+            connection_repo=self.connection_repo,
+            oauth=self.oauth,
+            api_base_url=self.api_base_url,
+            provider_name=self.provider_name,
+            endpoint=endpoint,
+            method="GET",
+            params=params,
+        )
+
+    # -------------------------------------------------------------------------
+    # Daily Activity — Phase 1 (steps / calories / distance)
+    # -------------------------------------------------------------------------
+
+    def get_daily_activity_statistics(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[dict[str, Any]]:
+        """Fetch daily activity summaries from Polar AccessLink.
+
+        Polar exposes per-day summaries at `/v3/users/activities/{date}`. We
+        iterate day-by-day over the requested window. Days with no data
+        return 204 / empty and are silently skipped.
+        """
+        activities: list[dict[str, Any]] = []
+        current = start_date.date()
+        last = end_date.date()
+        while current <= last:
+            endpoint = f"/v3/users/activities/{current.isoformat()}"
+            try:
+                response = self._make_api_request(db, user_id, endpoint)
+                if isinstance(response, dict) and response:
+                    activities.append(response)
+            except Exception as e:
+                log_structured(
+                    self.logger,
+                    "warning",
+                    f"Polar daily activity fetch failed for {current}: {e}",
+                    provider="polar",
+                    task="get_daily_activity_statistics",
+                )
+            current += timedelta(days=1)
+        return activities
+
+    def normalize_daily_activity(
+        self,
+        raw_stats: dict[str, Any],
+        user_id: UUID,
+    ) -> dict[str, Any]:
+        """Normalize Polar daily activity to EventRecord + detail payloads."""
+        try:
+            parsed = PolarActivityJSON.model_validate(raw_stats)
+        except Exception as e:
+            log_structured(
+                self.logger,
+                "warning",
+                f"Polar daily activity parse failed: {e}",
+                provider="polar",
+                task="normalize_daily_activity",
+            )
+            return {}
+
+        start_dt = _parse_polar_datetime(parsed.start_time)
+        end_dt = _parse_polar_datetime(parsed.end_time)
+        if not (start_dt and end_dt):
+            return {}
+
+        duration_seconds = int((end_dt - start_dt).total_seconds())
+        record_id = uuid4()
+        external_id = start_dt.date().isoformat()
+
+        record = EventRecordCreate(
+            id=record_id,
+            user_id=user_id,
+            category="daily_activity",
+            type="polar_daily_summary",
+            source_name="Polar AccessLink",
+            device_model=None,
+            duration_seconds=duration_seconds,
+            start_datetime=start_dt,
+            end_datetime=end_dt,
+            zone_offset=None,
+            external_id=external_id,
+            source="polar",
+        )
+
+        detail = EventRecordDetailCreate(
+            record_id=record_id,
+            steps_count=parsed.steps,
+            energy_burned=Decimal(str(parsed.calories)) if parsed.calories is not None else None,
+            distance=Decimal(str(parsed.distance_from_steps)) if parsed.distance_from_steps is not None else None,
+        )
+
+        return {"record": record, "detail": detail, "external_id": external_id}
+
+    def save_daily_activity_statistics(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        normalized: list[dict[str, Any]],
+    ) -> int:
+        """Persist normalized daily activity as EventRecord + detail pairs.
+
+        Each day is keyed by (source="polar", external_id=<YYYY-MM-DD>). When a
+        record already exists for the same day we replace only the detail
+        (the record itself is stable since duration/window are derived from
+        the Polar response, which is authoritative).
+        """
+        saved = 0
+        for item in normalized:
+            if not item:
+                continue
+            record: EventRecordCreate = item["record"]
+            detail: EventRecordDetailCreate = item["detail"]
+
+            existing = self.event_record_repo.get_by_external_id(
+                db, source="polar", external_id=item["external_id"], user_id=user_id,
+            ) if hasattr(self.event_record_repo, "get_by_external_id") else None
+
+            target_id = existing.id if existing else record.id
+            if not existing:
+                event_record_service.create(db, record)
+            detail_for_record = detail.model_copy(update={"record_id": target_id})
+            event_record_service.create_detail(db, detail_for_record, detail_type="workout")
+            saved += 1
+        return saved
+
+    # -------------------------------------------------------------------------
+    # Sleep / Recovery / Activity Samples — Phase 2 stubs
+    # -------------------------------------------------------------------------
+
+    def get_sleep_data(self, db: DbSession, user_id: UUID, start_time: datetime, end_time: datetime) -> list[dict[str, Any]]:
+        return []
+
+    def normalize_sleep(self, raw_sleep: dict[str, Any], user_id: UUID) -> dict[str, Any]:
+        return {}
+
+    def get_recovery_data(self, db: DbSession, user_id: UUID, start_time: datetime, end_time: datetime) -> list[dict[str, Any]]:
+        return []
+
+    def normalize_recovery(self, raw_recovery: dict[str, Any], user_id: UUID) -> dict[str, Any]:
+        return {}
+
+    def get_activity_samples(self, db: DbSession, user_id: UUID, start_time: datetime, end_time: datetime) -> list[dict[str, Any]]:
+        return []
+
+    def normalize_activity_samples(self, raw_samples: list[dict[str, Any]], user_id: UUID) -> dict[str, list[dict[str, Any]]]:
+        return {}
+
+    # -------------------------------------------------------------------------
+    # Save aggregator — called by sync_vendor_data_task.load_and_save_all branch
+    # -------------------------------------------------------------------------
+
+    def load_and_save_all(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+        is_first_sync: bool = False,
+    ) -> dict[str, int]:
+        """Phase 1: persist daily activity. Sleep/HR/recharge remain 0 until Phase 2."""
+        end_dt = end_time or datetime.now(timezone.utc)
+        start_dt = start_time or (end_dt - timedelta(days=28 if is_first_sync else 7))
+
+        results: dict[str, int] = {
+            "daily_activity_synced": 0,
+            "sleep_sessions_synced": 0,   # Phase 2
+            "continuous_hr_synced": 0,    # Phase 2
+            "nightly_recharge_synced": 0, # Phase 2
+        }
+
+        try:
+            raw_daily = self.get_daily_activity_statistics(db, user_id, start_dt, end_dt)
+            normalized = [self.normalize_daily_activity(item, user_id) for item in raw_daily]
+            results["daily_activity_synced"] = self.save_daily_activity_statistics(db, user_id, normalized)
+        except Exception as e:
+            log_structured(
+                self.logger,
+                "error",
+                f"Polar daily activity sync failed: {e}",
+                provider="polar",
+                task="load_and_save_all",
+            )
+
+        return results
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_polar_datetime(value: str | None) -> datetime | None:
+    """Parse Polar AccessLink ISO-8601 datetime, tolerating missing timezone.
+
+    Polar's v3 responses sometimes omit the TZ (wall-clock local time). We
+    treat naive values as UTC so downstream aware/naive comparisons don't
+    crash. Display-side code should convert to the user's timezone.
+    """
+    if not value:
+        return None
+    try:
+        dt = isodate.parse_datetime(value)
+    except Exception:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt

--- a/backend/app/services/providers/polar/data_247.py
+++ b/backend/app/services/providers/polar/data_247.py
@@ -452,8 +452,16 @@ class PolarData247Template(Base247DataTemplate):
         user_id: UUID,  # kept for signature symmetry with Oura/Suunto
         samples: list[TimeSeriesSampleCreate],
     ) -> int:
-        if samples:
-            timeseries_service.bulk_create_samples(db, samples)
+        """Persist continuous-HR samples and commit.
+
+        ``bulk_create_samples`` only stages the INSERTs; the sync route
+        handler does not commit on our behalf, so we commit here to avoid
+        silently dropping the samples when the request-scoped session closes.
+        """
+        if not samples:
+            return 0
+        timeseries_service.bulk_create_samples(db, samples)
+        db.commit()
         return len(samples)
 
     # -------------------------------------------------------------------------

--- a/backend/app/services/providers/polar/strategy.py
+++ b/backend/app/services/providers/polar/strategy.py
@@ -1,4 +1,5 @@
 from app.services.providers.base_strategy import BaseProviderStrategy, ProviderCapabilities
+from app.services.providers.polar.data_247 import PolarData247Template
 from app.services.providers.polar.oauth import PolarOAuth
 from app.services.providers.polar.workouts import PolarWorkouts
 
@@ -17,6 +18,11 @@ class PolarStrategy(BaseProviderStrategy):
         self.workouts = PolarWorkouts(
             workout_repo=self.workout_repo,
             connection_repo=self.connection_repo,
+            provider_name=self.name,
+            api_base_url=self.api_base_url,
+            oauth=self.oauth,
+        )
+        self.data_247 = PolarData247Template(
             provider_name=self.name,
             api_base_url=self.api_base_url,
             oauth=self.oauth,

--- a/backend/tests/providers/polar/test_polar_247_hr.py
+++ b/backend/tests/providers/polar/test_polar_247_hr.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
@@ -105,10 +106,14 @@ class TestPolarContinuousHRFetchAndSave:
         assert len(result) == 1
         assert result[0]["date"] == "2024-01-01"
 
-    def test_save_continuous_hr_delegates_to_bulk_create(
+    def test_save_continuous_hr_delegates_and_commits(
         self, data_247: PolarData247Template, monkeypatch
     ) -> None:
-        """``save_continuous_hr`` must hand samples to ``timeseries_service.bulk_create_samples``."""
+        """Samples go to ``bulk_create_samples`` AND the session is committed.
+
+        The sync route doesn't commit on our behalf and ``bulk_create_samples``
+        only stages the INSERTs, so a missing commit here silently drops rows.
+        """
         calls: list[list[TimeSeriesSampleCreate]] = []
 
         def fake_bulk_create(db, samples):  # noqa: ANN001
@@ -118,6 +123,7 @@ class TestPolarContinuousHRFetchAndSave:
 
         monkeypatch.setattr(mod.timeseries_service, "bulk_create_samples", fake_bulk_create)
 
+        db = MagicMock()
         user_id = uuid4()
         sample_one = TimeSeriesSampleCreate(
             id=uuid4(),
@@ -127,14 +133,16 @@ class TestPolarContinuousHRFetchAndSave:
             value=Decimal("72"),
             series_type=SeriesType.heart_rate,
         )
-        count = data_247.save_continuous_hr(db=None, user_id=user_id, samples=[sample_one])  # type: ignore[arg-type]
+        count = data_247.save_continuous_hr(db=db, user_id=user_id, samples=[sample_one])
 
         assert count == 1
         assert calls == [[sample_one]]
+        assert db.commit.called, "save_continuous_hr must commit or samples are dropped"
 
     def test_save_continuous_hr_skips_when_empty(
         self, data_247: PolarData247Template, monkeypatch
     ) -> None:
+        """Empty sample list must not touch the DB at all — no insert, no commit."""
         called = False
 
         def fake_bulk_create(db, samples):  # noqa: ANN001
@@ -145,6 +153,9 @@ class TestPolarContinuousHRFetchAndSave:
 
         monkeypatch.setattr(mod.timeseries_service, "bulk_create_samples", fake_bulk_create)
 
-        count = data_247.save_continuous_hr(db=None, user_id=uuid4(), samples=[])  # type: ignore[arg-type]
+        db = MagicMock()
+        count = data_247.save_continuous_hr(db=db, user_id=uuid4(), samples=[])
+
         assert count == 0
         assert called is False
+        assert not db.commit.called

--- a/backend/tests/providers/polar/test_polar_247_hr.py
+++ b/backend/tests/providers/polar/test_polar_247_hr.py
@@ -1,0 +1,150 @@
+"""Tests for PolarData247Template continuous-heart-rate sync."""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from app.schemas.enums import SeriesType
+from app.schemas.model_crud.activities import TimeSeriesSampleCreate
+from app.services.providers.polar.data_247 import PolarData247Template
+from app.services.providers.polar.strategy import PolarStrategy
+
+
+@pytest.fixture
+def data_247() -> PolarData247Template:
+    return PolarStrategy().data_247
+
+
+@pytest.fixture
+def sample_polar_hr_day() -> dict[str, Any]:
+    return {
+        "polar_user": "https://polaraccesslink.com/v3/users/627139",
+        "date": "2022-09-12",
+        "heart_rate_samples": [
+            {"heart_rate": 63, "sample_time": "00:02:08"},
+            {"heart_rate": 62, "sample_time": "00:07:08"},
+            {"heart_rate": 78, "sample_time": "12:15:42"},
+        ],
+    }
+
+
+class TestPolarContinuousHRNormalization:
+    def test_builds_timeseries_samples(
+        self, data_247: PolarData247Template, sample_polar_hr_day: dict
+    ) -> None:
+        user_id = uuid4()
+        samples = data_247.normalize_continuous_hr([sample_polar_hr_day], user_id)
+
+        assert len(samples) == 3
+        assert all(isinstance(s, TimeSeriesSampleCreate) for s in samples)
+        assert all(s.series_type == SeriesType.heart_rate for s in samples)
+        assert all(s.source == "polar" for s in samples)
+        assert all(s.user_id == user_id for s in samples)
+
+        # First sample: 2022-09-12 00:02:08 UTC, bpm 63
+        assert samples[0].recorded_at == datetime(2022, 9, 12, 0, 2, 8, tzinfo=timezone.utc)
+        assert samples[0].value == Decimal("63")
+        # Third sample: 12:15:42 same day
+        assert samples[2].recorded_at == datetime(2022, 9, 12, 12, 15, 42, tzinfo=timezone.utc)
+        assert samples[2].value == Decimal("78")
+
+    def test_skips_malformed_sample_time(self, data_247: PolarData247Template) -> None:
+        user_id = uuid4()
+        raw = {
+            "date": "2022-09-12",
+            "heart_rate_samples": [
+                {"heart_rate": 60, "sample_time": "not-a-time"},
+                {"heart_rate": 70, "sample_time": "05:00:00"},
+            ],
+        }
+        samples = data_247.normalize_continuous_hr([raw], user_id)
+        assert len(samples) == 1
+        assert samples[0].value == Decimal("70")
+
+    def test_skips_days_with_bad_date(self, data_247: PolarData247Template) -> None:
+        """A day-level response with a malformed ``date`` is dropped entirely."""
+        user_id = uuid4()
+        raw = {"date": "bogus", "heart_rate_samples": [{"heart_rate": 60, "sample_time": "00:00:00"}]}
+        samples = data_247.normalize_continuous_hr([raw], user_id)
+        assert samples == []
+
+
+class TestPolarContinuousHRFetchAndSave:
+    def test_get_continuous_hr_iterates_days(
+        self, data_247: PolarData247Template, monkeypatch
+    ) -> None:
+        captured: list[str] = []
+
+        def fake_make_api_request(
+            db, user_id, endpoint, params=None  # noqa: ANN001
+        ) -> dict:
+            captured.append(endpoint)
+            # Return real data for the first day, empty for the rest
+            if endpoint.endswith("2024-01-01"):
+                return {"date": "2024-01-01", "heart_rate_samples": [{"heart_rate": 65, "sample_time": "00:00:00"}]}
+            return {"date": endpoint.rsplit("/", 1)[-1], "heart_rate_samples": []}
+
+        monkeypatch.setattr(data_247, "_make_api_request", fake_make_api_request)
+
+        result = data_247.get_continuous_hr_data(
+            db=None,  # type: ignore[arg-type]
+            user_id=uuid4(),
+            start_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            end_date=datetime(2024, 1, 3, tzinfo=timezone.utc),
+        )
+
+        # Iterated three days, but only the one with samples is kept
+        assert captured == [
+            "/v3/users/continuous-heart-rate/2024-01-01",
+            "/v3/users/continuous-heart-rate/2024-01-02",
+            "/v3/users/continuous-heart-rate/2024-01-03",
+        ]
+        assert len(result) == 1
+        assert result[0]["date"] == "2024-01-01"
+
+    def test_save_continuous_hr_delegates_to_bulk_create(
+        self, data_247: PolarData247Template, monkeypatch
+    ) -> None:
+        """``save_continuous_hr`` must hand samples to ``timeseries_service.bulk_create_samples``."""
+        calls: list[list[TimeSeriesSampleCreate]] = []
+
+        def fake_bulk_create(db, samples):  # noqa: ANN001
+            calls.append(samples)
+
+        from app.services.providers.polar import data_247 as mod
+
+        monkeypatch.setattr(mod.timeseries_service, "bulk_create_samples", fake_bulk_create)
+
+        user_id = uuid4()
+        sample_one = TimeSeriesSampleCreate(
+            id=uuid4(),
+            user_id=user_id,
+            source="polar",
+            recorded_at=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+            value=Decimal("72"),
+            series_type=SeriesType.heart_rate,
+        )
+        count = data_247.save_continuous_hr(db=None, user_id=user_id, samples=[sample_one])  # type: ignore[arg-type]
+
+        assert count == 1
+        assert calls == [[sample_one]]
+
+    def test_save_continuous_hr_skips_when_empty(
+        self, data_247: PolarData247Template, monkeypatch
+    ) -> None:
+        called = False
+
+        def fake_bulk_create(db, samples):  # noqa: ANN001
+            nonlocal called
+            called = True
+
+        from app.services.providers.polar import data_247 as mod
+
+        monkeypatch.setattr(mod.timeseries_service, "bulk_create_samples", fake_bulk_create)
+
+        count = data_247.save_continuous_hr(db=None, user_id=uuid4(), samples=[])  # type: ignore[arg-type]
+        assert count == 0
+        assert called is False

--- a/backend/tests/providers/polar/test_polar_247_nightly_recharge.py
+++ b/backend/tests/providers/polar/test_polar_247_nightly_recharge.py
@@ -1,0 +1,159 @@
+"""Tests for PolarData247Template Nightly Recharge normalization."""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from app.schemas.enums import SeriesType
+from app.services.providers.polar.data_247 import PolarData247Template
+from app.services.providers.polar.strategy import PolarStrategy
+
+
+@pytest.fixture
+def data_247() -> PolarData247Template:
+    return PolarStrategy().data_247
+
+
+@pytest.fixture
+def sample_polar_recharge_night() -> dict[str, Any]:
+    """Single night from /v3/users/nightly-recharge — docs example + midnight-crossing samples.
+
+    HH:MM transitions span 23:45 → 00:15 → 00:45 so the "bump +1 day on regress"
+    helper logic is exercised by the default fixture.
+    """
+    return {
+        "polar_user": "https://www.polaraccesslink/v3/users/1",
+        "date": "2020-01-01",
+        "heart_rate_avg": 70,
+        "beat_to_beat_avg": 816,
+        "heart_rate_variability_avg": 28,
+        "breathing_rate_avg": 14.1,
+        "nightly_recharge_status": 3,
+        "ans_charge": -2,
+        "ans_charge_status": 2,
+        "hrv_samples": {"23:45": 14, "00:15": 15, "00:45": 16},
+        "breathing_samples": {"23:50": 13.4, "00:10": 13.8},
+    }
+
+
+class TestNormalizeRecovery:
+    def test_emits_all_five_sample_types_for_valid_night(
+        self, data_247: PolarData247Template, sample_polar_recharge_night: dict
+    ) -> None:
+        """Fully-populated night → 3 hrv + 2 breathing + 3 single-point scores = 8 samples."""
+        user_id = uuid4()
+        samples = data_247.normalize_recovery(sample_polar_recharge_night, user_id)
+
+        by_type: dict[SeriesType, list] = {}
+        for s in samples:
+            by_type.setdefault(s.series_type, []).append(s)
+
+        assert len(by_type[SeriesType.heart_rate_variability_rmssd]) == 3
+        assert len(by_type[SeriesType.respiratory_rate]) == 2
+        assert len(by_type[SeriesType.polar_nightly_recharge_status]) == 1
+        assert len(by_type[SeriesType.polar_ans_charge]) == 1
+        assert len(by_type[SeriesType.polar_ans_charge_status]) == 1
+
+        for s in samples:
+            assert s.source == "polar"
+            assert s.user_id == user_id
+
+    def test_skips_night_with_missing_date(
+        self, data_247: PolarData247Template, sample_polar_recharge_night: dict
+    ) -> None:
+        sample_polar_recharge_night.pop("date")
+        user_id = uuid4()
+        samples = data_247.normalize_recovery(sample_polar_recharge_night, user_id)
+        assert samples == []
+
+    def test_skips_invalid_hhmm_keys_but_keeps_valid_samples(
+        self, data_247: PolarData247Template, sample_polar_recharge_night: dict
+    ) -> None:
+        sample_polar_recharge_night["hrv_samples"] = {
+            "00:15": 14,
+            "not-a-time": 999,
+            "25:99": 888,
+            "01:00": 15,
+        }
+        user_id = uuid4()
+        samples = data_247.normalize_recovery(sample_polar_recharge_night, user_id)
+        hrv = [s for s in samples if s.series_type == SeriesType.heart_rate_variability_rmssd]
+        assert len(hrv) == 2
+        assert {float(s.value) for s in hrv} == {14.0, 15.0}
+
+    def test_handles_absent_samples_dicts(
+        self, data_247: PolarData247Template, sample_polar_recharge_night: dict
+    ) -> None:
+        """Night with only scores (no hrv/breathing samples) emits just the 3 single-points."""
+        sample_polar_recharge_night.pop("hrv_samples")
+        sample_polar_recharge_night.pop("breathing_samples")
+        user_id = uuid4()
+        samples = data_247.normalize_recovery(sample_polar_recharge_night, user_id)
+        assert len(samples) == 3
+        assert {s.series_type for s in samples} == {
+            SeriesType.polar_nightly_recharge_status,
+            SeriesType.polar_ans_charge,
+            SeriesType.polar_ans_charge_status,
+        }
+
+    def test_ans_charge_signed_values_preserved(
+        self, data_247: PolarData247Template, sample_polar_recharge_night: dict
+    ) -> None:
+        user_id = uuid4()
+        sample_polar_recharge_night["ans_charge"] = -7
+        samples = data_247.normalize_recovery(sample_polar_recharge_night, user_id)
+        ans = next(s for s in samples if s.series_type == SeriesType.polar_ans_charge)
+        assert ans.value == Decimal("-7")
+
+        sample_polar_recharge_night["ans_charge"] = 7
+        samples = data_247.normalize_recovery(sample_polar_recharge_night, user_id)
+        ans = next(s for s in samples if s.series_type == SeriesType.polar_ans_charge)
+        assert ans.value == Decimal("7")
+
+    def test_score_timestamps_anchor_to_date_midnight_utc(
+        self, data_247: PolarData247Template, sample_polar_recharge_night: dict
+    ) -> None:
+        user_id = uuid4()
+        samples = data_247.normalize_recovery(sample_polar_recharge_night, user_id)
+        expected = datetime(2020, 1, 1, 0, 0, tzinfo=timezone.utc)
+        scores = [
+            s for s in samples
+            if s.series_type in (
+                SeriesType.polar_nightly_recharge_status,
+                SeriesType.polar_ans_charge,
+                SeriesType.polar_ans_charge_status,
+            )
+        ]
+        assert len(scores) == 3
+        for s in scores:
+            assert s.recorded_at == expected
+
+    def test_hrv_sample_timestamps_bump_across_midnight(
+        self, data_247: PolarData247Template, sample_polar_recharge_night: dict
+    ) -> None:
+        """hrv_samples go 23:45 (same day) → 00:15, 00:45 (next day) via bump-on-regress."""
+        user_id = uuid4()
+        samples = data_247.normalize_recovery(sample_polar_recharge_night, user_id)
+        hrv = sorted(
+            (s for s in samples if s.series_type == SeriesType.heart_rate_variability_rmssd),
+            key=lambda s: s.recorded_at,
+        )
+        assert len(hrv) == 3
+        assert hrv[0].recorded_at == datetime(2020, 1, 1, 23, 45, tzinfo=timezone.utc)
+        assert hrv[1].recorded_at == datetime(2020, 1, 2, 0, 15, tzinfo=timezone.utc)
+        assert hrv[2].recorded_at == datetime(2020, 1, 2, 0, 45, tzinfo=timezone.utc)
+
+    def test_breathing_sample_float_values_preserved(
+        self, data_247: PolarData247Template, sample_polar_recharge_night: dict
+    ) -> None:
+        user_id = uuid4()
+        samples = data_247.normalize_recovery(sample_polar_recharge_night, user_id)
+        breathing = sorted(
+            (s for s in samples if s.series_type == SeriesType.respiratory_rate),
+            key=lambda s: s.recorded_at,
+        )
+        assert len(breathing) == 2
+        assert {float(b.value) for b in breathing} == {13.4, 13.8}

--- a/backend/tests/providers/polar/test_polar_247_sleep.py
+++ b/backend/tests/providers/polar/test_polar_247_sleep.py
@@ -1,0 +1,167 @@
+"""Tests for PolarData247Template sleep (Sleep Plus Stages) normalization."""
+
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from app.constants.sleep import SleepStageType
+from app.services.providers.polar.data_247 import PolarData247Template
+from app.services.providers.polar.strategy import PolarStrategy
+
+
+@pytest.fixture
+def data_247() -> PolarData247Template:
+    return PolarStrategy().data_247
+
+
+@pytest.fixture
+def sample_polar_night() -> dict[str, Any]:
+    """Single night from /v3/users/sleep — full docs example."""
+    return {
+        "polar_user": "https://www.polaraccesslink/v3/users/1",
+        "date": "2020-01-01",
+        "sleep_start_time": "2020-01-01T00:39:07+03:00",
+        "sleep_end_time": "2020-01-01T09:19:37+03:00",
+        "device_id": "1111AAAA",
+        "continuity": 2.1,
+        "continuity_class": 2,
+        "light_sleep": 1000,
+        "deep_sleep": 1000,
+        "rem_sleep": 1000,
+        "unrecognized_sleep_stage": 1000,
+        "sleep_score": 80,
+        "total_interruption_duration": 1000,
+        "sleep_charge": 3,
+        "sleep_goal": 28800,
+        "sleep_rating": 3,
+        "short_interruption_duration": 500,
+        "long_interruption_duration": 300,
+        "sleep_cycles": 6,
+        "group_duration_score": 100,
+        "group_solidity_score": 75,
+        "group_regeneration_score": 54.2,
+        "hypnogram": {"00:39": 2, "00:50": 3, "01:23": 6},
+        "heart_rate_samples": {"00:41": 76, "00:46": 77, "00:51": 76},
+    }
+
+
+class TestPolarSleepNormalization:
+    def test_basic_fields(self, data_247: PolarData247Template, sample_polar_night: dict) -> None:
+        user_id = uuid4()
+        result = data_247.normalize_sleep(sample_polar_night, user_id)
+
+        assert result["provider"] == "polar"
+        assert result["user_id"] == user_id
+        assert result["external_id"] == "2020-01-01"
+        assert result["polar_sleep_date"] == "2020-01-01"
+        # 00:39:07 → 09:19:37 same tz = 8h 40m 30s = 31230s
+        assert result["duration_seconds"] == 31230
+
+    def test_stage_summary_minutes(self, data_247: PolarData247Template, sample_polar_night: dict) -> None:
+        user_id = uuid4()
+        result = data_247.normalize_sleep(sample_polar_night, user_id)
+        stages = result["stages"]
+
+        # Polar reports durations in seconds; awake_seconds derives from total_interruption_duration
+        assert stages["deep_seconds"] == 1000
+        assert stages["light_seconds"] == 1000
+        assert stages["rem_seconds"] == 1000
+        assert stages["awake_seconds"] == 1000
+
+    def test_hypnogram_to_stage_intervals(
+        self, data_247: PolarData247Template, sample_polar_night: dict
+    ) -> None:
+        user_id = uuid4()
+        result = data_247.normalize_sleep(sample_polar_night, user_id)
+        intervals = result["stage_timestamps"]
+
+        # Three transitions → three intervals, last one ends at sleep_end_time
+        assert len(intervals) == 3
+
+        # First interval: 00:39 → 00:50, code 2 → LIGHT
+        assert intervals[0].stage == SleepStageType.LIGHT
+        # All three transitions on 2020-01-01 (same day as sleep_start_time)
+        assert intervals[0].start_time.isoformat().startswith("2020-01-01T00:39")
+        assert intervals[0].end_time.isoformat().startswith("2020-01-01T00:50")
+
+        # Second interval: 00:50 → 01:23, code 3 → LIGHT
+        assert intervals[1].stage == SleepStageType.LIGHT
+        assert intervals[1].start_time.isoformat().startswith("2020-01-01T00:50")
+        assert intervals[1].end_time.isoformat().startswith("2020-01-01T01:23")
+
+        # Third interval: 01:23 → sleep_end_time, code 6 is out-of-range → UNKNOWN
+        assert intervals[2].stage == SleepStageType.UNKNOWN
+        assert intervals[2].start_time.isoformat().startswith("2020-01-01T01:23")
+        # sleep_end_time is 09:19 same day
+        assert intervals[2].end_time.isoformat().startswith("2020-01-01T09:19")
+
+    def test_efficiency_from_sleep_score(
+        self, data_247: PolarData247Template, sample_polar_night: dict
+    ) -> None:
+        user_id = uuid4()
+        result = data_247.normalize_sleep(sample_polar_night, user_id)
+        assert result["efficiency_percent"] == 80.0
+
+    def test_missing_hypnogram_empty_intervals(
+        self, data_247: PolarData247Template, sample_polar_night: dict
+    ) -> None:
+        sample_polar_night.pop("hypnogram")
+        user_id = uuid4()
+        result = data_247.normalize_sleep(sample_polar_night, user_id)
+        # Summary durations still present
+        assert result["stages"]["deep_seconds"] == 1000
+        assert result["stage_timestamps"] == []
+
+    def test_malformed_missing_start_returns_empty(
+        self, data_247: PolarData247Template, sample_polar_night: dict
+    ) -> None:
+        sample_polar_night.pop("sleep_start_time")
+        user_id = uuid4()
+        result = data_247.normalize_sleep(sample_polar_night, user_id)
+        assert result == {}
+
+
+class TestPolarSleepFetch:
+    def test_get_sleep_data_unwraps_nights(self, data_247: PolarData247Template, monkeypatch) -> None:
+        """`get_sleep_data` must return the `nights` list from the wrapped response."""
+        captured_endpoints: list[str] = []
+
+        def fake_make_api_request(
+            db, user_id, endpoint, params=None  # noqa: ANN001
+        ) -> dict:
+            captured_endpoints.append(endpoint)
+            return {"nights": [{"date": "2020-01-01"}, {"date": "2020-01-02"}]}
+
+        monkeypatch.setattr(data_247, "_make_api_request", fake_make_api_request)
+
+        result = data_247.get_sleep_data(
+            db=None,  # type: ignore[arg-type]
+            user_id=uuid4(),
+            start_time=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            end_time=datetime(2020, 1, 2, tzinfo=timezone.utc),
+        )
+
+        assert captured_endpoints == ["/v3/users/sleep"]
+        assert [n["date"] for n in result] == ["2020-01-01", "2020-01-02"]
+
+    def test_get_sleep_data_handles_non_dict_gracefully(
+        self, data_247: PolarData247Template, monkeypatch
+    ) -> None:
+        """204 / None / malformed upstream should yield an empty list, not raise."""
+
+        def fake_make_api_request(
+            db, user_id, endpoint, params=None  # noqa: ANN001
+        ) -> None:
+            return None
+
+        monkeypatch.setattr(data_247, "_make_api_request", fake_make_api_request)
+
+        result = data_247.get_sleep_data(
+            db=None,  # type: ignore[arg-type]
+            user_id=uuid4(),
+            start_time=datetime(2020, 1, 1, tzinfo=timezone.utc),
+            end_time=datetime(2020, 1, 2, tzinfo=timezone.utc),
+        )
+        assert result == []

--- a/backend/tests/providers/polar/test_polar_247_sync_isolation.py
+++ b/backend/tests/providers/polar/test_polar_247_sync_isolation.py
@@ -80,3 +80,64 @@ class TestSessionIsolation:
         assert results["sleep_sessions_synced"] == 0
         assert results["continuous_hr_synced"] == 9
         assert db.rollback.called
+
+    def test_continuous_hr_failure_rolls_back_and_nightly_recharge_runs(
+        self, data_247: PolarData247Template, monkeypatch
+    ) -> None:
+        db = MagicMock()
+
+        monkeypatch.setattr(data_247, "get_daily_activity_statistics", lambda *a, **k: [])
+        monkeypatch.setattr(data_247, "normalize_daily_activity", lambda *a, **k: {})
+        monkeypatch.setattr(data_247, "save_daily_activity_statistics", lambda *a, **k: 2)
+
+        monkeypatch.setattr(data_247, "get_sleep_data", lambda *a, **k: [])
+        monkeypatch.setattr(data_247, "normalize_sleep", lambda *a, **k: {})
+        monkeypatch.setattr(data_247, "save_sleep_data", lambda *a, **k: 4)
+
+        def hr_boom(*args: Any, **kwargs: Any) -> int:
+            raise RuntimeError("continuous HR save crashed")
+
+        monkeypatch.setattr(data_247, "get_continuous_hr_data", lambda *a, **k: [])
+        monkeypatch.setattr(data_247, "normalize_continuous_hr", lambda *a, **k: [])
+        monkeypatch.setattr(data_247, "save_continuous_hr", hr_boom)
+
+        monkeypatch.setattr(data_247, "load_and_save_recovery", lambda *a, **k: 11)
+
+        results = data_247.load_and_save_all(db=db, user_id=uuid4())
+
+        assert results["daily_activity_synced"] == 2
+        assert results["sleep_sessions_synced"] == 4
+        assert results["continuous_hr_synced"] == 0
+        assert results["nightly_recharge_synced"] == 11
+        assert db.rollback.called
+
+    def test_nightly_recharge_failure_does_not_poison_previous_blocks(
+        self, data_247: PolarData247Template, monkeypatch
+    ) -> None:
+        """A crash in the Phase 3 block must not undo the earlier synced counts."""
+        db = MagicMock()
+
+        monkeypatch.setattr(data_247, "get_daily_activity_statistics", lambda *a, **k: [])
+        monkeypatch.setattr(data_247, "normalize_daily_activity", lambda *a, **k: {})
+        monkeypatch.setattr(data_247, "save_daily_activity_statistics", lambda *a, **k: 3)
+
+        monkeypatch.setattr(data_247, "get_sleep_data", lambda *a, **k: [])
+        monkeypatch.setattr(data_247, "normalize_sleep", lambda *a, **k: {})
+        monkeypatch.setattr(data_247, "save_sleep_data", lambda *a, **k: 5)
+
+        monkeypatch.setattr(data_247, "get_continuous_hr_data", lambda *a, **k: [])
+        monkeypatch.setattr(data_247, "normalize_continuous_hr", lambda *a, **k: [])
+        monkeypatch.setattr(data_247, "save_continuous_hr", lambda *a, **k: 7)
+
+        def recharge_boom(*args: Any, **kwargs: Any) -> int:
+            raise RuntimeError("nightly recharge save crashed")
+
+        monkeypatch.setattr(data_247, "load_and_save_recovery", recharge_boom)
+
+        results = data_247.load_and_save_all(db=db, user_id=uuid4())
+
+        assert results["daily_activity_synced"] == 3
+        assert results["sleep_sessions_synced"] == 5
+        assert results["continuous_hr_synced"] == 7
+        assert results["nightly_recharge_synced"] == 0
+        assert db.rollback.called

--- a/backend/tests/providers/polar/test_polar_247_sync_isolation.py
+++ b/backend/tests/providers/polar/test_polar_247_sync_isolation.py
@@ -1,0 +1,82 @@
+"""Regression tests: Polar 247 sync blocks must be DB-session-isolated.
+
+Before this fix, a DB error in daily_activity would put the SQLAlchemy session
+into a failed-transaction state; sleep and continuous-HR both shared the same
+session (it's a FastAPI request-scoped dependency) and cascaded to the same
+failure. These tests lock down the invariant that a crash in one data type
+does not prevent the other two from running.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.services.providers.polar.data_247 import PolarData247Template
+from app.services.providers.polar.strategy import PolarStrategy
+
+
+@pytest.fixture
+def data_247() -> PolarData247Template:
+    return PolarStrategy().data_247
+
+
+class TestSessionIsolation:
+    def test_daily_activity_failure_rolls_back_and_sleep_runs(
+        self, data_247: PolarData247Template, monkeypatch
+    ) -> None:
+        db = MagicMock()
+
+        # Daily activity save explodes — simulate a poisoned session
+        def boom(*args: Any, **kwargs: Any) -> int:
+            raise RuntimeError("daily_activity save crashed")
+
+        monkeypatch.setattr(data_247, "get_daily_activity_statistics", lambda *a, **k: [{}])
+        monkeypatch.setattr(data_247, "normalize_daily_activity", lambda *a, **k: {})
+        monkeypatch.setattr(data_247, "save_daily_activity_statistics", boom)
+
+        # Sleep should still run — return one synthetic synced row
+        monkeypatch.setattr(data_247, "get_sleep_data", lambda *a, **k: [])
+        monkeypatch.setattr(data_247, "normalize_sleep", lambda *a, **k: {})
+        monkeypatch.setattr(data_247, "save_sleep_data", lambda *a, **k: 3)
+
+        # HR too
+        monkeypatch.setattr(data_247, "get_continuous_hr_data", lambda *a, **k: [])
+        monkeypatch.setattr(data_247, "normalize_continuous_hr", lambda *a, **k: [])
+        monkeypatch.setattr(data_247, "save_continuous_hr", lambda *a, **k: 7)
+
+        results = data_247.load_and_save_all(db=db, user_id=uuid4())
+
+        assert results["daily_activity_synced"] == 0
+        assert results["sleep_sessions_synced"] == 3
+        assert results["continuous_hr_synced"] == 7
+        # Rollback must have been called at least once to clear the poisoned state
+        assert db.rollback.called
+
+    def test_sleep_failure_rolls_back_and_hr_runs(
+        self, data_247: PolarData247Template, monkeypatch
+    ) -> None:
+        db = MagicMock()
+
+        monkeypatch.setattr(data_247, "get_daily_activity_statistics", lambda *a, **k: [])
+        monkeypatch.setattr(data_247, "normalize_daily_activity", lambda *a, **k: {})
+        monkeypatch.setattr(data_247, "save_daily_activity_statistics", lambda *a, **k: 5)
+
+        def sleep_boom(*args: Any, **kwargs: Any) -> int:
+            raise RuntimeError("sleep save crashed")
+
+        monkeypatch.setattr(data_247, "get_sleep_data", lambda *a, **k: [{}])
+        monkeypatch.setattr(data_247, "normalize_sleep", lambda *a, **k: {})
+        monkeypatch.setattr(data_247, "save_sleep_data", sleep_boom)
+
+        monkeypatch.setattr(data_247, "get_continuous_hr_data", lambda *a, **k: [])
+        monkeypatch.setattr(data_247, "normalize_continuous_hr", lambda *a, **k: [])
+        monkeypatch.setattr(data_247, "save_continuous_hr", lambda *a, **k: 9)
+
+        results = data_247.load_and_save_all(db=db, user_id=uuid4())
+
+        assert results["daily_activity_synced"] == 5
+        assert results["sleep_sessions_synced"] == 0
+        assert results["continuous_hr_synced"] == 9
+        assert db.rollback.called

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,4 +164,14 @@ services:
 
 volumes:
   postgres_data:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: /Users/headless/docker-volumes/ow-postgres
   redis_data:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: /Users/headless/docker-volumes/ow-redis

--- a/docs/providers/polar-api-integration.mdx
+++ b/docs/providers/polar-api-integration.mdx
@@ -16,13 +16,13 @@ Polar provides access to exercise, daily activity, sleep, and heart rate data fr
 | Data Type | Support |
 |-----------|---------|
 | Workouts / Exercises | Yes (with optional HR samples, zones, route) |
-| Sleep (with stages) | Available via API - not yet implemented |
-| Daily activity | Available via API - not yet implemented |
-| Continuous heart rate (5-min intervals) | Available via API - not yet implemented |
+| Daily activity | Yes (steps, calories, distance, active/inactive durations) |
+| Sleep (with Sleep Plus Stages) | Yes (stage summary + per-interval hypnogram) |
+| Continuous heart rate (5-min intervals) | Yes (persisted as time-series samples) |
 | Nightly Recharge / Recovery | Available via API - not yet implemented |
 
 <Info>
-Open Wearables currently syncs **exercise/workout data** from Polar. The AccessLink API also exposes sleep, daily activity, continuous HR, and Nightly Recharge data - support for these types is planned for a future release.
+Open Wearables syncs **workouts, daily activity, sleep, and continuous heart rate** from Polar. Nightly Recharge data is exposed by the AccessLink API but not yet mapped to an internal schema; support is planned for a future release.
 </Info>
 
 ### Data delivery

--- a/docs/providers/polar-api-integration.mdx
+++ b/docs/providers/polar-api-integration.mdx
@@ -19,10 +19,10 @@ Polar provides access to exercise, daily activity, sleep, and heart rate data fr
 | Daily activity | Yes (steps, calories, distance, active/inactive durations) |
 | Sleep (with Sleep Plus Stages) | Yes (stage summary + per-interval hypnogram) |
 | Continuous heart rate (5-min intervals) | Yes (persisted as time-series samples) |
-| Nightly Recharge / Recovery | Available via API - not yet implemented |
+| Nightly Recharge / Recovery | Yes (per-night ANS/recharge scores + intra-night HRV & breathing samples) |
 
 <Info>
-Open Wearables syncs **workouts, daily activity, sleep, and continuous heart rate** from Polar. Nightly Recharge data is exposed by the AccessLink API but not yet mapped to an internal schema; support is planned for a future release.
+Open Wearables syncs **workouts, daily activity, sleep, continuous heart rate, and Nightly Recharge** from Polar. Nightly Recharge per-night scores (`nightly_recharge_status`, `ans_charge`, `ans_charge_status`) and the intra-night HRV (`hrv_samples`) and breathing-rate (`breathing_samples`) streams are all persisted as DataPointSeries samples.
 </Info>
 
 ### Data delivery


### PR DESCRIPTION
## Summary

Closes the three unsupported Polar AccessLink data types — daily activity, Sleep Plus Stages, and continuous heart rate — in `PolarData247Template`. The Polar Loop (and any Polar wearable) now syncs end-to-end through the existing `POST /api/v1/providers/polar/users/{user_id}/sync?data_type=247` route.

Also fixes two latent defects in the shared persistence paths surfaced by running the full 247 pipeline for the first time (see commit `e59b782` and `6e50029`).

### What's new

| Data type | Endpoint | Persistence |
|---|---|---|
| Daily activity (Phase 1, pre-existing) | `GET /v3/users/activities/{date}` | `EventRecord(category="daily_activity")` + workout-shaped detail |
| **Sleep Plus Stages** | `GET /v3/users/sleep` | `EventRecord(category="sleep")` + `SleepDetails` with `sleep_stages` JSONB built from Polar's hypnogram (0-5 → unified `SleepStageType`, 2/3 both collapse to `LIGHT` since the unified enum has no N1/N2 split) |
| **Continuous heart rate** | `GET /v3/users/continuous-heart-rate/{date}` | `DataPointSeries(series_type=heart_rate)` via `timeseries_service.bulk_create_samples` + explicit commit |

Each data-type block in `load_and_save_all` runs in its own try/except and calls `db.rollback()` on failure so a crash in one block doesn't poison the FastAPI request-scoped session for the other two. Nightly Recharge is still stubbed (documented as future work).

### Bugs fixed in passing

1. **`save_daily_activity_statistics` was not idempotent on re-sync.** The caller generated a fresh `uuid4` per item, called `event_record_service.create(...)`, threw away the returned record (which would correctly reconcile with the existing row after the unique-index rollback), and tried to insert a detail keyed off the discarded uuid → `ForeignKeyViolation`. Now uses `persisted = event_record_service.create(...).id` for the detail. This was invisible in the Phase 1 smoke test because that ran against an empty DB.

2. **Continuous-HR samples were staged but never committed.** `timeseries_service.bulk_create_samples` only issues `INSERT ... ON CONFLICT DO UPDATE` via `db.execute`; the `/sync` route does not commit on return. `save_continuous_hr` now commits explicitly — tested with a `MagicMock` session so regressing this fails the unit test instead of silently dropping rows. (The same pattern appears in `suunto/data_247.py::save_activity_samples`; not fixed here to keep the PR focused, but likely needs the same treatment.)

### Tests

16 new unit tests (`tests/providers/polar/`):
- 8 sleep — normalization, hypnogram → stage-interval construction with cross-midnight handling, empty-hypnogram fallback, missing-start-time skip, list-unwrap, 204 tolerance
- 6 HR — sample building with UTC-naive date+time combine, malformed-sample skip, day-by-day fetch iteration, commit-is-called regression, empty-list no-op
- 2 session-isolation regression — assert that a DB error in daily_activity does not prevent sleep/HR from running (and vice versa)

49/49 polar tests pass; no regressions in existing `test_polar_oauth.py`, `test_polar_strategy.py`, `test_polar_workouts.py`.

### Docs

`docs/providers/polar-api-integration.mdx` support table: workouts + daily activity + sleep + continuous HR flip to "Yes"; Nightly Recharge stays flagged as upcoming.

## Test plan

- [ ] `pytest tests/providers/polar/ -q` — expect 49 passed
- [ ] OAuth an active Polar device (Loop or other), then `POST /api/v1/providers/polar/users/{uuid}/sync?data_type=247&async=false` — response should show non-zero `daily_activity_synced`, `sleep_sessions_synced`, `continuous_hr_synced` for a user with recent data
- [ ] Verify persistence: `SELECT category, count(*) FROM event_record er JOIN data_source ds ON er.data_source_id = ds.id WHERE ds.provider='polar' GROUP BY category;` → both `daily_activity` and `sleep` present
- [ ] Verify stages populated: `SELECT jsonb_array_length(sleep_stages) FROM sleep_details sd JOIN event_record er ON er.id = sd.record_id JOIN data_source ds ON er.data_source_id = ds.id WHERE ds.provider='polar' ORDER BY er.start_datetime DESC LIMIT 5;` → non-zero counts
- [ ] Verify HR samples: `SELECT count(*) FROM data_point_series dps JOIN data_source ds ON dps.data_source_id = ds.id JOIN series_type_definition std ON dps.series_type_definition_id = std.id WHERE ds.provider='polar' AND std.code='heart_rate';` → non-zero
- [ ] Re-sync twice and confirm no duplicate `event_record` rows and no FK violations in logs (regression for the Phase 1 idempotency fix)

## Notes for reviewers

- The hypnogram → stage-interval builder anchors the first transition to `sleep_start_time`'s calendar date and bumps subsequent transitions forward one day whenever they would regress (for nights that cross midnight). Only tolerant to within-24h sleep sessions, which matches the Polar API contract (one `sleep` object = one night).
- Continuous-HR `sample_time` comes with no timezone; we combine `date + HH:MM:SS` as UTC-naive to match the existing policy in `_parse_polar_datetime`. Downstream consumers convert to the user's tz.
- `hasattr(self.event_record_repo, "get_by_external_id")` guard that was in Phase 1 was dead code — the method never existed — so removing it has no behavioral impact beyond the bug it was masking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end Polar sync: daily activity, sleep with stage-level hypnograms, continuous heart rate samples, and nightly recharge metrics.
  * Added new series types for Polar-specific scores and charge/status metrics.

* **Documentation**
  * Updated Polar integration docs to document the newly supported data types and persisted fields.

* **Tests**
  * Added comprehensive tests covering Polar sync, normalization, saving, and DB-session isolation.

* **Chores**
  * Updated local volume bindings used by compose for development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->