### PR TITLE
fix: save sleep efficiency correctly for Apple and Garmin

### DIFF
--- a/backend/app/services/apple/healthkit/sleep_service.py
+++ b/backend/app/services/apple/healthkit/sleep_service.py
@@ -485,6 +485,8 @@ def finish_sleep(db_session: DbSession, user_id: str, state: SleepState) -> None
     total_sleep_seconds = (
         metrics["sleeping_seconds"] + metrics["light_seconds"] + metrics["deep_seconds"] + metrics["rem_seconds"]
     )
+    time_in_bed_seconds = metrics["in_bed_seconds"]
+    sleep_efficiency = (total_sleep_seconds / time_in_bed_seconds) * 100 if time_in_bed_seconds > 0 else None
 
     sleep_record = EventRecordCreate(
         id=uuid4(),
@@ -505,12 +507,12 @@ def finish_sleep(db_session: DbSession, user_id: str, state: SleepState) -> None
     detail = EventRecordDetailCreate(
         record_id=sleep_record.id,
         sleep_total_duration_minutes=int(total_sleep_seconds // 60),
-        sleep_time_in_bed_minutes=int(metrics["in_bed_seconds"] // 60),
+        sleep_time_in_bed_minutes=int(time_in_bed_seconds // 60),
         sleep_deep_minutes=int(metrics["deep_seconds"] // 60),
         sleep_rem_minutes=int(metrics["rem_seconds"] // 60),
         sleep_light_minutes=int(metrics["light_seconds"] // 60),
         sleep_awake_minutes=int(metrics["awake_seconds"] // 60),
-        sleep_efficiency_score=None,  # TODO: Implement efficiency score
+        sleep_efficiency_score=sleep_efficiency,
         is_nap=False,  # TODO: Infer if nap, maybe from sleep length < 1 hour / 2 hours?
         sleep_stages=cleaned_stages or None,
     )

--- a/backend/app/services/apple/healthkit/sleep_service.py
+++ b/backend/app/services/apple/healthkit/sleep_service.py
@@ -486,7 +486,7 @@ def finish_sleep(db_session: DbSession, user_id: str, state: SleepState) -> None
     total_sleep_seconds = (
         metrics["sleeping_seconds"] + metrics["light_seconds"] + metrics["deep_seconds"] + metrics["rem_seconds"]
     )
-    time_in_bed_seconds = metrics["in_bed_seconds"]
+    time_in_bed_seconds = max(metrics["in_bed_seconds"], total_sleep_seconds + metrics["awake_seconds"])
     sleep_efficiency = (
         Decimal(str(total_sleep_seconds / time_in_bed_seconds * 100)) if time_in_bed_seconds > 0 else None
     )

--- a/backend/app/services/apple/healthkit/sleep_service.py
+++ b/backend/app/services/apple/healthkit/sleep_service.py
@@ -1,6 +1,7 @@
 import contextlib
 import json
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 from logging import getLogger
 from uuid import UUID, uuid4
 
@@ -486,7 +487,9 @@ def finish_sleep(db_session: DbSession, user_id: str, state: SleepState) -> None
         metrics["sleeping_seconds"] + metrics["light_seconds"] + metrics["deep_seconds"] + metrics["rem_seconds"]
     )
     time_in_bed_seconds = metrics["in_bed_seconds"]
-    sleep_efficiency = (total_sleep_seconds / time_in_bed_seconds) * 100 if time_in_bed_seconds > 0 else None
+    sleep_efficiency = (
+        Decimal(str(total_sleep_seconds / time_in_bed_seconds * 100)) if time_in_bed_seconds > 0 else None
+    )
 
     sleep_record = EventRecordCreate(
         id=uuid4(),

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -337,6 +337,7 @@ class Garmin247Data(Base247DataTemplate):
         detail = EventRecordDetailCreate(
             record_id=sleep_id,
             sleep_total_duration_minutes=asleep_seconds // 60,
+            sleep_time_in_bed_minutes=time_in_bed_seconds // 60,
             sleep_efficiency_score=efficiency_score,
             sleep_deep_minutes=stages.get("deep_seconds", 0) // 60,
             sleep_light_minutes=stages.get("light_seconds", 0) // 60,

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -331,12 +331,13 @@ class Garmin247Data(Base247DataTemplate):
 
         stages = normalized_sleep.get("stages", {})
         asleep_seconds = stages.get("deep_seconds", 0) + stages.get("light_seconds", 0) + stages.get("rem_seconds", 0)
+        time_in_bed_seconds = normalized_sleep.get("duration_seconds") or 0
+        efficiency_score = Decimal(str(asleep_seconds / time_in_bed_seconds * 100)) if time_in_bed_seconds > 0 else None
+
         detail = EventRecordDetailCreate(
             record_id=sleep_id,
             sleep_total_duration_minutes=asleep_seconds // 60,
-            sleep_efficiency_score=Decimal(str(normalized_sleep.get("sleep_score", 0)))
-            if normalized_sleep.get("sleep_score")
-            else None,
+            sleep_efficiency_score=efficiency_score,
             sleep_deep_minutes=stages.get("deep_seconds", 0) // 60,
             sleep_light_minutes=stages.get("light_seconds", 0) // 60,
             sleep_rem_minutes=stages.get("rem_seconds", 0) // 60,


### PR DESCRIPTION
## Description

correctly save sleep efficiency instead of None for Apple and sleep score for Garmin

Resolves #761

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sleep efficiency score is now calculated and stored for Apple HealthKit and Garmin sleep entries, expressed as a percentage of sleep time vs. time in bed.
  * Apple records now include a computed "time in bed" baseline when deriving sleep metrics.
  * Sleep records populate time-in-bed and total-sleep durations in minutes for clearer reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->