### PR TITLE
fix(strava): pad get_workouts window by 1 day on each side so periodic syncs don't strand recent activities

### DIFF
--- a/backend/app/services/providers/strava/workouts.py
+++ b/backend/app/services/providers/strava/workouts.py
@@ -38,13 +38,31 @@ class StravaWorkouts(BaseWorkoutsTemplate):
 
         Strava API uses epoch timestamps for after/before parameters
         and supports up to 200 activities per page.
+
+        Pads the [start_date, end_date] window by one day on each side
+        before serializing to ``after``/``before`` epochs.  Strava
+        finalises an activity asynchronously after upload (sometimes
+        minutes, sometimes longer for large GPS files), and a periodic
+        sync that polls ``[last_synced_at, now()]`` will sit at exactly
+        the moment the activity becomes visible on Strava — but the
+        next sync's window starts after the activity's ``start_date``,
+        so the activity is silently never returned again.  This is the
+        same class of bug as the Oura sleep narrow-window
+        (`get_sleep_data`) issue.
+
+        Padding by one day on each side guarantees recently-finalised
+        activities are picked up on the next periodic sync after the
+        Strava processing delay.  ``event_record_service.create``
+        upserts on ``(data_source_id, start_datetime, end_datetime)``
+        so the overlap at the trailing edge of consecutive syncs is
+        idempotent — duplicates are dropped by the unique index.
         """
         all_activities: list[Any] = []
         page = 1
         per_page = self.events_per_page
 
-        after = int(start_date.timestamp())
-        before = int(end_date.timestamp())
+        after = int((start_date - timedelta(days=1)).timestamp())
+        before = int((end_date + timedelta(days=1)).timestamp())
 
         while True:
             params: dict[str, Any] = {


### PR DESCRIPTION
## Summary

`StravaWorkouts.get_workouts` (`backend/app/services/providers/strava/workouts.py:30`) currently passes the caller's `start_date`/`end_date` straight to Strava's `/athlete/activities` as `after`/`before` epoch timestamps. With the periodic sync's natural window `[last_synced_at, now()]` that's almost always a few-minute window inside the same hour. Strava finalises uploads asynchronously — for large GPS rides this can take minutes or longer — and if the sync happens to run during that processing window, the activity becomes visible on Strava *after* the sync advanced `last_synced_at` past its `start_date`. The next sync's window starts after the activity, so Strava's range filter silently never returns it again.

This PR pads the window by one day on each side so recently-finalised activities are picked up on the next periodic sync.

## Repro (live Strava account, real production incident)

A user's Evening Ride had `start_date = 2026-05-08T16:01:32Z`. Periodic syncs ran at:

```
05-08 19:00:15  GET /athlete/activities?after=1778238007&before=1778266814   (window 14:46:47 → 22:46:54 UTC)
05-08 21:00:15  GET /athlete/activities?after=1778266815&before=1778274014   (window 22:46:55 → 5/9 00:46:54)
05-09 09:00:14  GET /athlete/activities?after=1778274015&before=1778317213   (window 5/9 00:46:55 → 12:46:53)
```

The 5/8 19:00 window arithmetically straddles 16:01:32Z so it *should* have returned the ride. It didn't (we know — the activity didn't reach our DB until a manual sync re-pulled it nearly a day later). Strava's processing for this particular activity completed somewhere between 19:00 and 21:00, by which point the next-sync window started at 22:46:55 — past the activity's `start_date`. From that point on, every periodic-sync window started after the activity.

Verified by hitting `/athlete/activities?after=<ride-1h>&before=<ride+1h>` directly with the same OAuth token a day later — the ride is fully visible in Strava's API. So the activity was always in Strava, the periodic-sync window just happened to never overlap it once advanced past it.

## Why padding works

`event_record_service.create` upserts on `(data_source_id, start_datetime, end_datetime)` via a unique index. A 1-day overlap at both edges of consecutive sync windows means activities that fall in the overlap arrive twice but are deduplicated by the index — no duplicate event records.

The padding cost is one extra page of REST on each side of the window, almost always 0–N rows. Strava's rate limits (200/15min, 2000/day) are nowhere near tight enough for this to matter.

## Fix

```python
after = int((start_date - timedelta(days=1)).timestamp())
before = int((end_date + timedelta(days=1)).timestamp())
```

`timedelta` is already imported (line 1).

## Adjacent: Strava push subscriptions

The cleaner fix long-term is to register a Strava push-subscription via `POST /api/v3/push_subscriptions` and rely on activity-create webhooks. The handler scaffold is already in `backend/app/services/providers/strava/handlers/webhook_helpers.py` and the route is wired (`backend/app/api/routes/v1/strava_webhooks.py`); the strategy just needs:

```python
return ProviderCapabilities(rest_pull=True, webhook_ping=True)
```

(currently the second arg is commented out in `strategy.py:48`.) But that's a separate concern — webhooks would require the deploy to also POST a subscription with verify-token from a config secret. This PR keeps the REST poll path working correctly until then.

## Risk

Very low. Duplicate-detection already exists; window is wider by 2 days; Strava range query is cheap.

## Test plan

- [x] Repro confirmed against the affected user's Strava account
- [x] Confirmed `event_record_service.create` is idempotent on `(data_source_id, start_datetime, end_datetime)`
- [x] Built and deployed against axl-integration fork; next periodic sync picked up the previously-stranded ride

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Strava workout data synchronization to ensure more reliable and complete activity capture during data import operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1018)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->