### PR TITLE
fix(backend): prevent InvalidRequestError in after_commit webhook listeners

### DIFF
--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from logging import Logger, getLogger
@@ -43,6 +44,31 @@ from app.services.outgoing_webhooks.events import on_sleep_created, on_workout_c
 from app.services.services import AppService
 from app.utils.exceptions import handle_exceptions
 from app.utils.pagination import encode_cursor
+
+
+@dataclass
+class _EventRecordSnapshot:
+    """Plain-value snapshot of EventRecord attributes for use in after_commit listeners.
+
+    after_commit expires all ORM objects; accessing attributes on them triggers lazy
+    loads that fail because the session is in 'committed' state. This snapshot captures
+    the needed values as plain Python objects before the listener is registered.
+    """
+
+    category: str | None
+    id: UUID
+    zone_offset: str | None
+    start_datetime: datetime
+    end_datetime: datetime
+    duration_seconds: int | None
+    type: str | None
+
+
+@dataclass
+class _DataSourceSnapshot:
+    provider: str
+    device_model: str | None
+    user_id: UUID
 
 
 class EventRecordService(
@@ -114,11 +140,28 @@ class EventRecordService(
         if record is not None and record.data_source_id is not None:
             data_source = db_session.get(DataSource, record.data_source_id)
             if data_source is not None:
-                _record, _data_source, _detail = record, data_source, detail
+                # Snapshot ORM attributes as plain values before registering the listener.
+                # after_commit expires all ORM objects, so accessing attributes inside the
+                # listener would trigger lazy loads on a committed session → InvalidRequestError.
+                _rec = _EventRecordSnapshot(
+                    category=record.category,
+                    id=record.id,
+                    zone_offset=record.zone_offset,
+                    start_datetime=record.start_datetime,
+                    end_datetime=record.end_datetime,
+                    duration_seconds=record.duration_seconds,
+                    type=getattr(record, "type", None),
+                )
+                _ds = _DataSourceSnapshot(
+                    provider=str(data_source.provider),
+                    device_model=data_source.device_model,
+                    user_id=data_source.user_id,
+                )
+                _detail = detail
 
                 @sa_event.listens_for(db_session, "after_commit", once=True)
                 def _dispatch_webhook(session: DbSession) -> None:  # noqa: ARG001
-                    self._emit_event_record_webhook(_record, _data_source, _detail)
+                    self._emit_event_record_webhook(_rec, _ds, _detail)
 
         return result  # type: ignore[return-value]
 
@@ -495,7 +538,10 @@ class EventRecordService(
         )
         data_sources_by_id = {ds.id: ds for ds in data_sources}
 
-        dispatches: list[tuple[EventRecord, DataSource, EventRecordDetailCreate]] = []
+        # Snapshot ORM attributes as plain values before registering the listener.
+        # after_commit expires all ORM objects, so the listener captures snapshots
+        # instead of live ORM references to avoid lazy loads on a committed session.
+        dispatches: list[tuple[_EventRecordSnapshot, _DataSourceSnapshot, EventRecordDetailCreate]] = []
         for detail in details:
             record = records_by_id.get(detail.record_id)
             if record is None or record.data_source_id is None:
@@ -503,15 +549,31 @@ class EventRecordService(
             data_source = data_sources_by_id.get(record.data_source_id)
             if data_source is None:
                 continue
-            dispatches.append((record, data_source, detail))
+            dispatches.append((
+                _EventRecordSnapshot(
+                    category=record.category,
+                    id=record.id,
+                    zone_offset=record.zone_offset,
+                    start_datetime=record.start_datetime,
+                    end_datetime=record.end_datetime,
+                    duration_seconds=record.duration_seconds,
+                    type=getattr(record, "type", None),
+                ),
+                _DataSourceSnapshot(
+                    provider=str(data_source.provider),
+                    device_model=data_source.device_model,
+                    user_id=data_source.user_id,
+                ),
+                detail,
+            ))
 
         if not dispatches:
             return
 
         @sa_event.listens_for(db_session, "after_commit", once=True)
         def _dispatch_bulk_webhooks(session: DbSession) -> None:  # noqa: ARG001
-            for record, data_source, detail in dispatches:
-                self._emit_event_record_webhook(record, data_source, detail)
+            for rec, ds, detail in dispatches:
+                self._emit_event_record_webhook(rec, ds, detail)
 
     @handle_exceptions
     def _get_records_with_filters(

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -438,8 +438,8 @@ class EventRecordService(
 
     @staticmethod
     def _emit_event_record_webhook(
-        record: EventRecord,
-        data_source: DataSource,
+        record: _EventRecordSnapshot,
+        data_source: _DataSourceSnapshot,
         detail: EventRecordDetailCreate,
     ) -> None:
         """Fire the appropriate outgoing webhook for a newly created event record."""

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -46,7 +46,7 @@ from app.utils.exceptions import handle_exceptions
 from app.utils.pagination import encode_cursor
 
 
-@dataclass
+@dataclass(frozen=True)
 class _EventRecordSnapshot:
     """Plain-value snapshot of EventRecord attributes for use in after_commit listeners.
 
@@ -64,7 +64,7 @@ class _EventRecordSnapshot:
     type: str | None
 
 
-@dataclass
+@dataclass(frozen=True)
 class _DataSourceSnapshot:
     provider: str
     device_model: str | None
@@ -157,11 +157,10 @@ class EventRecordService(
                     device_model=data_source.device_model,
                     user_id=data_source.user_id,
                 )
-                _detail = detail
 
                 @sa_event.listens_for(db_session, "after_commit", once=True)
                 def _dispatch_webhook(session: DbSession) -> None:  # noqa: ARG001
-                    self._emit_event_record_webhook(_rec, _ds, _detail)
+                    self._emit_event_record_webhook(_rec, _ds, detail)
 
         return result  # type: ignore[return-value]
 

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -549,23 +549,25 @@ class EventRecordService(
             data_source = data_sources_by_id.get(record.data_source_id)
             if data_source is None:
                 continue
-            dispatches.append((
-                _EventRecordSnapshot(
-                    category=record.category,
-                    id=record.id,
-                    zone_offset=record.zone_offset,
-                    start_datetime=record.start_datetime,
-                    end_datetime=record.end_datetime,
-                    duration_seconds=record.duration_seconds,
-                    type=getattr(record, "type", None),
-                ),
-                _DataSourceSnapshot(
-                    provider=str(data_source.provider),
-                    device_model=data_source.device_model,
-                    user_id=data_source.user_id,
-                ),
-                detail,
-            ))
+            dispatches.append(
+                (
+                    _EventRecordSnapshot(
+                        category=record.category,
+                        id=record.id,
+                        zone_offset=record.zone_offset,
+                        start_datetime=record.start_datetime,
+                        end_datetime=record.end_datetime,
+                        duration_seconds=record.duration_seconds,
+                        type=getattr(record, "type", None),
+                    ),
+                    _DataSourceSnapshot(
+                        provider=str(data_source.provider),
+                        device_model=data_source.device_model,
+                        user_id=data_source.user_id,
+                    ),
+                    detail,
+                )
+            )
 
         if not dispatches:
             return


### PR DESCRIPTION
## Problem

`EventRecordService.create_detail()` and `bulk_create_details()` register SQLAlchemy `after_commit` listeners to fire outgoing webhooks. Both captured live ORM objects (`EventRecord`, `DataSource`) in their closures and accessed their attributes inside the listener.

SQLAlchemy's default `expire_on_commit=True` expires **all** ORM objects the moment `commit()` returns. When the listener fires and accesses `record.category`, `record.id`, `record.start_datetime`, etc., each access triggers a lazy load on a session now in `"committed"` state:

```
sqlalchemy.exc.InvalidRequestError: This session is in 'committed' state;
no further SQL can be emitted within this transaction.
```

## Why this causes silent data loss

The crash occurs **after** the event record and detail are already committed to the database — the writes succeed. But the exception propagates out of the Celery task's per-provider sync loop, which:

1. Marks the provider sync as failed in the task result
2. Skips updating `last_synced_at` (the live-sync cursor)
3. For providers that return **multiple sessions per API call** (Whoop sleep returns several sleep sessions in one response): aborts processing of all remaining sessions in the batch

The result: the first sleep session in each batch saves correctly; every subsequent session is silently dropped. The Celery task reports success at the user level. No error surfaces to operators. In practice this caused complete sleep data loss for Whoop users during live sync — the task ran on schedule, returned no error, and produced no sleep records.

## Root cause

```python
# Before fix — create_detail()
_record, _data_source, _detail = record, data_source, detail

@sa_event.listens_for(db_session, "after_commit", once=True)
def _dispatch_webhook(session):
    # _record and _data_source are expired at this point
    self._emit_event_record_webhook(_record, _data_source, _detail)

# _emit_event_record_webhook — triggers lazy load on committed session
category = (record.category or "").lower()  # ← InvalidRequestError here
```

The same pattern exists in `bulk_create_details()`.

## Fix

Two private dataclasses (`_EventRecordSnapshot`, `_DataSourceSnapshot`) snapshot all attribute values needed by `_emit_event_record_webhook` as plain Python objects **before** the listener is registered. The closure captures snapshots instead of ORM references — no SQL is attempted inside the listener.

```python
_rec = _EventRecordSnapshot(
    category=record.category,
    id=record.id,
    zone_offset=record.zone_offset,
    start_datetime=record.start_datetime,
    end_datetime=record.end_datetime,
    duration_seconds=record.duration_seconds,
    type=getattr(record, "type", None),
)
_ds = _DataSourceSnapshot(
    provider=str(data_source.provider),
    device_model=data_source.device_model,
    user_id=data_source.user_id,
)

@sa_event.listens_for(db_session, "after_commit", once=True)
def _dispatch_webhook(session):
    self._emit_event_record_webhook(_rec, _ds, _detail)  # no ORM, no lazy load
```

`_emit_event_record_webhook`'s parameter types are updated from `EventRecord`/`DataSource` to the snapshot types. `bulk_create_details()` receives the same fix.

## Alternative considered: `expire_on_commit=False`

Disabling expiry on the shared session suppresses the error but makes ORM objects serve stale pre-commit values for the rest of the session's lifetime. For Celery tasks that commit multiple times in one run this creates a different class of data correctness bug. The snapshot approach is precise: it captures exactly the values needed, at the moment they are known fresh.

## Testing

Verified against a live Whoop connection: 90-day historical sync completes without errors; sleep records with full stage breakdown, efficiency, and duration are correctly persisted and returned by `/summaries/sleep`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved backend reliability for event creation: the system now snapshots event and source data before dispatching webhooks, preventing post-commit database access and ensuring webhooks (single and bulk) receive stable, consistent payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->