### PR TITLE
chore(backend): align Strava webhook verify token with other providers

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -142,7 +142,7 @@ class Settings(BaseSettings):
     strava_client_secret: SecretStr | None = None
     strava_redirect_uri: str | None = None  # Deprecated: use API_BASE_URL
     strava_default_scope: str = "activity:read_all,profile:read_all"
-    strava_webhook_verify_token: str = "open-wearables-strava-verify"
+    strava_webhook_verify_token: SecretStr | None = None
     # Strava API max is 200 activities per page
     strava_events_per_page: int = 200
 

--- a/backend/app/services/providers/strava/handlers/webhook_helpers.py
+++ b/backend/app/services/providers/strava/handlers/webhook_helpers.py
@@ -27,9 +27,7 @@ def handle_webhook_verification(
         raise HTTPException(status_code=400, detail="Invalid hub.mode")
 
     expected_token = (
-        settings.strava_webhook_verify_token.get_secret_value()
-        if settings.strava_webhook_verify_token
-        else None
+        settings.strava_webhook_verify_token.get_secret_value() if settings.strava_webhook_verify_token else None
     )
     if not expected_token or not hub_verify_token or not hmac.compare_digest(hub_verify_token, expected_token):
         log_structured(

--- a/backend/app/services/providers/strava/handlers/webhook_helpers.py
+++ b/backend/app/services/providers/strava/handlers/webhook_helpers.py
@@ -1,3 +1,4 @@
+import hmac
 from logging import getLogger
 from typing import Any
 from uuid import UUID
@@ -25,14 +26,18 @@ def handle_webhook_verification(
     if hub_mode != "subscribe":
         raise HTTPException(status_code=400, detail="Invalid hub.mode")
 
-    if hub_verify_token != settings.strava_webhook_verify_token:
+    expected_token = (
+        settings.strava_webhook_verify_token.get_secret_value()
+        if settings.strava_webhook_verify_token
+        else None
+    )
+    if not expected_token or not hub_verify_token or not hmac.compare_digest(hub_verify_token, expected_token):
         log_structured(
             logger,
             "warning",
             "Invalid verify token received",
             provider="strava",
             action="webhook_verification_failed",
-            verify_token=hub_verify_token,
         )
         raise HTTPException(status_code=403, detail="Invalid verify token")
 

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -103,7 +103,7 @@ OURA_WEBHOOK_VERIFICATION_TOKEN=your-webhook-verification-token
 STRAVA_CLIENT_ID=your-strava-client-id
 STRAVA_CLIENT_SECRET=your-strava-client-secret
 STRAVA_DEFAULT_SCOPE=activity:read_all,profile:read_all
-STRAVA_WEBHOOK_VERIFY_TOKEN=open-wearables-strava-verify
+STRAVA_WEBHOOK_VERIFY_TOKEN=your-strava-webhook-verify-token
 
 #--- Fitbit ---#
 FITBIT_CLIENT_ID=your-fitbit-client-id


### PR DESCRIPTION
Removes the public default for `strava_webhook_verify_token` so the Strava integration follows the same pattern as Oura and Suunto.

Changes:
- `config.py`: `strava_webhook_verify_token: SecretStr | None = None` (was `str = "open-wearables-strava-verify"`)
- `webhook_helpers.py`: unwrap secret, reject when unset, switch to `hmac.compare_digest` for timing-safe compare
- `.env.example`: placeholder value
- Drops the rejected token value from the failure log

Closes #976

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Strava webhook verification token is now optional and must be explicitly provided in configuration when using the Strava integration; example placeholder updated.

* **Security**
  * Stronger webhook verification: requests with missing/empty tokens are rejected, token comparisons use a secure constant-time method, and sensitive token values are no longer included in failure logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->