### PR TITLE
chore: disable SDNN fallback in HRV-CV score calculation pending validation

### DIFF
--- a/backend/app/services/scores/resilience_service.py
+++ b/backend/app/services/scores/resilience_service.py
@@ -212,11 +212,12 @@ class ResilienceScoreService:
         filtered_hrv = self._filter_points_to_windows(hrv_pts, windows)
         metric_type: str = "RMSSD"
 
-        if not filtered_hrv:
-            sdnn_type_id = get_series_type_id(SeriesType.heart_rate_variability_sdnn)
-            sdnn_pts = self._query_data_series(db_session, user_id, sdnn_type_id, start_dt, end_dt)
-            filtered_hrv = self._filter_points_to_windows(sdnn_pts, windows)
-            metric_type = "SDNN"
+        # NOTE: SDNN fallback is disabled pending validation — only RMSSD is used for now.
+        # if not filtered_hrv:
+        #     sdnn_type_id = get_series_type_id(SeriesType.heart_rate_variability_sdnn)
+        #     sdnn_pts = self._query_data_series(db_session, user_id, sdnn_type_id, start_dt, end_dt)
+        #     filtered_hrv = self._filter_points_to_windows(sdnn_pts, windows)
+        #     metric_type = "SDNN"
 
         if not filtered_hrv:
             return HrvCvScoreResult(
@@ -393,11 +394,12 @@ class ResilienceScoreService:
         filtered_hrv = self._filter_points_to_windows(hrv_pts, windows)
         metric_type: str = "RMSSD"
 
-        if not filtered_hrv:
-            sdnn_type_id = get_series_type_id(SeriesType.heart_rate_variability_sdnn)
-            sdnn_pts = self._query_data_series(db_session, user_id, sdnn_type_id, start_dt, end_dt)
-            filtered_hrv = self._filter_points_to_windows(sdnn_pts, windows)
-            metric_type = "SDNN"
+        # NOTE: SDNN fallback is disabled pending validation — only RMSSD is used for now.
+        # if not filtered_hrv:
+        #     sdnn_type_id = get_series_type_id(SeriesType.heart_rate_variability_sdnn)
+        #     sdnn_pts = self._query_data_series(db_session, user_id, sdnn_type_id, start_dt, end_dt)
+        #     filtered_hrv = self._filter_points_to_windows(sdnn_pts, windows)
+        #     metric_type = "SDNN"
 
         # Group all filtered points by UTC date once; reused for every reference_date.
         by_day = self._group_by_day(filtered_hrv)

--- a/backend/tests/services/scores/test_resilience_service.py
+++ b/backend/tests/services/scores/test_resilience_service.py
@@ -479,6 +479,7 @@ class TestGetHrvCvScore:
         result = service.get_hrv_cv_score(db, user.id, ref)
         assert result.metric_type == "RMSSD"
 
+    @pytest.mark.skip(reason="SDNN fallback disabled pending validation — re-enable when SDNN path is re-activated")
     def test_falls_back_to_sdnn_when_no_rmssd(self, db: Session) -> None:
         user = UserFactory()
         ds = DataSourceFactory(user=user)
@@ -502,6 +503,7 @@ class TestGetHrvCvScore:
         result = service.get_hrv_cv_score(db, user.id, ref)
         assert result.metric_type == "SDNN"
 
+    @pytest.mark.skip(reason="SDNN fallback disabled pending validation — re-enable when SDNN path is re-activated")
     def test_falls_back_to_sdnn_when_rmssd_only_outside_sleep(self, db: Session) -> None:
         """Daytime RMSSD (no overnight data) + overnight SDNN → SDNN is used."""
         user = UserFactory()


### PR DESCRIPTION
## Description

Disables the SDNN fallback in the HRV-CV resilience score calculation while it undergoes validation. Previously, if no overnight RMSSD data was found within the sleep-window filter, the score would silently fall back to SDNN. Until SDNN-based CV is validated, we want resilience scores to be computed exclusively from RMSSD — users without overnight RMSSD data will receive a null score rather than a potentially misleading SDNN-derived one.

The change touches two methods in `ResilienceScoreService`:
- `get_hrv_cv_score`
- `get_hrv_cv_scores_for_date_range`

The SDNN path is preserved as commented-out code for easy re-enablement once validation is complete.

The two tests that asserted the old fallback behaviour are skipped with a matching note.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

N/A

## Testing Instructions

**Steps to test:**
1. Find (or seed) a user who has only SDNN HRV data in the lookback window — no RMSSD at all.
2. Trigger a resilience score calculation for that user.
3. Confirm the response returns `hrv_cv: null` and `metric_type: null` instead of an SDNN-derived score.
4. For a user with overnight RMSSD data, confirm the score is unaffected.

**Expected behavior:**
- Users with RMSSD data → score calculated as before.
- Users without RMSSD data → null resilience score (no silent SDNN fallback).

## Screenshots

N/A

## Additional Notes

Temporary change. The SDNN fallback code is intentionally left in place (commented out) so it can be re-enabled without rewriting — just uncomment and unskip the two tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated resilience score calculation methodology; heart rate variability scores may now be unavailable when data is limited.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1040)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->