### PR TITLE
fix(backend): hide non implemented webhooks in UI

### DIFF
--- a/backend/app/services/providers/fitbit/strategy.py
+++ b/backend/app/services/providers/fitbit/strategy.py
@@ -38,4 +38,5 @@ class FitbitStrategy(BaseProviderStrategy):
         # Fitbit Web API supports REST polling and a subscription-based webhook
         # system.  The webhook notification contains the user_id and collection
         # type; actual data must be fetched via the REST API.
-        return ProviderCapabilities(rest_pull=True, webhook_ping=True)
+        return ProviderCapabilities(rest_pull=True)  # use the line below wafter implementing webhooks
+        # return ProviderCapabilities(rest_pull=True, webhook_ping=True)

--- a/backend/app/services/providers/oura/strategy.py
+++ b/backend/app/services/providers/oura/strategy.py
@@ -49,4 +49,5 @@ class OuraStrategy(BaseProviderStrategy):
         # Oura REST API supports historical and recent data polling.
         # Oura webhooks send a lightweight notification (event_type + user_id)
         # when new data is ready; actual data must still be fetched via REST.
-        return ProviderCapabilities(rest_pull=True, webhook_ping=True)
+        return ProviderCapabilities(rest_pull=True)  # use the line below after implementing webhooks
+        # return ProviderCapabilities(rest_pull=True, webhook_ping=True)

--- a/backend/app/services/providers/polar/strategy.py
+++ b/backend/app/services/providers/polar/strategy.py
@@ -35,4 +35,5 @@ class PolarStrategy(BaseProviderStrategy):
         # Polar AccessLink 3.0 uses a transaction-based REST API for data pull
         # and supports a webhook feature that sends a notification when new data
         # is available.  Actual data is fetched via the transaction endpoints.
-        return ProviderCapabilities(rest_pull=True, webhook_ping=True)
+        return ProviderCapabilities(rest_pull=True)  # use the line below after implementing webhooks
+        # return ProviderCapabilities(rest_pull=True, webhook_ping=True)

--- a/backend/app/services/providers/strava/strategy.py
+++ b/backend/app/services/providers/strava/strategy.py
@@ -44,4 +44,5 @@ class StravaStrategy(BaseProviderStrategy):
         # Strava REST API is used for historical activity backfills.
         # Strava webhook events contain only the object_id and aspect_type;
         # the full activity must still be fetched via GET /activities/{id}.
-        return ProviderCapabilities(rest_pull=True, webhook_ping=True)
+        return ProviderCapabilities(rest_pull=True)  # use the line below after implementing webhooks
+        # return ProviderCapabilities(rest_pull=True, webhook_ping=True)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated Fitbit, Oura, Polar, and Strava integrations to use REST-based data synchronization only. Webhook-based notifications have been disabled across these providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->