### PR TITLE
feat: continuous time-series in seed generator

### DIFF
--- a/backend/app/schemas/utils/seed_data.py
+++ b/backend/app/schemas/utils/seed_data.py
@@ -4,7 +4,7 @@ from datetime import date
 
 from pydantic import BaseModel, Field, model_validator
 
-from app.schemas.enums import ProviderName, WorkoutType
+from app.schemas.enums import ProviderName, SeriesType, WorkoutType
 
 
 class WorkoutConfig(BaseModel):
@@ -19,7 +19,6 @@ class WorkoutConfig(BaseModel):
     hr_min_range: tuple[int, int] = (90, 120)
     hr_max_range: tuple[int, int] = (140, 180)
     steps_range: tuple[int, int] = (500, 20_000)
-    time_series_chance_pct: int = Field(30, ge=0, le=100)
     date_range_months: int = Field(6, ge=1, le=24)
     date_from: date | None = Field(None, description="Explicit start date. Overrides date_range_months.")
     date_to: date | None = Field(None, description="Explicit end date. Overrides date_range_months.")
@@ -145,6 +144,39 @@ class SleepConfig(BaseModel):
         return self
 
 
+class TimeSeriesConfig(BaseModel):
+    """Parameters controlling continuous time-series generation.
+
+    Continuous time-series are emitted across the full date range independently
+    from workouts (e.g. heart rate every 5 min, weight weekly). Workout-bound
+    series (running_power, cadence, ...) are still emitted inside workout
+    windows and are not controlled by this config.
+    """
+
+    enabled_types: list[SeriesType] | None = Field(
+        None,
+        description=(
+            "Specific series types to emit. None = emit every type defined in "
+            "series_type_config.yaml. Workout-bound types are never affected by "
+            "this list - they follow the workout generator."
+        ),
+    )
+    include_blood_pressure: bool = Field(
+        True,
+        description="Emit paired blood_pressure_systolic + blood_pressure_diastolic.",
+    )
+    date_range_months: int = Field(6, ge=1, le=24)
+    date_from: date | None = Field(None, description="Explicit start date. Overrides date_range_months.")
+    date_to: date | None = Field(None, description="Explicit end date. Overrides date_range_months.")
+
+    @model_validator(mode="after")
+    def _validate_ranges(self) -> "TimeSeriesConfig":
+        if self.date_from and self.date_to and self.date_from > self.date_to:
+            msg = f"date_from ({self.date_from}) must be <= date_to ({self.date_to})"
+            raise ValueError(msg)
+        return self
+
+
 class SeedProfileConfig(BaseModel):
     """Complete seed data generation configuration."""
 
@@ -156,6 +188,7 @@ class SeedProfileConfig(BaseModel):
     num_connections: int = Field(2, ge=1, le=5)
     workout_config: WorkoutConfig = WorkoutConfig()
     sleep_config: SleepConfig = SleepConfig()
+    time_series_config: TimeSeriesConfig = TimeSeriesConfig()
 
 
 class SeedDataRequest(BaseModel):
@@ -212,7 +245,6 @@ SEED_PRESETS: dict[str, dict] = {
                 hr_min_range=(80, 110),
                 hr_max_range=(160, 195),
                 steps_range=(2000, 25_000),
-                time_series_chance_pct=50,
             ),
             sleep_config=SleepConfig(count=30, stage_profile="athlete_recovery"),
         ),
@@ -237,7 +269,6 @@ SEED_PRESETS: dict[str, dict] = {
                 duration_max_minutes=120,
                 hr_min_range=(85, 115),
                 hr_max_range=(155, 190),
-                time_series_chance_pct=40,
             ),
         ),
     },
@@ -249,7 +280,7 @@ SEED_PRESETS: dict[str, dict] = {
             generate_workouts=True,
             generate_sleep=True,
             generate_time_series=True,
-            workout_config=WorkoutConfig(count=10, time_series_chance_pct=20),
+            workout_config=WorkoutConfig(count=10),
             sleep_config=SleepConfig(
                 count=60,
                 duration_min_minutes=240,
@@ -267,7 +298,7 @@ SEED_PRESETS: dict[str, dict] = {
             generate_workouts=True,
             generate_sleep=True,
             generate_time_series=True,
-            workout_config=WorkoutConfig(count=10, time_series_chance_pct=15),
+            workout_config=WorkoutConfig(count=10),
             sleep_config=SleepConfig(
                 count=60,
                 duration_min_minutes=240,
@@ -284,7 +315,7 @@ SEED_PRESETS: dict[str, dict] = {
             generate_workouts=True,
             generate_sleep=True,
             generate_time_series=True,
-            workout_config=WorkoutConfig(count=5, time_series_chance_pct=15),
+            workout_config=WorkoutConfig(count=5),
             sleep_config=SleepConfig(
                 count=90,
                 duration_min_minutes=180,
@@ -330,7 +361,7 @@ SEED_PRESETS: dict[str, dict] = {
     },
     "comprehensive": {
         "label": "Comprehensive",
-        "description": "Large, rich dataset - 150 workouts, 60 sleeps, 5 providers, 80% time series.",
+        "description": "Large, rich dataset - 150 workouts, 60 sleeps, 5 providers, full time series.",
         "profile": SeedProfileConfig(
             preset="comprehensive",
             generate_workouts=True,
@@ -339,7 +370,6 @@ SEED_PRESETS: dict[str, dict] = {
             num_connections=5,
             workout_config=WorkoutConfig(
                 count=150,
-                time_series_chance_pct=80,
                 duration_min_minutes=10,
                 duration_max_minutes=240,
             ),

--- a/backend/app/services/seed_data/constants.py
+++ b/backend/app/services/seed_data/constants.py
@@ -1,6 +1,8 @@
 """Constants and configuration for seed data generation."""
 
 import logging
+from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 
 import yaml
@@ -111,24 +113,51 @@ _GARMIN_STRESS_QUALIFIERS = ["Low Stress", "Medium Stress", "High Stress"]
 # ---------------------------------------------------------------------------
 
 
-def _load_series_type_config() -> tuple[dict[SeriesType, tuple[float, float]], dict[SeriesType, int]]:
-    # __file__ = backend/app/services/seed_data/constants.py → .parent x4 = backend/
+class Cadence(str, Enum):
+    INTRADAY = "intraday"
+    DAILY = "daily"
+    DAILY_MORNING = "daily_morning"
+    WEEKLY = "weekly"
+    WORKOUT_BOUND = "workout_bound"
+    PAIRED = "paired"
+
+
+@dataclass(frozen=True)
+class SeriesTypeGenSpec:
+    """Generation parameters for a single series type loaded from YAML."""
+
+    cadence: Cadence
+    min_value: float = 0.0
+    max_value: float = 0.0
+    interval_seconds: int | None = None
+    workout_types: frozenset[WorkoutType] = field(default_factory=frozenset)
+
+
+@dataclass(frozen=True)
+class PairedGenSpec:
+    """Paired-emission spec - emits multiple series types at the same timestamp."""
+
+    cadence: Cadence  # how often to emit (DAILY, WEEKLY, ...)
+    members: dict[SeriesType, tuple[float, float]]  # series_type -> (min, max)
+
+
+def _load_series_type_config() -> tuple[dict[SeriesType, SeriesTypeGenSpec], list[PairedGenSpec]]:
+    """Load and validate the YAML series-type config.
+
+    Returns (specs, paired_specs):
+    - specs: mapping from each SeriesType to its generation parameters
+    - paired_specs: list of paired emissions (e.g. blood pressure)
+    """
     config_path = Path(__file__).parent.parent.parent.parent / "scripts" / "init" / "series_type_config.yaml"
     if not config_path.exists():
         config_path = Path("scripts/init/series_type_config.yaml")
-    values_ranges: dict[SeriesType, tuple[float, float]] = {}
-    percentages: dict[SeriesType, int] = {}
+
+    specs: dict[SeriesType, SeriesTypeGenSpec] = {}
+    paired_specs: list[PairedGenSpec] = []
 
     try:
         with open(config_path, encoding="utf-8") as f:
             config = yaml.safe_load(f) or {}
-        for name, vals in config.get("series_types", {}).items():
-            try:
-                st = SeriesType(name)
-                values_ranges[st] = (float(vals["min_value"]), float(vals["max_value"]))
-                percentages[st] = int(vals["percentage"])
-            except (ValueError, KeyError):
-                continue
     except FileNotFoundError:
         log_structured(
             logger,
@@ -137,8 +166,83 @@ def _load_series_type_config() -> tuple[dict[SeriesType, tuple[float, float]], d
             provider="seed_data_service",
             task="load_config",
         )
+        return specs, paired_specs
 
-    return values_ranges, percentages
+    for name, vals in config.get("series_types", {}).items():
+        try:
+            cadence = Cadence(vals["cadence"])
+        except (KeyError, ValueError):
+            log_structured(
+                logger,
+                "warning",
+                f"Skipping '{name}' - missing or invalid cadence",
+                provider="seed_data_service",
+                task="load_config",
+            )
+            continue
+
+        if cadence is Cadence.PAIRED:
+            paired = _parse_paired(name, vals)
+            if paired is not None:
+                paired_specs.append(paired)
+            continue
+
+        try:
+            st = SeriesType(name)
+        except ValueError:
+            continue
+
+        workout_types: frozenset[WorkoutType] = frozenset()
+        if cadence is Cadence.WORKOUT_BOUND:
+            workout_types = _parse_workout_types(vals.get("workout_types", []))
+
+        specs[st] = SeriesTypeGenSpec(
+            cadence=cadence,
+            min_value=float(vals.get("min_value", 0.0)),
+            max_value=float(vals.get("max_value", 0.0)),
+            interval_seconds=int(vals["interval_seconds"]) if "interval_seconds" in vals else None,
+            workout_types=workout_types,
+        )
+
+    return specs, paired_specs
 
 
-SERIES_VALUES_RANGES, SERIES_TYPE_PERCENTAGES = _load_series_type_config()
+def _parse_paired(name: str, vals: dict) -> PairedGenSpec | None:
+    try:
+        members_raw = vals["members"]
+        members: dict[SeriesType, tuple[float, float]] = {}
+        for member_name, member_vals in members_raw.items():
+            st = SeriesType(member_name)
+            members[st] = (float(member_vals["min_value"]), float(member_vals["max_value"]))
+        if not members:
+            return None
+        frequency = Cadence(vals.get("frequency", "daily"))
+        return PairedGenSpec(cadence=frequency, members=members)
+    except (KeyError, ValueError):
+        log_structured(
+            logger,
+            "warning",
+            f"Skipping paired entry '{name}' - malformed members or frequency",
+            provider="seed_data_service",
+            task="load_config",
+        )
+        return None
+
+
+def _parse_workout_types(raw: list[str]) -> frozenset[WorkoutType]:
+    result: set[WorkoutType] = set()
+    for wt in raw:
+        try:
+            result.add(WorkoutType(wt))
+        except ValueError:
+            log_structured(
+                logger,
+                "warning",
+                f"Unknown workout type '{wt}' in series_type_config.yaml",
+                provider="seed_data_service",
+                task="load_config",
+            )
+    return frozenset(result)
+
+
+SERIES_TYPE_SPECS, PAIRED_SERIES_SPECS = _load_series_type_config()

--- a/backend/app/services/seed_data/service.py
+++ b/backend/app/services/seed_data/service.py
@@ -1,9 +1,9 @@
-"""SeedDataService — orchestrates seed data generation across all entity types."""
+"""SeedDataService - orchestrates seed data generation across all entity types."""
 
 import logging
 import os
 import random
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 from faker import Faker
 from sqlalchemy.orm import Session
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from app.models import EventRecordDetail, PersonalRecord, UserConnection
 from app.repositories import CrudRepository
 from app.repositories.event_record_detail_repository import EventRecordDetailRepository
-from app.schemas.enums import ProviderName
+from app.schemas.enums import ProviderName, SeriesType, WorkoutType
 from app.schemas.model_crud.user_management import UserConnectionUpdate, UserCreate
 from app.schemas.utils.seed_data import SeedDataRequest
 from app.services.event_record_service import event_record_service
@@ -19,11 +19,65 @@ from app.services.health_score_service import health_score_service
 from app.services.timeseries_service import timeseries_service
 from app.services.user_service import user_service
 
+from .constants import PAIRED_SERIES_SPECS, PROVIDER_CONFIGS, SERIES_TYPE_SPECS, Cadence
 from .event_generators import _generate_personal_record, _generate_sleep, _generate_workout
 from .health_score_generators import _generate_health_scores
 from .support_generators import _generate_time_series_samples, _generate_user_connections
+from .time_series_generators import ProviderDescriptor, _generate_continuous_time_series
 
 logger = logging.getLogger(__name__)
+
+
+def _build_provider_map(
+    providers: list[ProviderName],
+    fake: Faker,
+) -> dict[SeriesType, ProviderDescriptor]:
+    """Assign one provider descriptor per series type, reused for all samples.
+
+    Ensures that e.g. every heart_rate sample for a user comes from the same
+    provider + device + software version. Covers non-workout-bound types plus
+    paired members (blood pressure).
+    """
+    provider_map: dict[SeriesType, ProviderDescriptor] = {}
+    if not providers:
+        return provider_map
+
+    all_series = [st for st, spec in SERIES_TYPE_SPECS.items() if spec.cadence is not Cadence.WORKOUT_BOUND]
+    for paired in PAIRED_SERIES_SPECS:
+        all_series.extend(paired.members.keys())
+
+    for series_type in all_series:
+        prov = fake.random.choice(providers)
+        prov_config = PROVIDER_CONFIGS[prov]
+        is_sdk = prov == ProviderName.APPLE
+        # Oura exposes no device info; Apple is SDK-style (source name only)
+        device_model = None if prov == ProviderName.OURA else fake.random.choice(prov_config["devices"])
+        software_version = (
+            None if prov == ProviderName.OURA or is_sdk else fake.random.choice(prov_config["os_versions"])
+        )
+        provider_map[series_type] = ProviderDescriptor(
+            provider=prov,
+            source=prov_config["source_name"],
+            device_model=device_model,
+            software_version=software_version,
+        )
+
+    return provider_map
+
+
+def _resolve_time_series_window(
+    config_date_from: date | None,
+    config_date_to: date | None,
+    date_range_months: int,
+    last_synced_at: datetime,
+) -> tuple[datetime, datetime]:
+    if config_date_from and config_date_to:
+        start = datetime(config_date_from.year, config_date_from.month, config_date_from.day, tzinfo=timezone.utc)
+        end = datetime(config_date_to.year, config_date_to.month, config_date_to.day, 23, 59, 59, tzinfo=timezone.utc)
+    else:
+        start = last_synced_at - timedelta(days=date_range_months * 30)
+        end = last_synced_at
+    return start, end
 
 
 class SeedDataService:
@@ -61,6 +115,12 @@ class SeedDataService:
             "health_scores": 0,
         }
 
+        enabled_types: set[SeriesType] | None = (
+            set(profile.time_series_config.enabled_types)
+            if profile.time_series_config.enabled_types is not None
+            else None
+        )
+
         for user_num in range(1, request.num_users + 1):
             user = user_service.create(
                 db,
@@ -91,7 +151,11 @@ class SeedDataService:
                     connection_repo.update(db, created, UserConnectionUpdate(last_synced_at=provider_sync_times[prov]))
                     summary["connections"] += 1
 
-            # Workouts
+            # Stable per-user mapping: each series type gets one provider, used
+            # for every sample of that type across the whole generation run.
+            provider_map = _build_provider_map(list(provider_sync_times.keys()), fake)
+
+            # Workouts (+ workout-bound time series)
             if profile.generate_workouts:
                 for _ in range(profile.workout_config.count):
                     prov = fake.random.choice(list(provider_sync_times.keys()))
@@ -102,13 +166,11 @@ class SeedDataService:
                     event_record_service.create_detail(db, detail)
                     summary["workouts"] += 1
 
-                    # Time series
-                    if profile.generate_time_series and fake.boolean(
-                        chance_of_getting_true=profile.workout_config.time_series_chance_pct
-                    ):
+                    if profile.generate_time_series and record.type is not None:
                         samples = _generate_time_series_samples(
                             record.start_datetime,
                             record.end_datetime,
+                            WorkoutType(record.type),
                             fake,
                             user_id=user.id,
                             source=record.source or "unknown",
@@ -131,7 +193,29 @@ class SeedDataService:
                     event_detail_repo.create(db, detail, detail_type="sleep")
                     summary["sleeps"] += 1
 
-            # Health scores — one batch per provider covering the full seeded date range
+            # Continuous time series (independent of workouts)
+            if profile.generate_time_series and provider_sync_times:
+                last_synced_at = max(provider_sync_times.values())
+                ts_start, ts_end = _resolve_time_series_window(
+                    profile.time_series_config.date_from,
+                    profile.time_series_config.date_to,
+                    profile.time_series_config.date_range_months,
+                    last_synced_at,
+                )
+                continuous_samples = _generate_continuous_time_series(
+                    user_id=user.id,
+                    start=ts_start,
+                    end=ts_end,
+                    enabled_types=enabled_types,
+                    include_blood_pressure=profile.time_series_config.include_blood_pressure,
+                    provider_map=provider_map,
+                    fake=fake,
+                )
+                if continuous_samples:
+                    timeseries_service.bulk_create_samples(db, continuous_samples)
+                    summary["time_series_samples"] += len(continuous_samples)
+
+            # Health scores - one batch per provider covering the full seeded date range
             if profile.generate_workouts or profile.generate_sleep:
                 date_range_months = (
                     max(

--- a/backend/app/services/seed_data/support_generators.py
+++ b/backend/app/services/seed_data/support_generators.py
@@ -1,4 +1,4 @@
-"""Generators for time series samples and user connections."""
+"""Generators for workout-bound time-series samples and user connections."""
 
 from datetime import datetime, timedelta
 from decimal import Decimal
@@ -7,16 +7,31 @@ from uuid import UUID, uuid4
 from faker import Faker
 
 from app.schemas.auth import ConnectionStatus
-from app.schemas.enums import ProviderName
+from app.schemas.enums import ProviderName, SeriesType, WorkoutType
 from app.schemas.model_crud.activities import TimeSeriesSampleCreate
 from app.schemas.model_crud.user_management import UserConnectionCreate
 
-from .constants import SEED_PROVIDERS, SERIES_TYPE_PERCENTAGES, SERIES_VALUES_RANGES
+from .constants import SEED_PROVIDERS, SERIES_TYPE_SPECS, Cadence
+
+
+def _workout_bound_types_for(workout_type: WorkoutType) -> list[SeriesType]:
+    """Return series types whose workout_types spec includes this workout type."""
+    matches: list[SeriesType] = []
+    for series_type, spec in SERIES_TYPE_SPECS.items():
+        if spec.cadence is not Cadence.WORKOUT_BOUND:
+            continue
+        if workout_type in spec.workout_types:
+            matches.append(series_type)
+    # Heart rate is always included during workouts regardless of sport
+    if SeriesType.heart_rate in SERIES_TYPE_SPECS and SeriesType.heart_rate not in matches:
+        matches.append(SeriesType.heart_rate)
+    return matches
 
 
 def _generate_time_series_samples(
     workout_start: datetime,
     workout_end: datetime,
+    workout_type: WorkoutType,
     fake: Faker,
     *,
     user_id: UUID,
@@ -25,34 +40,43 @@ def _generate_time_series_samples(
     provider: str | None = None,
     software_version: str | None = None,
 ) -> list[TimeSeriesSampleCreate]:
-    """Generate time series samples for a workout period."""
-    samples: list[TimeSeriesSampleCreate] = []
-    if not SERIES_TYPE_PERCENTAGES or not SERIES_VALUES_RANGES:
-        return samples
+    """Generate time-series samples within a single workout window.
 
+    Samples are emitted for:
+    - ``heart_rate`` (every workout)
+    - any ``workout_bound`` series whose ``workout_types`` spec matches
+    """
+    if not SERIES_TYPE_SPECS:
+        return []
+
+    applicable = _workout_bound_types_for(workout_type)
+    if not applicable:
+        return []
+
+    samples: list[TimeSeriesSampleCreate] = []
     current_time = workout_start
     while current_time <= workout_end:
-        for series_type, percentage in SERIES_TYPE_PERCENTAGES.items():
-            min_value, max_value = SERIES_VALUES_RANGES[series_type]
-            if fake.boolean(chance_of_getting_true=percentage):
-                if min_value != int(min_value) or max_value != int(max_value):
-                    value = fake.random.uniform(min_value, max_value)
-                else:
-                    value = fake.random_int(min=int(min_value), max=int(max_value))
+        for series_type in applicable:
+            spec = SERIES_TYPE_SPECS[series_type]
+            min_v, max_v = spec.min_value, spec.max_value
+            if min_v != int(min_v) or max_v != int(max_v):
+                value = fake.random.uniform(min_v, max_v)
+            else:
+                value = fake.random_int(min=int(min_v), max=int(max_v))
 
-                samples.append(
-                    TimeSeriesSampleCreate(
-                        id=uuid4(),
-                        user_id=user_id,
-                        source=source,
-                        device_model=device_model,
-                        provider=provider,
-                        software_version=software_version,
-                        recorded_at=current_time,
-                        value=Decimal(str(value)),
-                        series_type=series_type,
-                    )
+            samples.append(
+                TimeSeriesSampleCreate(
+                    id=uuid4(),
+                    user_id=user_id,
+                    source=source,
+                    device_model=device_model,
+                    provider=provider,
+                    software_version=software_version,
+                    recorded_at=current_time,
+                    value=Decimal(str(value)),
+                    series_type=series_type,
                 )
+            )
         current_time += timedelta(seconds=fake.random_int(min=20, max=60))
 
     return samples

--- a/backend/app/services/seed_data/time_series_generators.py
+++ b/backend/app/services/seed_data/time_series_generators.py
@@ -1,0 +1,233 @@
+"""Continuous time-series generators (independent of workouts).
+
+Emits samples across a date range based on per-type cadence declared in
+``series_type_config.yaml``. Workout-bound series are emitted by
+``support_generators._generate_time_series_samples`` instead.
+"""
+
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from faker import Faker
+
+from app.schemas.enums import ProviderName, SeriesType
+from app.schemas.model_crud.activities import TimeSeriesSampleCreate
+
+from .constants import PAIRED_SERIES_SPECS, SERIES_TYPE_SPECS, Cadence, PairedGenSpec, SeriesTypeGenSpec
+
+
+@dataclass(frozen=True)
+class ProviderDescriptor:
+    """Identifies a provider source for a generated sample."""
+
+    provider: ProviderName
+    source: str
+    device_model: str | None
+    software_version: str | None
+
+
+def _sample_value(fake: Faker, min_value: float, max_value: float) -> Decimal:
+    if min_value != int(min_value) or max_value != int(max_value):
+        value = fake.random.uniform(min_value, max_value)
+    else:
+        value = fake.random_int(min=int(min_value), max=int(max_value))
+    return Decimal(str(value))
+
+
+def _make_sample(
+    user_id: UUID,
+    recorded_at: datetime,
+    series_type: SeriesType,
+    value: Decimal,
+    provider_desc: ProviderDescriptor,
+) -> TimeSeriesSampleCreate:
+    return TimeSeriesSampleCreate(
+        id=uuid4(),
+        user_id=user_id,
+        source=provider_desc.source,
+        device_model=provider_desc.device_model,
+        provider=provider_desc.provider.value,
+        software_version=provider_desc.software_version,
+        recorded_at=recorded_at,
+        value=value,
+        series_type=series_type,
+    )
+
+
+def _iter_intraday_timestamps(start: datetime, end: datetime, interval_seconds: int) -> Iterator[datetime]:
+    cursor = start
+    step = timedelta(seconds=interval_seconds)
+    while cursor <= end:
+        yield cursor
+        cursor += step
+
+
+def _iter_daily_timestamps(
+    start: datetime, end: datetime, fake: Faker, hour_min: int, hour_max: int
+) -> Iterator[datetime]:
+    """Yield one timestamp per calendar day in [start, end]."""
+    day = start.replace(hour=0, minute=0, second=0, microsecond=0)
+    end_day = end.replace(hour=23, minute=59, second=59, microsecond=0)
+    while day <= end_day:
+        hour = fake.random_int(min=hour_min, max=hour_max)
+        minute = fake.random_int(min=0, max=59)
+        ts = day.replace(hour=hour, minute=minute)
+        if start <= ts <= end:
+            yield ts
+        day += timedelta(days=1)
+
+
+def _iter_weekly_timestamps(start: datetime, end: datetime, fake: Faker) -> Iterator[datetime]:
+    cursor = start
+    while cursor <= end:
+        hour = fake.random_int(min=8, max=20)
+        minute = fake.random_int(min=0, max=59)
+        yield cursor.replace(hour=hour, minute=minute)
+        cursor += timedelta(days=fake.random_int(min=6, max=8))
+
+
+def _emit_intraday(
+    spec: SeriesTypeGenSpec,
+    series_type: SeriesType,
+    user_id: UUID,
+    start: datetime,
+    end: datetime,
+    provider_desc: ProviderDescriptor,
+    fake: Faker,
+) -> list[TimeSeriesSampleCreate]:
+    interval = spec.interval_seconds or 600
+    return [
+        _make_sample(
+            user_id,
+            ts,
+            series_type,
+            _sample_value(fake, spec.min_value, spec.max_value),
+            provider_desc,
+        )
+        for ts in _iter_intraday_timestamps(start, end, interval)
+    ]
+
+
+def _emit_daily(
+    spec: SeriesTypeGenSpec,
+    series_type: SeriesType,
+    user_id: UUID,
+    start: datetime,
+    end: datetime,
+    provider_desc: ProviderDescriptor,
+    fake: Faker,
+    *,
+    hour_min: int = 8,
+    hour_max: int = 21,
+) -> list[TimeSeriesSampleCreate]:
+    return [
+        _make_sample(
+            user_id,
+            ts,
+            series_type,
+            _sample_value(fake, spec.min_value, spec.max_value),
+            provider_desc,
+        )
+        for ts in _iter_daily_timestamps(start, end, fake, hour_min, hour_max)
+    ]
+
+
+def _emit_weekly(
+    spec: SeriesTypeGenSpec,
+    series_type: SeriesType,
+    user_id: UUID,
+    start: datetime,
+    end: datetime,
+    provider_desc: ProviderDescriptor,
+    fake: Faker,
+) -> list[TimeSeriesSampleCreate]:
+    return [
+        _make_sample(
+            user_id,
+            ts,
+            series_type,
+            _sample_value(fake, spec.min_value, spec.max_value),
+            provider_desc,
+        )
+        for ts in _iter_weekly_timestamps(start, end, fake)
+    ]
+
+
+def _emit_paired(
+    paired: PairedGenSpec,
+    user_id: UUID,
+    start: datetime,
+    end: datetime,
+    provider_resolver: Callable[[SeriesType], ProviderDescriptor | None],
+    fake: Faker,
+) -> list[TimeSeriesSampleCreate]:
+    """Emit each member series at the SAME timestamp (e.g. BP systolic+diastolic)."""
+    if paired.cadence is Cadence.WEEKLY:
+        timestamps = list(_iter_weekly_timestamps(start, end, fake))
+    else:
+        timestamps = list(_iter_daily_timestamps(start, end, fake, 8, 21))
+
+    samples: list[TimeSeriesSampleCreate] = []
+    for ts in timestamps:
+        for series_type, (lo, hi) in paired.members.items():
+            provider_desc = provider_resolver(series_type)
+            if provider_desc is None:
+                continue
+            samples.append(
+                _make_sample(
+                    user_id,
+                    ts,
+                    series_type,
+                    _sample_value(fake, lo, hi),
+                    provider_desc,
+                )
+            )
+    return samples
+
+
+def _generate_continuous_time_series(
+    user_id: UUID,
+    start: datetime,
+    end: datetime,
+    enabled_types: set[SeriesType] | None,
+    include_blood_pressure: bool,
+    provider_map: dict[SeriesType, ProviderDescriptor],
+    fake: Faker,
+) -> list[TimeSeriesSampleCreate]:
+    """Generate continuous time-series samples across [start, end].
+
+    ``enabled_types=None`` emits every non-workout-bound type defined in the
+    YAML config. Workout-bound types are always skipped here (handled by the
+    workout generator).
+    """
+    samples: list[TimeSeriesSampleCreate] = []
+
+    for series_type, spec in SERIES_TYPE_SPECS.items():
+        if spec.cadence is Cadence.WORKOUT_BOUND:
+            continue
+        if enabled_types is not None and series_type not in enabled_types:
+            continue
+        provider_desc = provider_map.get(series_type)
+        if provider_desc is None:
+            continue
+
+        match spec.cadence:
+            case Cadence.INTRADAY:
+                samples.extend(_emit_intraday(spec, series_type, user_id, start, end, provider_desc, fake))
+            case Cadence.DAILY:
+                samples.extend(_emit_daily(spec, series_type, user_id, start, end, provider_desc, fake))
+            case Cadence.DAILY_MORNING:
+                samples.extend(
+                    _emit_daily(spec, series_type, user_id, start, end, provider_desc, fake, hour_min=6, hour_max=9)
+                )
+            case Cadence.WEEKLY:
+                samples.extend(_emit_weekly(spec, series_type, user_id, start, end, provider_desc, fake))
+
+    if include_blood_pressure:
+        for paired in PAIRED_SERIES_SPECS:
+            samples.extend(_emit_paired(paired, user_id, start, end, provider_map.get, fake))
+
+    return samples

--- a/backend/scripts/init/series_type_config.yaml
+++ b/backend/scripts/init/series_type_config.yaml
@@ -1,249 +1,196 @@
-# Series type configuration for activity data seeding
-# Each entry defines the value range and sampling percentage for a series type
+# Series type configuration for seed data generation.
+#
+# Each entry defines:
+#   cadence:       how samples are spaced in time. One of:
+#                    - intraday            -> every `interval_seconds`, 24h
+#                    - daily               -> one sample per day at a random hour
+#                    - daily_morning       -> one sample per day shortly after wake (06-09)
+#                    - weekly              -> one sample every ~7 days
+#                    - workout_bound       -> only during workouts, filtered by `workout_types`
+#                    - paired              -> emits multiple series at the same recorded_at
+#                                             (used for blood pressure)
+#   interval_seconds:  only for cadence=intraday
+#   min_value / max_value:  uniform sample range
+#   workout_types:     only for cadence=workout_bound - list of WorkoutType values
+#   members:           only for cadence=paired - mapping of SeriesType -> {min_value, max_value}
+#
+# Adding a new type: pick a cadence, give realistic min/max, done.
 
 series_types:
-  # Heart & Cardiovascular
+  # -------------------------------------------------------------------------
+  # Intraday continuous (24/7)
+  # -------------------------------------------------------------------------
   heart_rate:
-    min_value: 90
-    max_value: 180
-    percentage: 80
-
-  resting_heart_rate:
+    cadence: intraday
+    interval_seconds: 300
     min_value: 55
-    max_value: 75
-    percentage: 1
+    max_value: 110
 
-  walking_heart_rate_average:
-    min_value: 100
-    max_value: 140
-    percentage: 8
-
-  heart_rate_variability_sdnn:
-    min_value: 20
-    max_value: 80
-    percentage: 3
-
-  # Activity - Basic
   steps:
-    min_value: 10
-    max_value: 50
-    percentage: 30
+    cadence: intraday
+    interval_seconds: 600
+    min_value: 0
+    max_value: 200
 
   energy:
-    min_value: 5
+    cadence: intraday
+    interval_seconds: 600
+    min_value: 1
     max_value: 20
-    percentage: 25
 
   basal_energy:
-    min_value: 0.4
-    max_value: 1.0
-    percentage: 2
+    cadence: intraday
+    interval_seconds: 900
+    min_value: 0.5
+    max_value: 1.5
+
+  respiratory_rate:
+    cadence: intraday
+    interval_seconds: 1800
+    min_value: 12
+    max_value: 20
+
+  distance_walking_running:
+    cadence: intraday
+    interval_seconds: 600
+    min_value: 0
+    max_value: 150
 
   flights_climbed:
+    cadence: intraday
+    interval_seconds: 1800
     min_value: 0
-    max_value: 2
-    percentage: 2
+    max_value: 3
 
-  physical_effort:
-    min_value: 1
-    max_value: 10
-    percentage: 2
-
-  # Activity - Distance
-  distance_walking_running:
-    min_value: 10
-    max_value: 100
-    percentage: 20
-
-  distance_cycling:
-    min_value: 50
-    max_value: 250
-    percentage: 10
-
-  distance_swimming:
-    min_value: 5
-    max_value: 30
-    percentage: 5
-
-  # Respiratory & Blood
-  respiratory_rate:
-    min_value: 12
-    max_value: 30
-    percentage: 25
-
-  oxygen_saturation:
-    min_value: 95
-    max_value: 100
-    percentage: 3
-
-  # Body Composition
-  body_temperature:
-    min_value: 36.0
-    max_value: 37.5
-    percentage: 1
-
-  skin_temperature:
-    min_value: 33.5
-    max_value: 36.9
-    percentage: 1
-
-  weight:
-    min_value: 50.0
-    max_value: 120.0
-    percentage: 1
-
-  body_fat_percentage:
-    min_value: 10.0
-    max_value: 35.0
-    percentage: 1
-
-  height:
-    min_value: 150
-    max_value: 200
-    percentage: 1
-
-  # Fitness Metrics
-  vo2_max:
-    min_value: 25
-    max_value: 80
-    percentage: 1
-
-  six_minute_walk_test_distance:
-    min_value: 400
-    max_value: 700
-    percentage: 1
-
-  # Running Metrics
-  running_power:
-    min_value: 200
-    max_value: 400
-    percentage: 8
-
-  running_speed:
-    min_value: 2.0
-    max_value: 6.0
-    percentage: 8
-
-  running_vertical_oscillation:
-    min_value: 6
-    max_value: 15
-    percentage: 5
-
-  running_ground_contact_time:
-    min_value: 150
-    max_value: 300
-    percentage: 5
-
-  running_stride_length:
-    min_value: 80
-    max_value: 150
-    percentage: 5
-
-  # Swimming Metrics
-  swimming_stroke_count:
-    min_value: 5
-    max_value: 20
-    percentage: 5
-
-  # Generic Activity Metrics
-  cadence:
-    min_value: 150
-    max_value: 200
-    percentage: 15
-
-  power:
-    min_value: 100
-    max_value: 300
-    percentage: 12
-
-  # Environmental
   environmental_audio_exposure:
+    cadence: intraday
+    interval_seconds: 1800
     min_value: 40
     max_value: 85
-    percentage: 1
 
   headphone_audio_exposure:
+    cadence: intraday
+    interval_seconds: 1800
     min_value: 50
     max_value: 95
-    percentage: 1
 
-  environmental_sound_reduction:
-    min_value: 5
-    max_value: 30
-    percentage: 1
+  # -------------------------------------------------------------------------
+  # Daily morning (resting / overnight metrics)
+  # -------------------------------------------------------------------------
+  resting_heart_rate:
+    cadence: daily_morning
+    min_value: 50
+    max_value: 75
 
-  time_in_daylight:
-    min_value: 0
-    max_value: 30
-    percentage: 1
+  heart_rate_variability_sdnn:
+    cadence: daily_morning
+    min_value: 25
+    max_value: 80
 
-  water_temperature:
-    min_value: 15
-    max_value: 30
-    percentage: 1
-
-  # Generic
-  speed:
-    min_value: 1.0
-    max_value: 15.0
-    percentage: 5
-
-  distance_other:
-    min_value: 5
+  oxygen_saturation:
+    cadence: daily_morning
+    min_value: 95
     max_value: 100
-    percentage: 3
+
+  skin_temperature:
+    cadence: daily_morning
+    min_value: 33.5
+    max_value: 36.9
+
+  # -------------------------------------------------------------------------
+  # Daily (anytime)
+  # -------------------------------------------------------------------------
+  stand_time:
+    cadence: daily
+    min_value: 120
+    max_value: 720
 
   exercise_time:
-    min_value: 5
-    max_value: 60
-    percentage: 5
-
-  stand_time:
-    min_value: 0
-    max_value: 15
-    percentage: 3
-
-  distance_downhill_snow_sports:
-    min_value: 5
-    max_value: 50
-    percentage: 2
-
-  walking_step_length:
-    min_value: 60
-    max_value: 85
-    percentage: 3
-
-  walking_speed:
-    min_value: 1.0
-    max_value: 2.0
-    percentage: 3
-
-  stair_descent_speed:
-    min_value: 0.5
-    max_value: 2.0
-    percentage: 2
-
-  stair_ascent_speed:
-    min_value: 0.3
-    max_value: 1.5
-    percentage: 2
-
-  heart_rate_recovery_one_minute:
+    cadence: daily
     min_value: 10
-    max_value: 40
-    percentage: 2
+    max_value: 120
+
+  time_in_daylight:
+    cadence: daily
+    min_value: 15
+    max_value: 240
 
   blood_glucose:
-    min_value: 70
-    max_value: 200
-    percentage: 1
+    cadence: daily
+    min_value: 80
+    max_value: 160
 
-  blood_pressure_systolic:
-    min_value: 100
-    max_value: 150
-    percentage: 2
+  body_temperature:
+    cadence: daily
+    min_value: 36.1
+    max_value: 37.2
 
-  blood_pressure_diastolic:
+  # -------------------------------------------------------------------------
+  # Paired daily (always emitted together at same timestamp)
+  # -------------------------------------------------------------------------
+  blood_pressure:
+    cadence: paired
+    frequency: daily
+    members:
+      blood_pressure_systolic:
+        min_value: 105
+        max_value: 135
+      blood_pressure_diastolic:
+        min_value: 65
+        max_value: 88
+
+  # -------------------------------------------------------------------------
+  # Weekly
+  # -------------------------------------------------------------------------
+  weight:
+    cadence: weekly
     min_value: 60
-    max_value: 90
-    percentage: 2
+    max_value: 95
+
+  body_fat_percentage:
+    cadence: weekly
+    min_value: 12
+    max_value: 32
+
+  vo2_max:
+    cadence: weekly
+    min_value: 35
+    max_value: 65
+
+  # -------------------------------------------------------------------------
+  # Workout-bound (only during matching workouts)
+  # -------------------------------------------------------------------------
+  running_power:
+    cadence: workout_bound
+    interval_seconds: 30
+    min_value: 200
+    max_value: 400
+    workout_types: [running, trail_running, treadmill]
+
+  running_speed:
+    cadence: workout_bound
+    interval_seconds: 30
+    min_value: 2.0
+    max_value: 6.0
+    workout_types: [running, trail_running, treadmill]
+
+  cadence:
+    cadence: workout_bound
+    interval_seconds: 30
+    min_value: 60
+    max_value: 200
+    workout_types: [running, trail_running, treadmill, cycling, indoor_cycling, mountain_biking]
+
+  power:
+    cadence: workout_bound
+    interval_seconds: 30
+    min_value: 100
+    max_value: 300
+    workout_types: [cycling, indoor_cycling, mountain_biking]
+
+  swimming_stroke_count:
+    cadence: workout_bound
+    interval_seconds: 60
+    min_value: 5
+    max_value: 20
+    workout_types: [swimming, pool_swimming, open_water_swimming]

--- a/backend/tests/services/test_seed_data_service.py
+++ b/backend/tests/services/test_seed_data_service.py
@@ -1,13 +1,24 @@
 """Tests for the seed data generation service."""
 
+from datetime import date
+
 from sqlalchemy.orm import Session
 
-from app.models import EventRecord, PersonalRecord, User, UserConnection
-from app.schemas.enums import ProviderName, WorkoutType
+from app.models import (
+    DataPointSeries,
+    DataSource,
+    EventRecord,
+    PersonalRecord,
+    SeriesTypeDefinition,
+    User,
+    UserConnection,
+)
+from app.schemas.enums import ProviderName, SeriesType, WorkoutType
 from app.schemas.utils.seed_data import (
     SeedDataRequest,
     SeedProfileConfig,
     SleepConfig,
+    TimeSeriesConfig,
     WorkoutConfig,
 )
 from app.services.seed_data import seed_data_service
@@ -139,3 +150,137 @@ class TestSeedDataServiceGenerate:
         connections = db.query(UserConnection).all()
         provider_set = {c.provider for c in connections}
         assert provider_set == {"garmin", "polar"}
+
+
+def _samples_by_series(db: Session, series_type: SeriesType) -> list[DataPointSeries]:
+    return (
+        db.query(DataPointSeries)
+        .join(SeriesTypeDefinition, DataPointSeries.series_type_definition_id == SeriesTypeDefinition.id)
+        .filter(SeriesTypeDefinition.code == series_type.value)
+        .all()
+    )
+
+
+class TestContinuousTimeSeries:
+    """Continuous time-series generation runs independently of workouts."""
+
+    def test_continuous_series_emitted_without_workouts(self, db: Session) -> None:
+        """Time series should be produced even when no workouts are generated."""
+        request = SeedDataRequest(
+            num_users=1,
+            random_seed=42,
+            profile=SeedProfileConfig(
+                generate_workouts=False,
+                generate_sleep=False,
+                generate_time_series=True,
+                providers=[ProviderName.GARMIN],
+                num_connections=1,
+                time_series_config=TimeSeriesConfig(
+                    enabled_types=[SeriesType.heart_rate, SeriesType.resting_heart_rate],
+                    include_blood_pressure=False,
+                    date_from=date(2024, 11, 1),
+                    date_to=date(2024, 11, 3),
+                ),
+            ),
+        )
+
+        summary = seed_data_service.generate(db, request)
+
+        assert summary["workouts"] == 0
+        # heart_rate @ 5min for 3 days = plenty; resting_heart_rate = ~3 samples
+        hr = _samples_by_series(db, SeriesType.heart_rate)
+        rhr = _samples_by_series(db, SeriesType.resting_heart_rate)
+        assert len(hr) > 100, f"expected dense heart_rate samples, got {len(hr)}"
+        assert 1 <= len(rhr) <= 5, f"expected one RHR per day, got {len(rhr)}"
+
+    def test_blood_pressure_samples_are_paired(self, db: Session) -> None:
+        """Every systolic sample must share its recorded_at with a diastolic sample."""
+        request = SeedDataRequest(
+            num_users=1,
+            random_seed=7,
+            profile=SeedProfileConfig(
+                generate_workouts=False,
+                generate_sleep=False,
+                generate_time_series=True,
+                providers=[ProviderName.GARMIN],
+                num_connections=1,
+                time_series_config=TimeSeriesConfig(
+                    enabled_types=[],  # exclude other types
+                    include_blood_pressure=True,
+                    date_from=date(2024, 11, 1),
+                    date_to=date(2024, 11, 7),
+                ),
+            ),
+        )
+
+        seed_data_service.generate(db, request)
+
+        sys = _samples_by_series(db, SeriesType.blood_pressure_systolic)
+        dia = _samples_by_series(db, SeriesType.blood_pressure_diastolic)
+        assert len(sys) == len(dia) > 0
+        assert {s.recorded_at for s in sys} == {d.recorded_at for d in dia}
+
+    def test_per_user_provider_consistency(self, db: Session) -> None:
+        """All samples of a given series type for a user share the same provider."""
+        request = SeedDataRequest(
+            num_users=1,
+            random_seed=11,
+            profile=SeedProfileConfig(
+                generate_workouts=False,
+                generate_sleep=False,
+                generate_time_series=True,
+                providers=[ProviderName.GARMIN, ProviderName.OURA, ProviderName.WHOOP],
+                num_connections=3,
+                time_series_config=TimeSeriesConfig(
+                    enabled_types=[SeriesType.heart_rate, SeriesType.weight],
+                    include_blood_pressure=False,
+                    date_from=date(2024, 11, 1),
+                    date_to=date(2024, 11, 14),
+                ),
+            ),
+        )
+
+        seed_data_service.generate(db, request)
+
+        for series_type in (SeriesType.heart_rate, SeriesType.weight):
+            samples = _samples_by_series(db, series_type)
+            assert samples, f"no samples generated for {series_type}"
+            sources = (
+                db.query(DataSource.provider)
+                .filter(DataSource.id.in_({s.data_source_id for s in samples}))
+                .distinct()
+                .all()
+            )
+            assert len(sources) == 1, f"{series_type} used multiple providers: {sources}"
+
+    def test_workout_bound_series_filtered_by_workout_type(self, db: Session) -> None:
+        """running_power should only appear for running workouts, not cycling."""
+        request = SeedDataRequest(
+            num_users=1,
+            random_seed=99,
+            profile=SeedProfileConfig(
+                generate_workouts=True,
+                generate_sleep=False,
+                generate_time_series=True,
+                providers=[ProviderName.GARMIN],
+                num_connections=1,
+                workout_config=WorkoutConfig(
+                    count=4,
+                    workout_types=[WorkoutType.CYCLING],
+                    duration_min_minutes=10,
+                    duration_max_minutes=15,
+                ),
+                time_series_config=TimeSeriesConfig(
+                    enabled_types=[],  # disable continuous
+                    include_blood_pressure=False,
+                ),
+            ),
+        )
+
+        seed_data_service.generate(db, request)
+
+        running_power = _samples_by_series(db, SeriesType.running_power)
+        assert running_power == [], "running_power must not be emitted for cycling workouts"
+        # power is allowed for cycling and should be emitted
+        power = _samples_by_series(db, SeriesType.power)
+        assert power, "power should be emitted for cycling workouts"

--- a/frontend/src/lib/api/services/seed-data.service.ts
+++ b/frontend/src/lib/api/services/seed-data.service.ts
@@ -12,7 +12,14 @@ export interface WorkoutConfig {
   hr_min_range: [number, number];
   hr_max_range: [number, number];
   steps_range: [number, number];
-  time_series_chance_pct: number;
+  date_range_months: number;
+  date_from: string | null;
+  date_to: string | null;
+}
+
+export interface TimeSeriesConfig {
+  enabled_types: string[] | null;
+  include_blood_pressure: boolean;
   date_range_months: number;
   date_from: string | null;
   date_to: string | null;
@@ -53,6 +60,7 @@ export interface SeedProfileConfig {
   num_connections: number;
   workout_config: WorkoutConfig;
   sleep_config: SleepConfig;
+  time_series_config: TimeSeriesConfig;
 }
 
 export interface SeedDataRequest {

--- a/frontend/src/routes/_authenticated/settings/seed-data-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/seed-data-tab.tsx
@@ -60,7 +60,6 @@ const DEFAULT_PROFILE: SeedProfileConfig = {
     hr_min_range: [90, 120],
     hr_max_range: [140, 180],
     steps_range: [500, 20000],
-    time_series_chance_pct: 30,
     date_range_months: 6,
     date_from: DEFAULT_DATE_FROM,
     date_to: DEFAULT_DATE_TO,
@@ -81,7 +80,68 @@ const DEFAULT_PROFILE: SeedProfileConfig = {
       awake_pct_range: [2, 8],
     },
   },
+  time_series_config: {
+    enabled_types: [],
+    include_blood_pressure: false,
+    date_range_months: 6,
+    date_from: DEFAULT_DATE_FROM,
+    date_to: DEFAULT_DATE_TO,
+  },
 };
+
+// Curated list of the 20-30 most common continuous series types, grouped
+// semantically. Paired blood_pressure is rendered as a single toggle below.
+const CONTINUOUS_SERIES_GROUPS: {
+  label: string;
+  types: { id: string; label: string }[];
+}[] = [
+  {
+    label: 'Heart & cardiovascular',
+    types: [
+      { id: 'heart_rate', label: 'Heart rate' },
+      { id: 'resting_heart_rate', label: 'Resting heart rate' },
+      { id: 'heart_rate_variability_sdnn', label: 'HRV (SDNN)' },
+    ],
+  },
+  {
+    label: 'Blood & respiratory',
+    types: [
+      { id: 'respiratory_rate', label: 'Respiratory rate' },
+      { id: 'oxygen_saturation', label: 'Oxygen saturation' },
+      { id: 'blood_glucose', label: 'Blood glucose' },
+    ],
+  },
+  {
+    label: 'Body',
+    types: [
+      { id: 'weight', label: 'Weight' },
+      { id: 'body_fat_percentage', label: 'Body fat %' },
+      { id: 'body_temperature', label: 'Body temperature' },
+      { id: 'skin_temperature', label: 'Skin temperature' },
+      { id: 'vo2_max', label: 'VO₂ max' },
+    ],
+  },
+  {
+    label: 'Activity',
+    types: [
+      { id: 'steps', label: 'Steps' },
+      { id: 'energy', label: 'Energy burned' },
+      { id: 'basal_energy', label: 'Basal energy' },
+      { id: 'distance_walking_running', label: 'Distance (walk/run)' },
+      { id: 'flights_climbed', label: 'Flights climbed' },
+      { id: 'stand_time', label: 'Stand time' },
+      { id: 'exercise_time', label: 'Exercise time' },
+    ],
+  },
+  {
+    label: 'Environmental',
+    types: [
+      { id: 'time_in_daylight', label: 'Time in daylight' },
+      { id: 'environmental_audio_exposure', label: 'Environmental audio' },
+      { id: 'headphone_audio_exposure', label: 'Headphone audio' },
+    ],
+  },
+];
 
 const DEFAULT_STAGE_DISTRIBUTION: SleepStageDistribution = {
   deep_pct_range: [15, 25],
@@ -153,6 +213,13 @@ export function SeedDataTab() {
         stage_distribution:
           preset.profile.sleep_config.stage_distribution ??
           DEFAULT_STAGE_DISTRIBUTION,
+      },
+      time_series_config: {
+        ...(preset.profile.time_series_config ??
+          DEFAULT_PROFILE.time_series_config),
+        date_from:
+          preset.profile.time_series_config?.date_from ?? DEFAULT_DATE_FROM,
+        date_to: preset.profile.time_series_config?.date_to ?? DEFAULT_DATE_TO,
       },
     });
   };
@@ -873,7 +940,7 @@ export function SeedDataTab() {
 
       {/* Time Series */}
       <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl p-6">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-3">
             <Activity className="h-4 w-4 text-zinc-400" />
             <h3 className="text-sm font-medium text-white">Time Series</h3>
@@ -886,34 +953,161 @@ export function SeedDataTab() {
             }}
           />
         </div>
-        {profile.generate_time_series && profile.generate_workouts && (
-          <div className="mt-4">
-            <Label className="text-xs text-zinc-500">
-              Chance per workout (%)
-            </Label>
-            <Input
-              type="number"
-              min={0}
-              max={100}
-              value={profile.workout_config.time_series_chance_pct}
-              onChange={(e) => {
-                setProfile({
-                  ...profile,
-                  workout_config: {
-                    ...profile.workout_config,
-                    time_series_chance_pct: parseInt(e.target.value) || 0,
-                  },
-                });
-                clearPreset();
-              }}
-              className="mt-1 w-24"
-            />
+
+        {profile.generate_time_series && (
+          <div className="space-y-5">
+            <p className="text-xs text-zinc-500">
+              Continuous samples are emitted across the date range below,
+              independently of workouts. Workout-specific metrics (running
+              power, cadence, ...) still come from the workout generator.
+            </p>
+
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                <CalendarDays className="h-3.5 w-3.5 text-zinc-500" />
+                <Label className="text-xs text-zinc-500">Date range</Label>
+              </div>
+              <div className="grid grid-cols-2 gap-4">
+                <div>
+                  <Label className="text-xs text-zinc-600">From</Label>
+                  <Input
+                    type="date"
+                    value={profile.time_series_config.date_from ?? ''}
+                    onChange={(e) => {
+                      setProfile({
+                        ...profile,
+                        time_series_config: {
+                          ...profile.time_series_config,
+                          date_from: e.target.value || null,
+                        },
+                      });
+                      clearPreset();
+                    }}
+                    className="mt-1"
+                  />
+                </div>
+                <div>
+                  <Label className="text-xs text-zinc-600">To</Label>
+                  <Input
+                    type="date"
+                    value={profile.time_series_config.date_to ?? ''}
+                    onChange={(e) => {
+                      setProfile({
+                        ...profile,
+                        time_series_config: {
+                          ...profile.time_series_config,
+                          date_to: e.target.value || null,
+                        },
+                      });
+                      clearPreset();
+                    }}
+                    className="mt-1"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              {(() => {
+                const allTypeIds = CONTINUOUS_SERIES_GROUPS.flatMap((g) =>
+                  g.types.map((t) => t.id)
+                );
+                const enabled = profile.time_series_config.enabled_types;
+                const allEnabled =
+                  enabled !== null &&
+                  allTypeIds.every((id) => enabled.includes(id)) &&
+                  profile.time_series_config.include_blood_pressure;
+                return (
+                  <div className="flex items-center justify-between">
+                    <Label className="text-xs text-zinc-500">
+                      Series types
+                    </Label>
+                    <button
+                      onClick={() => {
+                        setProfile({
+                          ...profile,
+                          time_series_config: {
+                            ...profile.time_series_config,
+                            enabled_types: allEnabled ? [] : allTypeIds,
+                            include_blood_pressure: !allEnabled,
+                          },
+                        });
+                        clearPreset();
+                      }}
+                      className="text-xs text-zinc-500 hover:text-zinc-300"
+                    >
+                      {allEnabled ? 'Clear all' : 'Select all'}
+                    </button>
+                  </div>
+                );
+              })()}
+              {CONTINUOUS_SERIES_GROUPS.map((group) => (
+                <div key={group.label}>
+                  <div className="text-xs text-zinc-600 mb-1.5 uppercase tracking-wide">
+                    {group.label}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {group.types.map((type) => {
+                      const enabled =
+                        profile.time_series_config.enabled_types ?? [];
+                      const selected = enabled.includes(type.id);
+                      return (
+                        <button
+                          key={type.id}
+                          onClick={() => {
+                            const updated = selected
+                              ? enabled.filter((t) => t !== type.id)
+                              : [...enabled, type.id];
+                            setProfile({
+                              ...profile,
+                              time_series_config: {
+                                ...profile.time_series_config,
+                                enabled_types: updated,
+                              },
+                            });
+                            clearPreset();
+                          }}
+                          className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                            selected
+                              ? 'border-blue-500/50 bg-blue-500/15 text-blue-400'
+                              : 'border-zinc-700 text-zinc-400 hover:border-zinc-600'
+                          }`}
+                        >
+                          {type.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+
+              <div>
+                <div className="text-xs text-zinc-600 mb-1.5 uppercase tracking-wide">
+                  Paired
+                </div>
+                <button
+                  onClick={() => {
+                    setProfile({
+                      ...profile,
+                      time_series_config: {
+                        ...profile.time_series_config,
+                        include_blood_pressure:
+                          !profile.time_series_config.include_blood_pressure,
+                      },
+                    });
+                    clearPreset();
+                  }}
+                  className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                    profile.time_series_config.include_blood_pressure
+                      ? 'border-blue-500/50 bg-blue-500/15 text-blue-400'
+                      : 'border-zinc-700 text-zinc-400 hover:border-zinc-600'
+                  }`}
+                >
+                  Blood pressure (systolic + diastolic)
+                </button>
+              </div>
+            </div>
           </div>
-        )}
-        {profile.generate_time_series && !profile.generate_workouts && (
-          <p className="text-xs text-zinc-600 mt-3">
-            Time series data requires workouts to be enabled.
-          </p>
         )}
       </div>
 


### PR DESCRIPTION
## Description

Seed generator now emits realistic time-series samples across the full date range, not only inside workout windows. Each series type has its own cadence (intraday / daily / weekly / paired / workout_bound) declared in `series_type_config.yaml` with realistic min/max, so generated data actually looks like what a real wearable would send.

- Selectable series types in the seed dashboard with grouped checkboxes - pick exactly what you want (default: none selected)
- Blood pressure is emitted as paired systolic+diastolic at the same timestamp
- Workout-specific metrics (running_power, cadence, ...) stay in workout windows but now gate on workout type (e.g. running_power only for running)
- Each user gets a stable provider mapping so all samples of a given type come from the same provider/device
- Dropped the meaningless `time_series_chance_pct` field

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

- [x] `pnpm run format:check` passes
- [ ] `pnpm run lint` passes
- [ ] `pnpm run build` succeeds

## Testing Instructions

**Steps to test:**
1. Open the dashboard seed tab
2. Pick a couple of series types (e.g. Heart rate, Weight, Blood pressure)
3. Generate, then check the user - samples should span the whole date range, BP samples should come in systolic+diastolic pairs at the same timestamp
4. Try selecting no types and only Blood pressure - should generate only BP
5. Try a preset (e.g. Active Athlete) - should still work end-to-end

**Expected behavior:**
- Continuous types emitted across the configured date range independently of workouts
- Workout-bound types (running_power, cadence, power, swimming_stroke_count) only appear inside matching workouts
- All samples of a given series type for a user share the same provider

## Additional Notes

Future: add `valid_providers` whitelist to `series_type_config.yaml` for provider-specific metrics (e.g. `garmin_body_battery`). Skipped in this iteration since the top-25 types picked here are all cross-provider.