### PR TITLE
fix: commit each data type individually and rollback session on exception for Oura and Whoop

### DIFF
--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -344,6 +344,7 @@ class Oura247Data(Base247DataTemplate):
 
         if samples:
             timeseries_service.bulk_create_samples(db, samples)
+            db.commit()
         return len(samples)
 
     # -------------------------------------------------------------------------
@@ -674,6 +675,7 @@ class Oura247Data(Base247DataTemplate):
                 event_record_service.create_or_merge_sleep(db, user_id, record, detail, settings.sleep_end_gap_minutes)
                 count += 1
             except Exception as e:
+                db.rollback()
                 log_structured(
                     self.logger,
                     "error",
@@ -878,6 +880,7 @@ class Oura247Data(Base247DataTemplate):
 
         if samples:
             timeseries_service.bulk_create_samples(db, samples)
+            db.commit()
         return len(samples)
 
     # -------------------------------------------------------------------------
@@ -947,6 +950,7 @@ class Oura247Data(Base247DataTemplate):
 
         if samples:
             timeseries_service.bulk_create_samples(db, samples)
+            db.commit()
         return len(samples)
 
     # -------------------------------------------------------------------------
@@ -1037,6 +1041,7 @@ class Oura247Data(Base247DataTemplate):
 
         if samples:
             timeseries_service.bulk_create_samples(db, samples)
+            db.commit()
         return len(samples)
 
     # -------------------------------------------------------------------------
@@ -1095,6 +1100,7 @@ class Oura247Data(Base247DataTemplate):
 
         if samples:
             timeseries_service.bulk_create_samples(db, samples)
+            db.commit()
         return len(samples)
 
     # -------------------------------------------------------------------------
@@ -1169,6 +1175,7 @@ class Oura247Data(Base247DataTemplate):
             try:
                 results[data_type] = fn()
             except Exception as e:
+                db.rollback()
                 results[data_type] = 0
                 log_structured(
                     self.logger,

--- a/backend/app/services/providers/whoop/data_247.py
+++ b/backend/app/services/providers/whoop/data_247.py
@@ -415,6 +415,7 @@ class Whoop247Data(Base247DataTemplate):
                 if health_score:
                     health_scores.append(health_score)
             except Exception as e:
+                db.rollback()
                 log_structured(
                     self.logger,
                     "warning",
@@ -466,6 +467,7 @@ class Whoop247Data(Base247DataTemplate):
         try:
             results["sleep_sessions_synced"] = self.load_and_save_sleep(db, user_id, start_time, end_time)
         except Exception as e:
+            db.rollback()
             log_structured(
                 self.logger,
                 "error",
@@ -478,6 +480,7 @@ class Whoop247Data(Base247DataTemplate):
         try:
             results["recovery_samples_synced"] = self.load_and_save_recovery(db, user_id, start_time, end_time)
         except Exception as e:
+            db.rollback()
             log_structured(
                 self.logger,
                 "error",
@@ -490,6 +493,7 @@ class Whoop247Data(Base247DataTemplate):
         try:
             results["body_measurement_samples_synced"] = self.load_and_save_body_measurement(db, user_id)
         except Exception as e:
+            db.rollback()
             log_structured(
                 self.logger,
                 "error",
@@ -632,6 +636,7 @@ class Whoop247Data(Base247DataTemplate):
 
         if samples_to_create:
             timeseries_service.bulk_create_samples(db, samples_to_create)
+            db.commit()
 
         return len(samples_to_create)
 
@@ -847,6 +852,7 @@ class Whoop247Data(Base247DataTemplate):
 
         if samples_to_create:
             timeseries_service.bulk_create_samples(db, samples_to_create)
+            db.commit()
 
         return len(samples_to_create)
 
@@ -918,6 +924,7 @@ class Whoop247Data(Base247DataTemplate):
                     if health_score:
                         health_scores.append(health_score)
             except Exception as e:
+                db.rollback()
                 log_structured(
                     self.logger,
                     "warning",

--- a/backend/app/services/providers/whoop/workouts.py
+++ b/backend/app/services/providers/whoop/workouts.py
@@ -419,6 +419,10 @@ class WhoopWorkouts(BaseWorkoutsTemplate):
 
         if strain_scores:
             health_score_service.bulk_create(db, strain_scores)
-            db.commit()
+            try:
+                db.commit()
+            except Exception:
+                db.rollback()
+                raise
 
         return count

--- a/backend/app/services/providers/whoop/workouts.py
+++ b/backend/app/services/providers/whoop/workouts.py
@@ -418,8 +418,8 @@ class WhoopWorkouts(BaseWorkoutsTemplate):
                     strain_scores.append(strain_score)
 
         if strain_scores:
-            health_score_service.bulk_create(db, strain_scores)
             try:
+                health_score_service.bulk_create(db, strain_scores)
                 db.commit()
             except Exception:
                 db.rollback()


### PR DESCRIPTION
## Description

- call `db.commit()` after each successful data type so as not to drop any data already in session
- handle exceptions and call `db.rollback()` after errors


Resolves #930 
Resolves #948

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data synchronization reliability for Oura and Whoop: better transaction handling ensures successful bulk writes are finalized and failed operations are rolled back.
  * Added safer error handling during workout/strain score and health metric syncs to prevent partial or inconsistent data and protect data integrity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1022)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->