### PR TITLE
feat: Add webhook management endpoints

### DIFF
--- a/backend/app/api/routes/v1/oura_webhooks.py
+++ b/backend/app/api/routes/v1/oura_webhooks.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.database import DbSession
 from app.models import Developer
+from app.schemas.responses.incoming_webhooks import WebhookSubscriptionsResponse
 from app.services.providers.factory import ProviderFactory
 from app.services.providers.oura.webhook_service import oura_webhook_service
 from app.utils.auth import get_current_developer
@@ -74,11 +75,11 @@ async def create_webhook_subscriptions(
 @router.get("/subscriptions")
 async def list_webhook_subscriptions(
     current_developer: Annotated[Developer, Depends(get_current_developer)],
-) -> dict:
+) -> WebhookSubscriptionsResponse:
     """List active Oura webhook subscriptions."""
     try:
         subscriptions = await oura_webhook_service.list_subscriptions()
-        return {"subscriptions": subscriptions}
+        return WebhookSubscriptionsResponse(subscriptions=subscriptions)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except httpx.HTTPError as e:

--- a/backend/app/api/routes/v1/webhooks.py
+++ b/backend/app/api/routes/v1/webhooks.py
@@ -29,6 +29,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.database import DbSession
 from app.models import Developer
+from app.schemas.responses.incoming_webhooks import (
+    WebhookDeletedResponse,
+    WebhookSubscriptionResponse,
+    WebhookSubscriptionsResponse,
+    WebhookUpdatedResponse,
+)
 from app.services.providers.base_strategy import BaseProviderStrategy
 from app.services.providers.factory import ProviderFactory
 from app.services.providers.templates.base_webhook_handler import BaseWebhookHandler
@@ -126,14 +132,14 @@ def verify_provider_webhook(provider: str, request: Request) -> dict:
 async def list_webhook_subscriptions(
     provider: str,
     _dev: Annotated[Developer, Depends(get_current_developer)],
-) -> dict:
+) -> WebhookSubscriptionsResponse:
     """List active webhook subscriptions for a provider."""
     strategy = _get_strategy(provider)
     try:
         result = await strategy.list_subscriptions()
     except NotImplementedError as e:
         raise HTTPException(status_code=501, detail=str(e))
-    return {"subscriptions": result}
+    return WebhookSubscriptionsResponse(subscriptions=result)
 
 
 @router.post("/subscriptions")
@@ -170,14 +176,14 @@ async def get_webhook_subscription(
     provider: str,
     subscription_id: str,
     _dev: Annotated[Developer, Depends(get_current_developer)],
-) -> dict:
+) -> WebhookSubscriptionResponse:
     """Get a single webhook subscription by ID."""
     strategy = _get_strategy(provider)
     try:
         result = await strategy.get_subscription(subscription_id)
     except NotImplementedError as e:
         raise HTTPException(status_code=501, detail=str(e))
-    return {"subscription": result}
+    return WebhookSubscriptionResponse(subscription=result)
 
 
 @router.delete("/subscriptions/{subscription_id}")
@@ -185,14 +191,14 @@ async def delete_webhook_subscription(
     provider: str,
     subscription_id: str,
     _dev: Annotated[Developer, Depends(get_current_developer)],
-) -> dict:
+) -> WebhookDeletedResponse:
     """Delete a webhook subscription by ID."""
     strategy = _get_strategy(provider)
     try:
         result = await strategy.delete_subscription(subscription_id)
     except NotImplementedError as e:
         raise HTTPException(status_code=501, detail=str(e))
-    return {"deleted": result}
+    return WebhookDeletedResponse(deleted=result)
 
 
 @router.put("/subscriptions/{subscription_id}")
@@ -201,11 +207,11 @@ async def update_webhook_subscription(
     subscription_id: str,
     _dev: Annotated[Developer, Depends(get_current_developer)],
     callback_url: str,
-) -> dict:
+) -> WebhookUpdatedResponse:
     """Update the callback URL of a webhook subscription."""
     strategy = _get_strategy(provider)
     try:
         result = await strategy.update_subscription(subscription_id, callback_url)
     except NotImplementedError as e:
         raise HTTPException(status_code=501, detail=str(e))
-    return {"updated": result}
+    return WebhookUpdatedResponse(updated=result)

--- a/backend/app/api/routes/v1/webhooks.py
+++ b/backend/app/api/routes/v1/webhooks.py
@@ -25,10 +25,9 @@ into its strategy, traffic can be cut over to this router.
 from logging import getLogger
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from app.database import DbSession
-from app.models import Developer
 from app.schemas.responses.incoming_webhooks import (
     WebhookDeletedResponse,
     WebhookSubscriptionResponse,
@@ -38,7 +37,7 @@ from app.schemas.responses.incoming_webhooks import (
 from app.services.providers.base_strategy import BaseProviderStrategy
 from app.services.providers.factory import ProviderFactory
 from app.services.providers.templates.base_webhook_handler import BaseWebhookHandler
-from app.utils.auth import get_current_developer
+from app.utils.auth import DeveloperDep
 
 router = APIRouter()
 logger = getLogger(__name__)
@@ -51,7 +50,10 @@ def _get_strategy(provider: str) -> BaseProviderStrategy:
     try:
         return _factory.get_provider(provider)
     except ValueError:
-        raise HTTPException(status_code=404, detail=f"Unknown provider: '{provider}'")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Unknown provider: '{provider}'")
+
+
+StrategyDep = Annotated[BaseProviderStrategy, Depends(_get_strategy)]
 
 
 def _get_webhook_handler(provider: str) -> BaseWebhookHandler:
@@ -63,11 +65,11 @@ def _get_webhook_handler(provider: str) -> BaseWebhookHandler:
     try:
         strategy = _factory.get_provider(provider)
     except ValueError:
-        raise HTTPException(status_code=404, detail=f"Unknown provider: '{provider}'")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Unknown provider: '{provider}'")
 
     if strategy.webhooks is None:
         raise HTTPException(
-            status_code=501,
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
             detail=(
                 f"Provider '{provider}' has not implemented a webhook handler yet. "
                 f"Capabilities: {strategy.capabilities}"
@@ -130,88 +132,112 @@ def verify_provider_webhook(provider: str, request: Request) -> dict:
 
 @router.get("/subscriptions")
 async def list_webhook_subscriptions(
-    provider: str,
-    _dev: Annotated[Developer, Depends(get_current_developer)],
+    strategy: StrategyDep,
+    _dev: DeveloperDep,
 ) -> WebhookSubscriptionsResponse:
     """List active webhook subscriptions for a provider."""
-    strategy = _get_strategy(provider)
+    if strategy.webhook_service is None:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="Provider does not support webhook subscription management",
+        )
     try:
-        result = await strategy.list_subscriptions()
+        result = await strategy.webhook_service.list_subscriptions()
     except NotImplementedError as e:
-        raise HTTPException(status_code=501, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail=str(e))
     return WebhookSubscriptionsResponse(subscriptions=result)
 
 
 @router.post("/subscriptions")
 async def register_webhook_subscriptions(
-    provider: str,
-    _dev: Annotated[Developer, Depends(get_current_developer)],
+    strategy: StrategyDep,
+    _dev: DeveloperDep,
     callback_url: str,
 ) -> dict:
     """Register or update webhook subscriptions for a provider."""
-    strategy = _get_strategy(provider)
+    if strategy.webhook_service is None:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="Provider does not support webhook subscription management",
+        )
     try:
-        result = await strategy.register_webhooks(callback_url)
+        result = await strategy.webhook_service.register_subscriptions(callback_url)
     except NotImplementedError as e:
-        raise HTTPException(status_code=501, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail=str(e))
     return {"subscriptions": result}
 
 
 @router.post("/subscriptions/renew")
 async def renew_webhook_subscriptions(
-    provider: str,
-    _dev: Annotated[Developer, Depends(get_current_developer)],
+    strategy: StrategyDep,
+    _dev: DeveloperDep,
 ) -> dict:
     """Renew all active webhook subscriptions for a provider."""
-    strategy = _get_strategy(provider)
+    if strategy.webhook_service is None:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="Provider does not support webhook subscription management",
+        )
     try:
-        result = await strategy.renew_subscriptions()
+        result = await strategy.webhook_service.renew_subscriptions()
     except NotImplementedError as e:
-        raise HTTPException(status_code=501, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail=str(e))
     return {"renewed": result}
 
 
 @router.get("/subscriptions/{subscription_id}")
 async def get_webhook_subscription(
-    provider: str,
+    strategy: StrategyDep,
     subscription_id: str,
-    _dev: Annotated[Developer, Depends(get_current_developer)],
+    _dev: DeveloperDep,
 ) -> WebhookSubscriptionResponse:
     """Get a single webhook subscription by ID."""
-    strategy = _get_strategy(provider)
+    if strategy.webhook_service is None:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="Provider does not support webhook subscription management",
+        )
     try:
-        result = await strategy.get_subscription(subscription_id)
+        result = await strategy.webhook_service.get_subscription(subscription_id)
     except NotImplementedError as e:
-        raise HTTPException(status_code=501, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail=str(e))
     return WebhookSubscriptionResponse(subscription=result)
 
 
 @router.delete("/subscriptions/{subscription_id}")
 async def delete_webhook_subscription(
-    provider: str,
+    strategy: StrategyDep,
     subscription_id: str,
-    _dev: Annotated[Developer, Depends(get_current_developer)],
+    _dev: DeveloperDep,
 ) -> WebhookDeletedResponse:
     """Delete a webhook subscription by ID."""
-    strategy = _get_strategy(provider)
+    if strategy.webhook_service is None:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="Provider does not support webhook subscription management",
+        )
     try:
-        result = await strategy.delete_subscription(subscription_id)
+        result = await strategy.webhook_service.delete_subscription(subscription_id)
     except NotImplementedError as e:
-        raise HTTPException(status_code=501, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail=str(e))
     return WebhookDeletedResponse(deleted=result)
 
 
 @router.put("/subscriptions/{subscription_id}")
 async def update_webhook_subscription(
-    provider: str,
+    strategy: StrategyDep,
     subscription_id: str,
-    _dev: Annotated[Developer, Depends(get_current_developer)],
+    _dev: DeveloperDep,
     callback_url: str,
 ) -> WebhookUpdatedResponse:
     """Update the callback URL of a webhook subscription."""
-    strategy = _get_strategy(provider)
+    if strategy.webhook_service is None:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="Provider does not support webhook subscription management",
+        )
     try:
-        result = await strategy.update_subscription(subscription_id, callback_url)
+        result = await strategy.webhook_service.update_subscription(subscription_id, callback_url)
     except NotImplementedError as e:
-        raise HTTPException(status_code=501, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail=str(e))
     return WebhookUpdatedResponse(updated=result)

--- a/backend/app/api/routes/v1/webhooks.py
+++ b/backend/app/api/routes/v1/webhooks.py
@@ -28,13 +28,24 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.database import DbSession
+from app.models import Developer
+from app.services.providers.base_strategy import BaseProviderStrategy
 from app.services.providers.factory import ProviderFactory
 from app.services.providers.templates.base_webhook_handler import BaseWebhookHandler
+from app.utils.auth import get_current_developer
 
 router = APIRouter()
 logger = getLogger(__name__)
 
 _factory = ProviderFactory()
+
+
+def _get_strategy(provider: str) -> BaseProviderStrategy:
+    """Resolve and return the provider strategy, raising 404 for unknown providers."""
+    try:
+        return _factory.get_provider(provider)
+    except ValueError:
+        raise HTTPException(status_code=404, detail=f"Unknown provider: '{provider}'")
 
 
 def _get_webhook_handler(provider: str) -> BaseWebhookHandler:
@@ -104,3 +115,97 @@ def verify_provider_webhook(provider: str, request: Request) -> dict:
     """
     handler = _get_webhook_handler(provider)
     return handler.handle_challenge(request)
+
+
+# ---------------------------------------------------------------------------
+# Subscription management (internal / developer-only)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/subscriptions")
+async def list_webhook_subscriptions(
+    provider: str,
+    _dev: Annotated[Developer, Depends(get_current_developer)],
+) -> dict:
+    """List active webhook subscriptions for a provider."""
+    strategy = _get_strategy(provider)
+    try:
+        result = await strategy.list_subscriptions()
+    except NotImplementedError as e:
+        raise HTTPException(status_code=501, detail=str(e))
+    return {"subscriptions": result}
+
+
+@router.post("/subscriptions")
+async def register_webhook_subscriptions(
+    provider: str,
+    _dev: Annotated[Developer, Depends(get_current_developer)],
+    callback_url: str,
+) -> dict:
+    """Register or update webhook subscriptions for a provider."""
+    strategy = _get_strategy(provider)
+    try:
+        result = await strategy.register_webhooks(callback_url)
+    except NotImplementedError as e:
+        raise HTTPException(status_code=501, detail=str(e))
+    return {"subscriptions": result}
+
+
+@router.post("/subscriptions/renew")
+async def renew_webhook_subscriptions(
+    provider: str,
+    _dev: Annotated[Developer, Depends(get_current_developer)],
+) -> dict:
+    """Renew all active webhook subscriptions for a provider."""
+    strategy = _get_strategy(provider)
+    try:
+        result = await strategy.renew_subscriptions()
+    except NotImplementedError as e:
+        raise HTTPException(status_code=501, detail=str(e))
+    return {"renewed": result}
+
+
+@router.get("/subscriptions/{subscription_id}")
+async def get_webhook_subscription(
+    provider: str,
+    subscription_id: str,
+    _dev: Annotated[Developer, Depends(get_current_developer)],
+) -> dict:
+    """Get a single webhook subscription by ID."""
+    strategy = _get_strategy(provider)
+    try:
+        result = await strategy.get_subscription(subscription_id)
+    except NotImplementedError as e:
+        raise HTTPException(status_code=501, detail=str(e))
+    return {"subscription": result}
+
+
+@router.delete("/subscriptions/{subscription_id}")
+async def delete_webhook_subscription(
+    provider: str,
+    subscription_id: str,
+    _dev: Annotated[Developer, Depends(get_current_developer)],
+) -> dict:
+    """Delete a webhook subscription by ID."""
+    strategy = _get_strategy(provider)
+    try:
+        result = await strategy.delete_subscription(subscription_id)
+    except NotImplementedError as e:
+        raise HTTPException(status_code=501, detail=str(e))
+    return {"deleted": result}
+
+
+@router.put("/subscriptions/{subscription_id}")
+async def update_webhook_subscription(
+    provider: str,
+    subscription_id: str,
+    _dev: Annotated[Developer, Depends(get_current_developer)],
+    callback_url: str,
+) -> dict:
+    """Update the callback URL of a webhook subscription."""
+    strategy = _get_strategy(provider)
+    try:
+        result = await strategy.update_subscription(subscription_id, callback_url)
+    except NotImplementedError as e:
+        raise HTTPException(status_code=501, detail=str(e))
+    return {"updated": result}

--- a/backend/app/integrations/celery/tasks/register_provider_webhooks_task.py
+++ b/backend/app/integrations/celery/tasks/register_provider_webhooks_task.py
@@ -33,7 +33,9 @@ def register_provider_webhooks(self: Task, provider: str, callback_url: str) -> 
     """
     try:
         strategy = ProviderFactory().get_provider(provider)
-        results = asyncio.run(strategy.register_webhooks(callback_url))
+        if strategy.webhook_service is None:
+            raise NotImplementedError(f"Provider '{provider}' does not support webhook subscription management")
+        results = asyncio.run(strategy.webhook_service.register_subscriptions(callback_url))
         created = sum(1 for r in results if r.get("status") == "created")
         skipped = sum(1 for r in results if r.get("status") == "skipped")
         errors = sum(1 for r in results if r.get("status") == "error")

--- a/backend/app/schemas/responses/incoming_webhooks/__init__.py
+++ b/backend/app/schemas/responses/incoming_webhooks/__init__.py
@@ -1,0 +1,25 @@
+from .management import (
+    OuraWebhookSubscription,
+    PolarWebhookSubscription,
+    ProviderWebhookSubscription,
+    StravaWebhookSubscription,
+    WebhookDeletedResponse,
+    WebhookOperationResult,
+    WebhookSubscriptionResponse,
+    WebhookSubscriptionsResponse,
+    WebhookSubscriptionStatus,
+    WebhookUpdatedResponse,
+)
+
+__all__ = [
+    "OuraWebhookSubscription",
+    "PolarWebhookSubscription",
+    "ProviderWebhookSubscription",
+    "StravaWebhookSubscription",
+    "WebhookDeletedResponse",
+    "WebhookOperationResult",
+    "WebhookSubscriptionResponse",
+    "WebhookSubscriptionsResponse",
+    "WebhookSubscriptionStatus",
+    "WebhookUpdatedResponse",
+]

--- a/backend/app/schemas/responses/incoming_webhooks/management.py
+++ b/backend/app/schemas/responses/incoming_webhooks/management.py
@@ -1,0 +1,86 @@
+"""Response schemas for provider webhook subscription management operations.
+
+Covers list, get, delete, and update responses for Polar, Oura, and Strava.
+These are admin-level operations (register/inspect/remove subscriptions), not
+inbound event processing.
+"""
+
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+from app.schemas.providers.polar.webhook import PolarWebhookEventType
+
+
+class WebhookSubscriptionStatus(StrEnum):
+    CREATED = "created"
+    UPDATED = "updated"
+    PATCHED = "patched"
+    DELETED = "deleted"
+    SKIPPED = "skipped"
+    ERROR = "error"
+
+
+class WebhookOperationResult(BaseModel):
+    """Generic result for a single webhook subscription operation (delete / update)."""
+
+    subscription_id: str
+    status: WebhookSubscriptionStatus
+    error: str | None = None
+
+
+class ProviderWebhookSubscription(BaseModel):
+    """Base class for all provider webhook subscription responses."""
+
+
+class PolarWebhookSubscription(ProviderWebhookSubscription):
+    """A single Polar app-level webhook as returned by GET /v3/webhooks."""
+
+    id: str
+    events: list[PolarWebhookEventType]
+    url: str
+
+
+class OuraWebhookSubscription(ProviderWebhookSubscription):
+    """A single Oura webhook subscription as returned by GET /v2/webhook/subscription."""
+
+    id: str
+    callback_url: str
+    event_type: str
+    data_type: str
+    expiration_time: str | None = None
+
+
+class StravaWebhookSubscription(ProviderWebhookSubscription):
+    """A single Strava push subscription as returned by GET /api/v3/push_subscriptions."""
+
+    id: int
+    application_id: int
+    callback_url: str
+    created_at: str
+    updated_at: str
+    resource_state: int | None = None
+
+
+class WebhookSubscriptionsResponse(BaseModel):
+    """Response wrapper for listing webhook subscriptions (any provider)."""
+
+    subscriptions: list[ProviderWebhookSubscription]
+
+
+class WebhookSubscriptionResponse(BaseModel):
+    """Response wrapper for fetching a single webhook subscription."""
+
+    subscription: ProviderWebhookSubscription | None = None
+
+
+class WebhookDeletedResponse(BaseModel):
+    """Response wrapper for a delete operation result."""
+
+    deleted: WebhookOperationResult
+
+
+class WebhookUpdatedResponse(BaseModel):
+    """Response wrapper for an update operation result."""
+
+    updated: WebhookOperationResult

--- a/backend/app/schemas/responses/incoming_webhooks/management.py
+++ b/backend/app/schemas/responses/incoming_webhooks/management.py
@@ -7,7 +7,7 @@ inbound event processing.
 
 from enum import StrEnum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, SerializeAsAny, model_serializer
 
 from app.schemas.providers.polar.webhook import PolarWebhookEventType
 
@@ -27,6 +27,13 @@ class WebhookOperationResult(BaseModel):
     subscription_id: str
     status: WebhookSubscriptionStatus
     error: str | None = None
+
+    @model_serializer
+    def _serialize(self) -> dict:
+        out: dict = {"subscription_id": self.subscription_id, "status": self.status}
+        if self.error is not None:
+            out["error"] = self.error
+        return out
 
 
 class ProviderWebhookSubscription(BaseModel):
@@ -65,13 +72,13 @@ class StravaWebhookSubscription(ProviderWebhookSubscription):
 class WebhookSubscriptionsResponse(BaseModel):
     """Response wrapper for listing webhook subscriptions (any provider)."""
 
-    subscriptions: list[ProviderWebhookSubscription]
+    subscriptions: list[SerializeAsAny[ProviderWebhookSubscription]]
 
 
 class WebhookSubscriptionResponse(BaseModel):
     """Response wrapper for fetching a single webhook subscription."""
 
-    subscription: ProviderWebhookSubscription | None = None
+    subscription: SerializeAsAny[ProviderWebhookSubscription] | None = None
 
 
 class WebhookDeletedResponse(BaseModel):

--- a/backend/app/schemas/responses/incoming_webhooks/management.py
+++ b/backend/app/schemas/responses/incoming_webhooks/management.py
@@ -7,7 +7,7 @@ inbound event processing.
 
 from enum import StrEnum
 
-from pydantic import BaseModel, SerializeAsAny, model_serializer
+from pydantic import BaseModel, SerializeAsAny, model_serializer, model_validator
 
 from app.schemas.providers.polar.webhook import PolarWebhookEventType
 
@@ -28,10 +28,18 @@ class WebhookOperationResult(BaseModel):
     status: WebhookSubscriptionStatus
     error: str | None = None
 
+    @model_validator(mode="after")
+    def _validate_error_contract(self) -> "WebhookOperationResult":
+        if self.status == WebhookSubscriptionStatus.ERROR and self.error is None:
+            raise ValueError("error must be set when status is ERROR")
+        if self.error is not None and self.status != WebhookSubscriptionStatus.ERROR:
+            raise ValueError("error must only be set when status is ERROR")
+        return self
+
     @model_serializer
     def _serialize(self) -> dict:
         out: dict = {"subscription_id": self.subscription_id, "status": self.status}
-        if self.error is not None:
+        if self.status == WebhookSubscriptionStatus.ERROR:
             out["error"] = self.error
         return out
 

--- a/backend/app/services/providers/base_strategy.py
+++ b/backend/app/services/providers/base_strategy.py
@@ -11,6 +11,10 @@ from app.repositories.event_record_repository import EventRecordRepository
 from app.repositories.user_connection_repository import UserConnectionRepository
 from app.repositories.user_repository import UserRepository
 from app.schemas.auth import LiveSyncMode
+from app.schemas.responses.incoming_webhooks import (
+    ProviderWebhookSubscription,
+    WebhookOperationResult,
+)
 from app.services.providers.templates.base_247_data import Base247DataTemplate
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
 from app.services.providers.templates.base_webhook_handler import BaseWebhookHandler
@@ -229,11 +233,11 @@ class BaseProviderStrategy(ABC):
             f"Provider '{self.name}' does not support programmatic webhook registration at '{callback_url}'"
         )
 
-    async def list_subscriptions(self) -> Any:
+    async def list_subscriptions(self) -> list[ProviderWebhookSubscription]:
         """List active webhook subscriptions for this provider."""
         raise NotImplementedError(f"Provider '{self.name}' does not support listing webhook subscriptions")
 
-    async def get_subscription(self, subscription_id: str) -> Any:
+    async def get_subscription(self, subscription_id: str) -> ProviderWebhookSubscription | None:
         """Get a single webhook subscription by ID."""
         raise NotImplementedError(
             f"Provider '{self.name}' does not support fetching webhook subscription '{subscription_id}'"
@@ -243,13 +247,13 @@ class BaseProviderStrategy(ABC):
         """Renew active webhook subscriptions for this provider."""
         raise NotImplementedError(f"Provider '{self.name}' does not support renewing webhook subscriptions")
 
-    async def delete_subscription(self, subscription_id: str) -> Any:
+    async def delete_subscription(self, subscription_id: str) -> WebhookOperationResult:
         """Delete a webhook subscription by ID."""
         raise NotImplementedError(
             f"Provider '{self.name}' does not support deleting webhook subscription '{subscription_id}'"
         )
 
-    async def update_subscription(self, subscription_id: str, callback_url: str) -> Any:
+    async def update_subscription(self, subscription_id: str, callback_url: str) -> WebhookOperationResult:
         """Update the callback URL of an existing webhook subscription."""
         raise NotImplementedError(
             f"Provider '{self.name}' does not support updating webhook subscription"

--- a/backend/app/services/providers/base_strategy.py
+++ b/backend/app/services/providers/base_strategy.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Literal
+from typing import Literal
 from uuid import UUID
 
 from celery import current_app as celery_app
@@ -11,13 +11,10 @@ from app.repositories.event_record_repository import EventRecordRepository
 from app.repositories.user_connection_repository import UserConnectionRepository
 from app.repositories.user_repository import UserRepository
 from app.schemas.auth import LiveSyncMode
-from app.schemas.responses.incoming_webhooks import (
-    ProviderWebhookSubscription,
-    WebhookOperationResult,
-)
 from app.services.providers.templates.base_247_data import Base247DataTemplate
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
 from app.services.providers.templates.base_webhook_handler import BaseWebhookHandler
+from app.services.providers.templates.base_webhook_service import BaseWebhookService
 from app.services.providers.templates.base_workouts import BaseWorkoutsTemplate
 from app.utils.exceptions import UnsupportedProviderError
 
@@ -109,6 +106,7 @@ class BaseProviderStrategy(ABC):
         self.workouts: BaseWorkoutsTemplate | None = None
         self.data_247: Base247DataTemplate | None = None
         self.webhooks: BaseWebhookHandler | None = None
+        self.webhook_service: BaseWebhookService | None = None
 
     @property
     @abstractmethod
@@ -222,43 +220,6 @@ class BaseProviderStrategy(ABC):
         if caps.webhook_ping or caps.webhook_stream:
             return LiveSyncMode.WEBHOOK
         return None
-
-    async def register_webhooks(self, callback_url: str) -> Any:
-        """Register webhook subscriptions for this provider.
-
-        Only meaningful when ``capabilities.webhook_registration_api`` is True.
-        Concrete strategies that support programmatic registration should override this.
-        """
-        raise NotImplementedError(
-            f"Provider '{self.name}' does not support programmatic webhook registration at '{callback_url}'"
-        )
-
-    async def list_subscriptions(self) -> list[ProviderWebhookSubscription]:
-        """List active webhook subscriptions for this provider."""
-        raise NotImplementedError(f"Provider '{self.name}' does not support listing webhook subscriptions")
-
-    async def get_subscription(self, subscription_id: str) -> ProviderWebhookSubscription | None:
-        """Get a single webhook subscription by ID."""
-        raise NotImplementedError(
-            f"Provider '{self.name}' does not support fetching webhook subscription '{subscription_id}'"
-        )
-
-    async def renew_subscriptions(self) -> Any:
-        """Renew active webhook subscriptions for this provider."""
-        raise NotImplementedError(f"Provider '{self.name}' does not support renewing webhook subscriptions")
-
-    async def delete_subscription(self, subscription_id: str) -> WebhookOperationResult:
-        """Delete a webhook subscription by ID."""
-        raise NotImplementedError(
-            f"Provider '{self.name}' does not support deleting webhook subscription '{subscription_id}'"
-        )
-
-    async def update_subscription(self, subscription_id: str, callback_url: str) -> WebhookOperationResult:
-        """Update the callback URL of an existing webhook subscription."""
-        raise NotImplementedError(
-            f"Provider '{self.name}' does not support updating webhook subscription"
-            f" '{subscription_id}' to '{callback_url}'"
-        )
 
     @property
     def icon_url(self) -> str:

--- a/backend/app/services/providers/base_strategy.py
+++ b/backend/app/services/providers/base_strategy.py
@@ -225,7 +225,36 @@ class BaseProviderStrategy(ABC):
         Only meaningful when ``capabilities.webhook_registration_api`` is True.
         Concrete strategies that support programmatic registration should override this.
         """
-        raise NotImplementedError(f"Provider '{self.name}' does not support programmatic webhook registration")
+        raise NotImplementedError(
+            f"Provider '{self.name}' does not support programmatic webhook registration at '{callback_url}'"
+        )
+
+    async def list_subscriptions(self) -> Any:
+        """List active webhook subscriptions for this provider."""
+        raise NotImplementedError(f"Provider '{self.name}' does not support listing webhook subscriptions")
+
+    async def get_subscription(self, subscription_id: str) -> Any:
+        """Get a single webhook subscription by ID."""
+        raise NotImplementedError(
+            f"Provider '{self.name}' does not support fetching webhook subscription '{subscription_id}'"
+        )
+
+    async def renew_subscriptions(self) -> Any:
+        """Renew active webhook subscriptions for this provider."""
+        raise NotImplementedError(f"Provider '{self.name}' does not support renewing webhook subscriptions")
+
+    async def delete_subscription(self, subscription_id: str) -> Any:
+        """Delete a webhook subscription by ID."""
+        raise NotImplementedError(
+            f"Provider '{self.name}' does not support deleting webhook subscription '{subscription_id}'"
+        )
+
+    async def update_subscription(self, subscription_id: str, callback_url: str) -> Any:
+        """Update the callback URL of an existing webhook subscription."""
+        raise NotImplementedError(
+            f"Provider '{self.name}' does not support updating webhook subscription"
+            f" '{subscription_id}' to '{callback_url}'"
+        )
 
     @property
     def icon_url(self) -> str:

--- a/backend/app/services/providers/base_strategy.py
+++ b/backend/app/services/providers/base_strategy.py
@@ -209,7 +209,36 @@ class BaseProviderStrategy(ABC):
         Only meaningful when ``capabilities.webhook_registration_api`` is True.
         Concrete strategies that support programmatic registration should override this.
         """
-        raise NotImplementedError(f"Provider '{self.name}' does not support programmatic webhook registration")
+        raise NotImplementedError(
+            f"Provider '{self.name}' does not support programmatic webhook registration at '{callback_url}'"
+        )
+
+    async def list_subscriptions(self) -> Any:
+        """List active webhook subscriptions for this provider."""
+        raise NotImplementedError(f"Provider '{self.name}' does not support listing webhook subscriptions")
+
+    async def get_subscription(self, subscription_id: str) -> Any:
+        """Get a single webhook subscription by ID."""
+        raise NotImplementedError(
+            f"Provider '{self.name}' does not support fetching webhook subscription '{subscription_id}'"
+        )
+
+    async def renew_subscriptions(self) -> Any:
+        """Renew active webhook subscriptions for this provider."""
+        raise NotImplementedError(f"Provider '{self.name}' does not support renewing webhook subscriptions")
+
+    async def delete_subscription(self, subscription_id: str) -> Any:
+        """Delete a webhook subscription by ID."""
+        raise NotImplementedError(
+            f"Provider '{self.name}' does not support deleting webhook subscription '{subscription_id}'"
+        )
+
+    async def update_subscription(self, subscription_id: str, callback_url: str) -> Any:
+        """Update the callback URL of an existing webhook subscription."""
+        raise NotImplementedError(
+            f"Provider '{self.name}' does not support updating webhook subscription"
+            f" '{subscription_id}' to '{callback_url}'"
+        )
 
     @property
     def icon_url(self) -> str:

--- a/backend/app/services/providers/oura/strategy.py
+++ b/backend/app/services/providers/oura/strategy.py
@@ -61,5 +61,14 @@ class OuraStrategy(BaseProviderStrategy):
     async def list_subscriptions(self) -> list[dict]:
         return await oura_webhook_service.list_subscriptions()
 
+    async def get_subscription(self, subscription_id: str) -> dict:
+        return await oura_webhook_service.get_subscription(subscription_id)
+
+    async def delete_subscription(self, subscription_id: str) -> dict:
+        return await oura_webhook_service.delete_subscription(subscription_id)
+
+    async def update_subscription(self, subscription_id: str, callback_url: str) -> dict:
+        return await oura_webhook_service.update_subscription(subscription_id, callback_url)
+
     async def renew_subscriptions(self) -> list[dict]:
         return await oura_webhook_service.renew_subscriptions()

--- a/backend/app/services/providers/oura/strategy.py
+++ b/backend/app/services/providers/oura/strategy.py
@@ -57,3 +57,9 @@ class OuraStrategy(BaseProviderStrategy):
 
     async def register_webhooks(self, callback_url: str) -> list[dict]:
         return await oura_webhook_service.register_subscriptions(callback_url)
+
+    async def list_subscriptions(self) -> list[dict]:
+        return await oura_webhook_service.list_subscriptions()
+
+    async def renew_subscriptions(self) -> list[dict]:
+        return await oura_webhook_service.renew_subscriptions()

--- a/backend/app/services/providers/oura/strategy.py
+++ b/backend/app/services/providers/oura/strategy.py
@@ -1,3 +1,8 @@
+from app.schemas.responses.incoming_webhooks import (
+    OuraWebhookSubscription,
+    ProviderWebhookSubscription,
+    WebhookOperationResult,
+)
 from app.services.providers.base_strategy import BaseProviderStrategy, ProviderCapabilities
 from app.services.providers.oura.data_247 import Oura247Data
 from app.services.providers.oura.oauth import OuraOAuth
@@ -58,16 +63,16 @@ class OuraStrategy(BaseProviderStrategy):
     async def register_webhooks(self, callback_url: str) -> list[dict]:
         return await oura_webhook_service.register_subscriptions(callback_url)
 
-    async def list_subscriptions(self) -> list[dict]:
+    async def list_subscriptions(self) -> list[ProviderWebhookSubscription]:
         return await oura_webhook_service.list_subscriptions()
 
-    async def get_subscription(self, subscription_id: str) -> dict:
+    async def get_subscription(self, subscription_id: str) -> OuraWebhookSubscription | None:
         return await oura_webhook_service.get_subscription(subscription_id)
 
-    async def delete_subscription(self, subscription_id: str) -> dict:
+    async def delete_subscription(self, subscription_id: str) -> WebhookOperationResult:
         return await oura_webhook_service.delete_subscription(subscription_id)
 
-    async def update_subscription(self, subscription_id: str, callback_url: str) -> dict:
+    async def update_subscription(self, subscription_id: str, callback_url: str) -> WebhookOperationResult:
         return await oura_webhook_service.update_subscription(subscription_id, callback_url)
 
     async def renew_subscriptions(self) -> list[dict]:

--- a/backend/app/services/providers/oura/strategy.py
+++ b/backend/app/services/providers/oura/strategy.py
@@ -1,8 +1,3 @@
-from app.schemas.responses.incoming_webhooks import (
-    OuraWebhookSubscription,
-    ProviderWebhookSubscription,
-    WebhookOperationResult,
-)
 from app.services.providers.base_strategy import BaseProviderStrategy, ProviderCapabilities
 from app.services.providers.oura.data_247 import Oura247Data
 from app.services.providers.oura.oauth import OuraOAuth
@@ -45,6 +40,7 @@ class OuraStrategy(BaseProviderStrategy):
             data_247=self.data_247,
             workouts=self.workouts,
         )
+        self.webhook_service = oura_webhook_service
 
     @property
     def name(self) -> str:
@@ -59,21 +55,3 @@ class OuraStrategy(BaseProviderStrategy):
     @property
     def capabilities(self) -> ProviderCapabilities:
         return ProviderCapabilities(rest_pull=True, webhook_ping=True, webhook_registration_api=True)
-
-    async def register_webhooks(self, callback_url: str) -> list[dict]:
-        return await oura_webhook_service.register_subscriptions(callback_url)
-
-    async def list_subscriptions(self) -> list[ProviderWebhookSubscription]:
-        return await oura_webhook_service.list_subscriptions()
-
-    async def get_subscription(self, subscription_id: str) -> OuraWebhookSubscription | None:
-        return await oura_webhook_service.get_subscription(subscription_id)
-
-    async def delete_subscription(self, subscription_id: str) -> WebhookOperationResult:
-        return await oura_webhook_service.delete_subscription(subscription_id)
-
-    async def update_subscription(self, subscription_id: str, callback_url: str) -> WebhookOperationResult:
-        return await oura_webhook_service.update_subscription(subscription_id, callback_url)
-
-    async def renew_subscriptions(self) -> list[dict]:
-        return await oura_webhook_service.renew_subscriptions()

--- a/backend/app/services/providers/oura/webhook_service.py
+++ b/backend/app/services/providers/oura/webhook_service.py
@@ -114,7 +114,7 @@ class OuraWebhookService:
                     action="oura_webhook_subscription_list_error",
                     error=str(e),
                 )
-                raise
+                return [{"status": "error", "error": str(e)}]
 
             for data_type, event_type in itertools.product(OURA_WEBHOOK_DATA_TYPES, OURA_WEBHOOK_EVENT_TYPES):
                 body = {
@@ -236,7 +236,7 @@ class OuraWebhookService:
                 error=str(e),
                 status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
             )
-            raise
+            return {}
 
     async def delete_subscription(self, subscription_id: str) -> dict[str, Any]:
         """Delete an Oura webhook subscription by ID."""
@@ -261,7 +261,7 @@ class OuraWebhookService:
                 error=str(e),
                 status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
             )
-            raise
+            return {"subscription_id": subscription_id, "status": "error", "error": str(e)}
 
         log_structured(
             logger,
@@ -314,7 +314,7 @@ class OuraWebhookService:
                 error=str(e),
                 status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
             )
-            raise
+            return {"subscription_id": subscription_id, "status": "error", "error": str(e)}
 
         log_structured(
             logger,

--- a/backend/app/services/providers/oura/webhook_service.py
+++ b/backend/app/services/providers/oura/webhook_service.py
@@ -212,6 +212,120 @@ class OuraWebhookService:
             response.raise_for_status()
             return response.json()
 
+    async def get_subscription(self, subscription_id: str) -> dict[str, Any]:
+        """Get a single Oura webhook subscription by ID."""
+        headers = self._get_client_headers()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{OURA_WEBHOOK_API_URL}/{subscription_id}",
+                    headers=headers,
+                    timeout=30.0,
+                )
+                response.raise_for_status()
+                return response.json()
+        except httpx.HTTPError as e:
+            log_structured(
+                logger,
+                "error",
+                "Failed to get Oura webhook subscription",
+                provider="oura",
+                action="oura_webhook_subscription_get_error",
+                subscription_id=subscription_id,
+                error=str(e),
+                status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
+            )
+            raise
+
+    async def delete_subscription(self, subscription_id: str) -> dict[str, Any]:
+        """Delete an Oura webhook subscription by ID."""
+        headers = self._get_client_headers()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.delete(
+                    f"{OURA_WEBHOOK_API_URL}/{subscription_id}",
+                    headers=headers,
+                    timeout=30.0,
+                )
+                response.raise_for_status()
+        except httpx.HTTPError as e:
+            log_structured(
+                logger,
+                "error",
+                "Failed to delete Oura webhook subscription",
+                provider="oura",
+                action="oura_webhook_subscription_delete_error",
+                subscription_id=subscription_id,
+                error=str(e),
+                status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
+            )
+            raise
+
+        log_structured(
+            logger,
+            "info",
+            "Oura webhook subscription deleted",
+            provider="oura",
+            action="oura_webhook_subscription_deleted",
+            subscription_id=subscription_id,
+        )
+        return {"subscription_id": subscription_id, "status": "deleted"}
+
+    async def update_subscription(self, subscription_id: str, callback_url: str) -> dict[str, Any]:
+        """Update the callback URL of an Oura webhook subscription.
+
+        GETs the existing subscription to retain its data_type and event_type,
+        then PUTs the updated body.
+        """
+        if not settings.oura_webhook_verification_token:
+            raise ValueError("Oura webhook verification token is not configured")
+        verification_token = settings.oura_webhook_verification_token.get_secret_value()
+
+        existing = await self.get_subscription(subscription_id)
+        headers = self._get_client_headers()
+        headers["Content-Type"] = "application/json"
+
+        body = {
+            "callback_url": callback_url,
+            "verification_token": verification_token,
+            "event_type": existing["event_type"],
+            "data_type": existing["data_type"],
+        }
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.put(
+                    f"{OURA_WEBHOOK_API_URL}/{subscription_id}",
+                    headers=headers,
+                    json=body,
+                    timeout=30.0,
+                )
+                response.raise_for_status()
+        except httpx.HTTPError as e:
+            log_structured(
+                logger,
+                "error",
+                "Failed to update Oura webhook subscription",
+                provider="oura",
+                action="oura_webhook_subscription_update_error",
+                subscription_id=subscription_id,
+                error=str(e),
+                status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
+            )
+            raise
+
+        log_structured(
+            logger,
+            "info",
+            "Oura webhook subscription updated",
+            provider="oura",
+            action="oura_webhook_subscription_updated",
+            subscription_id=subscription_id,
+        )
+        return {"subscription_id": subscription_id, "status": "updated"}
+
     async def renew_subscriptions(self) -> list[dict[str, Any]]:
         """Renew all active Oura webhook subscriptions."""
         headers = self._get_client_headers()

--- a/backend/app/services/providers/oura/webhook_service.py
+++ b/backend/app/services/providers/oura/webhook_service.py
@@ -21,6 +21,7 @@ from app.schemas.responses.incoming_webhooks import (
     WebhookOperationResult,
     WebhookSubscriptionStatus,
 )
+from app.services.providers.templates.base_webhook_service import BaseWebhookService
 from app.utils.structured_logging import log_structured
 
 logger = getLogger(__name__)
@@ -62,7 +63,7 @@ OURA_WEBHOOK_DATA_TYPES = [
 OURA_WEBHOOK_EVENT_TYPES = ["create", "update"]
 
 
-class OuraWebhookService:
+class OuraWebhookService(BaseWebhookService):
     """App-level Oura webhook subscription management."""
 
     def _get_oura_credentials(self) -> tuple[str, str]:

--- a/backend/app/services/providers/oura/webhook_service.py
+++ b/backend/app/services/providers/oura/webhook_service.py
@@ -12,8 +12,15 @@ from logging import getLogger
 from typing import Any
 
 import httpx
+from pydantic import ValidationError
 
 from app.config import settings
+from app.schemas.responses.incoming_webhooks import (
+    OuraWebhookSubscription,
+    ProviderWebhookSubscription,
+    WebhookOperationResult,
+    WebhookSubscriptionStatus,
+)
 from app.utils.structured_logging import log_structured
 
 logger = getLogger(__name__)
@@ -199,7 +206,7 @@ class OuraWebhookService:
 
         return results
 
-    async def list_subscriptions(self) -> list[dict[str, Any]] | dict[str, Any]:
+    async def list_subscriptions(self) -> list[ProviderWebhookSubscription]:
         """List active Oura webhook subscriptions."""
         headers = self._get_client_headers()
 
@@ -210,9 +217,23 @@ class OuraWebhookService:
                 timeout=30.0,
             )
             response.raise_for_status()
-            return response.json()
+            raw = response.json() or []
+            result: list[ProviderWebhookSubscription] = []
+            for item in raw if isinstance(raw, list) else []:
+                try:
+                    result.append(OuraWebhookSubscription.model_validate(item))
+                except ValidationError as ve:
+                    log_structured(
+                        logger,
+                        "error",
+                        "Failed to parse Oura webhook subscription",
+                        provider="oura",
+                        action="oura_webhook_subscription_parse_error",
+                        error=str(ve),
+                    )
+            return result
 
-    async def get_subscription(self, subscription_id: str) -> dict[str, Any]:
+    async def get_subscription(self, subscription_id: str) -> OuraWebhookSubscription | None:
         """Get a single Oura webhook subscription by ID."""
         headers = self._get_client_headers()
 
@@ -224,7 +245,19 @@ class OuraWebhookService:
                     timeout=30.0,
                 )
                 response.raise_for_status()
-                return response.json()
+                try:
+                    return OuraWebhookSubscription.model_validate(response.json())
+                except ValidationError as ve:
+                    log_structured(
+                        logger,
+                        "error",
+                        "Failed to parse Oura webhook subscription",
+                        provider="oura",
+                        action="oura_webhook_subscription_parse_error",
+                        subscription_id=subscription_id,
+                        error=str(ve),
+                    )
+                    return None
         except httpx.HTTPError as e:
             log_structured(
                 logger,
@@ -236,9 +269,9 @@ class OuraWebhookService:
                 error=str(e),
                 status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
             )
-            return {}
+            return None
 
-    async def delete_subscription(self, subscription_id: str) -> dict[str, Any]:
+    async def delete_subscription(self, subscription_id: str) -> WebhookOperationResult:
         """Delete an Oura webhook subscription by ID."""
         headers = self._get_client_headers()
 
@@ -261,7 +294,11 @@ class OuraWebhookService:
                 error=str(e),
                 status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
             )
-            return {"subscription_id": subscription_id, "status": "error", "error": str(e)}
+            return WebhookOperationResult(
+                subscription_id=subscription_id,
+                status=WebhookSubscriptionStatus.ERROR,
+                error=str(e),
+            )
 
         log_structured(
             logger,
@@ -271,9 +308,9 @@ class OuraWebhookService:
             action="oura_webhook_subscription_deleted",
             subscription_id=subscription_id,
         )
-        return {"subscription_id": subscription_id, "status": "deleted"}
+        return WebhookOperationResult(subscription_id=subscription_id, status=WebhookSubscriptionStatus.DELETED)
 
-    async def update_subscription(self, subscription_id: str, callback_url: str) -> dict[str, Any]:
+    async def update_subscription(self, subscription_id: str, callback_url: str) -> WebhookOperationResult:
         """Update the callback URL of an Oura webhook subscription.
 
         GETs the existing subscription to retain its data_type and event_type,
@@ -284,14 +321,19 @@ class OuraWebhookService:
         verification_token = settings.oura_webhook_verification_token.get_secret_value()
 
         existing = await self.get_subscription(subscription_id)
+        if not existing:
+            return WebhookOperationResult(
+                subscription_id=subscription_id, status=WebhookSubscriptionStatus.ERROR, error="subscription not found"
+            )
+
         headers = self._get_client_headers()
         headers["Content-Type"] = "application/json"
 
         body = {
             "callback_url": callback_url,
             "verification_token": verification_token,
-            "event_type": existing["event_type"],
-            "data_type": existing["data_type"],
+            "event_type": existing.event_type,
+            "data_type": existing.data_type,
         }
 
         try:
@@ -314,7 +356,11 @@ class OuraWebhookService:
                 error=str(e),
                 status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
             )
-            return {"subscription_id": subscription_id, "status": "error", "error": str(e)}
+            return WebhookOperationResult(
+                subscription_id=subscription_id,
+                status=WebhookSubscriptionStatus.ERROR,
+                error=str(e),
+            )
 
         log_structured(
             logger,
@@ -324,7 +370,7 @@ class OuraWebhookService:
             action="oura_webhook_subscription_updated",
             subscription_id=subscription_id,
         )
-        return {"subscription_id": subscription_id, "status": "updated"}
+        return WebhookOperationResult(subscription_id=subscription_id, status=WebhookSubscriptionStatus.UPDATED)
 
     async def renew_subscriptions(self) -> list[dict[str, Any]]:
         """Renew all active Oura webhook subscriptions."""

--- a/backend/app/services/providers/polar/strategy.py
+++ b/backend/app/services/providers/polar/strategy.py
@@ -1,10 +1,3 @@
-from app.database import SessionLocal
-from app.repositories.provider_settings_repository import ProviderSettingsRepository
-from app.schemas.enums import ProviderName
-from app.schemas.responses.incoming_webhooks import (
-    ProviderWebhookSubscription,
-    WebhookOperationResult,
-)
 from app.services.providers.base_strategy import BaseProviderStrategy, ProviderCapabilities
 from app.services.providers.polar.data_247 import Polar247Data
 from app.services.providers.polar.oauth import PolarOAuth
@@ -18,7 +11,6 @@ class PolarStrategy(BaseProviderStrategy):
 
     def __init__(self):
         super().__init__()
-        self.provider_settings_repo = ProviderSettingsRepository()
         self.oauth = PolarOAuth(
             user_repo=self.user_repo,
             connection_repo=self.connection_repo,
@@ -38,6 +30,7 @@ class PolarStrategy(BaseProviderStrategy):
             oauth=self.oauth,
         )
         self.webhooks = PolarWebhookHandler(workouts=self.workouts, data_247=self.data_247)
+        self.webhook_service = polar_webhook_service
 
     @property
     def name(self) -> str:
@@ -52,22 +45,3 @@ class PolarStrategy(BaseProviderStrategy):
         return ProviderCapabilities(
             rest_pull=True, webhook_ping=True, webhook_registration_api=True, webhook_inbound_secret=True
         )
-
-    async def register_webhooks(self, callback_url: str) -> list[dict]:
-        result = await polar_webhook_service.register_subscriptions(callback_url)
-        if result.get("status") == "created":
-            secret = result.get("response", {}).get("signature_secret_key")
-            if not secret:
-                raise ValueError("Polar webhook registration succeeded but no signature_secret_key was returned.")
-            with SessionLocal() as db:
-                self.provider_settings_repo.save_webhook_secret(db, ProviderName.POLAR, secret)
-        return [result]
-
-    async def list_subscriptions(self) -> list[ProviderWebhookSubscription]:
-        return await polar_webhook_service.list_subscriptions()
-
-    async def delete_subscription(self, subscription_id: str) -> WebhookOperationResult:
-        return await polar_webhook_service.delete_webhook(subscription_id)
-
-    async def update_subscription(self, subscription_id: str, callback_url: str) -> WebhookOperationResult:
-        return await polar_webhook_service.update_webhook(subscription_id, callback_url)

--- a/backend/app/services/providers/polar/strategy.py
+++ b/backend/app/services/providers/polar/strategy.py
@@ -1,6 +1,10 @@
 from app.database import SessionLocal
 from app.repositories.provider_settings_repository import ProviderSettingsRepository
 from app.schemas.enums import ProviderName
+from app.schemas.responses.incoming_webhooks import (
+    ProviderWebhookSubscription,
+    WebhookOperationResult,
+)
 from app.services.providers.base_strategy import BaseProviderStrategy, ProviderCapabilities
 from app.services.providers.polar.data_247 import Polar247Data
 from app.services.providers.polar.oauth import PolarOAuth
@@ -59,11 +63,11 @@ class PolarStrategy(BaseProviderStrategy):
                 self.provider_settings_repo.save_webhook_secret(db, ProviderName.POLAR, secret)
         return [result]
 
-    async def list_subscriptions(self) -> list[dict]:
+    async def list_subscriptions(self) -> list[ProviderWebhookSubscription]:
         return await polar_webhook_service.list_subscriptions()
 
-    async def delete_subscription(self, subscription_id: str) -> dict:
+    async def delete_subscription(self, subscription_id: str) -> WebhookOperationResult:
         return await polar_webhook_service.delete_webhook(subscription_id)
 
-    async def update_subscription(self, subscription_id: str, callback_url: str) -> dict:
+    async def update_subscription(self, subscription_id: str, callback_url: str) -> WebhookOperationResult:
         return await polar_webhook_service.update_webhook(subscription_id, callback_url)

--- a/backend/app/services/providers/polar/strategy.py
+++ b/backend/app/services/providers/polar/strategy.py
@@ -58,3 +58,12 @@ class PolarStrategy(BaseProviderStrategy):
             with SessionLocal() as db:
                 self.provider_settings_repo.save_webhook_secret(db, ProviderName.POLAR, secret)
         return [result]
+
+    async def list_subscriptions(self) -> list[dict]:
+        return await polar_webhook_service.list_subscriptions()
+
+    async def delete_subscription(self, subscription_id: str) -> dict:
+        return await polar_webhook_service.delete_webhook(subscription_id)
+
+    async def update_subscription(self, subscription_id: str, callback_url: str) -> dict:
+        return await polar_webhook_service.update_webhook(subscription_id, callback_url)

--- a/backend/app/services/providers/polar/webhook_service.py
+++ b/backend/app/services/providers/polar/webhook_service.py
@@ -165,23 +165,40 @@ class PolarWebhookService:
         return WebhookOperationResult(subscription_id=webhook_id, status=WebhookSubscriptionStatus.DELETED)
 
     async def _patch_webhook(self, auth: httpx.BasicAuth, webhook_id: str, callback_url: str) -> WebhookOperationResult:
-        async with httpx.AsyncClient() as client:
-            resp = await client.patch(
-                f"{_POLAR_API_URL}/v3/webhooks/{webhook_id}",
-                auth=auth,
-                json={"events": _ALL_EVENTS, "url": callback_url},
-                timeout=30.0,
-            )
-            resp.raise_for_status()
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.patch(
+                    f"{_POLAR_API_URL}/v3/webhooks/{webhook_id}",
+                    auth=auth,
+                    json={"events": _ALL_EVENTS, "url": callback_url},
+                    timeout=30.0,
+                )
+                resp.raise_for_status()
+        except httpx.HTTPError as e:
             log_structured(
                 logger,
-                "info",
-                "Patched Polar webhook URL",
+                "error",
+                "Failed to patch Polar webhook URL",
                 provider="polar",
-                action="polar_webhook_patched",
+                action="polar_webhook_patch_error",
                 webhook_id=webhook_id,
+                error=str(e),
+                status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
             )
-            return WebhookOperationResult(subscription_id=webhook_id, status=WebhookSubscriptionStatus.PATCHED)
+            return WebhookOperationResult(
+                subscription_id=webhook_id,
+                status=WebhookSubscriptionStatus.ERROR,
+                error=str(e),
+            )
+        log_structured(
+            logger,
+            "info",
+            "Patched Polar webhook URL",
+            provider="polar",
+            action="polar_webhook_patched",
+            webhook_id=webhook_id,
+        )
+        return WebhookOperationResult(subscription_id=webhook_id, status=WebhookSubscriptionStatus.PATCHED)
 
     async def _create_webhook(self, auth: httpx.BasicAuth, callback_url: str) -> dict[str, Any]:
         async with httpx.AsyncClient() as client:

--- a/backend/app/services/providers/polar/webhook_service.py
+++ b/backend/app/services/providers/polar/webhook_service.py
@@ -24,6 +24,9 @@ from fastapi import status
 from pydantic import ValidationError
 
 from app.config import settings
+from app.database import SessionLocal
+from app.repositories.provider_settings_repository import ProviderSettingsRepository
+from app.schemas.enums import ProviderName
 from app.schemas.providers.polar import PolarWebhookEventType
 from app.schemas.responses.incoming_webhooks import (
     PolarWebhookSubscription,
@@ -31,6 +34,7 @@ from app.schemas.responses.incoming_webhooks import (
     WebhookOperationResult,
     WebhookSubscriptionStatus,
 )
+from app.services.providers.templates.base_webhook_service import BaseWebhookService
 from app.utils.structured_logging import log_structured
 
 logger = getLogger(__name__)
@@ -40,7 +44,7 @@ _POLAR_API_URL = "https://www.polaraccesslink.com"
 _ALL_EVENTS = [e for e in PolarWebhookEventType if e is not PolarWebhookEventType.PING]
 
 
-class PolarWebhookService:
+class PolarWebhookService(BaseWebhookService):
     """App-level Polar webhook subscription management."""
 
     def _get_basic_auth(self) -> httpx.BasicAuth:
@@ -104,7 +108,7 @@ class PolarWebhookService:
         existing = await self.get_webhook()
         if existing:
             existing_url = existing.url
-            webhook_id = existing.id
+            subscription_id = existing.id
 
             if existing_url == callback_url:
                 log_structured(
@@ -113,27 +117,34 @@ class PolarWebhookService:
                     "Polar webhook already registered",
                     provider="polar",
                     action="polar_webhook_skipped",
-                    webhook_id=webhook_id,
+                    subscription_id=subscription_id,
                 )
-                return {"status": "skipped", "webhook_id": webhook_id}
+                return {"status": "skipped", "subscription_id": subscription_id}
 
             # URL changed — patch in place
-            return (await self._patch_webhook(auth, webhook_id, callback_url)).model_dump()
+            return (await self._patch_webhook(auth, subscription_id, callback_url)).model_dump()
 
-        return await self._create_webhook(auth, callback_url)
+        result = await self._create_webhook(auth, callback_url)
+        if result.get("status") == "created":
+            secret = result.get("response", {}).get("signature_secret_key")
+            if not secret:
+                raise ValueError("Polar webhook registration succeeded but no signature_secret_key was returned.")
+            with SessionLocal() as db:
+                ProviderSettingsRepository().save_webhook_secret(db, ProviderName.POLAR, secret)
+        return result
 
-    async def update_webhook(self, webhook_id: str, callback_url: str) -> WebhookOperationResult:
+    async def update_subscription(self, subscription_id: str, callback_url: str) -> WebhookOperationResult:
         """Update the URL of an existing Polar webhook (PATCH /v3/webhooks/{id})."""
         auth = self._get_basic_auth()
-        return await self._patch_webhook(auth, webhook_id, callback_url)
+        return await self._patch_webhook(auth, subscription_id, callback_url)
 
-    async def delete_webhook(self, webhook_id: str) -> WebhookOperationResult:
+    async def delete_subscription(self, subscription_id: str) -> WebhookOperationResult:
         """Delete the Polar webhook by ID (DELETE /v3/webhooks/{id})."""
         auth = self._get_basic_auth()
         try:
             async with httpx.AsyncClient() as client:
                 resp = await client.delete(
-                    f"{_POLAR_API_URL}/v3/webhooks/{webhook_id}",
+                    f"{_POLAR_API_URL}/v3/webhooks/{subscription_id}",
                     auth=auth,
                     timeout=30.0,
                 )
@@ -145,12 +156,12 @@ class PolarWebhookService:
                 "Failed to delete Polar webhook",
                 provider="polar",
                 action="polar_webhook_delete_error",
-                webhook_id=webhook_id,
+                subscription_id=subscription_id,
                 error=str(e),
                 status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
             )
             return WebhookOperationResult(
-                subscription_id=webhook_id,
+                subscription_id=subscription_id,
                 status=WebhookSubscriptionStatus.ERROR,
                 error=str(e),
             )
@@ -160,15 +171,17 @@ class PolarWebhookService:
             "Polar webhook deleted",
             provider="polar",
             action="polar_webhook_deleted",
-            webhook_id=webhook_id,
+            subscription_id=subscription_id,
         )
-        return WebhookOperationResult(subscription_id=webhook_id, status=WebhookSubscriptionStatus.DELETED)
+        return WebhookOperationResult(subscription_id=subscription_id, status=WebhookSubscriptionStatus.DELETED)
 
-    async def _patch_webhook(self, auth: httpx.BasicAuth, webhook_id: str, callback_url: str) -> WebhookOperationResult:
+    async def _patch_webhook(
+        self, auth: httpx.BasicAuth, subscription_id: str, callback_url: str
+    ) -> WebhookOperationResult:
         try:
             async with httpx.AsyncClient() as client:
                 resp = await client.patch(
-                    f"{_POLAR_API_URL}/v3/webhooks/{webhook_id}",
+                    f"{_POLAR_API_URL}/v3/webhooks/{subscription_id}",
                     auth=auth,
                     json={"events": _ALL_EVENTS, "url": callback_url},
                     timeout=30.0,
@@ -181,12 +194,12 @@ class PolarWebhookService:
                 "Failed to patch Polar webhook URL",
                 provider="polar",
                 action="polar_webhook_patch_error",
-                webhook_id=webhook_id,
+                subscription_id=subscription_id,
                 error=str(e),
                 status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
             )
             return WebhookOperationResult(
-                subscription_id=webhook_id,
+                subscription_id=subscription_id,
                 status=WebhookSubscriptionStatus.ERROR,
                 error=str(e),
             )
@@ -196,9 +209,9 @@ class PolarWebhookService:
             "Patched Polar webhook URL",
             provider="polar",
             action="polar_webhook_patched",
-            webhook_id=webhook_id,
+            subscription_id=subscription_id,
         )
-        return WebhookOperationResult(subscription_id=webhook_id, status=WebhookSubscriptionStatus.PATCHED)
+        return WebhookOperationResult(subscription_id=subscription_id, status=WebhookSubscriptionStatus.PATCHED)
 
     async def _create_webhook(self, auth: httpx.BasicAuth, callback_url: str) -> dict[str, Any]:
         async with httpx.AsyncClient() as client:
@@ -227,7 +240,7 @@ class PolarWebhookService:
                 "Polar webhook created",
                 provider="polar",
                 action="polar_webhook_created",
-                webhook_id=result.get("id"),
+                subscription_id=result.get("id"),
             )
             return {"status": "created", "response": result}
 

--- a/backend/app/services/providers/polar/webhook_service.py
+++ b/backend/app/services/providers/polar/webhook_service.py
@@ -63,7 +63,7 @@ class PolarWebhookService:
                 error=str(e),
                 status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
             )
-            raise
+            return None
 
     async def register_subscriptions(self, callback_url: str) -> dict[str, Any]:
         """Create or verify the Polar webhook subscription.
@@ -131,7 +131,7 @@ class PolarWebhookService:
                 error=str(e),
                 status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
             )
-            raise
+            return {"webhook_id": webhook_id, "status": "error", "error": str(e)}
         log_structured(
             logger,
             "info",

--- a/backend/app/services/providers/polar/webhook_service.py
+++ b/backend/app/services/providers/polar/webhook_service.py
@@ -46,12 +46,24 @@ class PolarWebhookService:
     async def get_webhook(self) -> dict[str, Any] | None:
         """Return the existing webhook config, or None if not registered."""
         auth = self._get_basic_auth()
-        async with httpx.AsyncClient() as client:
-            resp = await client.get(f"{_POLAR_API_URL}/v3/webhooks", auth=auth, timeout=30.0)
-            resp.raise_for_status()
-            data = resp.json()
-            webhooks = data.get("data", [])
-            return webhooks[0] if webhooks else None
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(f"{_POLAR_API_URL}/v3/webhooks", auth=auth, timeout=30.0)
+                resp.raise_for_status()
+                data = resp.json()
+                webhooks = data.get("data", [])
+                return webhooks[0] if webhooks else None
+        except httpx.HTTPError as e:
+            log_structured(
+                logger,
+                "error",
+                "Failed to fetch Polar webhook",
+                provider="polar",
+                action="polar_webhook_get_error",
+                error=str(e),
+                status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
+            )
+            raise
 
     async def register_subscriptions(self, callback_url: str) -> dict[str, Any]:
         """Create or verify the Polar webhook subscription.
@@ -91,6 +103,44 @@ class PolarWebhookService:
             return await self._patch_webhook(auth, webhook_id, callback_url)
 
         return await self._create_webhook(auth, callback_url)
+
+    async def update_webhook(self, webhook_id: str, callback_url: str) -> dict[str, Any]:
+        """Update the URL of an existing Polar webhook (PATCH /v3/webhooks/{id})."""
+        auth = self._get_basic_auth()
+        return await self._patch_webhook(auth, webhook_id, callback_url)
+
+    async def delete_webhook(self, webhook_id: str) -> dict[str, Any]:
+        """Delete the Polar webhook by ID (DELETE /v3/webhooks/{id})."""
+        auth = self._get_basic_auth()
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.delete(
+                    f"{_POLAR_API_URL}/v3/webhooks/{webhook_id}",
+                    auth=auth,
+                    timeout=30.0,
+                )
+                resp.raise_for_status()
+        except httpx.HTTPError as e:
+            log_structured(
+                logger,
+                "error",
+                "Failed to delete Polar webhook",
+                provider="polar",
+                action="polar_webhook_delete_error",
+                webhook_id=webhook_id,
+                error=str(e),
+                status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
+            )
+            raise
+        log_structured(
+            logger,
+            "info",
+            "Polar webhook deleted",
+            provider="polar",
+            action="polar_webhook_deleted",
+            webhook_id=webhook_id,
+        )
+        return {"webhook_id": webhook_id, "status": "deleted"}
 
     async def _patch_webhook(self, auth: httpx.BasicAuth, webhook_id: str, callback_url: str) -> dict[str, Any]:
         async with httpx.AsyncClient() as client:

--- a/backend/app/services/providers/polar/webhook_service.py
+++ b/backend/app/services/providers/polar/webhook_service.py
@@ -21,9 +21,16 @@ from typing import Any
 
 import httpx
 from fastapi import status
+from pydantic import ValidationError
 
 from app.config import settings
 from app.schemas.providers.polar import PolarWebhookEventType
+from app.schemas.responses.incoming_webhooks import (
+    PolarWebhookSubscription,
+    ProviderWebhookSubscription,
+    WebhookOperationResult,
+    WebhookSubscriptionStatus,
+)
 from app.utils.structured_logging import log_structured
 
 logger = getLogger(__name__)
@@ -43,7 +50,7 @@ class PolarWebhookService:
             raise ValueError("Polar client credentials (POLAR_CLIENT_ID / POLAR_CLIENT_SECRET) not configured")
         return httpx.BasicAuth(client_id, client_secret)
 
-    async def get_webhook(self) -> dict[str, Any] | None:
+    async def get_webhook(self) -> PolarWebhookSubscription | None:
         """Return the existing webhook config, or None if not registered."""
         auth = self._get_basic_auth()
         try:
@@ -52,7 +59,20 @@ class PolarWebhookService:
                 resp.raise_for_status()
                 data = resp.json()
                 webhooks = data.get("data", [])
-                return webhooks[0] if webhooks else None
+                if not webhooks:
+                    return None
+                try:
+                    return PolarWebhookSubscription.model_validate(webhooks[0])
+                except ValidationError as ve:
+                    log_structured(
+                        logger,
+                        "error",
+                        "Failed to parse Polar webhook response",
+                        provider="polar",
+                        action="polar_webhook_parse_error",
+                        error=str(ve),
+                    )
+                    return None
         except httpx.HTTPError as e:
             log_structured(
                 logger,
@@ -83,8 +103,8 @@ class PolarWebhookService:
 
         existing = await self.get_webhook()
         if existing:
-            existing_url = existing.get("url", "")
-            webhook_id = existing.get("id")
+            existing_url = existing.url
+            webhook_id = existing.id
 
             if existing_url == callback_url:
                 log_structured(
@@ -97,19 +117,17 @@ class PolarWebhookService:
                 )
                 return {"status": "skipped", "webhook_id": webhook_id}
 
-            if not webhook_id:
-                return {"status": "error", "error": "existing webhook has no id"}
             # URL changed — patch in place
-            return await self._patch_webhook(auth, webhook_id, callback_url)
+            return (await self._patch_webhook(auth, webhook_id, callback_url)).model_dump()
 
         return await self._create_webhook(auth, callback_url)
 
-    async def update_webhook(self, webhook_id: str, callback_url: str) -> dict[str, Any]:
+    async def update_webhook(self, webhook_id: str, callback_url: str) -> WebhookOperationResult:
         """Update the URL of an existing Polar webhook (PATCH /v3/webhooks/{id})."""
         auth = self._get_basic_auth()
         return await self._patch_webhook(auth, webhook_id, callback_url)
 
-    async def delete_webhook(self, webhook_id: str) -> dict[str, Any]:
+    async def delete_webhook(self, webhook_id: str) -> WebhookOperationResult:
         """Delete the Polar webhook by ID (DELETE /v3/webhooks/{id})."""
         auth = self._get_basic_auth()
         try:
@@ -131,7 +149,11 @@ class PolarWebhookService:
                 error=str(e),
                 status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
             )
-            return {"webhook_id": webhook_id, "status": "error", "error": str(e)}
+            return WebhookOperationResult(
+                subscription_id=webhook_id,
+                status=WebhookSubscriptionStatus.ERROR,
+                error=str(e),
+            )
         log_structured(
             logger,
             "info",
@@ -140,9 +162,9 @@ class PolarWebhookService:
             action="polar_webhook_deleted",
             webhook_id=webhook_id,
         )
-        return {"webhook_id": webhook_id, "status": "deleted"}
+        return WebhookOperationResult(subscription_id=webhook_id, status=WebhookSubscriptionStatus.DELETED)
 
-    async def _patch_webhook(self, auth: httpx.BasicAuth, webhook_id: str, callback_url: str) -> dict[str, Any]:
+    async def _patch_webhook(self, auth: httpx.BasicAuth, webhook_id: str, callback_url: str) -> WebhookOperationResult:
         async with httpx.AsyncClient() as client:
             resp = await client.patch(
                 f"{_POLAR_API_URL}/v3/webhooks/{webhook_id}",
@@ -151,7 +173,6 @@ class PolarWebhookService:
                 timeout=30.0,
             )
             resp.raise_for_status()
-            result = resp.json().get("data") or {}
             log_structured(
                 logger,
                 "info",
@@ -160,7 +181,7 @@ class PolarWebhookService:
                 action="polar_webhook_patched",
                 webhook_id=webhook_id,
             )
-            return {"status": "patched", "webhook_id": webhook_id, "response": result}
+            return WebhookOperationResult(subscription_id=webhook_id, status=WebhookSubscriptionStatus.PATCHED)
 
     async def _create_webhook(self, auth: httpx.BasicAuth, callback_url: str) -> dict[str, Any]:
         async with httpx.AsyncClient() as client:
@@ -213,7 +234,7 @@ class PolarWebhookService:
             log_structured(logger, "info", "Polar webhook deactivated", provider="polar")
             return {"status": "deactivated"}
 
-    async def list_subscriptions(self) -> list[dict[str, Any]]:
+    async def list_subscriptions(self) -> list[ProviderWebhookSubscription]:
         webhook = await self.get_webhook()
         return [webhook] if webhook else []
 

--- a/backend/app/services/providers/strava/strategy.py
+++ b/backend/app/services/providers/strava/strategy.py
@@ -66,3 +66,6 @@ class StravaStrategy(BaseProviderStrategy):
 
     async def list_subscriptions(self) -> list[dict]:
         return await strava_webhook_service.list_subscriptions()
+
+    async def delete_subscription(self, subscription_id: str) -> dict:
+        return await strava_webhook_service.delete_subscription(subscription_id)

--- a/backend/app/services/providers/strava/strategy.py
+++ b/backend/app/services/providers/strava/strategy.py
@@ -1,7 +1,3 @@
-from app.schemas.responses.incoming_webhooks import (
-    ProviderWebhookSubscription,
-    WebhookOperationResult,
-)
 from app.services.providers.base_strategy import BaseProviderStrategy, ProviderCapabilities
 from app.services.providers.strava.oauth import StravaOAuth
 from app.services.providers.strava.webhook_handler import StravaWebhookHandler
@@ -36,6 +32,7 @@ class StravaStrategy(BaseProviderStrategy):
         self.data_247 = None
 
         self.webhooks = StravaWebhookHandler(workouts=self.workouts)
+        self.webhook_service = strava_webhook_service
 
     @property
     def name(self) -> str:
@@ -64,12 +61,3 @@ class StravaStrategy(BaseProviderStrategy):
         # Strava webhook events contain only the object_id and aspect_type;
         # the full activity must still be fetched via GET /activities/{id}.
         return ProviderCapabilities(rest_pull=True, webhook_ping=True, webhook_registration_api=True)
-
-    async def register_webhooks(self, callback_url: str) -> list[dict]:
-        return await strava_webhook_service.register_subscriptions(callback_url)
-
-    async def list_subscriptions(self) -> list[ProviderWebhookSubscription]:
-        return await strava_webhook_service.list_subscriptions()
-
-    async def delete_subscription(self, subscription_id: str) -> WebhookOperationResult:
-        return await strava_webhook_service.delete_subscription(subscription_id)

--- a/backend/app/services/providers/strava/strategy.py
+++ b/backend/app/services/providers/strava/strategy.py
@@ -1,3 +1,7 @@
+from app.schemas.responses.incoming_webhooks import (
+    ProviderWebhookSubscription,
+    WebhookOperationResult,
+)
 from app.services.providers.base_strategy import BaseProviderStrategy, ProviderCapabilities
 from app.services.providers.strava.oauth import StravaOAuth
 from app.services.providers.strava.webhook_handler import StravaWebhookHandler
@@ -64,8 +68,8 @@ class StravaStrategy(BaseProviderStrategy):
     async def register_webhooks(self, callback_url: str) -> list[dict]:
         return await strava_webhook_service.register_subscriptions(callback_url)
 
-    async def list_subscriptions(self) -> list[dict]:
+    async def list_subscriptions(self) -> list[ProviderWebhookSubscription]:
         return await strava_webhook_service.list_subscriptions()
 
-    async def delete_subscription(self, subscription_id: str) -> dict:
+    async def delete_subscription(self, subscription_id: str) -> WebhookOperationResult:
         return await strava_webhook_service.delete_subscription(subscription_id)

--- a/backend/app/services/providers/strava/strategy.py
+++ b/backend/app/services/providers/strava/strategy.py
@@ -63,3 +63,6 @@ class StravaStrategy(BaseProviderStrategy):
 
     async def register_webhooks(self, callback_url: str) -> list[dict]:
         return await strava_webhook_service.register_subscriptions(callback_url)
+
+    async def list_subscriptions(self) -> list[dict]:
+        return await strava_webhook_service.list_subscriptions()

--- a/backend/app/services/providers/strava/webhook_service.py
+++ b/backend/app/services/providers/strava/webhook_service.py
@@ -14,8 +14,15 @@ from logging import getLogger
 from typing import Any
 
 import httpx
+from pydantic import ValidationError
 
 from app.config import settings
+from app.schemas.responses.incoming_webhooks import (
+    ProviderWebhookSubscription,
+    StravaWebhookSubscription,
+    WebhookOperationResult,
+    WebhookSubscriptionStatus,
+)
 from app.utils.structured_logging import log_structured
 
 logger = getLogger(__name__)
@@ -158,7 +165,7 @@ class StravaWebhookService:
                 )
                 return [{"status": "error", "error": str(e)}]
 
-    async def list_subscriptions(self) -> list[dict[str, Any]]:
+    async def list_subscriptions(self) -> list[ProviderWebhookSubscription]:
         """List active Strava webhook subscriptions."""
         client_id, client_secret = self._get_strava_credentials()
 
@@ -169,9 +176,23 @@ class StravaWebhookService:
                 timeout=30.0,
             )
             response.raise_for_status()
-            return response.json()
+            raw = response.json() or []
+            result: list[ProviderWebhookSubscription] = []
+            for item in raw if isinstance(raw, list) else []:
+                try:
+                    result.append(StravaWebhookSubscription.model_validate(item))
+                except ValidationError as ve:
+                    log_structured(
+                        logger,
+                        "error",
+                        "Failed to parse Strava webhook subscription",
+                        provider="strava",
+                        action="strava_webhook_subscription_parse_error",
+                        error=str(ve),
+                    )
+            return result
 
-    async def delete_subscription(self, subscription_id: str) -> dict[str, Any]:
+    async def delete_subscription(self, subscription_id: str) -> WebhookOperationResult:
         """Delete a Strava webhook subscription by ID."""
         client_id, client_secret = self._get_strava_credentials()
 
@@ -194,7 +215,11 @@ class StravaWebhookService:
                 error=str(e),
                 status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
             )
-            return {"subscription_id": subscription_id, "status": "error", "error": str(e)}
+            return WebhookOperationResult(
+                subscription_id=subscription_id,
+                status=WebhookSubscriptionStatus.ERROR,
+                error=str(e),
+            )
 
         log_structured(
             logger,
@@ -204,7 +229,7 @@ class StravaWebhookService:
             action="strava_webhook_subscription_deleted",
             subscription_id=subscription_id,
         )
-        return {"subscription_id": subscription_id, "status": "deleted"}
+        return WebhookOperationResult(subscription_id=subscription_id, status=WebhookSubscriptionStatus.DELETED)
 
 
 strava_webhook_service = StravaWebhookService()

--- a/backend/app/services/providers/strava/webhook_service.py
+++ b/backend/app/services/providers/strava/webhook_service.py
@@ -75,7 +75,7 @@ class StravaWebhookService:
                     action="strava_webhook_subscription_list_error",
                     error=str(e),
                 )
-                raise
+                return [{"status": "error", "error": str(e)}]
 
             if existing:
                 sub_id = existing.get("id")
@@ -194,7 +194,7 @@ class StravaWebhookService:
                 error=str(e),
                 status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
             )
-            raise
+            return {"subscription_id": subscription_id, "status": "error", "error": str(e)}
 
         log_structured(
             logger,

--- a/backend/app/services/providers/strava/webhook_service.py
+++ b/backend/app/services/providers/strava/webhook_service.py
@@ -23,6 +23,7 @@ from app.schemas.responses.incoming_webhooks import (
     WebhookOperationResult,
     WebhookSubscriptionStatus,
 )
+from app.services.providers.templates.base_webhook_service import BaseWebhookService
 from app.utils.structured_logging import log_structured
 
 logger = getLogger(__name__)
@@ -31,7 +32,7 @@ logger = getLogger(__name__)
 _STRAVA_API_URL = "https://www.strava.com/api/v3"
 
 
-class StravaWebhookService:
+class StravaWebhookService(BaseWebhookService):
     """App-level Strava webhook subscription management."""
 
     @property

--- a/backend/app/services/providers/strava/webhook_service.py
+++ b/backend/app/services/providers/strava/webhook_service.py
@@ -171,5 +171,40 @@ class StravaWebhookService:
             response.raise_for_status()
             return response.json()
 
+    async def delete_subscription(self, subscription_id: str) -> dict[str, Any]:
+        """Delete a Strava webhook subscription by ID."""
+        client_id, client_secret = self._get_strava_credentials()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.delete(
+                    f"{self.api_current_url}/push_subscriptions/{subscription_id}",
+                    params={"client_id": client_id, "client_secret": client_secret},
+                    timeout=30.0,
+                )
+                response.raise_for_status()
+        except httpx.HTTPError as e:
+            log_structured(
+                logger,
+                "error",
+                "Failed to delete Strava webhook subscription",
+                provider="strava",
+                action="strava_webhook_subscription_delete_error",
+                subscription_id=subscription_id,
+                error=str(e),
+                status_code=e.response.status_code if isinstance(e, httpx.HTTPStatusError) else None,
+            )
+            raise
+
+        log_structured(
+            logger,
+            "info",
+            "Strava webhook subscription deleted",
+            provider="strava",
+            action="strava_webhook_subscription_deleted",
+            subscription_id=subscription_id,
+        )
+        return {"subscription_id": subscription_id, "status": "deleted"}
+
 
 strava_webhook_service = StravaWebhookService()

--- a/backend/app/services/providers/templates/base_webhook_service.py
+++ b/backend/app/services/providers/templates/base_webhook_service.py
@@ -1,0 +1,30 @@
+"""Abstract base class for provider webhook subscription management services."""
+
+from typing import Any
+
+
+class BaseWebhookService:
+    """Base class for managing webhook subscriptions with a provider's API.
+
+    Concrete services override the methods supported by their provider.
+    Unsupported operations raise ``NotImplementedError``, which the router
+    maps to HTTP 501.
+    """
+
+    async def register_subscriptions(self, callback_url: str) -> Any:
+        raise NotImplementedError("This provider does not support programmatic webhook registration")
+
+    async def list_subscriptions(self) -> Any:
+        raise NotImplementedError("This provider does not support listing webhook subscriptions")
+
+    async def get_subscription(self, subscription_id: str) -> Any:
+        raise NotImplementedError("This provider does not support fetching a webhook subscription by ID")
+
+    async def renew_subscriptions(self) -> Any:
+        raise NotImplementedError("This provider does not support renewing webhook subscriptions")
+
+    async def delete_subscription(self, subscription_id: str) -> Any:
+        raise NotImplementedError("This provider does not support deleting a webhook subscription")
+
+    async def update_subscription(self, subscription_id: str, callback_url: str) -> Any:
+        raise NotImplementedError("This provider does not support updating a webhook subscription")

--- a/docs/api-reference/guides/provider-webhook-subscriptions.mdx
+++ b/docs/api-reference/guides/provider-webhook-subscriptions.mdx
@@ -1,0 +1,308 @@
+---
+title: "Provider Webhook Subscriptions"
+sidebarTitle: "Provider Webhook Subscriptions"
+description: "Manage app-level webhook subscriptions with Polar, Oura, and Strava so those providers push events to your Open Wearables instance in real time."
+keywords: ["provider webhooks", "webhook subscriptions", "polar webhook", "oura webhook", "strava webhook", "incoming webhooks"]
+"og:title": "Provider Webhook Subscriptions | Open Wearables"
+"og:description": "Register, inspect, update, and delete app-level webhook subscriptions with Polar, Oura, and Strava."
+"og:url": "https://docs.openwearables.io/api-reference/guides/provider-webhook-subscriptions"
+"og:type": "article"
+---
+
+## Overview
+
+Provider webhook subscriptions tell a wearable provider (Polar, Oura, Strava) where to send event notifications. When an active subscription is in place, the provider pushes a lightweight notification to your Open Wearables instance whenever new data is available. Open Wearables then fetches, normalizes, and stores the data — and can forward it onward via [Outgoing Webhooks](/api-reference/guides/webhooks).
+
+<Note>
+  This page covers **provider → Open Wearables** subscriptions (inbound). For **Open Wearables → your app** event delivery, see the [Outgoing Webhooks guide](/api-reference/guides/webhooks).
+</Note>
+
+All endpoints require a developer Bearer token:
+
+```
+Authorization: Bearer <token>
+```
+
+**Base path**: `/api/v1/providers/{provider}/webhooks/subscriptions`
+
+Supported `{provider}` values: `polar`, `oura`, `strava`
+
+---
+
+## Provider differences
+
+| Provider | Max subscriptions | Verification method | Secret |
+|----------|------------------|---------------------|--------|
+| **Polar** | 1 per app | Polar sends a `PING` event to the URL; must return `200 OK` | `signature_secret_key` returned once on creation — auto-saved to DB |
+| **Oura** | 1 per data type | GET challenge with `verification_token` query param | Client secret used for HMAC verification |
+| **Strava** | 1 per app | GET `hub.challenge` echo | `STRAVA_WEBHOOK_VERIFY_TOKEN` env var |
+
+<Warning>
+  **Polar only**: when you register or update a webhook, Polar immediately sends a `PING` to the configured URL. The request must respond `200 OK` before Polar accepts the subscription. Use a publicly reachable URL (e.g. set up via [ngrok](/dev-guides/ngrok-setup)).
+</Warning>
+
+---
+
+## Endpoints
+
+### List subscriptions
+
+Returns all active subscriptions for a provider.
+
+```bash
+curl "http://localhost:8000/api/v1/providers/{provider}/webhooks/subscriptions" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+
+<Tabs>
+  <Tab title="Polar">
+    ```json
+    {
+      "subscriptions": [
+        {
+          "id": "abc123",
+          "events": ["EXERCISE", "SLEEP", "CONTINUOUS_HEART_RATE", "DAILY_ACTIVITY"],
+          "url": "https://yourapp.com/api/v1/providers/polar/webhooks"
+        }
+      ]
+    }
+    ```
+  </Tab>
+  <Tab title="Oura">
+    ```json
+    {
+      "subscriptions": [
+        {
+          "id": "sub_01abc",
+          "callback_url": "https://yourapp.com/api/v1/providers/oura/webhooks",
+          "event_type": "create",
+          "data_type": "workout",
+          "expiration_time": "2026-06-28T00:00:00+00:00"
+        },
+        {
+          "id": "sub_01def",
+          "callback_url": "https://yourapp.com/api/v1/providers/oura/webhooks",
+          "event_type": "create",
+          "data_type": "sleep",
+          "expiration_time": "2026-06-28T00:00:00+00:00"
+        }
+      ]
+    }
+    ```
+  </Tab>
+  <Tab title="Strava">
+    ```json
+    {
+      "subscriptions": [
+        {
+          "id": 12345,
+          "application_id": 67890,
+          "callback_url": "https://yourapp.com/api/v1/providers/strava/webhooks",
+          "created_at": "2026-01-01T00:00:00Z",
+          "updated_at": "2026-01-01T00:00:00Z"
+        }
+      ]
+    }
+    ```
+  </Tab>
+</Tabs>
+
+---
+
+### Register subscriptions
+
+Creates a new subscription (or updates an existing one if the URL changed).
+Pass `callback_url` as a query parameter.
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/providers/{provider}/webhooks/subscriptions?callback_url=https://yourapp.com/api/v1/providers/{provider}/webhooks" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Provider-specific behaviour:
+
+| Provider | If no subscription exists | If subscription exists with same URL | If subscription exists with different URL |
+|----------|--------------------------|-------------------------------------|------------------------------------------|
+| **Polar** | Creates webhook; Polar POSTs a `PING` to verify. `signature_secret_key` auto-saved to DB. | Returns `skipped` | Updates URL via `PATCH`; Polar PINGs the new URL |
+| **Oura** | Creates one subscription per data type | Returns `skipped` per already-registered type | Creates new subscriptions for missing types |
+| **Strava** | Registers subscription; Strava sends a GET challenge that must echo back `hub.challenge` | Returns `skipped` | — |
+
+<Note>
+  **Polar**: the `signature_secret_key` is returned by Polar exactly once, on creation. Open Wearables saves it automatically to the `provider_settings` table (`webhook_secret` column). If you need to rotate it, delete and recreate the webhook.
+</Note>
+
+---
+
+### Get a subscription
+
+Fetch a single subscription by ID.
+
+```bash
+curl "http://localhost:8000/api/v1/providers/{provider}/webhooks/subscriptions/{subscription_id}" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+
+```json
+{
+  "subscription": {
+    "id": "sub_01abc",
+    "callback_url": "https://yourapp.com/api/v1/providers/oura/webhooks",
+    "event_type": "create",
+    "data_type": "workout",
+    "expiration_time": "2026-06-28T00:00:00+00:00"
+  }
+}
+```
+
+Returns `{ "subscription": null }` when the subscription is not found.
+
+<Note>
+  Get by ID is currently implemented for **Oura** only. Polar and Strava return `501 Not Implemented` — use list subscriptions instead.
+</Note>
+
+---
+
+### Update a subscription
+
+Change the callback URL of an existing subscription.
+
+```bash
+curl -X PUT "http://localhost:8000/api/v1/providers/{provider}/webhooks/subscriptions/{subscription_id}?callback_url=https://newurl.com/api/v1/providers/{provider}/webhooks" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+
+```json
+{
+  "updated": {
+    "subscription_id": "abc123",
+    "status": "patched"
+  }
+}
+```
+
+On error:
+
+```json
+{
+  "updated": {
+    "subscription_id": "abc123",
+    "status": "error",
+    "error": "422 Unprocessable Entity ..."
+  }
+}
+```
+
+<Warning>
+  **Polar**: updating the URL triggers a new `PING` from Polar to the new address. If the URL does not respond `200 OK`, the update is rejected by Polar and the endpoint returns `status: "error"`.
+</Warning>
+
+Possible `status` values: `updated`, `patched`, `deleted`, `created`, `skipped`, `error`.
+
+---
+
+### Delete a subscription
+
+Remove a webhook subscription from the provider.
+
+```bash
+curl -X DELETE "http://localhost:8000/api/v1/providers/{provider}/webhooks/subscriptions/{subscription_id}" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+
+```json
+{
+  "deleted": {
+    "subscription_id": "abc123",
+    "status": "deleted"
+  }
+}
+```
+
+---
+
+### Renew subscriptions (Oura only)
+
+Oura subscriptions have an `expiration_time`. Call this endpoint to extend all active subscriptions before they expire.
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/providers/oura/webhooks/subscriptions/renew" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Response:**
+
+```json
+{
+  "renewed": [
+    { "id": "sub_01abc", "status": "renewed", ... },
+    { "id": "sub_01def", "status": "renewed", ... }
+  ]
+}
+```
+
+---
+
+## Inbound event endpoints
+
+These endpoints receive the actual event notifications from providers. They are not management operations — you do not call them directly.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/providers/{provider}/webhooks` | Receives incoming event payloads. Verifies the provider signature, parses the event, and dispatches a background sync task. |
+| `GET` | `/api/v1/providers/{provider}/webhooks` | Handles subscription verification challenges (Oura `verification_token`, Strava `hub.challenge`). |
+
+The callback URL you register with a provider must point to `POST /api/v1/providers/{provider}/webhooks`. For local development, use [ngrok](/dev-guides/ngrok-setup) to expose that endpoint publicly.
+
+---
+
+## Response schema reference
+
+### Subscription objects
+
+Each provider returns a different subscription shape:
+
+**Polar**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Webhook ID assigned by Polar |
+| `events` | `string[]` | Subscribed event types (e.g. `EXERCISE`, `SLEEP`) |
+| `url` | `string` | Registered callback URL |
+
+**Oura**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Subscription ID |
+| `callback_url` | `string` | Registered callback URL |
+| `event_type` | `string` | `create` or `update` |
+| `data_type` | `string` | `workout`, `sleep`, `session`, etc. |
+| `expiration_time` | `string \| null` | ISO 8601 expiry datetime |
+
+**Strava**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `integer` | Subscription ID |
+| `application_id` | `integer` | Strava application ID |
+| `callback_url` | `string` | Registered callback URL |
+| `created_at` | `string` | ISO 8601 creation timestamp |
+| `updated_at` | `string` | ISO 8601 last-update timestamp |
+
+### Operation result
+
+Returned by delete and update endpoints.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `subscription_id` | `string` | ID of the affected subscription |
+| `status` | `string` | One of: `created`, `updated`, `patched`, `deleted`, `skipped`, `error` |
+| `error` | `string` | Present only when `status` is `error` |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -161,6 +161,7 @@
             "pages": [
               "api-reference/guides/quick-integration",
               "api-reference/guides/webhooks",
+              "api-reference/guides/provider-webhook-subscriptions",
               "api-reference/guides/sync-status-stream",
               "api-reference/guides/apple-xml-import",
               "api-reference/guides/provider-setup",


### PR DESCRIPTION
## Description

- add webhook management endpoint
- update base strategy to include optional base abstract methods
- wire Oura and Strava webhook methods - Polar not merged yet, so up to update

TODO: also add missing webhook management for Oura, Strava, maybe Polar later after merge

Frontend changes not implemented yet - thats why only a draft, will probably update after 0.5.2 / 0.6 release

Resolves #1011 


## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [ ] `pnpm run lint` passes
- [ ] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds


## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin endpoints to manage provider webhook subscriptions (list, register, renew, get, update, delete) with unified provider resolution and typed responses.
  * Services now provide lifecycle operations for Polar, Oura, and Strava; background task uses these services.

* **Documentation**
  * Added an API reference guide detailing provider webhook subscription management and provider-specific behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->