### PR TITLE
chore(backend): remove unused SERVER_HOST from .env.example

### DIFF
--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -3,7 +3,6 @@
 # Environment: local, test, staging, production
 ENVIRONMENT="local"
 CORS_ORIGINS=["http://localhost:3000"]
-SERVER_HOST="https://new_project_name.dev"
 
 # EMAIL SETTINGS (Resend)
 RESEND_API_KEY=your-resend-api-key


### PR DESCRIPTION
Removes the `SERVER_HOST="https://new_project_name.dev"` line from `backend/config/.env.example`. Variable referenced nowhere in code.

Closes #970

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Streamlined the environment configuration template by removing an outdated example configuration entry that is no longer needed. This housekeeping update keeps the setup documentation clean, current, and accurate, helping developers avoid potential confusion when configuring their local development environments or preparing the application for deployment to staging or production systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->