### PR TITLE
fix(oura): pad get_sleep_data end_date by 1 day so narrow live-sync windows return today's sleep

### DIFF
--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -505,10 +505,39 @@ class Oura247Data(Base247DataTemplate):
         start_time: datetime,
         end_time: datetime,
     ) -> list[dict[str, Any]]:
-        """Fetch sleep data from Oura API."""
+        """Fetch sleep data from Oura API.
+
+        Pads the ``[start_date, end_date]`` window by one day on each
+        side before serialization.  Oura's ``/v2/usercollection/sleep``
+        filters sessions by their ``day`` field with
+        ``start_date < day <= end_date`` semantics — the start is
+        exclusive — so a narrow request whose ``start_date`` falls on
+        the same calendar day as the target session returns ``[]``
+        even though that session exists in their database.
+
+        Empirically (verified against a live Oura account whose
+        ``day=2026-05-06`` session was visible in the dashboard):
+
+        ===============================  ==============
+        ``?start_date=…&end_date=…``     items returned
+        ===============================  ==============
+        ``05-06`` … ``05-06``            0
+        ``05-06`` … ``05-07``            0
+        ``05-06`` … ``05-08``            0
+        ``05-05`` … ``05-06``            1  ← day=05-06
+        ``05-05`` … ``05-07``            1
+        ``05-04`` … ``05-07``            2
+        ===============================  ==============
+
+        Without padding, live periodic syncs (where the natural
+        ``[start, end]`` window collapses to minutes inside the same
+        calendar day after the first cycle) silently miss today's
+        sleep.  ``save_sleep_data`` is idempotent on ``external_id``
+        so the over-fetch at both boundaries is safe.
+        """
         params = {
-            "start_date": start_time.strftime("%Y-%m-%d"),
-            "end_date": end_time.strftime("%Y-%m-%d"),
+            "start_date": (start_time - timedelta(days=1)).strftime("%Y-%m-%d"),
+            "end_date": (end_time + timedelta(days=1)).strftime("%Y-%m-%d"),
         }
         return self._paginate(db, user_id, "/v2/usercollection/sleep", params)
 


### PR DESCRIPTION
## Summary

`Oura247Data.get_sleep_data` (`backend/app/services/providers/oura/data_247.py`) currently passes `start_time`/`end_time` straight to Oura's `/v2/usercollection/sleep`. That endpoint filters sessions by their `day` field with `start_date < day <= end_date` semantics — the start is **exclusive** — so a request whose `start_date` falls on the same calendar day as the target session returns `[]` even when the session exists in Oura's database. Live periodic syncs collapse the natural `[last_synced_at, now()]` window to minutes inside the same calendar day after the first cycle, and today's sleep silently never reaches the database.

This PR pads the window by one day on each side so the request always covers the target `day` correctly.

## Repro (live Oura account, session with `day=2026-05-06`)

```
GET /v2/usercollection/sleep?start_date=2026-05-06&end_date=2026-05-06   → 0 items
GET /v2/usercollection/sleep?start_date=2026-05-06&end_date=2026-05-07   → 0 items
GET /v2/usercollection/sleep?start_date=2026-05-06&end_date=2026-05-08   → 0 items
GET /v2/usercollection/sleep?start_date=2026-05-05&end_date=2026-05-06   → 1 item, day=2026-05-06   ← start exclusive
GET /v2/usercollection/sleep?start_date=2026-05-05&end_date=2026-05-07   → 1 item, day=2026-05-06
GET /v2/usercollection/sleep?start_date=2026-05-04&end_date=2026-05-07   → 2 items, days=05-05/05-06
```

The conclusion: Oura's filter is `start_date < day <= end_date`. Padding **start_date** by `-1 day` is the part that actually matters; padding `end_date` by `+1 day` is a defensive belt-and-suspenders for edge cases where the caller passes an `end_time` early in the day.

## Why this matters in practice

`sync_vendor_data_task` resolves `effective_start = connection.last_synced_at` and `end_dt = datetime.now(timezone.utc)`. After the first successful sync of the day, `last_synced_at` is "a few minutes ago", `now()` is "now", and both `strftime("%Y-%m-%d")` calls produce the same string. Oura's exclusive-start filter then drops the matching session. Result: no `event_record` rows for sleep, no `sleep.created` outgoing webhook, downstream consumers (chat / coaching apps) silently miss today's sleep.

We hit this in production: nightly Oura webhook fired correctly, periodic sync ran every 5 minutes returning `sleep: 0` for the affected user, and rolling `last_synced_at` back manually + re-running the sync immediately recovered the missing sleep.

Sleep score (`/v2/usercollection/daily_sleep`) and the other `daily_*` collections do **not** exhibit this on narrow windows in our prod logs (they returned `1`, `2`, `3` items the same minutes `usercollection/sleep` returned `0`), so the strict-window quirk is specific to `/usercollection/sleep`.

## Fix

```python
"start_date": (start_time - timedelta(days=1)).strftime("%Y-%m-%d"),
"end_date":   (end_time   + timedelta(days=1)).strftime("%Y-%m-%d"),
```

`timedelta` is already imported. `save_sleep_data` is idempotent on `external_id` so the 1-day overlap at both edges is safe — the same session arriving in two consecutive syncs simply re-uses its row.

I deliberately did not touch `get_activity_samples` / `get_readiness_data` / `get_daily_sleep_score_data` / `get_spo2_data` / `get_vo2_data` / `get_cardiovascular_age_samples` — they don't show this issue in our logs and they each represent per-day aggregates rather than session ranges, so the day-filter semantics likely differ.

## Risk

Low. The patched window is two days wider per call; Oura returns at most a handful of extra session rows; the existing dedup path swallows them.

## Test plan

- [x] Verified the repro table above against a live Oura account
- [x] Verified that with the fix, an `effective_start` inside today returns today's session
- [x] Confirmed `save_sleep_data` is idempotent on `external_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sleep data collection to ensure sleep sessions at date range boundaries are properly captured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->