### PR TITLE
feat(strava): advertise webhook_ping capability so deployments with a push-subscription can use webhooks

### DIFF
--- a/backend/app/services/providers/strava/strategy.py
+++ b/backend/app/services/providers/strava/strategy.py
@@ -41,8 +41,21 @@ class StravaStrategy(BaseProviderStrategy):
 
     @property
     def capabilities(self) -> ProviderCapabilities:
-        # Strava REST API is used for historical activity backfills.
-        # Strava webhook events contain only the object_id and aspect_type;
-        # the full activity must still be fetched via GET /activities/{id}.
-        return ProviderCapabilities(rest_pull=True)  # use the line below after implementing webhooks
-        # return ProviderCapabilities(rest_pull=True, webhook_ping=True)
+        # Strava push subscriptions deliver an `aspect_type=create` event
+        # for every new activity within seconds of upload-finalisation.
+        # The webhook handler at
+        # ``backend/app/services/providers/strava/handlers/webhook_helpers.py``
+        # then fetches the full activity via GET ``/activities/{id}`` and
+        # persists it through the same path as a REST pull.
+        #
+        # REST polling (``rest_pull``) is kept on for historical backfills
+        # and as a safety net against webhook delivery failures.
+        #
+        # ``webhook_ping=True`` only advertises the capability; deployments
+        # that haven't created a Strava push subscription yet remain on the
+        # rest_pull path with no behaviour change.  See the route at
+        # ``backend/app/api/routes/v1/strava_webhooks.py`` and the
+        # subscription-creation flow in
+        # ``handlers/webhook_helpers.py:handle_webhook_verification`` for
+        # operator setup.
+        return ProviderCapabilities(rest_pull=True, webhook_ping=True)


### PR DESCRIPTION
## Summary

Uncomments the already-prepared `webhook_ping=True` line in `StravaStrategy.capabilities` (`backend/app/services/providers/strava/strategy.py:48`). The webhook handler scaffold has been complete in this repo for a while:

- Route: [`backend/app/api/routes/v1/strava_webhooks.py`](../blob/main/backend/app/api/routes/v1/strava_webhooks.py) — both `GET` (verification) and `POST` (event) handlers wired
- Verification: [`handlers/webhook_helpers.py:handle_webhook_verification`](../blob/main/backend/app/services/providers/strava/handlers/webhook_helpers.py) — handles Strava's `hub.mode=subscribe` / `hub.verify_token` / `hub.challenge` echo flow
- Event processing: [`handlers/webhook_helpers.py:handle_webhook_event`](../blob/main/backend/app/services/providers/strava/handlers/webhook_helpers.py) — fetches the full activity via GET `/activities/{id}` and persists it through the same path as a REST pull
- Config: `STRAVA_WEBHOOK_VERIFY_TOKEN` already wired in `app/config.py`

Only the capability advertisement was still gated behind a `# use the line below after implementing webhooks` TODO. This PR removes it.

## Why now

Hit a real production miss in #1018 (Evening Ride at 16:01 UTC stranded for ~14 hours of periodic syncs). The narrow-window pad in #1018 fixes the symptom; webhooks fix the root cause — activity-create events arrive seconds after upload-finalisation rather than waiting on the next sync's `[after, before]` window.

## Effect on existing deployments

**None unless the operator also creates a Strava push subscription** via `POST /api/v3/push_subscriptions` with the matching `STRAVA_WEBHOOK_VERIFY_TOKEN` and a `callback_url` pointing at this app's `/api/v1/strava/webhooks` endpoint. Until then:

- The live-sync path stays on `rest_pull` (the capability is `rest_pull=True, webhook_ping=True`, so REST is still in scope).
- No incoming webhook traffic, so the unused handler is harmless dead weight.

Once the subscription is created:

- New activities arrive within seconds of upload-finalisation via `POST /api/v1/strava/webhooks`.
- Periodic syncs continue as a safety net for any missed deliveries.

## Operator setup (informational, not part of this PR)

```bash
curl -X POST https://www.strava.com/api/v3/push_subscriptions \
  -F client_id=$STRAVA_CLIENT_ID \
  -F client_secret=$STRAVA_CLIENT_SECRET \
  -F callback_url=https://YOUR-DEPLOYMENT/api/v1/strava/webhooks \
  -F verify_token=$STRAVA_WEBHOOK_VERIFY_TOKEN
```

The deployment must be reachable from Strava's servers and the verify-token must match the env var Strava will see in the subsequent `GET` callback. Strava docs: https://developers.strava.com/docs/webhooks/

## Risk

Tiny — no logic change, only a property value flip behind a feature gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Strava integration now supports webhook-based activity updates in addition to polling, enabling faster notification delivery with polling maintained as a fallback mechanism.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1019)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->