### PR TITLE
docs: fix typo "envionment" in Makefile help text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help:	## Show this help.
 build:	## Builds docker image
 	$(DOCKER_COMMAND) build --no-cache
 
-run:	## Runs the envionment in detached mode
+run:	## Runs the environment in detached mode
 	$(DOCKER_COMMAND) up -d --force-recreate
 	$(DOCKER_COMMAND) rm -f db-svix-init
 


### PR DESCRIPTION
## Summary
- Fixes `envionment` -> `environment` in `make run` help text

Closes #966

## Test plan
- [x] `make help` shows corrected text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed a spelling error in the build help documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->