### PR TITLE
fix(integrations): emit outgoing webhook for suunto live workout push

### DIFF
--- a/backend/app/services/providers/suunto/webhook_handler.py
+++ b/backend/app/services/providers/suunto/webhook_handler.py
@@ -227,8 +227,8 @@ class SuuntoWebhookHandler(BaseWebhookHandler):
             workouts_list = raw_detail.get("payload", [raw_detail]) if isinstance(raw_detail, dict) else [raw_detail]
             saved = 0
             for raw in workouts_list:
-                self.suunto_workouts.process_push_activity(db, user_id, raw)
-                saved += 1
+                if self.suunto_workouts.process_push_activity(db, user_id, raw) is not None:
+                    saved += 1
             return {"status": "saved", "workout_key": str(workout_key), "saved_count": saved}
         except Exception as exc:
             log_structured(

--- a/backend/app/services/providers/suunto/webhook_handler.py
+++ b/backend/app/services/providers/suunto/webhook_handler.py
@@ -227,7 +227,7 @@ class SuuntoWebhookHandler(BaseWebhookHandler):
             workouts_list = raw_detail.get("payload", [raw_detail]) if isinstance(raw_detail, dict) else [raw_detail]
             saved = 0
             for raw in workouts_list:
-                self.suunto_workouts._process_single_workout(db, user_id, raw)
+                self.suunto_workouts.process_push_activity(db, user_id, raw)
                 saved += 1
             return {"status": "saved", "workout_key": str(workout_key), "saved_count": saved}
         except Exception as exc:

--- a/backend/app/services/providers/suunto/workouts.py
+++ b/backend/app/services/providers/suunto/workouts.py
@@ -272,15 +272,19 @@ class SuuntoWorkouts(BaseWorkoutsTemplate):
         headers = self._get_suunto_headers()
         return self._make_api_request(db, user_id, f"/v3/workouts/{workout_key}", headers=headers)
 
-    def _process_single_workout(self, db: DbSession, user_id: UUID, raw_workout: Any) -> None:
-        """Internal method to normalize and save a single workout.
-        Overridden to save device info first and ensure Pydantic model conversion.
+    def process_push_activity(self, db: DbSession, user_id: UUID, raw_workout: Any) -> UUID | None:
+        """Save a single workout received via the live webhook push path.
+
+        Mirrors the load_data backfill path: builds the record + detail bundle
+        and inserts both via event_record_service. create_detail schedules the
+        after_commit listener that fires the outgoing webhook (workout.created),
+        so consumers subscribed via Svix receive the new workout.
+
+        Returns the created event_record id, or None when the bundle was empty.
         """
-        # Convert dict to Pydantic model if needed
         if isinstance(raw_workout, dict):
             raw_workout = SuuntoWorkoutJSON(**raw_workout)
 
-        # Save device/data source info if available
         if raw_workout.gear:
             device_name = raw_workout.gear.displayName or raw_workout.gear.name
             self.data_source_repo.ensure_data_source(
@@ -292,4 +296,10 @@ class SuuntoWorkouts(BaseWorkoutsTemplate):
                 source=self.provider_name,
             )
 
-        super()._process_single_workout(db, user_id, raw_workout)
+        for record, detail in self._build_bundles([raw_workout], user_id):
+            created_record = event_record_service.create(db, record)
+            detail_for_record = detail.model_copy(update={"record_id": created_record.id})
+            event_record_service.create_detail(db, detail_for_record)
+            return created_record.id
+
+        return None

--- a/backend/tests/providers/suunto/test_suunto_workouts.py
+++ b/backend/tests/providers/suunto/test_suunto_workouts.py
@@ -352,3 +352,31 @@ class TestSuuntoWorkouts:
         mock_create_detail.assert_called_once()
         # Verify data source creation was attempted
         mock_ensure_data_source.assert_called_once()
+
+    @patch("app.services.event_record_service.event_record_service.create")
+    @patch("app.services.event_record_service.event_record_service.create_detail")
+    @patch("app.repositories.data_source_repository.DataSourceRepository.ensure_data_source")
+    def test_process_push_activity_creates_record_and_detail(
+        self,
+        mock_ensure_data_source: MagicMock,
+        mock_create_detail: MagicMock,
+        mock_create: MagicMock,
+        suunto_workouts: SuuntoWorkouts,
+        db: Session,
+        sample_workout_data: dict,
+    ) -> None:
+        """Webhook push path must persist both the event_record and its detail.
+
+        create_detail is what schedules the after_commit listener that emits
+        the workout.created outgoing webhook, so skipping it silently drops
+        live workouts from every downstream consumer.
+        """
+        from tests.factories import UserFactory
+
+        user = UserFactory()
+
+        suunto_workouts.process_push_activity(db, user.id, sample_workout_data)
+
+        mock_create.assert_called_once()
+        mock_create_detail.assert_called_once()
+        mock_ensure_data_source.assert_called_once()

--- a/backend/tests/providers/suunto/test_suunto_workouts.py
+++ b/backend/tests/providers/suunto/test_suunto_workouts.py
@@ -374,9 +374,14 @@ class TestSuuntoWorkouts:
         from tests.factories import UserFactory
 
         user = UserFactory()
+        expected_id = uuid4()
+        mock_create.return_value.id = expected_id
 
-        suunto_workouts.process_push_activity(db, user.id, sample_workout_data)
+        result = suunto_workouts.process_push_activity(db, user.id, sample_workout_data)
 
+        assert result == expected_id
         mock_create.assert_called_once()
         mock_create_detail.assert_called_once()
+        detail_arg = mock_create_detail.call_args.args[1]
+        assert detail_arg.record_id == expected_id
         mock_ensure_data_source.assert_called_once()


### PR DESCRIPTION
## Problem

Suunto workouts received over the live webhook push path (`WORKOUT_CREATED`) never trigger an outgoing `workout.created` event. Only signup-time backfill workouts reach downstream Svix subscribers; every live watch upload is silently dropped between OW and the consumer.

## Root cause

`SuuntoWorkouts._process_single_workout` (called from `SuuntoWebhookHandler._process_workout`) delegates to `BaseWorkouts._save_workout`:

```python
def _save_workout(self, db, record, detail):
    self.workout_repo.create(db, record)
    # Detail saving is handled by services in load_data implementations
```

That method inserts the `event_record` row but silently ignores the `detail` argument. Consequences:

- No `event_record_detail` row is written.
- The SQLAlchemy `after_commit` listener registered by `EventRecordService.create_detail` never fires.
- The outgoing `workout.created` event is never dispatched to Svix.

Strava (`process_push_activity`), Garmin (`process_push_activities`), Whoop (`load_single_workout`) and Oura (`save_by_id`) already handle the live push path correctly by calling `event_record_service.create` + `create_detail`. Suunto was the only remaining provider routing live push through the broken base helper.

## Fix

Add `SuuntoWorkouts.process_push_activity` mirroring the other live-push paths, and switch `SuuntoWebhookHandler` to call it instead of `_process_single_workout`. The new method:

- Ensures the data source for the gear.
- Builds the record + detail bundle via `_build_bundles`.
- Calls `event_record_service.create` + `event_record_service.create_detail`, so the `after_commit` listener schedules `emit_webhook_event` and the workout flows downstream.

## Tests

- New regression `test_process_push_activity_creates_record_and_detail` asserts both `create` and `create_detail` run on the push path.
- Full Suunto test module passes (13 tests).

## End-to-end verification

Verified on a staging deployment: with the fix, a new live Suunto workout triggers `emit_webhook_event` → Svix → consumer ingest. Without the fix, only signup-time backfill workouts ever reach the consumer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved webhook handling for pushed workouts so they reliably create full workout records and associated details; the saved count now only increments when a workout is actually persisted, reducing false positives and improving sync consistency.

* **Tests**
  * Added test coverage to validate webhook-driven workout record and detail creation and related data provisioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1045?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->