### PR TITLE
fix(integrations): subscribe the Celery worker to the webhook_sync queue

### DIFF
--- a/backend/scripts/start/worker.sh
+++ b/backend/scripts/start/worker.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e -x
 
-uv run celery -A app.main:celery_app worker --loglevel=info --pool=threads -Q default,sdk_sync,garmin_sync
+uv run celery -A app.main:celery_app worker --loglevel=info --pool=threads -Q default,sdk_sync,garmin_sync,webhook_sync


### PR DESCRIPTION
## Summary

The Celery app declares four queues in `backend/app/integrations/celery/core.py`:

```python
task_queues={
    "default": {},
    "sdk_sync": {},
    "garmin_sync": {},
    "webhook_sync": {},
},
```

And the Suunto webhook handler explicitly dispatches push tasks to the fourth one:

```python
# backend/app/services/providers/suunto/webhook_handler.py:119
celery_app.send_task(
    _PROCESS_PUSH_TASK,
    args=["suunto", payload, request_trace_id],
    queue="webhook_sync",
)
```

But the worker startup script in `backend/scripts/start/worker.sh` only subscribes to `default,sdk_sync,garmin_sync`. Any task that lands on `webhook_sync` (currently all Suunto webhook pushes; presumably a forward-looking queue for other providers' push flows too) piles up in Redis without being consumed.

This PR adds `webhook_sync` to the worker's `-Q` list so the same worker that already handles the other three queues picks these up.

## Why no config change

`core.py` already defines the queue. This is purely a runtime-subscription gap in the worker script, not a declaration gap. No code path assumes a dedicated worker for `webhook_sync` (none of the deployment manifests scale that queue separately).

## Testing notes

Found this in production against `0.4.3` when a Suunto webhook payload hung in Redis `webhook_sync`; `celery inspect active_queues` confirmed the worker wasn't subscribed. After adding `webhook_sync` to `-Q`, the backlog drained on the next restart.

## Test plan

- [ ] `celery inspect active_queues` after worker restart lists all four queues
- [ ] Trigger a Suunto webhook push (or any `send_task(..., queue="webhook_sync")` dispatch) and confirm the task is consumed rather than accumulating in Redis
- [ ] Verify the three existing queues (`default`, `sdk_sync`, `garmin_sync`) continue to be drained as before — no regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved backend queue management to support webhook synchronization processing in the background worker infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->