### PR TITLE
feat: delete workout/sleep endpoints + UI

### DIFF
--- a/backend/app/api/routes/v1/events.py
+++ b/backend/app/api/routes/v1/events.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query, status
 
 from app.database import DbSession
 from app.schemas.model_crud.activities import EventRecordQueryParams
@@ -57,3 +57,27 @@ def list_sleep_sessions(
         limit=limit,
     )
     return event_record_service.get_sleep_sessions(db, user_id, params)
+
+
+@router.delete("/users/{user_id}/events/workouts/{workout_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_workout(
+    user_id: UUID,
+    workout_id: UUID,
+    db: DbSession,
+    _api_key: ApiKeyDep,
+) -> None:
+    """Delete a workout session."""
+    if not event_record_service.delete_event_record(db, user_id, workout_id, "workout"):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workout not found")
+
+
+@router.delete("/users/{user_id}/events/sleep/{sleep_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_sleep_session(
+    user_id: UUID,
+    sleep_id: UUID,
+    db: DbSession,
+    _api_key: ApiKeyDep,
+) -> None:
+    """Delete a sleep session."""
+    if not event_record_service.delete_event_record(db, user_id, sleep_id, "sleep"):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sleep session not found")

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -779,5 +779,22 @@ class EventRecordService(
             ),
         )
 
+    def delete_event_record(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        record_id: UUID,
+        category: str,
+    ) -> bool:
+        """Delete an event record by id and category. Returns False if not found or not owned by user."""
+        record = self.crud.get_record_with_details(db_session, record_id, category)
+        if not record:
+            return False
+        data_source = self.data_source_repo.get(db_session, record.data_source_id)
+        if not data_source or data_source.user_id != user_id:
+            return False
+        self.crud.delete(db_session, record)
+        return True
+
 
 event_record_service = EventRecordService(log=getLogger(__name__))

--- a/backend/tests/api/v1/test_events_delete.py
+++ b/backend/tests/api/v1/test_events_delete.py
@@ -1,0 +1,183 @@
+"""
+Tests for event record DELETE endpoints.
+
+Tests the DELETE /api/v1/users/{user_id}/events/workouts/{id}
+and DELETE /api/v1/users/{user_id}/events/sleep/{id} endpoints including:
+- Successful deletion with cascade (details removed)
+- 404 for non-existent records
+- 404 for records belonging to another user
+- 404 for wrong category (e.g. deleting sleep via workouts endpoint)
+"""
+
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models import EventRecord, EventRecordDetail
+from tests.factories import (
+    ApiKeyFactory,
+    DataSourceFactory,
+    EventRecordFactory,
+    SleepDetailsFactory,
+    UserFactory,
+    WorkoutDetailsFactory,
+)
+from tests.utils import api_key_headers
+
+
+class TestDeleteWorkout:
+    """Test suite for DELETE /users/{user_id}/events/workouts/{workout_id}."""
+
+    def test_delete_workout_success(self, client: TestClient, db: Session) -> None:
+        user = UserFactory()
+        ds = DataSourceFactory(user=user)
+        workout = EventRecordFactory(mapping=ds, category="workout", type_="running")
+        WorkoutDetailsFactory(event_record=workout)
+        api_key = ApiKeyFactory()
+
+        response = client.delete(
+            f"/api/v1/users/{user.id}/events/workouts/{workout.id}",
+            headers=api_key_headers(api_key.id),
+        )
+
+        assert response.status_code == 204
+        assert db.get(EventRecord, workout.id) is None
+
+    def test_delete_workout_cascades_details(self, client: TestClient, db: Session) -> None:
+        user = UserFactory()
+        ds = DataSourceFactory(user=user)
+        workout = EventRecordFactory(mapping=ds, category="workout", type_="cycling")
+        detail = WorkoutDetailsFactory(event_record=workout)
+        detail_record_id = detail.record_id
+        api_key = ApiKeyFactory()
+
+        response = client.delete(
+            f"/api/v1/users/{user.id}/events/workouts/{workout.id}",
+            headers=api_key_headers(api_key.id),
+        )
+
+        assert response.status_code == 204
+        assert db.get(EventRecord, workout.id) is None
+        # Detail should be cascade-deleted
+        remaining = db.query(EventRecordDetail).filter(EventRecordDetail.record_id == detail_record_id).first()
+        assert remaining is None
+
+    def test_delete_workout_not_found(self, client: TestClient, db: Session) -> None:
+        user = UserFactory()
+        api_key = ApiKeyFactory()
+
+        response = client.delete(
+            f"/api/v1/users/{user.id}/events/workouts/{uuid4()}",
+            headers=api_key_headers(api_key.id),
+        )
+
+        assert response.status_code == 404
+
+    def test_delete_workout_wrong_user(self, client: TestClient, db: Session) -> None:
+        owner = UserFactory()
+        other_user = UserFactory()
+        ds = DataSourceFactory(user=owner)
+        workout = EventRecordFactory(mapping=ds, category="workout", type_="running")
+        api_key = ApiKeyFactory()
+
+        response = client.delete(
+            f"/api/v1/users/{other_user.id}/events/workouts/{workout.id}",
+            headers=api_key_headers(api_key.id),
+        )
+
+        assert response.status_code == 404
+        # Record should still exist
+        assert db.get(EventRecord, workout.id) is not None
+
+    def test_delete_workout_wrong_category(self, client: TestClient, db: Session) -> None:
+        """Deleting a sleep record via workouts endpoint should return 404."""
+        user = UserFactory()
+        ds = DataSourceFactory(user=user)
+        sleep = EventRecordFactory(mapping=ds, category="sleep", type="sleep")
+        api_key = ApiKeyFactory()
+
+        response = client.delete(
+            f"/api/v1/users/{user.id}/events/workouts/{sleep.id}",
+            headers=api_key_headers(api_key.id),
+        )
+
+        assert response.status_code == 404
+        assert db.get(EventRecord, sleep.id) is not None
+
+
+class TestDeleteSleepSession:
+    """Test suite for DELETE /users/{user_id}/events/sleep/{sleep_id}."""
+
+    def test_delete_sleep_success(self, client: TestClient, db: Session) -> None:
+        user = UserFactory()
+        ds = DataSourceFactory(user=user)
+        sleep = EventRecordFactory(mapping=ds, category="sleep", type="sleep")
+        SleepDetailsFactory(event_record=sleep)
+        api_key = ApiKeyFactory()
+
+        response = client.delete(
+            f"/api/v1/users/{user.id}/events/sleep/{sleep.id}",
+            headers=api_key_headers(api_key.id),
+        )
+
+        assert response.status_code == 204
+        assert db.get(EventRecord, sleep.id) is None
+
+    def test_delete_sleep_cascades_details(self, client: TestClient, db: Session) -> None:
+        user = UserFactory()
+        ds = DataSourceFactory(user=user)
+        sleep = EventRecordFactory(mapping=ds, category="sleep", type="sleep")
+        detail = SleepDetailsFactory(event_record=sleep)
+        detail_record_id = detail.record_id
+        api_key = ApiKeyFactory()
+
+        response = client.delete(
+            f"/api/v1/users/{user.id}/events/sleep/{sleep.id}",
+            headers=api_key_headers(api_key.id),
+        )
+
+        assert response.status_code == 204
+        remaining = db.query(EventRecordDetail).filter(EventRecordDetail.record_id == detail_record_id).first()
+        assert remaining is None
+
+    def test_delete_sleep_not_found(self, client: TestClient, db: Session) -> None:
+        user = UserFactory()
+        api_key = ApiKeyFactory()
+
+        response = client.delete(
+            f"/api/v1/users/{user.id}/events/sleep/{uuid4()}",
+            headers=api_key_headers(api_key.id),
+        )
+
+        assert response.status_code == 404
+
+    def test_delete_sleep_wrong_user(self, client: TestClient, db: Session) -> None:
+        owner = UserFactory()
+        other_user = UserFactory()
+        ds = DataSourceFactory(user=owner)
+        sleep = EventRecordFactory(mapping=ds, category="sleep", type="sleep")
+        api_key = ApiKeyFactory()
+
+        response = client.delete(
+            f"/api/v1/users/{other_user.id}/events/sleep/{sleep.id}",
+            headers=api_key_headers(api_key.id),
+        )
+
+        assert response.status_code == 404
+        assert db.get(EventRecord, sleep.id) is not None
+
+    def test_delete_sleep_wrong_category(self, client: TestClient, db: Session) -> None:
+        """Deleting a workout record via sleep endpoint should return 404."""
+        user = UserFactory()
+        ds = DataSourceFactory(user=user)
+        workout = EventRecordFactory(mapping=ds, category="workout", type_="running")
+        api_key = ApiKeyFactory()
+
+        response = client.delete(
+            f"/api/v1/users/{user.id}/events/sleep/{workout.id}",
+            headers=api_key_headers(api_key.id),
+        )
+
+        assert response.status_code == 404
+        assert db.get(EventRecord, workout.id) is not None

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -226,7 +226,9 @@
             "group": "Events",
             "pages": [
               "GET /api/v1/users/{user_id}/events/workouts",
-              "GET /api/v1/users/{user_id}/events/sleep"
+              "DELETE /api/v1/users/{user_id}/events/workouts/{workout_id}",
+              "GET /api/v1/users/{user_id}/events/sleep",
+              "DELETE /api/v1/users/{user_id}/events/sleep/{sleep_id}"
             ]
           },
           {

--- a/frontend/src/components/common/event-delete-dialog.tsx
+++ b/frontend/src/components/common/event-delete-dialog.tsx
@@ -1,0 +1,50 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+interface EventDeleteDialogProps {
+  open: boolean;
+  title: string;
+  description: string;
+  isPending: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export function EventDeleteDialog({
+  open,
+  title,
+  description,
+  isPending,
+  onClose,
+  onConfirm,
+}: EventDeleteDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-3">
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={isPending}
+            onClick={onConfirm}
+          >
+            {isPending ? 'Deleting...' : 'Delete'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/user/sleep-section.tsx
+++ b/frontend/src/components/user/sleep-section.tsx
@@ -16,11 +16,13 @@ import {
   BedDouble,
   ChevronDown,
   ChevronUp,
+  Trash2,
 } from 'lucide-react';
 import {
   useSleepSessions,
   useSleepSummaries,
   useTimeSeries,
+  useDeleteSleepSession,
 } from '@/hooks/api/use-health';
 import { useCursorPagination } from '@/hooks/use-cursor-pagination';
 import { useDateRange, useAllTimeRange } from '@/hooks/use-date-range';
@@ -61,6 +63,7 @@ import type {
   SleepStagesSummary,
   SleepSummary,
 } from '@/lib/api/types';
+import { EventDeleteDialog } from '@/components/common/event-delete-dialog';
 
 interface SleepSectionProps {
   userId: string;
@@ -170,6 +173,8 @@ function SleepSessionRow({
   userId: string;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [showDelete, setShowDelete] = useState(false);
+  const deleteSleep = useDeleteSleepSession(userId);
 
   // Fetch heart rate time series data when expanded
   const { data: hrData, isLoading: hrLoading } = useTimeSeries(userId, {
@@ -407,8 +412,32 @@ function SleepSessionRow({
               </div>
             </div>
           )}
+
+          {/* Delete button */}
+          <div className="flex justify-end pt-2 border-t border-zinc-800/50">
+            <button
+              onClick={() => setShowDelete(true)}
+              className="flex items-center gap-1.5 text-xs text-zinc-500 hover:text-red-400 transition-colors"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Delete sleep session
+            </button>
+          </div>
         </div>
       )}
+
+      <EventDeleteDialog
+        open={showDelete}
+        title="Delete sleep session?"
+        description="This sleep session and all associated data (stages, scores) will be permanently removed. This cannot be undone."
+        isPending={deleteSleep.isPending}
+        onClose={() => setShowDelete(false)}
+        onConfirm={() =>
+          deleteSleep.mutate(session.id, {
+            onSuccess: () => setShowDelete(false),
+          })
+        }
+      />
     </div>
   );
 }

--- a/frontend/src/components/user/workout-section.tsx
+++ b/frontend/src/components/user/workout-section.tsx
@@ -9,8 +9,13 @@ import {
   Heart,
   MoveHorizontal,
   Timer,
+  Trash2,
 } from 'lucide-react';
-import { useWorkouts, useTimeSeries } from '@/hooks/api/use-health';
+import {
+  useWorkouts,
+  useTimeSeries,
+  useDeleteWorkout,
+} from '@/hooks/api/use-health';
 import { useCursorPagination } from '@/hooks/use-cursor-pagination';
 import {
   useDateRangeDates,
@@ -36,6 +41,7 @@ import {
   dateToTimestamp,
 } from '@/lib/utils/workout';
 import type { EventRecordResponse } from '@/lib/api/types';
+import { EventDeleteDialog } from '@/components/common/event-delete-dialog';
 
 interface WorkoutSectionProps {
   userId: string;
@@ -52,6 +58,8 @@ function WorkoutRow({
   userId: string;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [showDelete, setShowDelete] = useState(false);
+  const deleteWorkout = useDeleteWorkout(userId);
   const style = getWorkoutStyle(workout.type || workout.category || '');
   const category = getWorkoutCategory(workout.type || workout.category || '');
 
@@ -263,8 +271,32 @@ function WorkoutRow({
               </div>
             </div>
           )}
+
+          {/* Delete button */}
+          <div className="flex justify-end pt-2 border-t border-zinc-800/50">
+            <button
+              onClick={() => setShowDelete(true)}
+              className="flex items-center gap-1.5 text-xs text-zinc-500 hover:text-red-400 transition-colors"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Delete workout
+            </button>
+          </div>
         </div>
       )}
+
+      <EventDeleteDialog
+        open={showDelete}
+        title="Delete workout?"
+        description="This workout and all associated data will be permanently removed. This cannot be undone."
+        isPending={deleteWorkout.isPending}
+        onClose={() => setShowDelete(false)}
+        onConfirm={() =>
+          deleteWorkout.mutate(workout.id, {
+            onSuccess: () => setShowDelete(false),
+          })
+        }
+      />
     </div>
   );
 }

--- a/frontend/src/hooks/api/use-health.ts
+++ b/frontend/src/hooks/api/use-health.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   healthService,
   type WorkoutsParams,
@@ -92,6 +92,60 @@ export function useSleepSummaries(userId: string, params: SummaryParams) {
     queryKey: queryKeys.health.sleepSummaries(userId, params),
     queryFn: () => healthService.getSleepSummaries(userId, params),
     enabled: !!userId && !!params.start_date && !!params.end_date,
+  });
+}
+
+/**
+ * Delete a workout event
+ */
+export function useDeleteWorkout(userId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (workoutId: string) =>
+      healthService.deleteWorkout(userId, workoutId),
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: [...queryKeys.health.all, 'workouts', userId],
+      });
+      qc.invalidateQueries({ queryKey: queryKeys.health.dataSummary(userId) });
+      toast.success('Workout deleted');
+    },
+    onError: (error: unknown) => {
+      const message =
+        error instanceof Error ? error.message : 'Failed to delete workout';
+      toast.error(message);
+    },
+  });
+}
+
+/**
+ * Delete a sleep session event
+ */
+export function useDeleteSleepSession(userId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (sessionId: string) =>
+      healthService.deleteSleepSession(userId, sessionId),
+    onSuccess: () => {
+      qc.invalidateQueries({
+        queryKey: [...queryKeys.health.all, 'sleepSessions', userId],
+      });
+      qc.invalidateQueries({ queryKey: queryKeys.health.dataSummary(userId) });
+      qc.invalidateQueries({
+        queryKey: [...queryKeys.health.all, 'sleepSummaries', userId],
+      });
+      qc.invalidateQueries({
+        queryKey: [...queryKeys.health.all, 'healthScores', userId],
+      });
+      toast.success('Sleep session deleted');
+    },
+    onError: (error: unknown) => {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Failed to delete sleep session';
+      toast.error(message);
+    },
   });
 }
 

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -101,7 +101,12 @@ export const apiClient = {
       let data: unknown;
       const contentType = response.headers.get('content-type');
 
-      if (contentType?.includes('application/json')) {
+      if (
+        response.status === 204 ||
+        response.headers.get('content-length') === '0'
+      ) {
+        data = undefined;
+      } else if (contentType?.includes('application/json')) {
         data = await response.json();
       } else {
         data = await response.text();

--- a/frontend/src/lib/api/config.ts
+++ b/frontend/src/lib/api/config.ts
@@ -23,6 +23,8 @@ export const API_ENDPOINTS = {
     `/api/v1/users/${userId}/connections/${provider}`,
   providerSetting: (provider: string) => `/api/v1/oauth/providers/${provider}`,
   userWorkouts: (userId: string) => `/api/v1/users/${userId}/events/workouts`,
+  userWorkoutDetail: (userId: string, workoutId: string) =>
+    `/api/v1/users/${userId}/events/workouts/${workoutId}`,
   userAppleXmlImport: (userId: string) =>
     `/api/v1/users/${userId}/import/apple/xml/direct`,
   userAppleXmlPresignedUrl: (userId: string) =>
@@ -87,6 +89,8 @@ export const API_ENDPOINTS = {
 
   // Sleep sessions endpoint
   userSleepSessions: (userId: string) => `/api/v1/users/${userId}/events/sleep`,
+  userSleepSessionDetail: (userId: string, sessionId: string) =>
+    `/api/v1/users/${userId}/events/sleep/${sessionId}`,
 
   // Health scores endpoint
   userHealthScores: (userId: string) => `/api/v1/users/${userId}/health-scores`,

--- a/frontend/src/lib/api/services/health.service.ts
+++ b/frontend/src/lib/api/services/health.service.ts
@@ -268,4 +268,22 @@ export const healthService = {
       API_ENDPOINTS.userDataSummary(userId)
     );
   },
+
+  /**
+   * Delete a workout event
+   */
+  async deleteWorkout(userId: string, workoutId: string): Promise<void> {
+    return apiClient.delete<void>(
+      API_ENDPOINTS.userWorkoutDetail(userId, workoutId)
+    );
+  },
+
+  /**
+   * Delete a sleep session event
+   */
+  async deleteSleepSession(userId: string, sessionId: string): Promise<void> {
+    return apiClient.delete<void>(
+      API_ENDPOINTS.userSleepSessionDetail(userId, sessionId)
+    );
+  },
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can delete individual workout and sleep session records from their profile with a confirmation dialog and pending state.

* **Bug Fixes**
  * Deletions now show clear success or error feedback; non‑existent or unauthorized deletes return a not‑found response.

* **Docs**
  * API reference updated to include the new delete endpoints.

* **Tests**
  * End‑to‑end tests added covering successful deletes, cascading detail removal, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->