### PR TITLE
feat(backend): add recovery summary endpoint

### DIFF
--- a/backend/app/api/routes/v1/summaries.py
+++ b/backend/app/api/routes/v1/summaries.py
@@ -1,7 +1,7 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Query
 
 from app.database import DbSession
 from app.schemas.responses.activity import (
@@ -67,8 +67,10 @@ def get_recovery_summary(
     cursor: str | None = None,
     limit: Annotated[int, Query(ge=1, le=100)] = 50,
 ) -> PaginatedResponse[RecoverySummary]:
-    """Returns daily recovery metrics (Sleep + HRV + RHR)."""
-    raise HTTPException(status_code=501, detail="Not implemented")
+    """Returns daily recovery metrics (recovery score, HRV, resting HR, SpO2)."""
+    start_datetime = parse_query_datetime(start_date)
+    end_datetime = parse_query_datetime(end_date)
+    return summaries_service.get_recovery_summaries(db, user_id, start_datetime, end_datetime, cursor, limit)
 
 
 @router.get("/users/{user_id}/summaries/body")

--- a/backend/app/repositories/health_score_repository.py
+++ b/backend/app/repositories/health_score_repository.py
@@ -1,7 +1,8 @@
 from datetime import date, datetime, timezone
+from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy import and_, desc
+from sqlalchemy import and_, asc, desc, tuple_
 from sqlalchemy.dialects.postgresql import insert
 
 from app.database import DbSession
@@ -9,6 +10,7 @@ from app.models import HealthScore
 from app.repositories.repositories import CrudRepository
 from app.schemas.enums import HealthScoreCategory
 from app.schemas.model_crud.activities import HealthScoreCreate, HealthScoreQueryParams, HealthScoreUpdate
+from app.utils.pagination import decode_cursor
 
 
 class HealthScoreRepository(CrudRepository[HealthScore, HealthScoreCreate, HealthScoreUpdate]):
@@ -94,6 +96,59 @@ class HealthScoreRepository(CrudRepository[HealthScore, HealthScoreCreate, Healt
             )
             .delete(synchronize_session=False)
         )
+
+    def get_recovery_summaries(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        start_date: datetime,
+        end_date: datetime,
+        cursor: str | None,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Get recovery health scores for a date range with cursor-based pagination.
+
+        Returns list of dicts with keys: recovery_date, source, device_model, record_id,
+        recorded_at, recovery_score, resting_heart_rate, hrv_rmssd_milli, spo2_percentage.
+        Fetches limit+1 rows so callers can detect has_more without a separate COUNT query.
+        Ordering matches get_sleep_summaries: ASC by default, DESC when paginating backward.
+        """
+        query = (
+            db_session.query(HealthScore)
+            .filter(
+                HealthScore.user_id == user_id,
+                HealthScore.category == HealthScoreCategory.RECOVERY,
+                HealthScore.recorded_at >= start_date,
+                HealthScore.recorded_at < end_date,
+            )
+            .order_by(asc(HealthScore.recorded_at), asc(HealthScore.id))
+        )
+
+        if cursor:
+            cursor_ts, cursor_id, direction = decode_cursor(cursor)
+            if direction == "prev":
+                query = query.filter(tuple_(HealthScore.recorded_at, HealthScore.id) < (cursor_ts, cursor_id)).order_by(
+                    desc(HealthScore.recorded_at), desc(HealthScore.id)
+                )
+            else:
+                query = query.filter(tuple_(HealthScore.recorded_at, HealthScore.id) > (cursor_ts, cursor_id))
+
+        rows = query.limit(limit + 1).all()
+
+        return [
+            {
+                "recovery_date": row.recorded_at.date(),
+                "source": row.provider,
+                "device_model": None,
+                "record_id": row.id,
+                "recorded_at": row.recorded_at,
+                "recovery_score": int(row.value) if row.value is not None else None,
+                "resting_heart_rate": cast(dict, row.components or {}).get("resting_heart_rate", {}).get("value"),
+                "hrv_rmssd_milli": cast(dict, row.components or {}).get("hrv_rmssd_milli", {}).get("value"),
+                "spo2_percentage": cast(dict, row.components or {}).get("spo2_percentage", {}).get("value"),
+            }
+            for row in rows
+        ]
 
     def get_latest_per_category(
         self,

--- a/backend/app/repositories/health_score_repository.py
+++ b/backend/app/repositories/health_score_repository.py
@@ -113,15 +113,11 @@ class HealthScoreRepository(CrudRepository[HealthScore, HealthScoreCreate, Healt
         Fetches limit+1 rows so callers can detect has_more without a separate COUNT query.
         Ordering matches get_sleep_summaries: ASC by default, DESC when paginating backward.
         """
-        query = (
-            db_session.query(HealthScore)
-            .filter(
-                HealthScore.user_id == user_id,
-                HealthScore.category == HealthScoreCategory.RECOVERY,
-                HealthScore.recorded_at >= start_date,
-                HealthScore.recorded_at < end_date,
-            )
-            .order_by(asc(HealthScore.recorded_at), asc(HealthScore.id))
+        query = db_session.query(HealthScore).filter(
+            HealthScore.user_id == user_id,
+            HealthScore.category == HealthScoreCategory.RECOVERY,
+            HealthScore.recorded_at >= start_date,
+            HealthScore.recorded_at < end_date,
         )
 
         if cursor:
@@ -131,7 +127,11 @@ class HealthScoreRepository(CrudRepository[HealthScore, HealthScoreCreate, Healt
                     desc(HealthScore.recorded_at), desc(HealthScore.id)
                 )
             else:
-                query = query.filter(tuple_(HealthScore.recorded_at, HealthScore.id) > (cursor_ts, cursor_id))
+                query = query.filter(tuple_(HealthScore.recorded_at, HealthScore.id) > (cursor_ts, cursor_id)).order_by(
+                    asc(HealthScore.recorded_at), asc(HealthScore.id)
+                )
+        else:
+            query = query.order_by(asc(HealthScore.recorded_at), asc(HealthScore.id))
 
         rows = query.limit(limit + 1).all()
 

--- a/backend/app/services/summaries_service.py
+++ b/backend/app/services/summaries_service.py
@@ -5,7 +5,7 @@ from logging import Logger, getLogger
 from uuid import UUID
 
 from app.database import DbSession
-from app.models import DataPointSeries, EventRecord, ProviderPriority, User
+from app.models import DataPointSeries, EventRecord, HealthScore, ProviderPriority, User
 from app.repositories import EventRecordRepository, ProviderPriorityRepository
 from app.repositories.archival_repository import (
     ArchivalSettingRepository,
@@ -17,6 +17,7 @@ from app.repositories.data_point_series_repository import (
     IntensityMinutesResult,
 )
 from app.repositories.device_type_priority_repository import DeviceTypePriorityRepository
+from app.repositories.health_score_repository import HealthScoreRepository
 from app.repositories.user_repository import UserRepository
 from app.schemas.enums import (
     ProviderName,
@@ -33,6 +34,7 @@ from app.schemas.responses.activity import (
     BodySummary,
     HeartRateStats,
     IntensityMinutes,
+    RecoverySummary,
     SleepStagesSummary,
     SleepSummary,
 )
@@ -98,6 +100,7 @@ class SummariesService:
         self.user_repo = UserRepository(User)
         self.archival_settings_repo = ArchivalSettingRepository()
         self.archive_repo = DataPointSeriesArchiveRepository()
+        self.health_score_repo = HealthScoreRepository(HealthScore)
 
     def _filter_by_priority(
         self,
@@ -352,6 +355,73 @@ class SummariesService:
                 avg_spo2_percent=None,
             )
             data.append(summary)
+
+        return PaginatedResponse(
+            data=data,
+            pagination=Pagination(
+                has_more=has_more,
+                next_cursor=next_cursor,
+                previous_cursor=previous_cursor,
+            ),
+            metadata=TimeseriesMetadata(
+                sample_count=len(data),
+                start_time=start_date,
+                end_time=end_date,
+            ),
+        )
+
+    @handle_exceptions
+    def get_recovery_summaries(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        start_date: datetime,
+        end_date: datetime,
+        cursor: str | None,
+        limit: int,
+    ) -> PaginatedResponse[RecoverySummary]:
+        """Get daily recovery summaries from HealthScore(RECOVERY) records.
+
+        Metrics come from the components JSONB stored alongside the recovery score:
+        resting_heart_rate, hrv_rmssd_milli, spo2_percentage.
+        """
+        results = self.health_score_repo.get_recovery_summaries(
+            db_session, user_id, start_date, end_date, cursor, limit
+        )
+
+        results = self._filter_by_priority(db_session, user_id, results, date_key="recovery_date")
+
+        has_more = len(results) > limit
+        if has_more:
+            results = results[:limit]
+
+        next_cursor: str | None = None
+        previous_cursor: str | None = None
+
+        if results:
+            last_result = results[-1]
+            if has_more:
+                next_cursor = encode_cursor(last_result["recorded_at"], last_result["record_id"], "next")
+
+            if cursor:
+                first_result = results[0]
+                previous_cursor = encode_cursor(first_result["recorded_at"], first_result["record_id"], "prev")
+
+        data = [
+            RecoverySummary(
+                date=r["recovery_date"],
+                source=SourceMetadata(provider=r["source"] or "unknown", device=r.get("device_model")),
+                sleep_duration_seconds=None,
+                sleep_efficiency_percent=None,
+                resting_heart_rate_bpm=int(r["resting_heart_rate"])
+                if r.get("resting_heart_rate") is not None
+                else None,
+                avg_hrv_sdnn_ms=float(r["hrv_rmssd_milli"]) if r.get("hrv_rmssd_milli") is not None else None,
+                avg_spo2_percent=float(r["spo2_percentage"]) if r.get("spo2_percentage") is not None else None,
+                recovery_score=r.get("recovery_score"),
+            )
+            for r in results
+        ]
 
         return PaginatedResponse(
             data=data,

--- a/backend/tests/api/v1/test_summaries.py
+++ b/backend/tests/api/v1/test_summaries.py
@@ -6,12 +6,13 @@ from decimal import Decimal
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app.schemas.enums import ProviderName
+from app.schemas.enums import HealthScoreCategory, ProviderName
 from tests.factories import (
     ApiKeyFactory,
     DataPointSeriesFactory,
     DataSourceFactory,
     EventRecordFactory,
+    HealthScoreFactory,
     PersonalRecordFactory,
     SeriesTypeDefinitionFactory,
     SleepDetailsFactory,
@@ -1295,3 +1296,191 @@ class TestBodySummaryEndpoint:
 
         # Should use the most recent value
         assert data["slow_changing"]["weight_kg"] == 72.5
+
+
+class TestRecoverySummaryEndpoint:
+    """Test suite for recovery summaries endpoint."""
+
+    BASE_PARAMS = {
+        "start_date": "2025-12-25T00:00:00Z",
+        "end_date": "2025-12-28T00:00:00Z",
+    }
+
+    def _url(self, user_id: object) -> str:
+        return f"/api/v1/users/{user_id}/summaries/recovery"
+
+    def test_returns_200_with_recovery_score(self, client: TestClient, db: Session) -> None:
+        """Basic recovery record is returned with correct score and date."""
+        user = UserFactory()
+        source = DataSourceFactory(user=user, source=ProviderName.WHOOP)
+        recorded_at = datetime(2025, 12, 26, 0, 0, 0, tzinfo=timezone.utc)
+        HealthScoreFactory(
+            data_source=source,
+            category=HealthScoreCategory.RECOVERY,
+            value=Decimal("78"),
+            provider=ProviderName.WHOOP,
+            recorded_at=recorded_at,
+            components=None,
+        )
+        api_key = ApiKeyFactory()
+
+        response = client.get(self._url(user.id), headers=api_key_headers(api_key.id), params=self.BASE_PARAMS)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 1
+        item = data["data"][0]
+        assert item["date"] == "2025-12-26"
+        assert item["recovery_score"] == 78
+        assert item["source"]["provider"] == "whoop"
+
+    def test_returns_component_metrics(self, client: TestClient, db: Session) -> None:
+        """RHR, HRV and SpO2 are populated from HealthScore components."""
+        user = UserFactory()
+        source = DataSourceFactory(user=user, source=ProviderName.WHOOP)
+        recorded_at = datetime(2025, 12, 26, 0, 0, 0, tzinfo=timezone.utc)
+        HealthScoreFactory(
+            data_source=source,
+            category=HealthScoreCategory.RECOVERY,
+            value=Decimal("65"),
+            provider=ProviderName.WHOOP,
+            recorded_at=recorded_at,
+            components={
+                "resting_heart_rate": {"value": 58.0},
+                "hrv_rmssd_milli": {"value": 45.5},
+                "spo2_percentage": {"value": 97.0},
+            },
+        )
+        api_key = ApiKeyFactory()
+
+        response = client.get(self._url(user.id), headers=api_key_headers(api_key.id), params=self.BASE_PARAMS)
+
+        assert response.status_code == 200
+        item = response.json()["data"][0]
+        assert item["resting_heart_rate_bpm"] == 58
+        assert item["avg_hrv_sdnn_ms"] == 45.5
+        assert item["avg_spo2_percent"] == 97.0
+
+    def test_empty_range_returns_no_data(self, client: TestClient, db: Session) -> None:
+        """Empty range returns empty list, not an error."""
+        user = UserFactory()
+        api_key = ApiKeyFactory()
+
+        response = client.get(
+            self._url(user.id),
+            headers=api_key_headers(api_key.id),
+            params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-26T00:00:00Z"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["data"] == []
+
+    def test_multiple_days_ordered_ascending(self, client: TestClient, db: Session) -> None:
+        """Multiple recovery records are returned in ascending date order."""
+        user = UserFactory()
+        source = DataSourceFactory(user=user, source=ProviderName.WHOOP)
+        api_key = ApiKeyFactory()
+
+        for day, score in ((26, 70), (27, 85), (25, 60)):
+            HealthScoreFactory(
+                data_source=source,
+                category=HealthScoreCategory.RECOVERY,
+                value=Decimal(str(score)),
+                provider=ProviderName.WHOOP,
+                recorded_at=datetime(2025, 12, day, 0, 0, 0, tzinfo=timezone.utc),
+            )
+
+        response = client.get(self._url(user.id), headers=api_key_headers(api_key.id), params=self.BASE_PARAMS)
+
+        assert response.status_code == 200
+        scores = [item["recovery_score"] for item in response.json()["data"]]
+        assert scores == [60, 70, 85]
+
+    def test_records_outside_range_excluded(self, client: TestClient, db: Session) -> None:
+        """Records outside the requested date range are not included."""
+        user = UserFactory()
+        source = DataSourceFactory(user=user, source=ProviderName.WHOOP)
+        api_key = ApiKeyFactory()
+
+        # Inside range
+        HealthScoreFactory(
+            data_source=source,
+            category=HealthScoreCategory.RECOVERY,
+            value=Decimal("72"),
+            provider=ProviderName.WHOOP,
+            recorded_at=datetime(2025, 12, 26, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        # Outside range (too early)
+        HealthScoreFactory(
+            data_source=source,
+            category=HealthScoreCategory.RECOVERY,
+            value=Decimal("50"),
+            provider=ProviderName.WHOOP,
+            recorded_at=datetime(2025, 12, 24, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        # Outside range (too late — end_date is exclusive)
+        HealthScoreFactory(
+            data_source=source,
+            category=HealthScoreCategory.RECOVERY,
+            value=Decimal("90"),
+            provider=ProviderName.WHOOP,
+            recorded_at=datetime(2025, 12, 28, 0, 0, 0, tzinfo=timezone.utc),
+        )
+
+        response = client.get(self._url(user.id), headers=api_key_headers(api_key.id), params=self.BASE_PARAMS)
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert len(data) == 1
+        assert data[0]["recovery_score"] == 72
+
+    def test_null_components_returns_none_metrics(self, client: TestClient, db: Session) -> None:
+        """Recovery record with no components returns None for all metric fields."""
+        user = UserFactory()
+        source = DataSourceFactory(user=user, source=ProviderName.WHOOP)
+        HealthScoreFactory(
+            data_source=source,
+            category=HealthScoreCategory.RECOVERY,
+            value=Decimal("55"),
+            provider=ProviderName.WHOOP,
+            recorded_at=datetime(2025, 12, 26, 0, 0, 0, tzinfo=timezone.utc),
+            components=None,
+        )
+        api_key = ApiKeyFactory()
+
+        response = client.get(self._url(user.id), headers=api_key_headers(api_key.id), params=self.BASE_PARAMS)
+
+        assert response.status_code == 200
+        item = response.json()["data"][0]
+        assert item["resting_heart_rate_bpm"] is None
+        assert item["avg_hrv_sdnn_ms"] is None
+        assert item["avg_spo2_percent"] is None
+        assert item["sleep_duration_seconds"] is None
+        assert item["sleep_efficiency_percent"] is None
+
+    def test_pagination_limit(self, client: TestClient, db: Session) -> None:
+        """Limit parameter caps results and has_more is set when more data exists."""
+        user = UserFactory()
+        source = DataSourceFactory(user=user, source=ProviderName.WHOOP)
+        api_key = ApiKeyFactory()
+
+        for day in range(1, 10):
+            HealthScoreFactory(
+                data_source=source,
+                category=HealthScoreCategory.RECOVERY,
+                value=Decimal("70"),
+                provider=ProviderName.WHOOP,
+                recorded_at=datetime(2026, 1, day, 0, 0, 0, tzinfo=timezone.utc),
+            )
+
+        response = client.get(
+            self._url(user.id),
+            headers=api_key_headers(api_key.id),
+            params={"start_date": "2026-01-01T00:00:00Z", "end_date": "2026-01-31T00:00:00Z", "limit": 3},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 3
+        assert data["pagination"]["has_more"] is True
+        assert data["pagination"]["next_cursor"] is not None

--- a/docs/dev-guides/integration-guide.mdx
+++ b/docs/dev-guides/integration-guide.mdx
@@ -631,6 +631,21 @@ To page through results, pass `cursor=<next_cursor>` until `has_more` is `false`
     ```
     `duration_minutes` / `time_in_bed_minutes` exclude naps. Units are minutes, not seconds.
   </Tab>
+  <Tab title="RecoverySummary">
+    ```json
+    {
+      "date": "2025-01-15",
+      "source": { "provider": "whoop", "device": null },
+      "sleep_duration_seconds": null,
+      "sleep_efficiency_percent": null,
+      "resting_heart_rate_bpm": 58,
+      "avg_hrv_sdnn_ms": 45.5,
+      "avg_spo2_percent": 97.0,
+      "recovery_score": 78
+    }
+    ```
+    `recovery_score` is 0–100. `avg_hrv_sdnn_ms` contains RMSSD for Whoop (the field holds whichever HRV metric the provider reports). All fields except `date` and `source` are nullable.
+  </Tab>
   <Tab title="BodySummary">
     ```json
     {
@@ -807,6 +822,12 @@ class OpenWearablesClient:
     async def get_sleep_summary(self, user_id: str, start_date: str, end_date: str) -> list[dict]:
         return await self._paginated(
             f"/api/v1/users/{user_id}/summaries/sleep",
+            {"start_date": start_date, "end_date": end_date},
+        )
+
+    async def get_recovery_summary(self, user_id: str, start_date: str, end_date: str) -> list[dict]:
+        return await self._paginated(
+            f"/api/v1/users/{user_id}/summaries/recovery",
             {"start_date": start_date, "end_date": end_date},
         )
 


### PR DESCRIPTION
Resolves #198 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery summaries endpoint now returns daily recovery scores and related metrics (HRV, resting heart rate, SpO2) for a user within a date range, with cursor-based pagination.

* **Documentation**
  * Added recovery summary response examples and updated client integration guidance.

* **Tests**
  * New test suite validating payloads, metric mapping, ordering, range exclusion, null-component behavior, and pagination.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1027)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->