### PR TITLE
feat: Add data migration script for body fat percentage

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -33,6 +33,7 @@ class Settings(BaseSettings):
 
     # API SETTINGS
     api_name: str = "Open Wearables API"
+    api_port: int = 8000
     api_v1: str = "/api/v1"
     api_latest: str = api_v1
     paging_limit: int = 100

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -2,6 +2,7 @@
 
 # Environment: local, test, staging, production
 ENVIRONMENT="local"
+API_PORT=8000
 CORS_ORIGINS=["http://localhost:3000"]
 
 # EMAIL SETTINGS (Resend)

--- a/backend/scripts/data_migrations/normalize_body_fat_percentage.py
+++ b/backend/scripts/data_migrations/normalize_body_fat_percentage.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Fix body_fat_percentage values incorrectly stored 100x too large.
+
+Android Health Connect (Samsung, Google) reports body_fat_percentage already in
+percent (e.g. 30.4), but the shared ImportService was unconditionally applying a
+ratio->percent x100 conversion intended only for Apple HealthKit, producing values
+like 3040. PR #917 fixed the ingestion path; this script corrects existing rows.
+
+Only rows with value > 100 are touched — valid body fat percentages are 0–100.
+
+Usage (inside Docker):
+    docker compose exec app uv run python scripts/data_migrations/normalize_body_fat_percentage.py --dry-run
+    docker compose exec app uv run python scripts/data_migrations/normalize_body_fat_percentage.py
+"""
+
+import argparse
+
+from sqlalchemy import text
+
+from app.database import SessionLocal
+
+SERIES_TYPE_CODE = "body_fat_percentage"
+
+_AFFECTED_COUNT = text("""
+    SELECT COUNT(*)
+    FROM data_point_series dps
+    JOIN series_type_definition std ON std.id = dps.series_type_definition_id
+    WHERE std.code = :code
+      AND dps.value > 100
+""")
+
+_SAMPLE_ROWS = text("""
+    SELECT dps.id, dps.value, dps.value / 100 AS corrected, ds.provider, dps.recorded_at
+    FROM data_point_series dps
+    JOIN series_type_definition std ON std.id = dps.series_type_definition_id
+    JOIN data_source ds ON ds.id = dps.data_source_id
+    WHERE std.code = :code
+      AND dps.value > 100
+    ORDER BY dps.value DESC
+    LIMIT 20
+""")
+
+_UPDATE = text("""
+    UPDATE data_point_series dps
+    SET value = dps.value / 100
+    FROM series_type_definition std
+    WHERE std.id = dps.series_type_definition_id
+      AND std.code = :code
+      AND dps.value > 100
+""")
+
+
+def main(dry_run: bool) -> None:
+    with SessionLocal() as db:
+        count = db.execute(_AFFECTED_COUNT, {"code": SERIES_TYPE_CODE}).scalar()
+
+        if count == 0:
+            print("No affected rows — nothing to do.")
+            return
+
+        print(f"Rows with body_fat_percentage > 100: {count}")
+
+        rows = db.execute(_SAMPLE_ROWS, {"code": SERIES_TYPE_CODE}).fetchall()
+        print(f"\n{'ID':<38} {'Provider':<12} {'Current':>10} {'Corrected':>10}  Recorded at")
+        print("-" * 95)
+        for row in rows:
+            print(f"{row.id!s:<38} {row.provider:<12} {row.value:>10.3f} {row.corrected:>10.3f}  {row.recorded_at}")
+        if count > 20:
+            print(f"  ... and {count - 20} more")
+
+        if dry_run:
+            print("\nDry run — no changes made.")
+            return
+
+        result = db.execute(_UPDATE, {"code": SERIES_TYPE_CODE})
+        db.commit()
+        print(f"\nUpdated {result.rowcount} row(s).")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Preview affected rows without updating")
+    args = parser.parse_args()
+    main(dry_run=args.dry_run)

--- a/backend/scripts/start/app.sh
+++ b/backend/scripts/start/app.sh
@@ -52,7 +52,7 @@ done || echo "Warning: Could not register webhook event types with Svix. Will re
 # Init app
 echo "Starting the FastAPI application..."
 if [ "$ENVIRONMENT" = "local" ]; then
-    uv run fastapi dev app/main.py --host 0.0.0.0 --port 8000
+    uv run fastapi dev app/main.py --host 0.0.0.0 --port "${API_PORT:-8000}"
 else
-    uv run fastapi run app/main.py --host 0.0.0.0 --port 8000
+    uv run fastapi run app/main.py --host 0.0.0.0 --port "${API_PORT:-8000}"
 fi

--- a/backend/scripts/start/app.sh
+++ b/backend/scripts/start/app.sh
@@ -31,6 +31,12 @@ echo 'Running recovery_score series type cleanup...'
 uv run python scripts/data_migrations/drop_recovery_score_series_type.py \
     || echo "Warning: recovery_score cleanup failed — will retry on next startup."
 
+# TODO: Remove this after ~2026-06-01 once all deployments have migrated.
+# Divides body_fat_percentage values stored 100x too large (Samsung/Google bug, PR #917); no-op if already corrected.
+echo 'Running body_fat_percentage normalization...'
+uv run python scripts/data_migrations/normalize_body_fat_percentage.py \
+    || echo "Warning: body_fat_percentage normalization failed — will retry on next startup."
+
 # Initialize archival settings
 echo 'Initializing archival settings...'
 uv run python scripts/init/seed_archival_settings.py

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: open-wearables
       POSTGRES_PASSWORD: open-wearables
     ports:
-      - "5432:5432"
+      - "${DB_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U open-wearables -d open-wearables"]
       interval: 5s
@@ -31,7 +31,7 @@ services:
       - DB_HOST=db
       - REDIS_HOST=redis
     ports:
-      - "8000:8000"
+      - "${API_PORT:-8000}:8000"
     depends_on:
       db:
         condition: service_healthy
@@ -82,7 +82,7 @@ services:
       - DB_HOST=db
       - REDIS_HOST=redis
     ports:
-      - 5555:5555
+      - "${FLOWER_PORT:-5555}:5555"
     depends_on:
       - redis
       - db
@@ -93,7 +93,7 @@ services:
     container_name: redis__open-wearables
     image: redis:8
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
     volumes:
       - redis_data:/var/lib/redis/data
     restart: unless-stopped
@@ -144,7 +144,7 @@ services:
     image: open-wearables-frontend:latest
     pull_policy: never
     ports:
-      - "3000:3000"
+      - "${FRONTEND_PORT:-3000}:3000"
     depends_on:
       - app
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_USER: open-wearables
       POSTGRES_PASSWORD: open-wearables
     ports:
-      - "5432:5432"
+      - "${DB_PORT:-5432}:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U open-wearables -d open-wearables"]
       interval: 5s
@@ -30,7 +30,7 @@ services:
       - DB_HOST=db
       - REDIS_HOST=redis
     ports:
-      - "8000:8000"
+      - "${API_PORT:-8000}:8000"
     depends_on:
       db:
         condition: service_healthy
@@ -114,7 +114,7 @@ services:
       - DB_HOST=db
       - REDIS_HOST=redis
     ports:
-      - 5555:5555
+      - "${FLOWER_PORT:-5555}:5555"
     depends_on:
       - redis
       - db
@@ -131,7 +131,7 @@ services:
     container_name: redis__open-wearables
     image: redis:8
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
     volumes:
       - redis_data:/var/lib/redis/data
 
@@ -155,7 +155,7 @@ services:
       SVIX_REDIS_DSN: "redis://redis:6379/1"
       SVIX_CACHE_TYPE: "redis"
     ports:
-      - "8071:8071"
+      - "${SVIX_PORT:-8071}:8071"
     depends_on:
       db:
         condition: service_healthy
@@ -179,7 +179,7 @@ services:
     image: open-wearables-frontend:dev
     pull_policy: never
     ports:
-      - "3000:3000"
+      - "${FRONTEND_PORT:-3000}:3000"
     depends_on:
       - app
     develop:

--- a/docs/data-migrations/normalize-body-fat-percentage.mdx
+++ b/docs/data-migrations/normalize-body-fat-percentage.mdx
@@ -1,0 +1,60 @@
+---
+title: "Normalize Body Fat Percentage"
+sidebarTitle: "Body Fat Percentage"
+description: "Divides body_fat_percentage values stored 100× too large back to the correct percentage, affecting Samsung and Google Health Connect data ingested before PR #917."
+keywords: ["body fat", "body fat percentage", "samsung", "google", "health connect", "data migration", "unit conversion"]
+"og:title": "Normalize Body Fat Percentage | Open Wearables"
+"og:description": "Corrects body_fat_percentage values stored 100× too large due to a unit conversion bug in the shared SDK import path."
+"og:url": "https://docs.openwearables.io/data-migrations/normalize-body-fat-percentage"
+"og:type": "article"
+---
+
+**Script:** `scripts/data_migrations/normalize_body_fat_percentage.py`
+
+## Problem
+
+`ImportService` (`backend/app/services/apple/healthkit/import_service.py`) is the shared ingestion path for Apple, Samsung, and Google SDK payloads. It unconditionally applied a ratio→percent `×100` conversion to `body_fat_percentage`.
+
+That conversion is correct only for Apple HealthKit, where `HKUnit.percent()` returns a `0..1` ratio. Android Health Connect (Samsung, Google) reports `BodyFatRecord.percentage.value` already in percent, so those values were stored ~100× too large — e.g. an actual `30.4%` was saved as `3040`.
+
+PR [#917](https://github.com/the-momentum/open-wearables/pull/917) fixed the ingestion path by gating the `×100` on `provider == "apple"`. This script corrects rows already in the database.
+
+## What it does
+
+Finds every `data_point_series` row for `body_fat_percentage` where `value > 100` and divides the value by `100`. Valid body fat percentages are always in the 0–100 range, so this threshold cleanly separates affected rows from correct ones without touching Apple or other provider data.
+
+The `data_point_series_archive` table is not touched — archive rows are historical snapshots and do not feed live queries.
+
+## Usage
+
+```bash
+# Preview affected rows (recommended first step)
+docker compose exec app uv run python scripts/data_migrations/normalize_body_fat_percentage.py --dry-run
+
+# Apply corrections
+docker compose exec app uv run python scripts/data_migrations/normalize_body_fat_percentage.py
+```
+
+## Options
+
+| Flag | Description |
+|---|---|
+| `--dry-run` | Print affected rows with current and corrected values. No changes made. |
+
+## Dry run output
+
+```
+Rows with body_fat_percentage > 100: 3
+
+ID                                     Provider        Current  Corrected  Recorded at
+-----------------------------------------------------------------------------------------------
+0c6b9ec9-...                           samsung        3040.000     30.400  2025-11-07 10:17:52+00:00
+a052baa2-...                           samsung        2200.000     22.000  2025-11-05 10:17:52+00:00
+632dffc6-...                           google         1850.000     18.500  2025-11-06 10:17:52+00:00
+
+Dry run — no changes made.
+```
+
+## Related
+
+- PR [#917](https://github.com/the-momentum/open-wearables/pull/917) — the ingestion fix that prevents new incorrect rows from being created.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -120,7 +120,8 @@
             "pages": [
               "data-migrations/index",
               "data-migrations/backfill-garmin-sleep-end-datetime",
-              "data-migrations/backfill-sleep-scores"
+              "data-migrations/backfill-sleep-scores",
+              "data-migrations/normalize-body-fat-percentage"
             ]
           },
           {


### PR DESCRIPTION
## Description

Following up to PR #917, adding data migration script to normalize incorrectly multiplied body fat percentage in database

Also add the script to startup - up to removal in ~ a month

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Body fat percentage values are now normalized to correct historical unit errors; a dry-run option lets operators preview fixes before they are applied.

* **Documentation**
  * Added a docs page describing the correction, usage examples, and sample dry-run output.

* **Chores**
  * Startup now attempts the migration non-blockingly and service ports (including the API port) are configurable via environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->