### PR TITLE
fix: sleep duration excludes awake time, add time in bed column

### DIFF
--- a/backend/app/schemas/responses/activity/events.py
+++ b/backend/app/schemas/responses/activity/events.py
@@ -65,6 +65,7 @@ class SleepSession(BaseModel):
     zone_offset: str | None = None
     source: SourceMetadata
     duration_seconds: int
+    sleep_duration_seconds: int | None = None
     efficiency_percent: float | None = None
     stages: SleepStagesSummary | None = None
     sleep_stage_intervals: list[SleepStage] | None = None

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -735,6 +735,11 @@ class EventRecordService(
         for record, data_source in records:
             details: SleepDetails | None = record.detail if isinstance(record.detail, SleepDetails) else None
 
+            sleep_duration_seconds = (
+                details.sleep_total_duration_minutes * 60
+                if details and details.sleep_total_duration_minutes is not None
+                else None
+            )
             session = SleepSession(
                 id=record.id,
                 start_time=record.start_datetime,
@@ -742,6 +747,7 @@ class EventRecordService(
                 zone_offset=record.zone_offset,
                 source=self._map_source(data_source),
                 duration_seconds=record.duration_seconds or 0,
+                sleep_duration_seconds=sleep_duration_seconds,
                 efficiency_percent=float(details.sleep_efficiency_score)
                 if details and details.sleep_efficiency_score
                 else None,

--- a/backend/tests/services/test_event_record_service.py
+++ b/backend/tests/services/test_event_record_service.py
@@ -769,3 +769,58 @@ class TestCreateOrMergeSleep:
         # Stages should be sorted by start_time (early first)
         assert stages[0]["stage"] == "light"
         assert stages[1]["stage"] == "deep"
+
+
+class TestGetSleepSessions:
+    """Test get_sleep_sessions response fields."""
+
+    def test_returns_sleep_duration_and_time_in_bed_when_details_present(self, db: Session) -> None:
+        """sleep_duration_seconds should come from sleep_total_duration_minutes; duration_seconds stays time-in-bed."""
+        user = UserFactory()
+        mapping = DataSourceFactory(user=user, source="oura")
+        start = datetime(2026, 4, 10, 23, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 4, 11, 7, 0, tzinfo=timezone.utc)  # 8h in bed = 28800s
+        record = EventRecordFactory(
+            mapping=mapping,
+            category="sleep",
+            type_="sleep",
+            start_datetime=start,
+            end_datetime=end,
+            duration_seconds=28800,
+        )
+        SleepDetailsFactory(
+            event_record=record,
+            sleep_total_duration_minutes=450,  # 7h30m of actual sleep
+            sleep_awake_minutes=30,
+        )
+
+        params = EventRecordQueryParams(
+            start_datetime=datetime(2026, 4, 1, tzinfo=timezone.utc),
+            end_datetime=datetime(2026, 4, 30, tzinfo=timezone.utc),
+        )
+        response = event_record_service.get_sleep_sessions(db, user.id, params)
+
+        session = next(s for s in response.data if s.id == record.id)
+        assert session.duration_seconds == 28800  # time in bed (unchanged)
+        assert session.sleep_duration_seconds == 450 * 60  # actual sleep
+
+    def test_sleep_duration_none_when_details_missing(self, db: Session) -> None:
+        """sleep_duration_seconds should be None if SleepDetails has no total duration."""
+        user = UserFactory()
+        mapping = DataSourceFactory(user=user, source="oura")
+        record = EventRecordFactory(
+            mapping=mapping,
+            category="sleep",
+            type_="sleep",
+            duration_seconds=28800,
+        )
+
+        params = EventRecordQueryParams(
+            start_datetime=datetime(2026, 4, 1, tzinfo=timezone.utc),
+            end_datetime=datetime(2026, 4, 30, tzinfo=timezone.utc),
+        )
+        response = event_record_service.get_sleep_sessions(db, user.id, params)
+
+        session = next(s for s in response.data if s.id == record.id)
+        assert session.duration_seconds == 28800
+        assert session.sleep_duration_seconds is None

--- a/frontend/src/components/user/sleep-section.tsx
+++ b/frontend/src/components/user/sleep-section.tsx
@@ -242,14 +242,27 @@ function SleepSessionRow({
               </div>
             </div>
 
-            {/* Duration */}
+            {/* Duration (actual sleep, awake time excluded) */}
             <div className="flex items-center gap-2">
               <Moon className="h-4 w-4 text-indigo-400" />
               <div>
                 <p className="text-sm font-medium text-white">
-                  {formatDuration(session.duration_seconds)}
+                  {session.sleep_duration_seconds !== null
+                    ? formatDuration(session.sleep_duration_seconds)
+                    : '-'}
                 </p>
                 <p className="text-xs text-zinc-500">Duration</p>
+              </div>
+            </div>
+
+            {/* Time in Bed (end - start) */}
+            <div className="flex items-center gap-2">
+              <BedDouble className="h-4 w-4 text-purple-400" />
+              <div>
+                <p className="text-sm font-medium text-white">
+                  {formatDuration(session.duration_seconds)}
+                </p>
+                <p className="text-xs text-zinc-500">Time in Bed</p>
               </div>
             </div>
 

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -259,6 +259,7 @@ export interface SleepSession {
   end_time: string;
   source: SourceMetadata;
   duration_seconds: number;
+  sleep_duration_seconds: number | null;
   efficiency_percent: number | null;
   stages: SleepStagesSummary | null;
   sleep_stage_intervals: SleepStage[] | null;


### PR DESCRIPTION
## Description

Dashboard showed total time in bed (end - start) as "Duration", hiding awake periods. Now "Duration" reflects actual sleep (from `SleepDetails.sleep_total_duration_minutes`), and a new "Time in Bed" column shows the full session span. Sessions without granular `SleepDetails` render "-" for Duration instead of masquerading time in bed as sleep.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` passes

## Screenshots 

<img width="1180" height="339" alt="image" src="https://github.com/user-attachments/assets/abd270a1-5286-484d-be23-5439e7d6581e" />

## Testing Instructions

**Steps to test:**
1. Open the user dashboard and scroll to Sleep section.
2. For a session sourced from a provider that populates `SleepDetails` (Oura, Whoop, etc.), verify "Duration" < "Time in Bed" when awake minutes > 0.
3. For a session without `SleepDetails` (e.g. Apple HealthKit raw `in_bed`), verify "Duration" shows "-" and "Time in Bed" shows the session span.

**Expected behavior:**
- "Duration" = actual sleep (awake excluded)
- "Time in Bed" = end_time - start_time
- No backward-incompatible change to the external API: `duration_seconds` still returns time in bed; the new `sleep_duration_seconds` is additive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Time in Bed" metric to sleep sessions, displaying the duration between sleep start and end times.

* **Improvements**
  * Updated sleep duration display to show actual sleep time when available, now distinct from total time in bed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->