### PR TITLE
fix: add hrv rmssd to body summary

### DIFF
--- a/backend/app/schemas/responses/activity/summaries.py
+++ b/backend/app/schemas/responses/activity/summaries.py
@@ -105,6 +105,7 @@ class BodyAveraged(BaseModel):
     period_days: int = Field(..., description="Number of days averaged (1 or 7)", example=7)
     resting_heart_rate_bpm: int | None = Field(None, description="Average resting heart rate", example=62)
     avg_hrv_sdnn_ms: float | None = Field(None, description="Average HRV (SDNN)", example=45.2)
+    avg_hrv_rmssd_ms: float | None = Field(None, description="Average HRV (RMSSD)", example=42.0)
     period_start: datetime = Field(..., description="Start of averaging period")
     period_end: datetime = Field(..., description="End of averaging period")
 

--- a/backend/app/services/summaries_service.py
+++ b/backend/app/services/summaries_service.py
@@ -80,6 +80,7 @@ BODY_SLOW_CHANGING_SERIES = [
 BODY_AVERAGED_SERIES = [
     SeriesType.resting_heart_rate,
     SeriesType.heart_rate_variability_sdnn,
+    SeriesType.heart_rate_variability_rmssd,
 ]
 
 # Default settings for body summary
@@ -714,17 +715,19 @@ class SummariesService:
         )
 
         resting_hr_data = vitals_aggregates.get(SeriesType.resting_heart_rate)
-        hrv_data = vitals_aggregates.get(SeriesType.heart_rate_variability_sdnn)
+        hrv_sdnn_data = vitals_aggregates.get(SeriesType.heart_rate_variability_sdnn)
+        hrv_rmssd_data = vitals_aggregates.get(SeriesType.heart_rate_variability_rmssd)
 
         resting_hr_avg = resting_hr_data.get("avg") if resting_hr_data else None
         resting_hr = int(round(resting_hr_avg)) if resting_hr_avg else None
-        hrv_avg = hrv_data.get("avg") if hrv_data else None
-        avg_hrv = round(hrv_avg, 1) if hrv_avg else None
+        hrv_sdnn_avg = hrv_sdnn_data.get("avg") if hrv_sdnn_data else None
+        hrv_rmssd_avg = hrv_rmssd_data.get("avg") if hrv_rmssd_data  else None
 
         body_averaged = BodyAveraged(
             period_days=average_period_days,
             resting_heart_rate_bpm=resting_hr,
-            avg_hrv_sdnn_ms=avg_hrv,
+            avg_hrv_sdnn_ms=hrv_sdnn_avg,
+            avg_hrv_rmssd_ms=hrv_rmssd_avg,
             period_start=period_start,
             period_end=period_end,
         )
@@ -774,10 +777,10 @@ class SummariesService:
 
         # Check if we have any data at all
         has_slow_changing = any([weight_kg, height_cm, body_fat_pct, muscle_mass_kg])
-        has_averaged = any([resting_hr, avg_hrv])
+        has_averaged = any([resting_hr, hrv_sdnn_avg, hrv_rmssd_avg])
         has_latest = any([body_temp_celsius, skin_temp_celsius, blood_pressure])
 
-        if not has_slow_changing and not has_averaged and not has_latest:
+        if not (has_slow_changing or has_averaged or has_latest):
             return None
 
         body_latest = BodyLatest(

--- a/backend/app/services/summaries_service.py
+++ b/backend/app/services/summaries_service.py
@@ -720,8 +720,10 @@ class SummariesService:
 
         resting_hr_avg = resting_hr_data.get("avg") if resting_hr_data else None
         resting_hr = int(round(resting_hr_avg)) if resting_hr_avg else None
-        hrv_sdnn_avg = hrv_sdnn_data.get("avg") if hrv_sdnn_data else None
-        hrv_rmssd_avg = hrv_rmssd_data.get("avg") if hrv_rmssd_data  else None
+        hrv_sdnn_raw = hrv_sdnn_data.get("avg") if hrv_sdnn_data else None
+        hrv_sdnn_avg = round(hrv_sdnn_raw, 1) if hrv_sdnn_raw is not None else None
+        hrv_rmssd_raw = hrv_rmssd_data.get("avg") if hrv_rmssd_data else None
+        hrv_rmssd_avg = round(hrv_rmssd_raw, 1) if hrv_rmssd_raw is not None else None
 
         body_averaged = BodyAveraged(
             period_days=average_period_days,

--- a/docs/dev-guides/integration-guide.mdx
+++ b/docs/dev-guides/integration-guide.mdx
@@ -576,6 +576,7 @@ To page through results, pass `cursor=<next_cursor>` until `has_more` is `false`
         "period_days": 7,
         "resting_heart_rate_bpm": 62,
         "avg_hrv_sdnn_ms": 45.2,
+        "avg_hrv_rmssd_ms": 42.0,
         "period_start": "2025-01-08T00:00:00Z",
         "period_end": "2025-01-15T00:00:00Z"
       },

--- a/frontend/src/components/user/body-section.tsx
+++ b/frontend/src/components/user/body-section.tsx
@@ -157,6 +157,14 @@ export function BodySection({ userId }: BodySectionProps) {
   const latestData = bodySummary?.latest;
   const bmiCategory = getBmiCategory(slowChangingData?.bmi);
 
+  const hrvValue = averagedData?.avg_hrv_sdnn_ms ?? averagedData?.avg_hrv_rmssd_ms ?? null;
+  const hrvLabel =
+    averagedData?.avg_hrv_sdnn_ms != null
+      ? 'HRV SDNN (ms)'
+      : averagedData?.avg_hrv_rmssd_ms != null
+        ? 'HRV RMSSD (ms)'
+        : 'HRV (ms)';
+
   return (
     <div className="bg-zinc-900/50 border border-zinc-800 rounded-xl overflow-hidden">
       <div className="px-6 py-4 border-b border-zinc-800 flex items-center justify-between">
@@ -247,8 +255,8 @@ export function BodySection({ userId }: BodySectionProps) {
                   icon={Activity}
                   iconColor="text-indigo-400"
                   iconBgColor="bg-indigo-500/10"
-                  value={formatHrv(averagedData?.avg_hrv_sdnn_ms)}
-                  label="HRV (ms)"
+                  value={formatHrv(hrvValue)}
+                  label={hrvLabel}
                 />
               </div>
             </div>

--- a/frontend/src/components/user/body-section.tsx
+++ b/frontend/src/components/user/body-section.tsx
@@ -157,7 +157,8 @@ export function BodySection({ userId }: BodySectionProps) {
   const latestData = bodySummary?.latest;
   const bmiCategory = getBmiCategory(slowChangingData?.bmi);
 
-  const hrvValue = averagedData?.avg_hrv_sdnn_ms ?? averagedData?.avg_hrv_rmssd_ms ?? null;
+  const hrvValue =
+    averagedData?.avg_hrv_sdnn_ms ?? averagedData?.avg_hrv_rmssd_ms ?? null;
   const hrvLabel =
     averagedData?.avg_hrv_sdnn_ms != null
       ? 'HRV SDNN (ms)'

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -322,6 +322,7 @@ export interface BodyAveraged {
   period_days: number;
   resting_heart_rate_bpm: number | null;
   avg_hrv_sdnn_ms: number | null;
+  avg_hrv_rmssd_ms: number | null;
   period_start: string;
   period_end: string;
 }


### PR DESCRIPTION
## Description

Add RMSSD HRV to body summaries (now it only queries SDNN). Also, add it to frontend schema and display RMSSD as a fallback when SDNN data is null to keep it consistent with current state of frontedn.

Resolves #934 

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Heart rate variability tracking extended to include an additional averaged HRV metric (RMSSD) alongside the existing SDNN metric.
  * HRV vitals card now selects whichever averaged HRV metric is available and updates its label to indicate which measurement is shown.

* **Documentation**
  * API/guide examples updated to include the new averaged HRV metric in averaged body summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->