### PR TITLE
fix(integrations): handle Suunto workout webhook edge cases

### DIFF
--- a/backend/app/schemas/providers/suunto/workout_import.py
+++ b/backend/app/schemas/providers/suunto/workout_import.py
@@ -35,7 +35,9 @@ class WorkoutJSON(BaseModel):
 
     # Unix timestamp (ms)
     startTime: int
-    stopTime: int
+    # Sometimes missing in fresh webhook payloads (Suunto computes it asynchronously);
+    # callers fall back to startTime + totalTime when None.
+    stopTime: int | None = None
     # Seconds
     totalTime: float
     timeOffsetInMinutes: int | None = None

--- a/backend/app/services/providers/suunto/webhook_handler.py
+++ b/backend/app/services/providers/suunto/webhook_handler.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 
 from celery import current_app as celery_app
 from fastapi import HTTPException, Request
+from sqlalchemy.exc import IntegrityError
 
 from app.config import settings
 from app.database import DbSession
@@ -223,13 +224,27 @@ class SuuntoWebhookHandler(BaseWebhookHandler):
 
         try:
             raw_detail = self.suunto_workouts.get_workout_detail(db, user_id, str(workout_key))
-            # REST response wraps workout in 'payload' list
-            workouts_list = raw_detail.get("payload", [raw_detail]) if isinstance(raw_detail, dict) else [raw_detail]
+            # `/v3/workouts/{workoutKey}` returns a single dict under 'payload'; `/v3/workouts` (sync) returns a list.
+            payload_detail = raw_detail.get("payload", raw_detail) if isinstance(raw_detail, dict) else raw_detail
+            workouts_list = payload_detail if isinstance(payload_detail, list) else [payload_detail]
             saved = 0
             for raw in workouts_list:
                 self.suunto_workouts._process_single_workout(db, user_id, raw)
                 saved += 1
             return {"status": "saved", "workout_key": str(workout_key), "saved_count": saved}
+        except IntegrityError:
+            db.rollback()
+            log_structured(
+                logger,
+                "info",
+                "Suunto workout already exists, skipping",
+                provider="suunto",
+                trace_id=trace_id,
+                action="webhook_duplicate_workout",
+                workout_key=str(workout_key),
+                user_id=str(user_id),
+            )
+            return {"status": "ignored", "reason": "duplicate_workout", "workout_key": str(workout_key)}
         except Exception as exc:
             log_structured(
                 logger,

--- a/backend/app/services/providers/suunto/workouts.py
+++ b/backend/app/services/providers/suunto/workouts.py
@@ -151,7 +151,10 @@ class SuuntoWorkouts(BaseWorkoutsTemplate):
 
         workout_type = get_unified_workout_type(raw_workout.activityId)
 
-        start_date, end_date = self._extract_dates(raw_workout.startTime, raw_workout.stopTime)
+        # Fresh webhook payloads sometimes omit stopTime; approximate it from startTime + totalTime.
+        # This ignores pauses, but the periodic /v3/workouts sync overwrites with the canonical value.
+        stop_time_ms = raw_workout.stopTime or raw_workout.startTime + int(raw_workout.totalTime * 1000)
+        start_date, end_date = self._extract_dates(raw_workout.startTime, stop_time_ms)
         duration_seconds = int(raw_workout.totalTime)
 
         zone_offset = None

--- a/backend/tests/providers/suunto/test_suunto_webhook_handler.py
+++ b/backend/tests/providers/suunto/test_suunto_webhook_handler.py
@@ -1,0 +1,221 @@
+"""Tests for SuuntoWebhookHandler._process_workout payload normalization.
+
+Regression coverage for two shapes returned by the Suunto REST API:
+- `/v3/workouts/{workoutKey}` (webhook path): single workout dict under `payload`.
+- `/v3/workouts` (periodic sync path): list of workouts under `payload`.
+
+Bugs fixed:
+1. Previous implementation iterated dict keys (strings) when `payload` was a
+   dict, raising `'str' object has no attribute 'gear'` in `_process_single_workout`.
+2. Fresh webhook payloads omit `stopTime`; the schema marked it as required so
+   Pydantic validation crashed even after the iteration fix. `stopTime` is now
+   optional with a `startTime + totalTime` fallback in `_normalize_workout`.
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.schemas.providers.suunto.workout_import import WorkoutJSON as SuuntoWorkoutJSON
+from app.services.providers.suunto.webhook_handler import SuuntoWebhookHandler
+
+WORKOUT_KEY = "test-workout-key-0001"
+TRACE_ID = "trace-test"
+
+
+@pytest.fixture
+def live_workout_payload() -> dict:
+    """Workout dict captured live from `/v3/workouts/{workoutKey}` (no `stopTime`, no `gear`)."""
+    return {
+        "workoutId": 0,
+        "activityId": 0,
+        "startTime": 1779025042670,
+        "totalTime": 12.144,
+        "estimatedFloorsClimbed": 0,
+        "totalDistance": 53.0,
+        "totalAscent": 2.4,
+        "totalDescent": 0.0,
+        "startPosition": {"x": 0.0, "y": 0.0},
+        "stopPosition": {"x": 0.0, "y": 0.0},
+        "centerPosition": {"x": 0.0, "y": 0.0},
+        "maxSpeed": 35.9,
+        "stepCount": 0,
+        "recoveryTime": 0,
+        "cumulativeRecoveryTime": 0,
+        "rankings": {
+            "totalTimeOnRouteRanking": {"originalRanking": 1, "originalNumberOfWorkouts": 1},
+        },
+        "extensionTypes": [
+            "ALTITUDESTREAM",
+            "BATTERYLEVELSTREAM",
+            "DISTANCEDELTA",
+            "FITNESS",
+            "HEARTRATE",
+            "HEARTRATESTREAM",
+            "INTENSITY",
+            "LOCATIONSTREAM",
+            "SEALEVELPRESSURESTREAM",
+            "SML",
+            "SPEEDSTREAM",
+            "SUMMARY",
+            "TEMPERATURESTREAM",
+            "VERTICALSPEEDSTREAM",
+            "WEATHER",
+        ],
+        "minAltitude": 875.0,
+        "maxAltitude": 900.0,
+        "isEdited": False,
+        "isManuallyAdded": False,
+        "tss": {
+            "calculationMethod": "HR",
+            "trainingStressScore": 0.09691667,
+            "intensityFactor": None,
+            "normalizedPower": None,
+            "averageGradeAdjustedPace": 26.675264,
+        },
+        "tssList": [
+            {
+                "calculationMethod": "HR",
+                "trainingStressScore": 0.09691667,
+                "intensityFactor": None,
+                "normalizedPower": None,
+                "averageGradeAdjustedPace": 26.675264,
+            },
+            {
+                "calculationMethod": "PACE",
+                "trainingStressScore": 15.870654,
+                "intensityFactor": 9.187365,
+                "normalizedPower": None,
+                "averageGradeAdjustedPace": 26.675264,
+            },
+            {
+                "calculationMethod": "MET",
+                "trainingStressScore": 0.11806667,
+                "intensityFactor": None,
+                "normalizedPower": None,
+                "averageGradeAdjustedPace": None,
+            },
+        ],
+        "avgSpeedInKmH": 15.696000000000002,
+        "avgSpeed": 4.36,
+        "avgPace": 3.82,
+        "commentCount": 0,
+        "timeOffsetInMinutes": 120,
+        "pictureCount": 0,
+        "hrdata": {
+            "workoutMaxHR": 79,
+            "workoutAvgHR": 78,
+            "userMaxHR": 196,
+            "hrmax": 79,
+            "avg": 78,
+            "max": 196,
+        },
+        "cadence": {"max": 0, "avg": 0},
+        "energyConsumption": 0,
+        "workoutKey": WORKOUT_KEY,
+        "viewCount": 0,
+    }
+
+
+@pytest.fixture
+def live_response(live_workout_payload: dict) -> dict:
+    """Full `/v3/workouts/{workoutKey}` response wrapping the single workout under `payload`."""
+    return {
+        "error": None,
+        "payload": live_workout_payload,
+        "metadata": {"ts": "1779025734324"},
+    }
+
+
+class TestProcessWorkoutPayloadShapes:
+    """Verify `_process_workout` handles both single-dict and list `payload` shapes."""
+
+    @pytest.fixture
+    def handler(self) -> SuuntoWebhookHandler:
+        return SuuntoWebhookHandler(suunto_workouts=MagicMock(), suunto_247=MagicMock())
+
+    @pytest.fixture
+    def webhook_payload(self) -> dict:
+        return {"workout": {"workoutKey": WORKOUT_KEY}}
+
+    def test_single_object_payload_processed_once(
+        self,
+        handler: SuuntoWebhookHandler,
+        webhook_payload: dict,
+        live_response: dict,
+        live_workout_payload: dict,
+    ) -> None:
+        """Single-dict `payload` (real webhook shape) is processed exactly once with the dict itself."""
+        handler.suunto_workouts.get_workout_detail.return_value = live_response
+
+        result = handler._process_workout(MagicMock(), uuid4(), webhook_payload, TRACE_ID)
+
+        handler.suunto_workouts._process_single_workout.assert_called_once()
+        passed = handler.suunto_workouts._process_single_workout.call_args.args[2]
+        assert passed == live_workout_payload
+        assert result == {"status": "saved", "workout_key": WORKOUT_KEY, "saved_count": 1}
+
+    def test_list_payload_processes_each_entry(
+        self,
+        handler: SuuntoWebhookHandler,
+        webhook_payload: dict,
+        live_workout_payload: dict,
+    ) -> None:
+        """List `payload` (sync shape) iterates each workout dict."""
+        second_workout = {**live_workout_payload, "workoutKey": "second"}
+        handler.suunto_workouts.get_workout_detail.return_value = {
+            "error": None,
+            "payload": [live_workout_payload, second_workout],
+            "metadata": {"ts": "1779025734324"},
+        }
+
+        result = handler._process_workout(MagicMock(), uuid4(), webhook_payload, TRACE_ID)
+
+        assert handler.suunto_workouts._process_single_workout.call_count == 2
+        processed = [c.args[2] for c in handler.suunto_workouts._process_single_workout.call_args_list]
+        assert processed == [live_workout_payload, second_workout]
+        assert result == {"status": "saved", "workout_key": WORKOUT_KEY, "saved_count": 2}
+
+    def test_missing_workout_key_returns_error(self, handler: SuuntoWebhookHandler) -> None:
+        """`WORKOUT_CREATED` without a workoutKey/workoutId is rejected without an API call."""
+        result = handler._process_workout(MagicMock(), uuid4(), {"workout": {}}, TRACE_ID)
+
+        assert result == {"status": "error", "error": "Missing workoutKey in WORKOUT_CREATED payload"}
+        handler.suunto_workouts.get_workout_detail.assert_not_called()
+        handler.suunto_workouts._process_single_workout.assert_not_called()
+
+    def test_duplicate_workout_returns_ignored_status(
+        self,
+        handler: SuuntoWebhookHandler,
+        webhook_payload: dict,
+        live_response: dict,
+    ) -> None:
+        """IntegrityError on save is caught, rolled back, and returned as an `ignored` status."""
+        db = MagicMock()
+        handler.suunto_workouts.get_workout_detail.return_value = live_response
+        handler.suunto_workouts._process_single_workout.side_effect = IntegrityError(
+            statement="INSERT INTO event_record ...",
+            params={},
+            orig=Exception("duplicate key value violates unique constraint ix_event_record_source_time"),
+        )
+
+        result = handler._process_workout(db, uuid4(), webhook_payload, TRACE_ID)
+
+        assert result == {"status": "ignored", "reason": "duplicate_workout", "workout_key": WORKOUT_KEY}
+        db.rollback.assert_called_once()
+
+
+class TestLivePayloadParsing:
+    """Verify the schema accepts the exact live response shape (no `stopTime`)."""
+
+    def test_pydantic_parses_live_payload(self, live_workout_payload: dict) -> None:
+        """Schema accepts a fresh webhook payload without `stopTime`."""
+        workout = SuuntoWorkoutJSON(**live_workout_payload)
+
+        assert workout.stopTime is None
+        assert workout.startTime == live_workout_payload["startTime"]
+        assert workout.totalTime == live_workout_payload["totalTime"]
+        assert workout.workoutId == live_workout_payload["workoutId"]
+        assert workout.gear is None


### PR DESCRIPTION
## Summary

`WORKOUT_CREATED` Suunto webhooks crashed in Celery with `AttributeError: 'str' object has no attribute 'gear'` because `/v3/workouts/{workoutKey}` returns a single workout dict (`{"payload": {...}}`), not a list. The previous normalization iterated dict keys (strings) and passed them to `_process_single_workout`.

After fixing the iteration, a second crash surfaced: `SuuntoWorkoutJSON.stopTime` was marked required, but Suunto omits the field for workouts it has not yet finalized server-side, so Pydantic raised a `ValidationError`.

Periodic sync (`/v3/workouts` list endpoint) was unaffected because it always returns a list and full workout records with `stopTime` populated.

## Change

- `SuuntoWebhookHandler._process_workout`: normalize `payload` to a list before iterating, regardless of whether the REST API returned a single dict or a list.
- `SuuntoWorkoutJSON.stopTime` is now `int | None = None`.
- `SuuntoWorkouts._normalize_workout` falls back to `startTime + totalTime * 1000` when `stopTime` is absent. This matches Suunto's FIT-derived convention (`totalTime` is the active timer time; pauses are excluded). The periodic sync overwrites with the canonical value later if Suunto emits a different one.
- New fixture `backend/tests/providers/suunto/fixtures/workout_single_payload.json` captures the exact live response shape that reproduced the bug (committed via `-f` because the repo's `.gitignore` blanket-ignores `*.json`).

## Test plan

- [x] Added `test_suunto_webhook_handler.py` covering single-dict and list `payload` shapes, the missing-`workoutKey` early return, and Pydantic acceptance of the live response.
- [x] Full `pytest tests/providers/suunto/` suite green (36 passed).
- [x] `ruff check` / `ruff format` clean on touched files.
- [x] Validated against staging: pushed a real Suunto workout, observed:
  ```
  Processing Suunto webhook event ... event_type=WORKOUT_CREATED
  Fetching Suunto workout via REST ... workout_key=...
  HTTP/1.1 200 OK (GET /v3/workouts/<key>)
  process_webhook_push[...] succeeded ... 'status': 'saved', 'saved_count': 1
  ```
  No `AttributeError`, no `ValidationError`.

## Known limitation (out of scope here)

Suunto's `totalTime` is the active timer time (FIT `total_timer_time`), so pauses are excluded. The fallback `stopTime` therefore equals `startTime + active_time`, which matches `duration_seconds` but underestimates real elapsed time when the user paused. Standard fitness-app convention. Accurate elapsed handling would require querying `?extensions=PauseMarkerExtension` and summing pause markers; that is left for a follow-up PR #1043  because the extension's response shape is not publicly documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improve Suunto workout import: handle missing end-time by deriving it from start time + duration; correctly process both single-workout and batch-sync webhook payload shapes; gracefully ignore duplicate saves.
* **Tests**
  * Add coverage validating payload normalization, missing end-time parsing, batch vs single payload handling, error paths, and duplicate-save behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1042?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->