### PR TITLE
Chore/disable sdnn hrv cv

### DIFF
--- a/backend/app/integrations/celery/tasks/fill_missing_sleep_scores_task.py
+++ b/backend/app/integrations/celery/tasks/fill_missing_sleep_scores_task.py
@@ -19,9 +19,12 @@ logger = getLogger(__name__)
 
 # Find all non-nap sleep sessions that have no corresponding OW sleep score.
 # The match is on sleep_record_id (direct FK) so each session gets exactly one
-# score regardless of timezone-induced date collisions. wake_date (end_datetime
-# local date) is used purely to set recorded_at for API range queries.
-# Limited to sessions within the configured backfill window.
+# score regardless of timezone-induced date collisions. wake_date (local end
+# date) is used as the lookup key for get_sleep_scores_for_records and for
+# result ordering. recorded_at is set to the session's exact local end datetime
+# (local_end_datetime) so two sessions sharing the same wake date still produce
+# distinct recorded_at values. Limited to sessions within the configured
+# backfill window.
 _MISSING_SCORES_QUERY = text("""
     SELECT DISTINCT
         ds.user_id,

--- a/backend/app/integrations/celery/tasks/fill_missing_sleep_scores_task.py
+++ b/backend/app/integrations/celery/tasks/fill_missing_sleep_scores_task.py
@@ -26,7 +26,8 @@ _MISSING_SCORES_QUERY = text("""
     SELECT DISTINCT
         ds.user_id,
         er.id AS record_id,
-        (er.end_datetime + COALESCE(er.zone_offset, '+00:00')::interval)::date AS wake_date
+        (er.end_datetime + COALESCE(er.zone_offset, '+00:00')::interval)::date AS wake_date,
+        (er.end_datetime + COALESCE(er.zone_offset, '+00:00')::interval) AS local_end_datetime
     FROM event_record er
     JOIN data_source ds   ON ds.id = er.data_source_id
     JOIN sleep_details sd ON sd.record_id = er.id
@@ -60,10 +61,10 @@ def fill_missing_sleep_scores() -> dict:
         if not rows:
             return {"saved": 0, "skipped": 0}
 
-        # Group (record_id, wake_date) pairs per user
-        records_by_user: dict[UUID, list[tuple[UUID, date]]] = defaultdict(list)
-        for user_id, record_id, wake_date in rows:
-            records_by_user[UUID(str(user_id))].append((UUID(str(record_id)), wake_date))
+        # Group (record_id, wake_date, local_end_datetime) triples per user
+        records_by_user: dict[UUID, list[tuple[UUID, date, datetime]]] = defaultdict(list)
+        for user_id, record_id, wake_date, local_end in rows:
+            records_by_user[UUID(str(user_id))].append((UUID(str(record_id)), wake_date, local_end))
 
         log_structured(
             logger,
@@ -75,7 +76,11 @@ def fill_missing_sleep_scores() -> dict:
         total_saved = 0
         total_skipped = 0
 
-        for uid, record_wakes in records_by_user.items():
+        for uid, record_wakes_extended in records_by_user.items():
+            record_wakes = [(rid, wd) for rid, wd, _ in record_wakes_extended]
+            # Map record_id → local end datetime so recorded_at is unique per
+            # session even when two sessions share the same local wake date.
+            local_end_by_id: dict[UUID, datetime] = {rid: le for rid, _, le in record_wakes_extended}
             try:
                 scores_by_record = sleep_score_service.get_sleep_scores_for_records(db, uid, record_wakes)
             except Exception as e:
@@ -101,7 +106,7 @@ def fill_missing_sleep_scores() -> dict:
                     category=HealthScoreCategory.SLEEP,
                     value=result.overall_score,
                     sleep_record_id=record_id,
-                    recorded_at=datetime(wake_date.year, wake_date.month, wake_date.day, tzinfo=timezone.utc),
+                    recorded_at=local_end_by_id[record_id].replace(tzinfo=timezone.utc),
                     components={
                         "duration": ScoreComponent(value=result.breakdown.duration.score),
                         "stages": ScoreComponent(value=result.breakdown.stages.score),
@@ -109,7 +114,7 @@ def fill_missing_sleep_scores() -> dict:
                         "interruptions": ScoreComponent(value=result.breakdown.interruptions.score),
                     },
                 )
-                for (record_id, wake_date), result in scores_by_record.items()
+                for (record_id, _), result in scores_by_record.items()
             ]
 
             try:
@@ -119,7 +124,7 @@ def fill_missing_sleep_scores() -> dict:
                 total_skipped += len(record_wakes) - len(scores_to_save)
             except Exception as e:
                 db.rollback()
-                total_skipped += len(scores_to_save)
+                total_skipped += len(record_wakes)
                 log_and_capture_error(
                     e,
                     logger,

--- a/backend/app/integrations/celery/tasks/fill_missing_sleep_scores_task.py
+++ b/backend/app/integrations/celery/tasks/fill_missing_sleep_scores_task.py
@@ -18,28 +18,29 @@ from celery import shared_task
 logger = getLogger(__name__)
 
 # Find all non-nap sleep sessions that have no corresponding OW sleep score.
-# The match is on user + calendar date (UTC) of start_datetime vs recorded_at.
-# Limited to sessions within the configured backfill window to avoid scanning
-# the entire history on every run.
+# The match is on sleep_record_id (direct FK) so each session gets exactly one
+# score regardless of timezone-induced date collisions. wake_date (end_datetime
+# local date) is used purely to set recorded_at for API range queries.
+# Limited to sessions within the configured backfill window.
 _MISSING_SCORES_QUERY = text("""
     SELECT DISTINCT
         ds.user_id,
-        (er.start_datetime + COALESCE(er.zone_offset, '+00:00')::interval)::date AS sleep_date
+        er.id AS record_id,
+        (er.end_datetime + COALESCE(er.zone_offset, '+00:00')::interval)::date AS wake_date
     FROM event_record er
     JOIN data_source ds   ON ds.id = er.data_source_id
     JOIN sleep_details sd ON sd.record_id = er.id
     LEFT JOIN health_score hs
-           ON hs.user_id     = ds.user_id
+           ON hs.sleep_record_id = er.id
           AND hs.category     = 'sleep'
           AND hs.provider     = 'internal'
-          AND hs.recorded_at::date = (er.start_datetime + COALESCE(er.zone_offset, '+00:00')::interval)::date
     WHERE er.category = 'sleep'
       AND (sd.is_nap IS NULL OR sd.is_nap = false)
       AND sd.sleep_total_duration_minutes IS NOT NULL
       AND sd.sleep_total_duration_minutes > 0
       AND hs.id IS NULL
       AND er.start_datetime >= :cutoff
-    ORDER BY ds.user_id, sleep_date DESC
+    ORDER BY ds.user_id, wake_date DESC
 """)
 
 
@@ -48,8 +49,8 @@ def fill_missing_sleep_scores() -> dict:
     """Find sleep sessions without an OW sleep score and calculate them.
 
     Runs frequently (every few minutes) so scores appear shortly after any sync
-    path (periodic pull, webhook, SDK upload). Uses a LEFT JOIN to guarantee
-    idempotency — already-scored sessions are never re-processed.
+    path (periodic pull, webhook, SDK upload). Uses a LEFT JOIN on sleep_record_id
+    to guarantee idempotency — already-scored sessions are never re-processed.
     """
     cutoff = datetime.now(timezone.utc) - timedelta(days=settings.score_backfill_days)
 
@@ -59,26 +60,26 @@ def fill_missing_sleep_scores() -> dict:
         if not rows:
             return {"saved": 0, "skipped": 0}
 
-        # Group dates per user
-        dates_by_user: dict[UUID, list[date]] = defaultdict(list)
-        for user_id, sleep_date in rows:
-            dates_by_user[UUID(str(user_id))].append(sleep_date)
+        # Group (record_id, wake_date) pairs per user
+        records_by_user: dict[UUID, list[tuple[UUID, date]]] = defaultdict(list)
+        for user_id, record_id, wake_date in rows:
+            records_by_user[UUID(str(user_id))].append((UUID(str(record_id)), wake_date))
 
         log_structured(
             logger,
             "info",
-            f"Found {len(rows)} session(s) missing scores across {len(dates_by_user)} user(s)",
+            f"Found {len(rows)} session(s) missing scores across {len(records_by_user)} user(s)",
             task="fill_missing_sleep_scores",
         )
 
         total_saved = 0
         total_skipped = 0
 
-        for uid, dates in dates_by_user.items():
+        for uid, record_wakes in records_by_user.items():
             try:
-                scores_by_date = sleep_score_service.get_sleep_scores_for_date_range(db, uid, dates)
+                scores_by_record = sleep_score_service.get_sleep_scores_for_records(db, uid, record_wakes)
             except Exception as e:
-                total_skipped += len(dates)
+                total_skipped += len(record_wakes)
                 log_and_capture_error(
                     e,
                     logger,
@@ -87,8 +88,8 @@ def fill_missing_sleep_scores() -> dict:
                 )
                 continue
 
-            if not scores_by_date:
-                total_skipped += len(dates)
+            if not scores_by_record:
+                total_skipped += len(record_wakes)
                 continue
 
             scores_to_save = [
@@ -99,7 +100,8 @@ def fill_missing_sleep_scores() -> dict:
                     provider=ProviderName.INTERNAL,
                     category=HealthScoreCategory.SLEEP,
                     value=result.overall_score,
-                    recorded_at=datetime(d.year, d.month, d.day, tzinfo=timezone.utc),
+                    sleep_record_id=record_id,
+                    recorded_at=datetime(wake_date.year, wake_date.month, wake_date.day, tzinfo=timezone.utc),
                     components={
                         "duration": ScoreComponent(value=result.breakdown.duration.score),
                         "stages": ScoreComponent(value=result.breakdown.stages.score),
@@ -107,14 +109,14 @@ def fill_missing_sleep_scores() -> dict:
                         "interruptions": ScoreComponent(value=result.breakdown.interruptions.score),
                     },
                 )
-                for d, result in scores_by_date.items()
+                for (record_id, wake_date), result in scores_by_record.items()
             ]
 
             try:
                 health_score_service.bulk_create(db, scores_to_save)
                 db.commit()
                 total_saved += len(scores_to_save)
-                total_skipped += len(dates) - len(scores_to_save)
+                total_skipped += len(record_wakes) - len(scores_to_save)
             except Exception as e:
                 db.rollback()
                 total_skipped += len(scores_to_save)

--- a/backend/app/models/health_score.py
+++ b/backend/app/models/health_score.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import UniqueConstraint
-from sqlalchemy.orm import Mapped
+from sqlalchemy import ForeignKey, Index, UniqueConstraint, text
+from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import BaseDbModel
 from app.mappings import FKDataSource, FKUser, PrimaryKey, json_binary, numeric_5_2, str_10, str_32
@@ -21,6 +21,12 @@ class HealthScore(BaseDbModel):
             "recorded_at",
             name="uq_health_score_user_provider_category_time",
         ),
+        Index(
+            "uq_health_score_sleep_record",
+            "sleep_record_id",
+            unique=True,
+            postgresql_where=text("sleep_record_id IS NOT NULL"),
+        ),
     )
 
     id: Mapped[PrimaryKey[UUID]]
@@ -36,3 +42,7 @@ class HealthScore(BaseDbModel):
     zone_offset: Mapped[str_10 | None]
 
     components: Mapped[json_binary | None]
+
+    sleep_record_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("event_record.id", ondelete="CASCADE"), nullable=True, index=True
+    )

--- a/backend/app/models/health_score.py
+++ b/backend/app/models/health_score.py
@@ -21,6 +21,8 @@ class HealthScore(BaseDbModel):
             "recorded_at",
             name="uq_health_score_user_provider_category_time",
         ),
+        # SQLAlchemy's UniqueConstraint doesn't support postgresql_where, so we
+        # use Index(..., unique=True) to express this partial unique constraint.
         Index(
             "uq_health_score_sleep_record",
             "sleep_record_id",
@@ -44,5 +46,5 @@ class HealthScore(BaseDbModel):
     components: Mapped[json_binary | None]
 
     sleep_record_id: Mapped[UUID | None] = mapped_column(
-        ForeignKey("event_record.id", ondelete="CASCADE"), nullable=True, index=True
+        ForeignKey("event_record.id", ondelete="CASCADE"), nullable=True
     )

--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -422,9 +422,11 @@ class EventRecordRepository(
         # is_nap can be True, False, or NULL - we treat NULL as "not a nap"
         is_main_sleep = func.coalesce(SleepDetails.is_nap, False) == False  # noqa: E712
 
-        # Local calendar date the session started — mirrors score date logic in fill_missing_sleep_scores_task.
+        # Local calendar date the session ended (wake-up date) — mirrors score
+        # date logic in fill_missing_sleep_scores_task so chart, score, and
+        # session list all key on the same date.
         local_sleep_date = cast(
-            EventRecord.start_datetime + cast(func.coalesce(EventRecord.zone_offset, "+00:00"), Interval),
+            EventRecord.end_datetime + cast(func.coalesce(EventRecord.zone_offset, "+00:00"), Interval),
             Date,
         )
 

--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -496,7 +496,7 @@ class EventRecordRepository(
             .filter(
                 DataSource.user_id == user_id,
                 EventRecord.category == "sleep",
-                EventRecord.end_datetime >= start_date,
+                EventRecord.end_datetime >= start_date - timedelta(days=1),
                 local_sleep_date >= cast(start_date, Date),
                 local_sleep_date < cast(end_date, Date),
             )

--- a/backend/app/repositories/health_score_repository.py
+++ b/backend/app/repositories/health_score_repository.py
@@ -51,11 +51,7 @@ class HealthScoreRepository(CrudRepository[HealthScore, HealthScoreCreate, Healt
 
         values = [c.model_dump() for c in creators]
 
-        stmt = (
-            insert(HealthScore)
-            .values(values)
-            .on_conflict_do_nothing(index_elements=["user_id", "provider", "category", "recorded_at"])
-        )
+        stmt = insert(HealthScore).values(values).on_conflict_do_nothing()
         db_session.execute(stmt)
         # Caller is responsible for commit — allows batching with other operations
 

--- a/backend/app/schemas/model_crud/activities/health_score.py
+++ b/backend/app/schemas/model_crud/activities/health_score.py
@@ -36,6 +36,7 @@ class HealthScoreCreate(HealthScoreBase):
     user_id: UUID
     data_source_id: UUID | None = None
     provider: ProviderName
+    sleep_record_id: UUID | None = None
 
 
 class HealthScoreUpdate(HealthScoreBase): ...

--- a/backend/app/services/scores/resilience_service.py
+++ b/backend/app/services/scores/resilience_service.py
@@ -212,11 +212,12 @@ class ResilienceScoreService:
         filtered_hrv = self._filter_points_to_windows(hrv_pts, windows)
         metric_type: str = "RMSSD"
 
-        if not filtered_hrv:
-            sdnn_type_id = get_series_type_id(SeriesType.heart_rate_variability_sdnn)
-            sdnn_pts = self._query_data_series(db_session, user_id, sdnn_type_id, start_dt, end_dt)
-            filtered_hrv = self._filter_points_to_windows(sdnn_pts, windows)
-            metric_type = "SDNN"
+        # NOTE: SDNN fallback is disabled pending validation — only RMSSD is used for now.
+        # if not filtered_hrv:
+        #     sdnn_type_id = get_series_type_id(SeriesType.heart_rate_variability_sdnn)
+        #     sdnn_pts = self._query_data_series(db_session, user_id, sdnn_type_id, start_dt, end_dt)
+        #     filtered_hrv = self._filter_points_to_windows(sdnn_pts, windows)
+        #     metric_type = "SDNN"
 
         if not filtered_hrv:
             return HrvCvScoreResult(
@@ -393,11 +394,12 @@ class ResilienceScoreService:
         filtered_hrv = self._filter_points_to_windows(hrv_pts, windows)
         metric_type: str = "RMSSD"
 
-        if not filtered_hrv:
-            sdnn_type_id = get_series_type_id(SeriesType.heart_rate_variability_sdnn)
-            sdnn_pts = self._query_data_series(db_session, user_id, sdnn_type_id, start_dt, end_dt)
-            filtered_hrv = self._filter_points_to_windows(sdnn_pts, windows)
-            metric_type = "SDNN"
+        # NOTE: SDNN fallback is disabled pending validation — only RMSSD is used for now.
+        # if not filtered_hrv:
+        #     sdnn_type_id = get_series_type_id(SeriesType.heart_rate_variability_sdnn)
+        #     sdnn_pts = self._query_data_series(db_session, user_id, sdnn_type_id, start_dt, end_dt)
+        #     filtered_hrv = self._filter_points_to_windows(sdnn_pts, windows)
+        #     metric_type = "SDNN"
 
         # Group all filtered points by UTC date once; reused for every reference_date.
         by_day = self._group_by_day(filtered_hrv)

--- a/backend/app/services/scores/sleep_service.py
+++ b/backend/app/services/scores/sleep_service.py
@@ -226,6 +226,118 @@ class SleepScoreService:
             sleep_stages=sleep_stages,
         )
 
+    def get_sleep_scores_for_records(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        record_wakes: list[tuple[UUID, date]],
+    ) -> dict[tuple[UUID, date], SleepScoreResult]:
+        """Calculate sleep scores for specific event records identified by ID.
+
+        Accepts (record_id, wake_date) pairs so each session is matched exactly
+        — no date-collision issues for users in extreme time zones. Returns a
+        dict keyed by the same (record_id, wake_date) tuples so callers can
+        retrieve the wake_date when persisting recorded_at.
+
+        Calculation logic (historical bedtimes, stage parsing, algorithm) is
+        unchanged relative to get_sleep_scores_for_date_range.
+        """
+        if not record_wakes:
+            return {}
+
+        target_ids = {r_id for r_id, _ in record_wakes}
+        wake_by_id = {r_id: wake_d for r_id, wake_d in record_wakes}
+
+        earliest_wake = min(wake_d for _, wake_d in record_wakes)
+        latest_wake = max(wake_d for _, wake_d in record_wakes)
+
+        # Fetch a window broad enough to cover target sessions (which may start
+        # the evening before their wake_date) plus rolling history for consistency.
+        window_start = datetime(earliest_wake.year, earliest_wake.month, earliest_wake.day) - timedelta(
+            days=sleep_config.rolling_window_nights + 2
+        )
+        window_end = datetime(latest_wake.year, latest_wake.month, latest_wake.day) + timedelta(days=2)
+
+        all_records, _ = self.event_record_repo.get_records_with_filters(
+            db_session,
+            EventRecordQueryParams(
+                category="sleep",
+                start_datetime=window_start,
+                end_datetime=window_end,
+                sort_by="start_datetime",
+                sort_order="asc",
+                limit=(len(record_wakes) + sleep_config.rolling_window_nights) * 4,
+            ),
+            str(user_id),
+        )
+
+        # Build a sorted list of all valid non-nap sessions in the window for
+        # history lookup, and separately index the target sessions by record id.
+        all_sessions_asc: list[tuple[date, EventRecord, SleepDetails]] = []
+        target_by_id: dict[UUID, tuple[EventRecord, SleepDetails]] = {}
+
+        for record, _ in all_records:
+            if isinstance((detail := record.detail), SleepDetails) and not detail.is_nap:
+                local_start = self._apply_zone_offset(record.start_datetime, record.zone_offset)
+                all_sessions_asc.append((local_start.date(), record, detail))
+                if record.id in target_ids:
+                    target_by_id[record.id] = (record, detail)
+
+        all_sessions_asc.sort(key=lambda x: x[0])
+
+        results: dict[tuple[UUID, date], SleepScoreResult] = {}
+        skipped: list[tuple[UUID, str, str]] = []  # (record_id, record_id_str, reason)
+
+        for r_id, (record, detail) in target_by_id.items():
+            local_start = self._apply_zone_offset(record.start_datetime, record.zone_offset)
+            target_night = local_start.date()
+
+            # Historical bedtimes: non-nap sessions before this one within the
+            # rolling window. Deduplicate by calendar start-date so multiple
+            # sources on the same night don't crowd out earlier history.
+            history_cutoff = target_night - timedelta(days=sleep_config.rolling_window_nights + 1)
+            seen_nights: set[date] = set()
+            historical_bedtimes: list[datetime] = []
+            for night, hist_record, _ in reversed(all_sessions_asc):
+                if night >= target_night:
+                    continue
+                if night < history_cutoff:
+                    break
+                if night not in seen_nights:
+                    seen_nights.add(night)
+                    historical_bedtimes.append(
+                        self._apply_zone_offset(hist_record.start_datetime, hist_record.zone_offset)
+                    )
+                if len(historical_bedtimes) >= sleep_config.rolling_window_nights:
+                    break
+
+            sleep_stages: list[SleepStage] | None = None
+            if detail.sleep_stages:
+                sleep_stages = [SleepStage(**s) for s in detail.sleep_stages]
+
+            try:
+                results[(r_id, wake_by_id[r_id])] = self.get_sleep_score(
+                    total_sleep_duration_minutes=float(detail.sleep_total_duration_minutes or 0),
+                    deep_minutes=float(detail.sleep_deep_minutes or 0),
+                    rem_minutes=float(detail.sleep_rem_minutes or 0),
+                    awake_minutes=float(detail.sleep_awake_minutes or 0),
+                    session_start=local_start,
+                    historical_bedtimes=historical_bedtimes,
+                    sleep_stages=sleep_stages,
+                )
+            except (ValueError, OverflowError) as exc:
+                skipped.append((r_id, str(record.id), str(exc)))
+
+        if skipped:
+            log_structured(
+                self.logger,
+                "warning",
+                f"Skipped sleep score for {len(skipped)} record(s): invalid session data",
+                skipped=[{"record_id": rid, "reason": reason} for _, rid, reason in skipped],
+            )
+
+        return results
+
     def get_sleep_scores_for_date_range(
         self,
         db_session: DbSession,

--- a/backend/migrations/versions/2026_04_16_1200-a3f8c1d2e4b5_clear_internal_sleep_scores.py
+++ b/backend/migrations/versions/2026_04_16_1200-a3f8c1d2e4b5_clear_internal_sleep_scores.py
@@ -46,6 +46,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # NOTE: The internal sleep-score rows deleted in upgrade() cannot be restored
+    # here. fill_missing_sleep_scores will recreate them on the next run.
     op.drop_index("uq_health_score_sleep_record", table_name="health_score")
     op.drop_constraint("fk_health_score_sleep_record_id", "health_score", type_="foreignkey")
     op.drop_column("health_score", "sleep_record_id")

--- a/backend/migrations/versions/2026_04_16_1200-a3f8c1d2e4b5_clear_internal_sleep_scores.py
+++ b/backend/migrations/versions/2026_04_16_1200-a3f8c1d2e4b5_clear_internal_sleep_scores.py
@@ -1,0 +1,51 @@
+"""align internal sleep scores to wake-up date with direct record linkage
+
+Revision ID: a3f8c1d2e4b5
+Revises: cdac07b15b04
+
+Adds a sleep_record_id FK column to health_score so each internal sleep score
+is linked directly to the event_record it was calculated from, eliminating
+date-collision issues for users in extreme time zones. recorded_at is now
+set to midnight of the local wake-up date (end_datetime) rather than bedtime.
+
+Existing internal sleep scores are deleted so fill_missing_sleep_scores can
+recreate them with the new linkage and correct dates.
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a3f8c1d2e4b5"
+down_revision: Union[str, None] = "cdac07b15b04"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("health_score", sa.Column("sleep_record_id", sa.UUID(), nullable=True))
+    op.create_foreign_key(
+        "fk_health_score_sleep_record_id",
+        "health_score",
+        "event_record",
+        ["sleep_record_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index(
+        "uq_health_score_sleep_record",
+        "health_score",
+        ["sleep_record_id"],
+        unique=True,
+        postgresql_where=sa.text("sleep_record_id IS NOT NULL"),
+    )
+    op.execute("DELETE FROM health_score WHERE provider = 'internal' AND category = 'sleep'")
+
+
+def downgrade() -> None:
+    op.drop_index("uq_health_score_sleep_record", table_name="health_score")
+    op.drop_constraint("fk_health_score_sleep_record_id", "health_score", type_="foreignkey")
+    op.drop_column("health_score", "sleep_record_id")

--- a/backend/tests/api/v1/test_summaries.py
+++ b/backend/tests/api/v1/test_summaries.py
@@ -46,7 +46,7 @@ class TestSleepSummaryEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert len(data["data"]) == 1
-        assert data["data"][0]["date"] == "2025-12-25"
+        assert data["data"][0]["date"] == "2025-12-26"  # wake-up date (end_datetime)
         assert data["data"][0]["start_time"] == "2025-12-25T22:00:00Z"
         assert data["data"][0]["end_time"] == "2025-12-26T05:00:00Z"
         assert data["data"][0]["duration_minutes"] == 420  # 7 hours
@@ -91,7 +91,7 @@ class TestSleepSummaryEndpoint:
         assert len(data["data"]) == 1
 
         sleep_data = data["data"][0]
-        assert sleep_data["date"] == "2025-12-25"
+        assert sleep_data["date"] == "2025-12-26"  # wake-up date (end_datetime)
         assert sleep_data["duration_minutes"] == 420  # net sleep (sleep_total_duration_minutes), not time_in_bed
 
         # Verify sleep details are populated
@@ -256,11 +256,12 @@ class TestSleepSummaryEndpoint:
 
         assert response.status_code == 200
         data = response.json()
-        # Main sleep (local start Dec 25) and nap (local start Dec 26) land on separate dates.
-        assert len(data["data"]) == 2
+        # Both sessions end on Dec 26 (wake-up date), so they collapse into one summary entry.
+        # Main sleep fields come from the overnight session; nap fields are aggregated alongside.
+        assert len(data["data"]) == 1
 
         main_sleep_data = data["data"][0]
-        assert main_sleep_data["date"] == "2025-12-25"
+        assert main_sleep_data["date"] == "2025-12-26"  # wake-up date (end_datetime)
         assert main_sleep_data["start_time"] == "2025-12-25T22:00:00Z"
         assert main_sleep_data["end_time"] == "2025-12-26T06:00:00Z"
         assert main_sleep_data["duration_minutes"] == 480
@@ -268,13 +269,8 @@ class TestSleepSummaryEndpoint:
         assert main_sleep_data["efficiency_percent"] == 85.0
         assert main_sleep_data["stages"]["deep_minutes"] == 90
         assert main_sleep_data["stages"]["light_minutes"] == 210
-        assert main_sleep_data["nap_count"] == 0
-        assert main_sleep_data["nap_duration_minutes"] == 0
-
-        nap_data = data["data"][1]
-        assert nap_data["date"] == "2025-12-26"
-        assert nap_data["nap_count"] == 1
-        assert nap_data["nap_duration_minutes"] == 30
+        assert main_sleep_data["nap_count"] == 1
+        assert main_sleep_data["nap_duration_minutes"] == 30
 
     def test_get_sleep_summary_no_naps(self, client: TestClient, db: Session) -> None:
         """Test sleep summary returns null for nap fields when no naps exist."""

--- a/backend/tests/services/scores/test_resilience_service.py
+++ b/backend/tests/services/scores/test_resilience_service.py
@@ -479,6 +479,7 @@ class TestGetHrvCvScore:
         result = service.get_hrv_cv_score(db, user.id, ref)
         assert result.metric_type == "RMSSD"
 
+    @pytest.mark.skip(reason="SDNN fallback disabled pending validation — re-enable when SDNN path is re-activated")
     def test_falls_back_to_sdnn_when_no_rmssd(self, db: Session) -> None:
         user = UserFactory()
         ds = DataSourceFactory(user=user)
@@ -502,6 +503,7 @@ class TestGetHrvCvScore:
         result = service.get_hrv_cv_score(db, user.id, ref)
         assert result.metric_type == "SDNN"
 
+    @pytest.mark.skip(reason="SDNN fallback disabled pending validation — re-enable when SDNN path is re-activated")
     def test_falls_back_to_sdnn_when_rmssd_only_outside_sleep(self, db: Session) -> None:
         """Daytime RMSSD (no overnight data) + overnight SDNN → SDNN is used."""
         user = UserFactory()

--- a/backend/tests/services/scores/test_sleep_score_service.py
+++ b/backend/tests/services/scores/test_sleep_score_service.py
@@ -669,3 +669,181 @@ class TestGetSleepScoreEdgeCases:
             sleep_stages=None,
         )
         assert result_high_awake.breakdown.interruptions.score < result_low_awake.breakdown.interruptions.score
+
+
+# ---------------------------------------------------------------------------
+# DB-backed tests for get_sleep_scores_for_records
+# ---------------------------------------------------------------------------
+
+
+class TestGetSleepScoresForRecords:
+    """E2E tests for SleepScoreService.get_sleep_scores_for_records.
+
+    Verifies that scores are keyed by record_id (not date) so that:
+    - overnight sessions that cross midnight land on their wake date
+    - two sessions whose local wake dates collide still produce two distinct scores
+    """
+
+    def _make_sleep_record(
+        self,
+        db: Session,
+        data_source: DataSource,
+        start: datetime,
+        end: datetime,
+        duration_minutes: int = 480,
+        deep_minutes: int = 120,
+        rem_minutes: int = 90,
+        awake_minutes: int = 20,
+        zone_offset: str | None = None,
+        is_nap: bool = False,
+    ) -> EventRecord:
+        record = EventRecordFactory(
+            category="sleep",
+            type_="sleep",
+            start_datetime=start,
+            end_datetime=end,
+            duration_seconds=(duration_minutes + awake_minutes) * 60,
+            data_source=data_source,
+            zone_offset=zone_offset,
+        )
+        SleepDetailsFactory(
+            event_record=record,
+            sleep_total_duration_minutes=duration_minutes,
+            sleep_deep_minutes=deep_minutes,
+            sleep_rem_minutes=rem_minutes,
+            sleep_awake_minutes=awake_minutes,
+            sleep_light_minutes=max(0, duration_minutes - deep_minutes - rem_minutes),
+            is_nap=is_nap,
+        )
+        db.flush()
+        return record
+
+    def test_empty_input_returns_empty(self, db: Session) -> None:
+        user = UserFactory()
+        db.flush()
+        result = service.get_sleep_scores_for_records(db, user.id, [])
+        assert result == {}
+
+    def test_overnight_session_keyed_by_record_id(self, db: Session) -> None:
+        """An overnight session (Mon 23:00 → Tue 07:00 UTC) is keyed by record_id."""
+        user = UserFactory()
+        ds = DataSourceFactory(user=user)
+        db.flush()
+
+        start = datetime(2026, 3, 10, 23, 0, tzinfo=timezone.utc)
+        end = datetime(2026, 3, 11, 7, 0, tzinfo=timezone.utc)
+        record = self._make_sleep_record(db, ds, start, end)
+
+        # wake_date is the local end date (UTC here, so Tue 2026-03-11)
+        wake_date = date(2026, 3, 11)
+        results = service.get_sleep_scores_for_records(db, user.id, [(record.id, wake_date)])
+
+        assert len(results) == 1
+        key = (record.id, wake_date)
+        assert key in results
+        assert 0 <= results[key].overall_score <= 100
+
+    def test_two_sessions_same_wake_date_both_scored(self, db: Session) -> None:
+        """Two sessions with the same local end_date produce two distinct scores.
+
+        This is the core timezone-collision case the record-id approach solves.
+        """
+        user = UserFactory()
+        ds = DataSourceFactory(user=user)
+        db.flush()
+
+        # Session A: finishes early Tue morning (shorter)
+        record_a = self._make_sleep_record(
+            db,
+            ds,
+            start=datetime(2026, 3, 10, 1, 0, tzinfo=timezone.utc),
+            end=datetime(2026, 3, 10, 5, 0, tzinfo=timezone.utc),
+            duration_minutes=220,
+            deep_minutes=40,
+            rem_minutes=40,
+            awake_minutes=20,
+        )
+        # Session B: normal overnight on the same calendar day (longer)
+        record_b = self._make_sleep_record(
+            db,
+            ds,
+            start=datetime(2026, 3, 10, 23, 0, tzinfo=timezone.utc),
+            end=datetime(2026, 3, 11, 7, 0, tzinfo=timezone.utc),
+            duration_minutes=460,
+            deep_minutes=100,
+            rem_minutes=90,
+            awake_minutes=20,
+        )
+
+        wake_a = date(2026, 3, 10)
+        wake_b = date(2026, 3, 11)
+        results = service.get_sleep_scores_for_records(db, user.id, [(record_a.id, wake_a), (record_b.id, wake_b)])
+
+        assert len(results) == 2
+        assert (record_a.id, wake_a) in results
+        assert (record_b.id, wake_b) in results
+        # Longer session should score better on duration
+        assert (
+            results[(record_b.id, wake_b)].breakdown.duration.score
+            > results[(record_a.id, wake_a)].breakdown.duration.score
+        )
+
+    def test_history_contributes_to_consistency_score(self, db: Session) -> None:
+        """Prior sessions are still used for consistency scoring."""
+        user = UserFactory()
+        ds = DataSourceFactory(user=user)
+        db.flush()
+
+        # 7 prior nights of consistent 23:00 bedtime
+        base = date(2026, 3, 10)
+        for delta in range(7, 0, -1):
+            prior = base - timedelta(days=delta)
+            self._make_sleep_record(
+                db,
+                ds,
+                start=datetime(prior.year, prior.month, prior.day, 23, 0, tzinfo=timezone.utc),
+                end=datetime(prior.year, prior.month, prior.day + 1, 7, 0, tzinfo=timezone.utc),
+            )
+
+        # Target night, same bedtime
+        record = self._make_sleep_record(
+            db,
+            ds,
+            start=datetime(2026, 3, 10, 23, 0, tzinfo=timezone.utc),
+            end=datetime(2026, 3, 11, 7, 0, tzinfo=timezone.utc),
+        )
+        db.flush()
+
+        wake_date = date(2026, 3, 11)
+        results = service.get_sleep_scores_for_records(db, user.id, [(record.id, wake_date)])
+
+        assert (record.id, wake_date) in results
+        assert results[(record.id, wake_date)].breakdown.consistency.score > 0
+
+    def test_invalid_session_zero_duration_is_skipped(self, db: Session) -> None:
+        """A record with zero sleep duration is silently skipped (no key in result)."""
+        user = UserFactory()
+        ds = DataSourceFactory(user=user)
+        db.flush()
+
+        record = EventRecordFactory(
+            category="sleep",
+            type_="sleep",
+            start_datetime=datetime(2026, 3, 10, 23, 0, tzinfo=timezone.utc),
+            end_datetime=datetime(2026, 3, 11, 7, 0, tzinfo=timezone.utc),
+            data_source=ds,
+        )
+        SleepDetailsFactory(
+            event_record=record,
+            sleep_total_duration_minutes=0,
+            sleep_deep_minutes=0,
+            sleep_rem_minutes=0,
+            sleep_awake_minutes=0,
+            is_nap=False,
+        )
+        db.flush()
+
+        wake_date = date(2026, 3, 11)
+        results = service.get_sleep_scores_for_records(db, user.id, [(record.id, wake_date)])
+
+        assert (record.id, wake_date) not in results

--- a/backend/tests/services/scores/test_sleep_score_service.py
+++ b/backend/tests/services/scores/test_sleep_score_service.py
@@ -763,29 +763,30 @@ class TestGetSleepScoresForRecords:
             rem_minutes=40,
             awake_minutes=20,
         )
-        # Session B: normal overnight on the same calendar day (longer)
+        # Session B: also ends on 2026-03-10 — same local wake date as A.
+        # This is the core collision case: a date-keyed implementation would
+        # silently drop one score, but record-id keying returns both.
         record_b = self._make_sleep_record(
             db,
             ds,
-            start=datetime(2026, 3, 10, 23, 0, tzinfo=timezone.utc),
-            end=datetime(2026, 3, 11, 7, 0, tzinfo=timezone.utc),
+            start=datetime(2026, 3, 9, 23, 0, tzinfo=timezone.utc),
+            end=datetime(2026, 3, 10, 7, 0, tzinfo=timezone.utc),
             duration_minutes=460,
             deep_minutes=100,
             rem_minutes=90,
             awake_minutes=20,
         )
 
-        wake_a = date(2026, 3, 10)
-        wake_b = date(2026, 3, 11)
-        results = service.get_sleep_scores_for_records(db, user.id, [(record_a.id, wake_a), (record_b.id, wake_b)])
+        wake = date(2026, 3, 10)  # both sessions share the same local wake date
+        results = service.get_sleep_scores_for_records(db, user.id, [(record_a.id, wake), (record_b.id, wake)])
 
         assert len(results) == 2
-        assert (record_a.id, wake_a) in results
-        assert (record_b.id, wake_b) in results
+        assert (record_a.id, wake) in results
+        assert (record_b.id, wake) in results
         # Longer session should score better on duration
         assert (
-            results[(record_b.id, wake_b)].breakdown.duration.score
-            > results[(record_a.id, wake_a)].breakdown.duration.score
+            results[(record_b.id, wake)].breakdown.duration.score
+            > results[(record_a.id, wake)].breakdown.duration.score
         )
 
     def test_history_contributes_to_consistency_score(self, db: Session) -> None:


### PR DESCRIPTION
Disables the SDNN fallback in the HRV-CV resilience score calculation while it undergoes validation. Previously, if no overnight RMSSD data were found within the sleep-window filter, the score would silently fall back to SDNN. Until SDNN-based CV is validated, we want resilience scores to be computed exclusively from RMSSD — users without overnight RMSSD data will receive a null score rather than a potentially misleading SDNN-derived one.                                                                                                                

*Additional Notes*
 Temporary change. The SDNN fallback code is intentionally left in place (commented out) so it can be re-enabled without rewriting — just uncomment and unskip the two tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sleep summaries now group sessions by wake-up date instead of sleep start date
  * Sleep and nap sessions ending on the same date now consolidate into a single daily summary with combined metrics

* **Changes**
  * SDNN fallback for heart rate variability metrics has been temporarily disabled

* **Bug Fixes**
  * Enhanced internal sleep score tracking and data alignment

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1038)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->