### PR TITLE
fix(suunto): add Ocp-Apim-Subscription-Key header to OAuth token exchange

### DIFF
--- a/backend/app/services/providers/suunto/oauth.py
+++ b/backend/app/services/providers/suunto/oauth.py
@@ -32,6 +32,18 @@ class SuuntoOAuth(BaseOAuthTemplate):
             ),
         )
 
+    def _prepare_token_request(self, code: str, code_verifier: str | None) -> tuple[dict, dict]:
+        token_data, headers = super()._prepare_token_request(code, code_verifier)
+        if self.credentials.subscription_key:
+            headers["Ocp-Apim-Subscription-Key"] = self.credentials.subscription_key
+        return token_data, headers
+
+    def _prepare_refresh_request(self, refresh_token: str) -> tuple[dict, dict]:
+        token_data, headers = super()._prepare_refresh_request(refresh_token)
+        if self.credentials.subscription_key:
+            headers["Ocp-Apim-Subscription-Key"] = self.credentials.subscription_key
+        return token_data, headers
+
     def _get_provider_user_info(self, token_response: OAuthTokenResponse, user_id: str) -> dict[str, str | None]:
         """Extracts Suunto user info from JWT access token."""
         try:


### PR DESCRIPTION
## Summary

Suunto's OAuth endpoints (`POST cloudapi-oauth.suunto.com/oauth/token`, including the refresh endpoint) sit behind the same Azure API Management gateway as the workout/data APIs and now reject calls that omit `Ocp-Apim-Subscription-Key`. Without the header, every fresh authorization attempt fails with:

```
POST https://cloudapi-oauth.suunto.com/oauth/token → 401 Unauthorized
{"code":401,"data":null,"message":"Unauthorized"}
```

The same 401 also blocks refresh once an existing access token expires.

## Change

Override `_prepare_token_request` and `_prepare_refresh_request` in `SuuntoOAuth` to attach `Ocp-Apim-Subscription-Key` from `self.credentials.subscription_key` when present, on top of the Basic Auth headers built by the base template.

12 lines, scoped to `app/services/providers/suunto/oauth.py`. Independent of #1042 / #1043.

## Test plan

- [x] Reproduced the 401 in staging logs: `Failed to exchange authorization code: {"code":401,"data":null,"message":"Unauthorized"}`.
- [x] Verified `SUUNTO_SUBSCRIPTION_KEY` in staging `.env` matches the value shown in the Suunto developer portal, so the missing piece was the header on the request, not the credential.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Suunto integration with improved OAuth authentication support to properly handle subscription key credentials during login and token refresh processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1044?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->