### PR TITLE
feat(frontend): add API key update functionality and UI support

### DIFF
--- a/frontend/src/hooks/api/use-credentials.ts
+++ b/frontend/src/hooks/api/use-credentials.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { credentialsService } from '@/lib/api/services/credentials.service';
-import type { ApiKeyCreate } from '@/lib/api/types';
+import type { ApiKeyCreate, ApiKeyUpdate } from '@/lib/api/types';
 import { queryKeys } from '@/lib/query/keys';
 import { toast } from 'sonner';
 import { getErrorMessage } from '@/lib/errors/handler';
@@ -19,6 +19,23 @@ export function useApiKey(id: string) {
     queryKey: queryKeys.credentials.detail(id),
     queryFn: () => credentialsService.getApiKey(id),
     enabled: !!id,
+  });
+}
+
+// Update API key (e.g. rename)
+export function useUpdateApiKey() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: ApiKeyUpdate }) =>
+      credentialsService.updateApiKey(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.credentials.list() });
+      toast.success('API key updated successfully');
+    },
+    onError: (error) => {
+      toast.error(`Failed to update API key: ${getErrorMessage(error)}`);
+    },
   });
 }
 

--- a/frontend/src/lib/api/services/credentials.service.ts
+++ b/frontend/src/lib/api/services/credentials.service.ts
@@ -1,6 +1,6 @@
 import { apiClient } from '../client';
 import { API_ENDPOINTS } from '../config';
-import type { ApiKey, ApiKeyCreate } from '../types';
+import type { ApiKey, ApiKeyCreate, ApiKeyUpdate } from '../types';
 
 export const credentialsService = {
   async getApiKeys(): Promise<ApiKey[]> {
@@ -13,6 +13,10 @@ export const credentialsService = {
 
   async createApiKey(data: ApiKeyCreate): Promise<ApiKey> {
     return apiClient.post<ApiKey>(API_ENDPOINTS.apiKeys, data);
+  },
+
+  async updateApiKey(id: string, data: ApiKeyUpdate): Promise<ApiKey> {
+    return apiClient.patch<ApiKey>(API_ENDPOINTS.apiKeyDetail(id), data);
   },
 
   async revokeApiKey(id: string): Promise<void> {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -424,6 +424,10 @@ export interface ApiKeyCreate {
   name: string;
 }
 
+export interface ApiKeyUpdate {
+  name?: string | null;
+}
+
 export interface Automation {
   id: string;
   name: string;

--- a/frontend/src/routes/_authenticated/settings/-credentials-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/-credentials-tab.tsx
@@ -31,9 +31,6 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 
-const editApiKeyButtonClassName =
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer border border-border/50 bg-background hover:bg-card hover:border-primary/50 hover:shadow-[0_0_10px_hsla(185,100%,50%,0.2)] h-10 w-10';
-
 export function CredentialsTab() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [visibleKeys, setVisibleKeys] = useState<Set<string>>(new Set());
@@ -242,14 +239,14 @@ export function CredentialsTab() {
                     </td>
                     <td className="px-6 py-4">
                       <div className="flex justify-end items-center gap-2">
-                        <button
-                          type="button"
-                          className={editApiKeyButtonClassName}
+                        <Button
+                          variant="outline"
+                          size="icon"
                           aria-label="Rename API key"
                           onClick={() => openRenameDialog(key)}
                         >
                           <Pencil className="h-4 w-4" aria-hidden />
-                        </button>
+                        </Button>
                         <Button
                           variant="destructive-outline"
                           size="icon"

--- a/frontend/src/routes/_authenticated/settings/-credentials-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/-credentials-tab.tsx
@@ -1,5 +1,14 @@
 import { useState } from 'react';
-import { Plus, Eye, EyeOff, Copy, Trash2, Key, Globe, Pencil } from 'lucide-react';
+import {
+  Plus,
+  Eye,
+  EyeOff,
+  Copy,
+  Trash2,
+  Key,
+  Globe,
+  Pencil,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import {
   useApiKeys,

--- a/frontend/src/routes/_authenticated/settings/-credentials-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/-credentials-tab.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
-import { Plus, Eye, EyeOff, Copy, Trash2, Key, Globe } from 'lucide-react';
+import { Plus, Eye, EyeOff, Copy, Trash2, Key, Globe, Pencil } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   useApiKeys,
   useCreateApiKey,
   useDeleteApiKey,
+  useUpdateApiKey,
 } from '@/hooks/api/use-credentials';
+import type { ApiKey } from '@/lib/api/types';
 import { copyToClipboard } from '@/lib/utils/clipboard';
 import { API_CONFIG } from '@/lib/api/config';
 import { Button } from '@/components/ui/button';
@@ -20,14 +22,20 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 
+const editApiKeyButtonClassName =
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 cursor-pointer border border-border/50 bg-background hover:bg-card hover:border-primary/50 hover:shadow-[0_0_10px_hsla(185,100%,50%,0.2)] h-10 w-10';
+
 export function CredentialsTab() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [visibleKeys, setVisibleKeys] = useState<Set<string>>(new Set());
   const [keyName, setKeyName] = useState('');
+  const [editingKey, setEditingKey] = useState<ApiKey | null>(null);
+  const [renameKeyName, setRenameKeyName] = useState('');
 
   const { data: apiKeys, isLoading, error, refetch } = useApiKeys();
   const createMutation = useCreateApiKey();
   const deleteMutation = useDeleteApiKey();
+  const updateMutation = useUpdateApiKey();
 
   const handleCreate = async () => {
     if (!keyName.trim()) {
@@ -50,6 +58,26 @@ export function CredentialsTab() {
     ) {
       await deleteMutation.mutateAsync(id);
     }
+  };
+
+  const openRenameDialog = (key: ApiKey) => {
+    setEditingKey(key);
+    setRenameKeyName(key.name);
+  };
+
+  const handleRenameSubmit = async () => {
+    if (!editingKey) return;
+    if (!renameKeyName.trim()) {
+      toast.error('Please enter a key name');
+      return;
+    }
+
+    await updateMutation.mutateAsync({
+      id: editingKey.id,
+      data: { name: renameKeyName.trim() },
+    });
+    setEditingKey(null);
+    setRenameKeyName('');
   };
 
   const toggleKeyVisibility = (id: string) => {
@@ -204,12 +232,21 @@ export function CredentialsTab() {
                       {formatDate(key.created_at)}
                     </td>
                     <td className="px-6 py-4">
-                      <div className="flex justify-end">
+                      <div className="flex justify-end items-center gap-2">
+                        <button
+                          type="button"
+                          className={editApiKeyButtonClassName}
+                          aria-label="Rename API key"
+                          onClick={() => openRenameDialog(key)}
+                        >
+                          <Pencil className="h-4 w-4" aria-hidden />
+                        </button>
                         <Button
                           variant="destructive-outline"
-                          size="icon-sm"
+                          size="icon"
                           onClick={() => handleDelete(key.id)}
                           disabled={deleteMutation.isPending}
+                          aria-label="Delete API key"
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>
@@ -237,6 +274,60 @@ export function CredentialsTab() {
           </div>
         )}
       </div>
+
+      {/* Rename API key */}
+      <Dialog
+        open={editingKey !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditingKey(null);
+            setRenameKeyName('');
+          }
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Rename API Key</DialogTitle>
+            <DialogDescription>
+              Update the display name for this API key
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5">
+            <Label htmlFor="rename_key_name" className="text-zinc-300">
+              Key Name
+            </Label>
+            <Input
+              id="rename_key_name"
+              type="text"
+              placeholder="e.g., Production API Key"
+              value={renameKeyName}
+              onChange={(e) => setRenameKeyName(e.target.value)}
+              className="bg-zinc-800 border-zinc-700"
+            />
+            <p className="text-[10px] text-zinc-600">
+              A descriptive name to identify this key
+            </p>
+          </div>
+          <DialogFooter className="gap-3">
+            <Button
+              variant="outline"
+              onClick={() => {
+                setEditingKey(null);
+                setRenameKeyName('');
+              }}
+              disabled={updateMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleRenameSubmit}
+              disabled={updateMutation.isPending}
+            >
+              {updateMutation.isPending ? 'Saving...' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Create Dialog */}
       <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>


### PR DESCRIPTION
- Introduced `useUpdateApiKey` hook for updating API keys.
- Added `ApiKeyUpdate` type definition for API key updates.
- Implemented rename functionality in the CredentialsTab component, including a dialog for user input.
- Enhanced UI with a pencil icon for renaming API keys and integrated toast notifications for success and error handling.

## Description

The feature adds the edit button for the API Keys, so the user can rename the existing API key.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

No backend changes.

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

## Testing Instructions

**Steps to test:**
1. Go to the Settings -> Credentials
2. Click the 'Edit' button
3. In the popup type the new name
4. Hit 'Save Changes' to update

**Expected behavior:**
The API keys have a new name.


## Screenshots
<img width="3018" height="1462" alt="CleanShot 2026-04-27 at 17 45 11@2x" src="https://github.com/user-attachments/assets/369a99dc-1868-4c3e-90dc-c188c305f896" />

<img width="3016" height="1466" alt="CleanShot 2026-04-27 at 17 45 28@2x" src="https://github.com/user-attachments/assets/ca587820-d714-4690-8c60-4b9aeda0db28" />

<img width="3012" height="1462" alt="CleanShot 2026-04-27 at 17 45 36@2x" src="https://github.com/user-attachments/assets/9818eb0e-878f-44a0-a069-fbc452b2874e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rename API keys from the credentials settings via a new dialog with inline action button.
* **Improvements**
  * Client-side validation prevents empty names; Save/Cancel are disabled while update is processing.
  * Users receive success/error toast notifications after rename attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->