### PR TITLE
fix: Handle duplicate EventRecordDetail inserts gracefully with savepoint

### DIFF
--- a/backend/app/repositories/event_record_detail_repository.py
+++ b/backend/app/repositories/event_record_detail_repository.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from sqlalchemy import Table
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.exc import IntegrityError
 
 from app.database import DbSession
 from app.models import (
@@ -61,11 +62,23 @@ class EventRecordDetailRepository(
         creator: EventRecordDetailCreate,
         detail_type: DetailType = "workout",
     ) -> EventRecordDetail:
-        """Like create() but flushes instead of committing; caller is responsible for the commit."""
+        """Like create() but flushes instead of committing; caller is responsible for the commit.
+
+        Uses a savepoint for IntegrityError handling so a conflict rolls back only
+        the INSERT and leaves the outer transaction intact.
+        """
         detail = self._build_detail(creator, detail_type)
-        db_session.add(detail)
-        db_session.flush()
-        return detail
+        nested = db_session.begin_nested()
+        try:
+            db_session.add(detail)
+            db_session.flush()
+            nested.commit()
+            return detail
+        except IntegrityError:
+            nested.rollback()
+            if existing := self.get_by_record_id(db_session, creator.record_id):
+                return existing
+            raise
 
     @handle_exceptions
     def bulk_create(


### PR DESCRIPTION

## Description

`EventRecordDetailRepository.create_and_flush()` does a plain ORM add+flush with no conflict handling. When a sync re-processes data that already exists (e.g. due to overlapping date windows), it hits a `UniqueViolation` on `event_record_detail_pkey`, which poisons the SQLAlchemy session and causes a `PendingRollbackError` on the next `commit()`.

Resolves #730 

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate event record details. The system now gracefully manages conflicts when creating event records, preventing errors and recovering existing records instead of failing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->