### PR TITLE
fix(backend): correct peak_expiratory_flow_rate unit to L/min

### DIFF
--- a/backend/app/schemas/enums/series_types.py
+++ b/backend/app/schemas/enums/series_types.py
@@ -193,7 +193,7 @@ SERIES_TYPE_DEFINITIONS: list[tuple[int, SeriesType, str]] = [
     (27, SeriesType.peripheral_perfusion_index, "score"),
     (28, SeriesType.forced_vital_capacity, "liters"),
     (29, SeriesType.forced_expiratory_volume_1, "liters"),
-    (30, SeriesType.peak_expiratory_flow_rate, "liters"),
+    (30, SeriesType.peak_expiratory_flow_rate, "L/min"),
     (31, SeriesType.breathing_disturbance_index, "score"),
     # -------------------------------------------------------------------------
     # BIOMETRICS - Body Composition (IDs 40-59)

--- a/docs/architecture/data-types.mdx
+++ b/docs/architecture/data-types.mdx
@@ -48,7 +48,7 @@ The `types` parameter in the timeseries endpoint accepts the following values:
 | `peripheral_perfusion_index` | score | Peripheral perfusion index |
 | `forced_vital_capacity` | liters | Forced vital capacity |
 | `forced_expiratory_volume_1` | liters | Forced expiratory volume (1s) |
-| `peak_expiratory_flow_rate` | liters | Peak expiratory flow rate |
+| `peak_expiratory_flow_rate` | L/min | Peak expiratory flow rate |
 
 ### Body Composition
 


### PR DESCRIPTION
## Description

The `peak_expiratory_flow_rate` series type was labeled with the unit `liters`, but PEFR is a flow measurement and sources like Apple HealthKit emits samples in `L/min` - which is what we've been storing all along. This fixes the unit string in both the schema source-of-truth and the docs so API/webhook consumers see the correct label. Closes #549.

No data migration needed: numeric values are unchanged, and `seed_series_types.py` will update the `series_type_definition.unit` row automatically on next deploy.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. Pull the branch and run `seed_series_types.py` against a DB that already has the `peak_expiratory_flow_rate` row - confirm it updates the unit from `liters` to `L/min`.
2. Hit `/timeseries` for a user with PEFR samples and confirm the response now returns `"unit": "L/min"`.

**Expected behavior:**
PEFR samples are returned with `unit: "L/min"` in API responses and webhook payloads. Numeric values are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the measurement unit for peak expiratory flow rate from "liters" to "L/min" to ensure accurate display of respiratory measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->