### PR TITLE
refactor(frontend): remove redundant webhook manage button

### DIFF
--- a/frontend/src/components/webhooks/webhooks-table.tsx
+++ b/frontend/src/components/webhooks/webhooks-table.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from '@tanstack/react-router';
-import { Trash2, Settings as SettingsIcon } from 'lucide-react';
+import { Trash2 } from 'lucide-react';
 
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -97,25 +97,15 @@ export function WebhooksTable({ data, onDelete }: WebhooksTableProps) {
                   className="text-right"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <div className="flex justify-end gap-1">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={goToDetail}
-                      title="Manage"
-                    >
-                      <SettingsIcon className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => onDelete(endpoint.id)}
-                      title="Delete"
-                      className="text-zinc-400 hover:text-red-400"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onDelete(endpoint.id)}
+                    title="Delete"
+                    className="text-zinc-400 hover:text-red-400"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
                 </TableCell>
               </TableRow>
             );


### PR DESCRIPTION
## Description

Removes the redundant settings (gear) icon button from the Webhooks table Actions column. Clicking the button navigated to the webhook detail page - the same behavior already provided by clicking anywhere on the row. The delete button remains as the only explicit action in the column, and row-click navigation is preserved.

Also removes the now-unnecessary div flex wrapper that previously grouped two buttons, and cleans up the unused Settings icon import.

## Checklist

### General

- [X ] My code follows the project's code style
- [X] I have performed a self-review of my code
- [NA] I have added tests that prove my fix/feature works (if applicable)
- [NA] New and existing tests pass locally
- [NA] I have updated relevant documentation in `docs/` (or no docs update needed)
 
### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [X] `pnpm run lint` passes
- [X] `pnpm run format:check` passes
- [X] `pnpm run build` succeeds

## Testing Instructions
1. Navigate to the Webhooks page
2. Verify the gear icon is no longer visible in the Actions column
3. Click anywhere on a webhook row and confirm navigation to the detail page works
4. Click the trash icon and confirm the delete action triggers correctly

**Expected behavior:**
Row click navigates to webhook detail. Trash icon deletes the webhook. No gear button visible.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the "Manage" action button from the webhooks table, streamlining the interface to display only the "Delete" option in the Actions column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->