### PR TITLE
fix(backend): replace debug print() with structured logging in Whoop provider

### DIFF
--- a/backend/app/services/providers/whoop/data_247.py
+++ b/backend/app/services/providers/whoop/data_247.py
@@ -52,7 +52,14 @@ class Whoop247Data(Base247DataTemplate):
         headers: dict[str, str] | None = None,
     ) -> Any:
         """Make authenticated request to Whoop API."""
-        print(f"Making API request to {endpoint} with params: {params}")
+        log_structured(
+            self.logger,
+            "debug",
+            f"Making API request to {endpoint}",
+            provider="whoop",
+            endpoint=endpoint,
+            params=params,
+        )
         return make_authenticated_request(
             db=db,
             user_id=user_id,


### PR DESCRIPTION
## Summary
- Replaces stray `print()` in `Whoop247Data._make_api_request` with `log_structured(self.logger, "debug", ...)` matching the rest of the file
- Drops `params` dict from message body, attaches as structured field

Closes #968

## Test plan
- [ ] Whoop sync still runs end-to-end
- [ ] No `print` output to stdout from this method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal request logging infrastructure for data retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->