### PR TITLE
fix: seed time-series UX follow-ups

### DIFF
--- a/backend/app/schemas/utils/seed_data.py
+++ b/backend/app/schemas/utils/seed_data.py
@@ -162,7 +162,7 @@ class TimeSeriesConfig(BaseModel):
         ),
     )
     include_blood_pressure: bool = Field(
-        True,
+        False,
         description="Emit paired blood_pressure_systolic + blood_pressure_diastolic.",
     )
     date_range_months: int = Field(6, ge=1, le=24)

--- a/backend/app/schemas/utils/seed_data.py
+++ b/backend/app/schemas/utils/seed_data.py
@@ -223,6 +223,55 @@ class SeedPresetInfo(BaseModel):
 # Preset definitions
 # ---------------------------------------------------------------------------
 
+_ACTIVITY_CORE_TYPES = [
+    SeriesType.heart_rate,
+    SeriesType.steps,
+    SeriesType.energy,
+    SeriesType.basal_energy,
+    SeriesType.distance_walking_running,
+    SeriesType.flights_climbed,
+]
+
+_SLEEP_RECOVERY_TYPES = [
+    SeriesType.resting_heart_rate,
+    SeriesType.heart_rate_variability_sdnn,
+    SeriesType.oxygen_saturation,
+    SeriesType.skin_temperature,
+    SeriesType.respiratory_rate,
+]
+
+_BODY_COMPOSITION_TYPES = [
+    SeriesType.weight,
+    SeriesType.body_fat_percentage,
+    SeriesType.vo2_max,
+]
+
+_WORKOUT_BOUND_TYPES = [
+    SeriesType.running_power,
+    SeriesType.running_speed,
+    SeriesType.cadence,
+    SeriesType.power,
+    SeriesType.swimming_stroke_count,
+]
+
+_ALL_CONTINUOUS_TYPES = list(
+    dict.fromkeys(
+        _ACTIVITY_CORE_TYPES
+        + _SLEEP_RECOVERY_TYPES
+        + _BODY_COMPOSITION_TYPES
+        + [
+            SeriesType.body_temperature,
+            SeriesType.blood_glucose,
+            SeriesType.stand_time,
+            SeriesType.exercise_time,
+            SeriesType.time_in_daylight,
+            SeriesType.environmental_audio_exposure,
+            SeriesType.headphone_audio_exposure,
+        ]
+    )
+)
+
+
 SEED_PRESETS: dict[str, dict] = {
     "active_athlete": {
         "label": "Active Athlete",
@@ -247,6 +296,14 @@ SEED_PRESETS: dict[str, dict] = {
                 steps_range=(2000, 25_000),
             ),
             sleep_config=SleepConfig(count=30, stage_profile="athlete_recovery"),
+            time_series_config=TimeSeriesConfig(
+                enabled_types=[
+                    *_ACTIVITY_CORE_TYPES,
+                    *_SLEEP_RECOVERY_TYPES,
+                    *_BODY_COMPOSITION_TYPES,
+                    *_WORKOUT_BOUND_TYPES,
+                ],
+            ),
         ),
     },
     "boxer_footballer": {
@@ -270,6 +327,14 @@ SEED_PRESETS: dict[str, dict] = {
                 hr_min_range=(85, 115),
                 hr_max_range=(155, 190),
             ),
+            time_series_config=TimeSeriesConfig(
+                enabled_types=[
+                    *_ACTIVITY_CORE_TYPES,
+                    SeriesType.running_power,
+                    SeriesType.running_speed,
+                    SeriesType.cadence,
+                ],
+            ),
         ),
     },
     "sleep_deprived": {
@@ -288,6 +353,15 @@ SEED_PRESETS: dict[str, dict] = {
                 nap_chance_pct=5,
                 stage_profile="deep_deficit",
             ),
+            time_series_config=TimeSeriesConfig(
+                enabled_types=[
+                    SeriesType.heart_rate,
+                    SeriesType.steps,
+                    SeriesType.energy,
+                    *_SLEEP_RECOVERY_TYPES,
+                ],
+                include_blood_pressure=True,  # elevated BP correlates with poor sleep
+            ),
         ),
     },
     "weekend_catchup": {
@@ -304,6 +378,12 @@ SEED_PRESETS: dict[str, dict] = {
                 duration_min_minutes=240,
                 duration_max_minutes=360,
                 weekend_catchup=True,
+            ),
+            time_series_config=TimeSeriesConfig(
+                enabled_types=[
+                    *_ACTIVITY_CORE_TYPES,
+                    *_SLEEP_RECOVERY_TYPES,
+                ],
             ),
         ),
     },
@@ -323,6 +403,12 @@ SEED_PRESETS: dict[str, dict] = {
                 nap_chance_pct=20,
                 stage_profile="restless",
             ),
+            time_series_config=TimeSeriesConfig(
+                enabled_types=[
+                    SeriesType.heart_rate,
+                    *_SLEEP_RECOVERY_TYPES,
+                ],
+            ),
         ),
     },
     "activity_only": {
@@ -334,6 +420,12 @@ SEED_PRESETS: dict[str, dict] = {
             generate_sleep=False,
             generate_time_series=True,
             workout_config=WorkoutConfig(count=80),
+            time_series_config=TimeSeriesConfig(
+                enabled_types=[
+                    *_ACTIVITY_CORE_TYPES,
+                    *_WORKOUT_BOUND_TYPES,
+                ],
+            ),
         ),
     },
     "sleep_only": {
@@ -374,6 +466,10 @@ SEED_PRESETS: dict[str, dict] = {
                 duration_max_minutes=240,
             ),
             sleep_config=SleepConfig(count=60),
+            time_series_config=TimeSeriesConfig(
+                enabled_types=[*_ALL_CONTINUOUS_TYPES, *_WORKOUT_BOUND_TYPES],
+                include_blood_pressure=True,
+            ),
         ),
     },
 }

--- a/backend/app/schemas/utils/seed_data.py
+++ b/backend/app/schemas/utils/seed_data.py
@@ -153,12 +153,12 @@ class TimeSeriesConfig(BaseModel):
     windows and are not controlled by this config.
     """
 
-    enabled_types: list[SeriesType] | None = Field(
-        None,
+    enabled_types: list[SeriesType] = Field(
+        default_factory=list,
         description=(
-            "Specific series types to emit. None = emit every type defined in "
-            "series_type_config.yaml. Workout-bound types are never affected by "
-            "this list - they follow the workout generator."
+            "Specific series types to emit. Empty list = no continuous series "
+            "emitted. Workout-bound types are never affected by this list - "
+            "they follow the workout generator."
         ),
     )
     include_blood_pressure: bool = Field(

--- a/backend/app/services/seed_data/service.py
+++ b/backend/app/services/seed_data/service.py
@@ -162,11 +162,12 @@ class SeedDataService:
                     event_record_service.create_detail(db, detail)
                     summary["workouts"] += 1
 
-                    if profile.generate_time_series and record.type is not None:
+                    if profile.generate_time_series and record.type is not None and enabled_types:
                         samples = _generate_time_series_samples(
                             record.start_datetime,
                             record.end_datetime,
                             WorkoutType(record.type),
+                            enabled_types,
                             fake,
                             user_id=user.id,
                             source=record.source or "unknown",

--- a/backend/app/services/seed_data/service.py
+++ b/backend/app/services/seed_data/service.py
@@ -115,11 +115,7 @@ class SeedDataService:
             "health_scores": 0,
         }
 
-        enabled_types: set[SeriesType] | None = (
-            set(profile.time_series_config.enabled_types)
-            if profile.time_series_config.enabled_types is not None
-            else None
-        )
+        enabled_types: set[SeriesType] = set(profile.time_series_config.enabled_types)
 
         for user_num in range(1, request.num_users + 1):
             user = user_service.create(

--- a/backend/app/services/seed_data/support_generators.py
+++ b/backend/app/services/seed_data/support_generators.py
@@ -14,17 +14,19 @@ from app.schemas.model_crud.user_management import UserConnectionCreate
 from .constants import SEED_PROVIDERS, SERIES_TYPE_SPECS, Cadence
 
 
-def _workout_bound_types_for(workout_type: WorkoutType) -> list[SeriesType]:
-    """Return series types whose workout_types spec includes this workout type."""
+def _workout_bound_types_for(workout_type: WorkoutType, enabled_types: set[SeriesType]) -> list[SeriesType]:
+    """Return series types emitted during a workout of this type.
+
+    A type is included only if the user has opted in via ``enabled_types``.
+    ``heart_rate`` follows the same rule - no implicit fallback.
+    """
     matches: list[SeriesType] = []
     for series_type, spec in SERIES_TYPE_SPECS.items():
-        if spec.cadence is not Cadence.WORKOUT_BOUND:
+        if series_type not in enabled_types:
             continue
-        if workout_type in spec.workout_types:
+        is_workout_bound_match = spec.cadence is Cadence.WORKOUT_BOUND and workout_type in spec.workout_types
+        if is_workout_bound_match or series_type is SeriesType.heart_rate:
             matches.append(series_type)
-    # Heart rate is always included during workouts regardless of sport
-    if SeriesType.heart_rate in SERIES_TYPE_SPECS and SeriesType.heart_rate not in matches:
-        matches.append(SeriesType.heart_rate)
     return matches
 
 
@@ -32,6 +34,7 @@ def _generate_time_series_samples(
     workout_start: datetime,
     workout_end: datetime,
     workout_type: WorkoutType,
+    enabled_types: set[SeriesType],
     fake: Faker,
     *,
     user_id: UUID,
@@ -42,14 +45,13 @@ def _generate_time_series_samples(
 ) -> list[TimeSeriesSampleCreate]:
     """Generate time-series samples within a single workout window.
 
-    Samples are emitted for:
-    - ``heart_rate`` (every workout)
-    - any ``workout_bound`` series whose ``workout_types`` spec matches
+    Only types present in ``enabled_types`` are emitted. Workout-bound types
+    require the workout type to match their ``workout_types`` spec.
     """
     if not SERIES_TYPE_SPECS:
         return []
 
-    applicable = _workout_bound_types_for(workout_type)
+    applicable = _workout_bound_types_for(workout_type, enabled_types)
     if not applicable:
         return []
 

--- a/backend/app/services/seed_data/time_series_generators.py
+++ b/backend/app/services/seed_data/time_series_generators.py
@@ -192,23 +192,22 @@ def _generate_continuous_time_series(
     user_id: UUID,
     start: datetime,
     end: datetime,
-    enabled_types: set[SeriesType] | None,
+    enabled_types: set[SeriesType],
     include_blood_pressure: bool,
     provider_map: dict[SeriesType, ProviderDescriptor],
     fake: Faker,
 ) -> list[TimeSeriesSampleCreate]:
     """Generate continuous time-series samples across [start, end].
 
-    ``enabled_types=None`` emits every non-workout-bound type defined in the
-    YAML config. Workout-bound types are always skipped here (handled by the
-    workout generator).
+    Only types present in ``enabled_types`` are emitted. Workout-bound types
+    are skipped here (handled by the workout generator).
     """
     samples: list[TimeSeriesSampleCreate] = []
 
     for series_type, spec in SERIES_TYPE_SPECS.items():
         if spec.cadence is Cadence.WORKOUT_BOUND:
             continue
-        if enabled_types is not None and series_type not in enabled_types:
+        if series_type not in enabled_types:
             continue
         provider_desc = provider_map.get(series_type)
         if provider_desc is None:

--- a/backend/scripts/init/series_type_config.yaml
+++ b/backend/scripts/init/series_type_config.yaml
@@ -179,14 +179,24 @@ series_types:
     interval_seconds: 30
     min_value: 60
     max_value: 200
-    workout_types: [running, trail_running, treadmill, cycling, indoor_cycling, mountain_biking]
+    workout_types:
+      - running
+      - trail_running
+      - treadmill
+      - cycling
+      - indoor_cycling
+      - mountain_biking
+      - cyclocross
+      - e_biking
+      - rowing
+      - rowing_machine
 
   power:
     cadence: workout_bound
     interval_seconds: 30
     min_value: 100
     max_value: 300
-    workout_types: [cycling, indoor_cycling, mountain_biking]
+    workout_types: [cycling, indoor_cycling, mountain_biking, cyclocross, e_biking, rowing_machine]
 
   swimming_stroke_count:
     cadence: workout_bound

--- a/backend/tests/services/test_seed_data_service.py
+++ b/backend/tests/services/test_seed_data_service.py
@@ -271,7 +271,7 @@ class TestContinuousTimeSeries:
                     duration_max_minutes=15,
                 ),
                 time_series_config=TimeSeriesConfig(
-                    enabled_types=[],  # disable continuous
+                    enabled_types=[SeriesType.running_power, SeriesType.power],
                     include_blood_pressure=False,
                 ),
             ),
@@ -284,3 +284,26 @@ class TestContinuousTimeSeries:
         # power is allowed for cycling and should be emitted
         power = _samples_by_series(db, SeriesType.power)
         assert power, "power should be emitted for cycling workouts"
+
+    def test_no_samples_when_nothing_selected(self, db: Session) -> None:
+        """With empty enabled_types and BP off, zero time-series samples emit."""
+        request = SeedDataRequest(
+            num_users=1,
+            random_seed=5,
+            profile=SeedProfileConfig(
+                generate_workouts=True,
+                generate_sleep=False,
+                generate_time_series=True,
+                providers=[ProviderName.GARMIN],
+                num_connections=1,
+                workout_config=WorkoutConfig(count=3),
+                time_series_config=TimeSeriesConfig(
+                    enabled_types=[],
+                    include_blood_pressure=False,
+                ),
+            ),
+        )
+
+        summary = seed_data_service.generate(db, request)
+
+        assert summary["time_series_samples"] == 0

--- a/frontend/src/lib/api/services/seed-data.service.ts
+++ b/frontend/src/lib/api/services/seed-data.service.ts
@@ -18,7 +18,7 @@ export interface WorkoutConfig {
 }
 
 export interface TimeSeriesConfig {
-  enabled_types: string[] | null;
+  enabled_types: string[];
   include_blood_pressure: boolean;
   date_range_months: number;
   date_from: string | null;

--- a/frontend/src/routes/_authenticated/settings/seed-data-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/seed-data-tab.tsx
@@ -141,6 +141,16 @@ const CONTINUOUS_SERIES_GROUPS: {
       { id: 'headphone_audio_exposure', label: 'Headphone audio' },
     ],
   },
+  {
+    label: 'During workouts only',
+    types: [
+      { id: 'running_power', label: 'Running power' },
+      { id: 'running_speed', label: 'Running speed' },
+      { id: 'cadence', label: 'Cadence' },
+      { id: 'power', label: 'Power' },
+      { id: 'swimming_stroke_count', label: 'Swim stroke count' },
+    ],
+  },
 ];
 
 const DEFAULT_STAGE_DISTRIBUTION: SleepStageDistribution = {

--- a/frontend/src/routes/_authenticated/settings/seed-data-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/seed-data-tab.tsx
@@ -166,19 +166,124 @@ const STAGE_COLORS = {
   light: 'bg-zinc-600',
 } as const;
 
-// Common workout types displayed as checkboxes
-const COMMON_WORKOUT_TYPES = [
-  'running',
-  'cycling',
-  'swimming',
-  'strength_training',
-  'boxing',
-  'soccer',
-  'walking',
-  'hiking',
-  'yoga',
-  'rowing',
-] as const;
+// Workout types grouped for the seed form. Mirrors the categories in
+// backend/app/schemas/enums/workout_types.py (some niche types omitted).
+const WORKOUT_TYPE_GROUPS: { label: string; types: string[] }[] = [
+  {
+    label: 'Running & walking',
+    types: [
+      'running',
+      'trail_running',
+      'treadmill',
+      'walking',
+      'walking_fitness',
+      'hiking',
+      'trail_hiking',
+      'mountaineering',
+    ],
+  },
+  {
+    label: 'Cycling',
+    types: [
+      'cycling',
+      'indoor_cycling',
+      'mountain_biking',
+      'cyclocross',
+      'e_biking',
+    ],
+  },
+  {
+    label: 'Swimming & water',
+    types: [
+      'swimming',
+      'pool_swimming',
+      'open_water_swimming',
+      'rowing',
+      'kayaking',
+      'canoeing',
+      'paddling',
+      'stand_up_paddleboarding',
+      'surfing',
+    ],
+  },
+  {
+    label: 'Gym & fitness',
+    types: [
+      'strength_training',
+      'cardio_training',
+      'fitness_equipment',
+      'elliptical',
+      'rowing_machine',
+      'stair_climbing',
+    ],
+  },
+  {
+    label: 'Mind & body',
+    types: ['yoga', 'pilates', 'stretching', 'meditation'],
+  },
+  {
+    label: 'Winter',
+    types: [
+      'cross_country_skiing',
+      'alpine_skiing',
+      'backcountry_skiing',
+      'downhill_skiing',
+      'snowboarding',
+      'snowshoeing',
+      'ice_skating',
+    ],
+  },
+  {
+    label: 'Team sports',
+    types: [
+      'soccer',
+      'basketball',
+      'football',
+      'american_football',
+      'baseball',
+      'volleyball',
+      'handball',
+      'rugby',
+      'hockey',
+    ],
+  },
+  {
+    label: 'Racket sports',
+    types: [
+      'tennis',
+      'badminton',
+      'squash',
+      'table_tennis',
+      'padel',
+      'pickleball',
+    ],
+  },
+  {
+    label: 'Combat & climbing',
+    types: [
+      'boxing',
+      'martial_arts',
+      'wrestling',
+      'rock_climbing',
+      'indoor_climbing',
+      'bouldering',
+    ],
+  },
+  {
+    label: 'Multisport & other',
+    types: [
+      'triathlon',
+      'multisport',
+      'dance',
+      'aerobics',
+      'skating',
+      'inline_skating',
+      'skateboarding',
+      'horseback_riding',
+      'golf',
+    ],
+  },
+];
 
 const PROVIDERS = [
   { id: 'apple', label: 'Apple Health' },
@@ -600,28 +705,35 @@ export function SeedDataTab() {
               </div>
             </div>
 
-            <div>
-              <Label className="text-xs text-zinc-500 mb-2 block">
+            <div className="space-y-3">
+              <Label className="text-xs text-zinc-500 block">
                 Workout types{' '}
                 <span className="text-zinc-600">
                   (none selected = all types)
                 </span>
               </Label>
-              <div className="flex flex-wrap gap-2">
-                {COMMON_WORKOUT_TYPES.map((type) => (
-                  <button
-                    key={type}
-                    onClick={() => toggleWorkoutType(type)}
-                    className={`px-3 py-1 text-xs rounded-full border transition-colors ${
-                      selectedWorkoutTypes?.includes(type)
-                        ? 'border-blue-500/50 bg-blue-500/15 text-blue-400'
-                        : 'border-zinc-700 text-zinc-400 hover:border-zinc-600'
-                    }`}
-                  >
-                    {type.replace(/_/g, ' ')}
-                  </button>
-                ))}
-              </div>
+              {WORKOUT_TYPE_GROUPS.map((group) => (
+                <div key={group.label}>
+                  <div className="text-xs text-zinc-600 mb-1.5 uppercase tracking-wide">
+                    {group.label}
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {group.types.map((type) => (
+                      <button
+                        key={type}
+                        onClick={() => toggleWorkoutType(type)}
+                        className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                          selectedWorkoutTypes?.includes(type)
+                            ? 'border-blue-500/50 bg-blue-500/15 text-blue-400'
+                            : 'border-zinc-700 text-zinc-400 hover:border-zinc-600'
+                        }`}
+                      >
+                        {type.replace(/_/g, ' ')}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         )}

--- a/frontend/src/routes/_authenticated/settings/seed-data-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/seed-data-tab.tsx
@@ -1014,7 +1014,6 @@ export function SeedDataTab() {
                 );
                 const enabled = profile.time_series_config.enabled_types;
                 const allEnabled =
-                  enabled !== null &&
                   allTypeIds.every((id) => enabled.includes(id)) &&
                   profile.time_series_config.include_blood_pressure;
                 return (
@@ -1048,8 +1047,7 @@ export function SeedDataTab() {
                   </div>
                   <div className="flex flex-wrap gap-2">
                     {group.types.map((type) => {
-                      const enabled =
-                        profile.time_series_config.enabled_types ?? [];
+                      const enabled = profile.time_series_config.enabled_types;
                       const selected = enabled.includes(type.id);
                       return (
                         <button


### PR DESCRIPTION
## Description

Follow-up to #931 - fixes a few ways the seed generator still produced data the user didn't ask for, plus UX polish.

- Nothing-selected now really means nothing-generated. Previously `enabled_types=null` silently meant "emit all" on the backend while the UI rendered chips as unselected, and `include_blood_pressure` defaulted to True. Picking the Active Athlete preset without touching Time Series still produced ~40k samples.
- Workout-bound metrics and the implicit heart-rate fallback now also go through `enabled_types`, so they respect user selection too. Workout-bound types are exposed in the Time Series section as their own group.
- Presets ship with curated `enabled_types` so clicking one actually fills the chips.
- Workouts picker expanded to the full grouped catalog of `WorkoutType` (running, cycling, swimming, gym, winter, team/racket sports, combat, etc.).
- `cyclocross`, `e_biking`, `rowing`, `rowing_machine` added to workout-bound mappings in `series_type_config.yaml` where they belong.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

### Backend Changes

- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

- [x] `pnpm run format:check` passes

## Screenshoots 

<img width="906" height="823" alt="image" src="https://github.com/user-attachments/assets/30d9eb04-bbb2-463f-a7c4-7be00880edfc" />

https://github.com/user-attachments/assets/23722290-9a92-4586-a810-56574454ecf5

## Testing Instructions

**Steps to test:**
1. Turn everything off in Time Series and generate - expect zero samples, including no workout HR
2. Click any preset - chips should light up; generate, verify samples match
3. Pick only Blood pressure - only paired systolic+diastolic at identical timestamps
4. Pick Cycling workouts + Power/Cadence workout-bound - running_power stays empty, power is emitted
5. Expand Workouts picker - all categories (running, cycling, swimming, gym, winter, team/racket sports, combat, ...) visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "During workouts only" group for selecting workout-specific time-series metrics.
  * Expanded available workout types including cyclocross, e-biking, and rowing options.
  * Reorganized workout type selection with labeled categories for improved usability.

* **Improvements**
  * Updated default configurations for time-series data generation and collection preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->