### PR TITLE
fix(logging): drop uvicorn 2xx access lines in production

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,9 @@ from app.integrations.sentry import init_sentry
 from app.middlewares import add_cors_middleware
 from app.services import raw_payload_storage
 from app.services.outgoing_webhooks import svix as svix_service
+from app.utils.config_utils import EnvironmentType
 from app.utils.exceptions import DatetimeParseError, handle_exception
+from app.utils.log_filters import UvicornAccess2xxFilter
 
 # Configure logging to use stdout instead of stderr
 # Some platforms convert stderr logs to level.error automatically, so we must use stdout
@@ -34,6 +36,12 @@ for _name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
     _logger = logging.getLogger(_name)
     _logger.handlers.clear()
     _logger.propagate = True
+
+# In production, drop happy-path 2xx access lines from uvicorn — they
+# were 88% of GCP log ingest on this project (axlbrains/open-wearables#8).
+# 4xx/5xx pass through unchanged, and dev gets the full firehose still.
+if settings.environment == EnvironmentType.PRODUCTION:
+    logging.getLogger("uvicorn.access").addFilter(UvicornAccess2xxFilter())
 
 
 @asynccontextmanager

--- a/backend/app/utils/log_filters.py
+++ b/backend/app/utils/log_filters.py
@@ -1,0 +1,31 @@
+"""Logging filters applied to third-party loggers (uvicorn, etc).
+
+Production OW emitted ~88% of the GCP project log ingest in May 2026,
+almost entirely from uvicorn's per-request access lines on happy-path
+``2xx`` responses (see axlbrains/open-wearables#8).  4xx/5xx access
+lines remain — those carry signal — and the structured app logger is
+unaffected.
+"""
+
+import logging
+
+
+class UvicornAccess2xxFilter(logging.Filter):
+    """Drop ``uvicorn.access`` records for ``2xx`` responses.
+
+    ``uvicorn.access`` records carry the status code as the 5th element
+    of ``record.args`` (a 5-tuple ``(client_addr, method, full_path,
+    http_version, status_code)``).  When that shape isn't present we
+    leave the record alone — losing a noisy line is fine, dropping a
+    real error because the format changed is not.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        args = record.args
+        if isinstance(args, tuple) and len(args) >= 5:
+            try:
+                status = int(args[4])
+            except (TypeError, ValueError):
+                return True
+            return not (200 <= status < 300)
+        return True

--- a/backend/tests/utils_tests/test_log_filters.py
+++ b/backend/tests/utils_tests/test_log_filters.py
@@ -1,0 +1,43 @@
+import logging
+
+from app.utils.log_filters import UvicornAccess2xxFilter
+
+
+def _make_record(args: tuple | None) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=0,
+        msg='%s - "%s %s HTTP/%s" %d',
+        args=args,
+        exc_info=None,
+    )
+    return record
+
+
+def test_drops_200() -> None:
+    f = UvicornAccess2xxFilter()
+    assert f.filter(_make_record(("169.254.169.126:48108", "GET", "/api/v1/x", "1.1", 200))) is False
+
+
+def test_drops_204() -> None:
+    f = UvicornAccess2xxFilter()
+    assert f.filter(_make_record(("169.254.169.126:48108", "GET", "/api/v1/x", "1.1", 204))) is False
+
+
+def test_keeps_400() -> None:
+    f = UvicornAccess2xxFilter()
+    assert f.filter(_make_record(("169.254.169.126:48108", "GET", "/api/v1/x", "1.1", 400))) is True
+
+
+def test_keeps_500() -> None:
+    f = UvicornAccess2xxFilter()
+    assert f.filter(_make_record(("169.254.169.126:48108", "POST", "/api/v1/x", "1.1", 500))) is True
+
+
+def test_keeps_record_with_unexpected_args_shape() -> None:
+    f = UvicornAccess2xxFilter()
+    assert f.filter(_make_record(None)) is True
+    assert f.filter(_make_record(("only", "three", "args"))) is True
+    assert f.filter(_make_record(("a", "b", "c", "d", "not-int"))) is True


### PR DESCRIPTION
## Problem

In a real production deployment of OW we measured that `uvicorn.access` log lines for happy-path 2xx responses make up **~88% of the entire GCP Cloud Logging volume** for the project — almost all of it is the standard uvicorn line for routine GET requests:

```
169.254.169.126:48108 - "GET /api/v1/users/{uuid}/events/workouts?... HTTP/1.1" 200
```

At our scale (~50 wearables-connected athletes polling every 15 min plus a few external integrations) this was running at ~€1100/mo for Cloud Logging ingest. The lines duplicate what the structured app logger already records (and what 4xx/5xx access lines flag for free), so the cost is paying for noise.

This is a default-config trap — every production OW install will hit the same wall unless they know to patch it.

## Change

Two additive files, one tiny edit in `app/main.py`. No removals, no behavior change in dev/staging/test.

1. **New `backend/app/utils/log_filters.py`** — a `logging.Filter` subclass that drops `uvicorn.access` records whose status code is `2xx`. Detection uses `record.args[4]` (canonical uvicorn access-log shape: `(client_addr, method, full_path, http_version, status_code)`). If the shape is unexpected the filter is permissive — a noisy log line is fine, a silently dropped error is not.

2. **Edit `backend/app/main.py`** — when `settings.environment == EnvironmentType.PRODUCTION`, attach the filter to the `uvicorn.access` logger. Placed right after the existing block that strips uvicorn's default handlers, so the two operations live next to each other.

3. **Unit tests** — `tests/utils_tests/test_log_filters.py` covers drop-on-200/204, keep-on-400/500, and keep-on-unexpected-args-shape (None, short tuple, non-int status code).

## What stays the same

- 4xx and 5xx access lines — still emitted, still go through the existing root-logger handler.
- `app/utils/structured_logging.py` (`log_structured(...)`) — completely independent path, unaffected.
- Dev / staging / test environments — `settings.environment != PRODUCTION`, so the filter is never attached. Full firehose for local debugging.
- No new runtime dependencies, no measurable perf overhead.

## Why gate on `EnvironmentType.PRODUCTION` rather than a flag

The "right" default in production is "off"; making it a config knob just gives users one more way to forget about it and overpay. If someone has a genuine need to keep 2xx in prod (e.g. compliance audit), they can override the logger config or remove the conditional in a downstream fork. Happy to add a `UVICORN_ACCESS_LOG_2XX` flag if reviewers want it — say the word.

## Verification

- `python -m pytest tests/utils_tests/test_log_filters.py` — 5 cases pass.
- Manual: in a local instance with `ENVIRONMENT=production`, hit `GET /` (200) and `GET /nonexistent` (404). Confirm only the 404 line appears in stdout; structured logs continue normally.

## Cost data (anecdotal, our deployment)

| Period | OW ingest | Project total |
|---|---|---|
| Before fix (May 2026 first half) | ~330 GiB/mo | ~88% of project |
| After project-level exclusion (mitigation already in place) | ~60 GiB/mo | back under 50 GiB free tier |
| After this PR (source-side, complementary) | ~6 GiB/mo expected | structured app logs only |

The exclusion alone solved the immediate cost, but masks future regressions — if a new endpoint starts emitting more noisy patterns the exclusion silently keeps the bill flat until the next sweep. Fixing at the source is the durable form.

---

Happy to iterate on the design — keep it minimal, can move the filter attach into a helper, accept any naming. The core idea is the only debate: should production OW emit a log line for every 2xx response? We think the answer is no.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized production access logging by filtering out successful request logs (2xx status codes) while preserving error logs for better operational efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1024)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->