### PR TITLE
refactor(frontend): provider live sync mode badges

### DIFF
--- a/frontend/src/components/settings/providers/provider-item.tsx
+++ b/frontend/src/components/settings/providers/provider-item.tsx
@@ -4,6 +4,7 @@ import { Switch } from '@/components/ui/switch';
 import { useState } from 'react';
 import { cn } from '@/lib/utils';
 import { useUpdateProviderLiveSyncMode } from '@/hooks/api/use-oauth-providers';
+import { Timer, Zap } from 'lucide-react';
 
 interface ProviderItemProps {
   provider: Provider;
@@ -22,9 +23,10 @@ export function ProviderItem({
     ? new URL(provider.icon_url, API_CONFIG.baseUrl).toString()
     : null;
 
-  const { mutate: updateLiveSyncMode } = useUpdateProviderLiveSyncMode(
-    provider.provider
-  );
+  const { mutate: updateLiveSyncMode, isPending } =
+    useUpdateProviderLiveSyncMode(provider.provider);
+
+  const currentMode = provider.live_sync_mode ?? 'pull';
 
   return (
     <div className="px-6 py-4 hover:bg-zinc-800/30 transition-colors">
@@ -48,7 +50,7 @@ export function ProviderItem({
           </div>
 
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 flex-wrap">
               <h4 className="text-sm font-medium text-white">
                 {provider.name}
               </h4>
@@ -63,35 +65,52 @@ export function ProviderItem({
               )}
             </div>
 
-            {provider.live_sync_configurable && (
-              <div className="flex items-center gap-2 mt-2">
-                <span className="text-xs text-zinc-500">Live sync</span>
-                <div
-                  role="group"
-                  aria-label="Live sync mode"
-                  className="flex items-center rounded-md bg-zinc-800 p-0.5"
-                >
-                  {(['pull', 'webhook'] as const).map((mode) => (
+            <div className="mt-2">
+              {provider.live_sync_configurable ? (
+                /* Segmented control for configurable providers */
+                <div className="inline-flex items-center gap-1 p-1 rounded-lg bg-zinc-900 border border-zinc-800">
+                  {(
+                    [
+                      { mode: 'pull', label: 'Periodic pull', Icon: Timer },
+                      { mode: 'webhook', label: 'Webhook', Icon: Zap },
+                    ] as const
+                  ).map(({ mode, label, Icon }) => (
                     <button
                       key={mode}
                       type="button"
-                      aria-pressed={
-                        (provider.live_sync_mode ?? 'pull') === mode
-                      }
+                      disabled={isPending}
                       onClick={() => updateLiveSyncMode(mode)}
                       className={cn(
-                        'px-2 py-0.5 text-xs rounded transition-colors',
-                        (provider.live_sync_mode ?? 'pull') === mode
-                          ? 'bg-zinc-600 text-white'
-                          : 'text-zinc-400 hover:text-zinc-300'
+                        'flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all duration-150',
+                        currentMode === mode && mode === 'webhook'
+                          ? 'bg-indigo-500/20 text-indigo-300 shadow-sm border border-indigo-500/30'
+                          : currentMode === mode && mode === 'pull'
+                            ? 'bg-zinc-700 text-zinc-100 shadow-sm border border-zinc-600'
+                            : 'text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800/60'
                       )}
                     >
-                      {mode === 'pull' ? 'Periodic pull' : 'Webhook'}
+                      <Icon className="h-3 w-3" />
+                      {label}
                     </button>
                   ))}
                 </div>
-              </div>
-            )}
+              ) : (
+                /* Static badge for non-configurable providers */
+                <div className="inline-flex items-center gap-1.5">
+                  {currentMode === 'webhook' ? (
+                    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium bg-indigo-500/10 text-indigo-400 border border-indigo-500/20">
+                      <Zap className="h-3 w-3" />
+                      Webhook only
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium bg-zinc-800 text-zinc-400 border border-zinc-700">
+                      <Timer className="h-3 w-3" />
+                      Periodic pull only
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
           </div>
         </div>
 

--- a/frontend/src/components/user/connection-card.tsx
+++ b/frontend/src/components/user/connection-card.tsx
@@ -8,10 +8,12 @@ import {
   Loader2,
   RefreshCw,
   RotateCcw,
+  Timer,
   TriangleAlert,
   Unlink,
   Watch,
   XCircle,
+  Zap,
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { UserConnection } from '@/lib/api/types';
@@ -179,6 +181,21 @@ export function ConnectionCard({ connection, className }: ConnectionCardProps) {
                     })
                   : 'Never'}
               </p>
+              {connection.live_sync_mode && (
+                <div className="mt-1.5">
+                  {connection.live_sync_mode === 'webhook' ? (
+                    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-indigo-500/10 text-indigo-400 border border-indigo-500/20">
+                      <Zap className="h-3 w-3" />
+                      Webhook
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-zinc-800 text-zinc-400 border border-zinc-700">
+                      <Timer className="h-3 w-3" />
+                      Periodic pull
+                    </span>
+                  )}
+                </div>
+              )}
             </div>
           </div>
           <div className="flex items-center gap-2">


### PR DESCRIPTION
<img width="509" height="597" alt="image" src="https://github.com/user-attachments/assets/e81686a1-9e99-4c99-8ab3-cae3bc6d5707" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicators to display active sync modes (Webhook or Periodic Pull) in connection cards and provider configuration screens.
  * Introduced icon-based segmented controls for managing sync mode preferences on configurable providers.
  * Non-configurable providers now display a static badge indicating their supported sync mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->