### PR TITLE
fix: Cast to local date for summary endpoints

### DIFF
--- a/backend/app/repositories/data_point_series_repository.py
+++ b/backend/app/repositories/data_point_series_repository.py
@@ -3,7 +3,7 @@ from datetime import datetime, time, timedelta
 from uuid import UUID
 
 from psycopg.errors import UniqueViolation
-from sqlalchemy import Date, String, asc, case, cast, func, literal_column, text, tuple_
+from sqlalchemy import Date, Interval, String, asc, case, cast, func, literal_column, text, tuple_
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError as SQLAIntegrityError
 
@@ -501,10 +501,15 @@ class DataPointSeriesRepository(
         distance_id = get_series_type_id(SeriesType.distance_walking_running)
         flights_id = get_series_type_id(SeriesType.flights_climbed)
 
+        local_date = cast(
+            self.model.recorded_at + cast(func.coalesce(self.model.zone_offset, "+00:00"), Interval),
+            Date,
+        )
+
         # Build aggregation query
         results = (
             db_session.query(
-                cast(self.model.recorded_at, Date).label("activity_date"),
+                local_date.label("activity_date"),
                 DataSource.source.label("source"),
                 DataSource.device_model.label("device_model"),
                 # Steps - sum for the day
@@ -542,17 +547,17 @@ class DataPointSeriesRepository(
             .filter(
                 DataSource.user_id == user_id,
                 self.model.recorded_at >= start_date,
-                cast(self.model.recorded_at, Date) < cast(end_date, Date),
+                local_date < cast(end_date, Date),
                 self.model.series_type_definition_id.in_(
                     [steps_id, energy_id, basal_energy_id, hr_id, distance_id, flights_id]
                 ),
             )
             .group_by(
-                cast(self.model.recorded_at, Date),
+                local_date,
                 DataSource.source,
                 DataSource.device_model,
             )
-            .order_by(asc(cast(self.model.recorded_at, Date)))
+            .order_by(asc(local_date))
             .all()
         )
 
@@ -602,13 +607,18 @@ class DataPointSeriesRepository(
         """
         steps_id = get_series_type_id(SeriesType.steps)
 
+        local_date = cast(
+            self.model.recorded_at + cast(func.coalesce(self.model.zone_offset, "+00:00"), Interval),
+            Date,
+        )
+
         # Create minute bucket expression using literal 'minute' text
         minute_trunc = func.date_trunc(literal_column("'minute'"), self.model.recorded_at)
 
         # Subquery: bucket step data by minute and sum steps per minute
         minute_bucket = (
             db_session.query(
-                cast(self.model.recorded_at, Date).label("activity_date"),
+                local_date.label("activity_date"),
                 DataSource.source,
                 DataSource.device_model,
                 minute_trunc.label("minute_bucket"),
@@ -618,11 +628,11 @@ class DataPointSeriesRepository(
             .filter(
                 DataSource.user_id == user_id,
                 self.model.recorded_at >= start_date,
-                cast(self.model.recorded_at, Date) < cast(end_date, Date),
+                local_date < cast(end_date, Date),
                 self.model.series_type_definition_id == steps_id,
             )
             .group_by(
-                cast(self.model.recorded_at, Date),
+                local_date,
                 DataSource.source,
                 DataSource.device_model,
                 minute_trunc,
@@ -698,13 +708,18 @@ class DataPointSeriesRepository(
         """
         hr_id = get_series_type_id(SeriesType.heart_rate)
 
+        local_date = cast(
+            self.model.recorded_at + cast(func.coalesce(self.model.zone_offset, "+00:00"), Interval),
+            Date,
+        )
+
         # Create minute bucket expression
         minute_trunc = func.date_trunc(literal_column("'minute'"), self.model.recorded_at)
 
         # Subquery: bucket HR data by minute and get avg HR per minute
         minute_bucket = (
             db_session.query(
-                cast(self.model.recorded_at, Date).label("activity_date"),
+                local_date.label("activity_date"),
                 DataSource.source,
                 DataSource.device_model,
                 minute_trunc.label("minute_bucket"),
@@ -714,11 +729,11 @@ class DataPointSeriesRepository(
             .filter(
                 DataSource.user_id == user_id,
                 self.model.recorded_at >= start_date,
-                cast(self.model.recorded_at, Date) < cast(end_date, Date),
+                local_date < cast(end_date, Date),
                 self.model.series_type_definition_id == hr_id,
             )
             .group_by(
-                cast(self.model.recorded_at, Date),
+                local_date,
                 DataSource.source,
                 DataSource.device_model,
                 minute_trunc,

--- a/backend/app/repositories/data_point_series_repository.py
+++ b/backend/app/repositories/data_point_series_repository.py
@@ -546,7 +546,8 @@ class DataPointSeriesRepository(
             .join(DataSource, self.model.data_source_id == DataSource.id)
             .filter(
                 DataSource.user_id == user_id,
-                self.model.recorded_at >= start_date,
+                self.model.recorded_at >= start_date - timedelta(days=1),
+                local_date >= cast(start_date, Date),
                 local_date < cast(end_date, Date),
                 self.model.series_type_definition_id.in_(
                     [steps_id, energy_id, basal_energy_id, hr_id, distance_id, flights_id]
@@ -627,7 +628,8 @@ class DataPointSeriesRepository(
             .join(DataSource, self.model.data_source_id == DataSource.id)
             .filter(
                 DataSource.user_id == user_id,
-                self.model.recorded_at >= start_date,
+                self.model.recorded_at >= start_date - timedelta(days=1),
+                local_date >= cast(start_date, Date),
                 local_date < cast(end_date, Date),
                 self.model.series_type_definition_id == steps_id,
             )
@@ -728,7 +730,8 @@ class DataPointSeriesRepository(
             .join(DataSource, self.model.data_source_id == DataSource.id)
             .filter(
                 DataSource.user_id == user_id,
-                self.model.recorded_at >= start_date,
+                self.model.recorded_at >= start_date - timedelta(days=1),
+                local_date >= cast(start_date, Date),
                 local_date < cast(end_date, Date),
                 self.model.series_type_definition_id == hr_id,
             )

--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -644,9 +644,14 @@ class EventRecordRepository(
         - workout_date, source, device_model
         - elevation_meters, distance_meters, energy_burned_kcal
         """
+        local_workout_date = cast(
+            self.model.end_datetime + cast(func.coalesce(self.model.zone_offset, "+00:00"), Interval),
+            Date,
+        )
+
         results = (
             db_session.query(
-                cast(self.model.end_datetime, Date).label("workout_date"),
+                local_workout_date.label("workout_date"),
                 DataSource.source,
                 DataSource.device_model,
                 # Sum elevation gain for all workouts on that day
@@ -663,14 +668,14 @@ class EventRecordRepository(
                 DataSource.user_id == user_id,
                 self.model.category == "workout",
                 self.model.end_datetime >= start_date,
-                cast(self.model.end_datetime, Date) < cast(end_date, Date),
+                local_workout_date < cast(end_date, Date),
             )
             .group_by(
-                cast(self.model.end_datetime, Date),
+                local_workout_date,
                 DataSource.source,
                 DataSource.device_model,
             )
-            .order_by(asc(cast(self.model.end_datetime, Date)))
+            .order_by(asc(local_workout_date))
             .all()
         )
 

--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -667,7 +667,8 @@ class EventRecordRepository(
             .filter(
                 DataSource.user_id == user_id,
                 self.model.category == "workout",
-                self.model.end_datetime >= start_date,
+                self.model.end_datetime >= start_date - timedelta(days=1),
+                local_workout_date >= cast(start_date, Date),
                 local_workout_date < cast(end_date, Date),
             )
             .group_by(


### PR DESCRIPTION
## Description

Group daily aggregates/summaries/workouts (already implemented for sleep summaries) by local date
(add zone offset to UTC data stored in db) instead of incorrectly grouping everything by UTC

Resolves #396

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Daily summaries (activity, active minutes, intensity minutes, and workouts) now use local dates aligned to timezone offsets so events are attributed to the correct day.
  * Date-range filtering improved to include edge records near day boundaries, yielding more accurate daily aggregates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1033)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->