### PR TITLE
fix: three startup crashes introduced in 0.4.3

### DIFF
--- a/backend/app/integrations/celery/tasks/garmin_webhook_task.py
+++ b/backend/app/integrations/celery/tasks/garmin_webhook_task.py
@@ -11,7 +11,6 @@ from logging import getLogger
 from typing import Any, cast
 
 from app.database import SessionLocal
-from app.services.providers.garmin.strategy import GarminStrategy
 from app.services.providers.garmin.webhook_handler import GarminWebhookHandler
 from app.utils.structured_logging import log_structured
 from celery import Task, shared_task
@@ -38,6 +37,7 @@ def process_push(self: Task, payload: dict[str, Any], request_trace_id: str) -> 
     """
     db = SessionLocal()
     try:
+        from app.services.providers.garmin.strategy import GarminStrategy  # deferred: breaks circular import
         strategy = GarminStrategy()
         handler = cast(GarminWebhookHandler, strategy.webhooks)
         return handler.process_payload(db, payload, request_trace_id)

--- a/backend/app/services/providers/garmin/strategy.py
+++ b/backend/app/services/providers/garmin/strategy.py
@@ -1,6 +1,5 @@
 from uuid import UUID
 
-from app.integrations.celery.tasks.garmin_backfill_task import start_full_backfill as start_garmin_full_backfill
 from app.services.providers.base_strategy import BaseProviderStrategy, HistoricalSyncResult, ProviderCapabilities
 from app.services.providers.garmin.data_247 import Garmin247Data
 from app.services.providers.garmin.oauth import GarminOAuth
@@ -65,6 +64,7 @@ class GarminStrategy(BaseProviderStrategy):
         The ``days`` parameter is ignored - Garmin limits historical access
         to 30 days before the user's consent date.
         """
+        from app.integrations.celery.tasks.garmin_backfill_task import start_full_backfill as start_garmin_full_backfill  # deferred: breaks circular import
         task = start_garmin_full_backfill.delay(str(user_id))
         return HistoricalSyncResult(
             task_id=task.id,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "pyyaml>=6.0.3",
     "svix>=1.90.0",
     "numpy>=2.4.4",
+    "faker>=33.1.0",
 ]
 
 [dependency-groups]
@@ -41,7 +42,6 @@ dev = [
     "pytest-cov>=6.2.1",
     "freezegun>=1.5.0",
     "factory-boy>=3.3.0",
-    "faker>=33.1.0",
     "psycopg-binary>=3.3.2",
     "ruff>=0.14.7",
     "testcontainers[postgres,redis]>=4.14.2",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.13"
 
 [options]
-exclude-newer = "2026-04-13T00:34:08.779168094Z"
+exclude-newer = "2026-04-17T07:29:58.545078Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -951,6 +951,7 @@ dependencies = [
     { name = "celery" },
     { name = "cryptography" },
     { name = "email-validator" },
+    { name = "faker" },
     { name = "fastapi" },
     { name = "fastapi-cli" },
     { name = "flower" },
@@ -978,7 +979,6 @@ code-quality = [
 ]
 dev = [
     { name = "factory-boy" },
-    { name = "faker" },
     { name = "freezegun" },
     { name = "psycopg-binary" },
     { name = "pytest" },
@@ -996,6 +996,7 @@ requires-dist = [
     { name = "celery", specifier = ">=5.5.3" },
     { name = "cryptography", specifier = ">=45.0.4" },
     { name = "email-validator", specifier = ">=2.2.0" },
+    { name = "faker", specifier = ">=33.1.0" },
     { name = "fastapi", specifier = ">=0.120.4" },
     { name = "fastapi-cli", specifier = ">=0.0.8" },
     { name = "flower", specifier = ">=2.0.1" },
@@ -1023,7 +1024,6 @@ code-quality = [
 ]
 dev = [
     { name = "factory-boy", specifier = ">=3.3.0" },
-    { name = "faker", specifier = ">=33.1.0" },
     { name = "freezegun", specifier = ">=1.5.0" },
     { name = "psycopg-binary", specifier = ">=3.3.2" },
     { name = "pytest", specifier = ">=8.4.1" },


### PR DESCRIPTION
## Summary

Three bugs introduced in 0.4.3 that prevent the server from starting in production (`uv sync --no-dev`):

- **Circular import #1** — `garmin_webhook_task.py` imports `GarminStrategy` at module level, which creates a cycle: `factory` → `garmin/strategy` → `celery/tasks/__init__` → `garmin_webhook_task` → `garmin/strategy`. Fixed by deferring the import inside the function body.

- **Circular import #2** — `garmin/strategy.py` imports `start_full_backfill` from `garmin_backfill_task` at module level, creating: `factory` → `garmin/strategy` → `celery/tasks/__init__` → `process_aws_upload_task` → `user_service` → `factory`. Fixed by deferring the import inside `start_historical_sync`.

- **Missing prod dependency** — `seed_data_service` and related modules import `faker`, but `faker` is declared as a dev-only dependency. Production Docker builds use `uv sync --no-dev`, causing `ModuleNotFoundError: No module named 'faker'` on startup. Fixed by moving `faker` to the main `dependencies` list.

## Test plan

- [ ] `python -c "from app.services.providers.factory import ProviderFactory"` exits with code 0
- [ ] `python -c "from app.main import app"` exits with code 0
- [ ] Docker build with `uv sync --no-dev` starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved module initialization and import management
  * Updated project dependencies to include the faker library as a runtime component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->