### PR TITLE
fix(integrations): drop non-retriable 4xx webhook deliveries instead of retrying forever

### DIFF
--- a/backend/app/integrations/celery/tasks/webhook_push_task.py
+++ b/backend/app/integrations/celery/tasks/webhook_push_task.py
@@ -19,9 +19,8 @@ from app.utils.structured_logging import log_structured
 
 logger = getLogger(__name__)
 
-# Provider upstream returns where retrying is futile (the object/event the webhook
-# refers to is simply not (yet) fetchable). 401 stays out — token refresh can fix
-# that on the next attempt. 429 stays out — that's pure rate limiting, retry helps.
+# Upstream 4xx where retrying can't recover the object. 401 (token refresh) and
+# 429 (rate limit) are excluded — those still benefit from a retry.
 _NONRETRIABLE_UPSTREAM_STATUSES = frozenset({400, 403, 404, 410, 422})
 
 
@@ -60,11 +59,8 @@ def process_webhook_push(
         )
         raise
     except HTTPException as exc:
-        # Upstream provider API errors. 4xx (except 401/429) means the object the
-        # webhook references is not retrievable (deleted, never persisted upstream,
-        # or a race condition between push and the data being queryable). Retrying
-        # for hours via Cloud Tasks won't recover the object — log and ack so the
-        # task drops cleanly. 5xx and 401/429 still go through the retry path.
+        # Non-retriable upstream 4xx (deleted/unqueryable object): ack so the task
+        # drops instead of retrying forever. 5xx and 401/429 fall through to retry.
         if exc.status_code in _NONRETRIABLE_UPSTREAM_STATUSES:
             log_structured(
                 logger,

--- a/backend/app/integrations/celery/tasks/webhook_push_task.py
+++ b/backend/app/integrations/celery/tasks/webhook_push_task.py
@@ -11,12 +11,18 @@ from logging import getLogger
 from typing import Any
 
 from celery import Task, shared_task
+from fastapi import HTTPException
 
 from app.database import SessionLocal
 from app.services.providers.factory import ProviderFactory
 from app.utils.structured_logging import log_structured
 
 logger = getLogger(__name__)
+
+# Provider upstream returns where retrying is futile (the object/event the webhook
+# refers to is simply not (yet) fetchable). 401 stays out — token refresh can fix
+# that on the next attempt. 429 stays out — that's pure rate limiting, retry helps.
+_NONRETRIABLE_UPSTREAM_STATUSES = frozenset({400, 403, 404, 410, 422})
 
 
 @shared_task(
@@ -53,6 +59,39 @@ def process_webhook_push(
             error=str(exc),
         )
         raise
+    except HTTPException as exc:
+        # Upstream provider API errors. 4xx (except 401/429) means the object the
+        # webhook references is not retrievable (deleted, never persisted upstream,
+        # or a race condition between push and the data being queryable). Retrying
+        # for hours via Cloud Tasks won't recover the object — log and ack so the
+        # task drops cleanly. 5xx and 401/429 still go through the retry path.
+        if exc.status_code in _NONRETRIABLE_UPSTREAM_STATUSES:
+            log_structured(
+                logger,
+                "warning",
+                "Webhook push task skipped — upstream non-retriable response",
+                provider=provider_name,
+                trace_id=request_trace_id,
+                upstream_status=exc.status_code,
+                error=str(exc.detail),
+            )
+            return {
+                "status": "skipped",
+                "reason": "upstream_non_retriable",
+                "upstream_status": exc.status_code,
+            }
+        log_structured(
+            logger,
+            "error",
+            "Webhook push task failed, scheduling retry",
+            provider=provider_name,
+            trace_id=request_trace_id,
+            upstream_status=exc.status_code,
+            error=str(exc.detail),
+            attempt=self.request.retries,
+            max_retries=self.max_retries,
+        )
+        raise self.retry(exc=exc)
     except Exception as exc:
         log_structured(
             logger,


### PR DESCRIPTION
## Problem

`process_webhook_push` treats every exception from `WebhookHandler.process_payload` as transient and calls `self.retry(exc=exc)`. When the provider's REST API returns a 4xx for the object the webhook just announced (e.g. Oura sends a `sleep` webhook but `GET /v2/usercollection/sleep/<id>` returns `400 Document not found` for that id — race between the push and the data becoming queryable, or the object was deleted upstream), `api_client.make_authenticated_request` wraps the 4xx into an `HTTPException` and the task re-raises it.

The dispatcher (Celery or Cloud Tasks HTTP) then retries the same task ~10× with exponential back-off — none of which can recover an object the provider isn't going to return. The retries fail the same way, eventually the dispatcher drops the task, and the data is lost regardless.

On our prod the rate was a steady 50-100 retries/h sustained for days, **0 successes recorded out of 462 attempts** across a week, with `last_synced_at` advancing on `user_connection` so monitoring looked fine.

## Fix

Catch `HTTPException` separately in the task handler. For statuses `{400, 403, 404, 410, 422}` — log a warning and return a `skipped` result, so the dispatcher marks delivery successful and stops retrying. `401`/`429` and `5xx` continue through the existing retry path (token refresh / rate-limit window / server bounce all benefit from a retry).

## Behavioural change

- Before: webhook for a deleted/race-conditioned object → ~10 failed retries + dispatcher drop.
- After: same webhook → 1 attempt, warning logged with `upstream_status` and `error` fields, task acked.

No change for the happy path or for genuinely transient failures.

## Test plan

- [ ] Existing tests pass.
- [ ] Replay a webhook with a synthetic `object_id` that the provider returns 4xx for → task returns 200, logs `Webhook push task skipped — upstream non-retriable response`, dispatcher does not retry.
- [ ] Replay a webhook with a valid `object_id` → unchanged, returns `processed`.
- [ ] Mock the provider call to raise `HTTPException(503)` → task still calls `self.retry()` (retry path intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook push behavior: certain upstream 4xx responses are now treated as non-retriable and marked as "skipped" (with upstream status logged) instead of triggering repeated retries, reducing unnecessary processing and noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->