### PR TITLE
fix(worker): cache last_synced_at before workouts commit to avoid exp…

### DIFF
--- a/backend/app/integrations/celery/tasks/sync_vendor_data_task.py
+++ b/backend/app/integrations/celery/tasks/sync_vendor_data_task.py
@@ -150,11 +150,16 @@ def sync_vendor_data(
                     strategy = factory.get_provider(provider_name)
                     provider_result = ProviderSyncResult(success=True, params={})
 
+                    # Read before any DB writes: workouts.load_data commits the session,
+                    # expiring all ORM objects. Accessing this after commit triggers a
+                    # failed lazy-load on an already-committed session.
+                    last_synced_at = connection.last_synced_at
+
                     # Resolve effective start: explicit arg > last_synced_at > now
                     # This ensures live syncs never re-pull history.
                     effective_start = start_date
                     if effective_start is None:
-                        last = connection.last_synced_at
+                        last = last_synced_at
                         if last is not None:
                             if last.tzinfo is None:
                                 last = last.replace(tzinfo=timezone.utc)
@@ -194,7 +199,7 @@ def sync_vendor_data(
                     # Sync 247 data (sleep, recovery, activity) and SAVE to database
                     if hasattr(strategy, "data_247") and strategy.data_247:
                         # Determine if this is first sync (for API compatibility with providers)
-                        is_first_sync = connection.last_synced_at is None
+                        is_first_sync = last_synced_at is None
 
                         # effective_start is always set above; parse into datetime objects
                         start_dt = datetime.fromisoformat(effective_start.replace("Z", "+00:00"))


### PR DESCRIPTION
…ired-session lazy-load

workouts.load_data commits the SQLAlchemy session (explicit db.commit after bulk_create of strain health scores), which expires all ORM objects. Accessing connection.last_synced_at after that triggers a lazy-load on an already-committed session, raising InvalidRequestError. Cache the value at the top of the loop body before any DB writes.

## Description

<!-- Provide a brief summary of your changes. What problem does this solve? -->

## Checklist

### General

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [ ] `pnpm run lint` passes
- [ ] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds

## Testing Instructions

<!-- Describe how reviewers can test your changes -->

**Steps to test:**
1.
2.
3.

**Expected behavior:**



## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->



## Additional Notes

<!-- Any additional context or information reviewers should know -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a stability issue in the vendor data synchronization process to ensure more reliable data syncing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->