### PR TITLE
fix: pass effective start_date correctly for periodic sync task

### DIFF
--- a/backend/app/integrations/celery/tasks/sync_vendor_data_task.py
+++ b/backend/app/integrations/celery/tasks/sync_vendor_data_task.py
@@ -164,11 +164,10 @@ def sync_vendor_data(
 
                     # Sync 247 data (sleep, recovery, activity) and SAVE to database
                     if hasattr(strategy, "data_247") and strategy.data_247:
-                        # Determine if this is first sync (for API compatibility with providers)
-                        is_first_sync = connection.last_synced_at is None
-
-                        # effective_start is always set above; parse into datetime objects
+                        # On first sync pass None so providers use their own default lookback.
+                        # On subsequent syncs use last_synced_at (or explicit start_date arg).
                         start_dt = datetime.fromisoformat(effective_start.replace("Z", "+00:00"))
+
                         end_dt = datetime.now(timezone.utc)
                         if end_date:
                             with suppress(ValueError):
@@ -184,7 +183,6 @@ def sync_vendor_data(
                                     user_uuid,
                                     start_time=start_dt,
                                     end_time=end_dt,
-                                    is_first_sync=is_first_sync,
                                 )
                                 provider_result.params["data_247"] = {"success": True, "saved": True, **results_247}
                             else:

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -1851,7 +1851,6 @@ class Garmin247Data(Base247DataTemplate):
         user_id: UUID,
         start_time: datetime | str | None = None,
         end_time: datetime | str | None = None,
-        is_first_sync: bool = False,
     ) -> dict[str, Any]:
         """No-op: Garmin 247 data arrives via webhooks.
 
@@ -1863,7 +1862,6 @@ class Garmin247Data(Base247DataTemplate):
             user_id: User ID
             start_time: Unused (kept for interface compatibility)
             end_time: Unused (kept for interface compatibility)
-            is_first_sync: Unused (kept for interface compatibility)
 
         Returns:
             Dict indicating data arrives via webhooks

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -1108,7 +1108,6 @@ class Oura247Data(Base247DataTemplate):
         user_id: UUID,
         start_time: datetime | str | None = None,
         end_time: datetime | str | None = None,
-        is_first_sync: bool = False,
     ) -> dict[str, int]:
         """Load and save all 247 data types.
 
@@ -1117,7 +1116,6 @@ class Oura247Data(Base247DataTemplate):
             user_id: User UUID
             start_time: Start of date range (defaults to 30 days ago)
             end_time: End of date range (defaults to now)
-            is_first_sync: Whether this is the first sync (unused, for API compatibility)
         """
         if isinstance(start_time, str):
             start_time = datetime.fromisoformat(start_time.replace("Z", "+00:00"))

--- a/backend/app/services/providers/suunto/data_247.py
+++ b/backend/app/services/providers/suunto/data_247.py
@@ -671,7 +671,6 @@ class Suunto247Data(Base247DataTemplate):
         user_id: UUID,
         start_time: datetime | str | None = None,
         end_time: datetime | str | None = None,
-        is_first_sync: bool = False,
     ) -> dict[str, int]:
         """Load all 247 data types and save to database."""
         now = datetime.now(timezone.utc)

--- a/backend/app/services/providers/ultrahuman/data_247.py
+++ b/backend/app/services/providers/ultrahuman/data_247.py
@@ -434,7 +434,6 @@ class Ultrahuman247Data(Base247DataTemplate):
         user_id: UUID,
         start_time: datetime | str | None = None,
         end_time: datetime | str | None = None,
-        is_first_sync: bool = False,
     ) -> dict[str, Any]:
         """Load and save all 247 data types by fetching daily metrics.
 

--- a/backend/app/services/providers/whoop/data_247.py
+++ b/backend/app/services/providers/whoop/data_247.py
@@ -384,7 +384,6 @@ class Whoop247Data(Base247DataTemplate):
         user_id: UUID,
         start_time: datetime | str | None = None,
         end_time: datetime | str | None = None,
-        is_first_sync: bool = False,
     ) -> dict[str, int]:
         """Load and save all 247 data types (sleep, recovery, activity).
 
@@ -393,7 +392,6 @@ class Whoop247Data(Base247DataTemplate):
             user_id: User UUID
             start_time: Start of date range (defaults to 30 days ago)
             end_time: End of date range (defaults to now)
-            is_first_sync: Whether this is the first sync (unused, for API compatibility)
         """
         # Handle date defaults (last 30 days if not specified)
         if isinstance(start_time, str):


### PR DESCRIPTION
## Description

- pass effective start_date correctly for periodic sync task
- remove unused `is_first_sync` flag for `load_and_save_all_data` (not used anywhere)

Resolves #704 

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal data synchronization logic across health data providers by streamlining parameter handling in sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->