### PR TITLE
fix(integrations): coerce Fitbit string start/end dates to datetime before strftime

### DIFF
--- a/backend/app/services/providers/fitbit/workouts.py
+++ b/backend/app/services/providers/fitbit/workouts.py
@@ -137,10 +137,27 @@ class FitbitWorkouts(BaseWorkoutsTemplate):
 
         return all_activities
 
+    @staticmethod
+    def _coerce_to_datetime(value: Any, fallback: datetime) -> datetime:
+        """Accept either a datetime or an ISO 8601 string and return a datetime.
+
+        ``sync_vendor_data`` forwards ``start_date`` / ``end_date`` as raw ISO
+        strings (that's the on-wire format from periodic_sync / sync_data API),
+        but the Fitbit ``get_workouts`` path expects ``datetime`` for
+        ``.strftime``.  Without this coercion the hourly cron task crashes on
+        every Fitbit user with ``AttributeError: 'str' object has no attribute
+        'strftime'``.
+        """
+        if value is None:
+            return fallback
+        if isinstance(value, datetime):
+            return value
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+
     def get_workouts_from_api(self, db: DbSession, user_id: UUID, **kwargs: Any) -> Any:
         """Fetch workouts from Fitbit API with optional date range."""
-        start_date = kwargs.get("start_date") or (datetime.now(timezone.utc) - timedelta(days=30))
-        end_date = kwargs.get("end_date") or datetime.now(timezone.utc)
+        start_date = self._coerce_to_datetime(kwargs.get("start_date"), datetime.now(timezone.utc) - timedelta(days=30))
+        end_date = self._coerce_to_datetime(kwargs.get("end_date"), datetime.now(timezone.utc))
         return self.get_workouts(db, user_id, start_date, end_date)
 
     def load_data(
@@ -150,8 +167,8 @@ class FitbitWorkouts(BaseWorkoutsTemplate):
         **kwargs: Any,
     ) -> bool:
         """Fetch activities since start_date and save to database."""
-        start_date = kwargs.get("start_date") or (datetime.now(timezone.utc) - timedelta(days=30))
-        end_date = kwargs.get("end_date") or datetime.now(timezone.utc)
+        start_date = self._coerce_to_datetime(kwargs.get("start_date"), datetime.now(timezone.utc) - timedelta(days=30))
+        end_date = self._coerce_to_datetime(kwargs.get("end_date"), datetime.now(timezone.utc))
 
         activities = self.get_workouts(db, user_id, start_date, end_date)
 

--- a/backend/app/services/providers/fitbit/workouts.py
+++ b/backend/app/services/providers/fitbit/workouts.py
@@ -138,16 +138,8 @@ class FitbitWorkouts(BaseWorkoutsTemplate):
         return all_activities
 
     @staticmethod
-    def _coerce_to_datetime(value: Any, fallback: datetime) -> datetime:
-        """Accept either a datetime or an ISO 8601 string and return a datetime.
-
-        ``sync_vendor_data`` forwards ``start_date`` / ``end_date`` as raw ISO
-        strings (that's the on-wire format from periodic_sync / sync_data API),
-        but the Fitbit ``get_workouts`` path expects ``datetime`` for
-        ``.strftime``.  Without this coercion the hourly cron task crashes on
-        every Fitbit user with ``AttributeError: 'str' object has no attribute
-        'strftime'``.
-        """
+    def _coerce_to_datetime(value: datetime | str | None, fallback: datetime) -> datetime:
+        """Coerce a datetime or ISO 8601 string to datetime (sync_vendor_data passes ISO strings)."""
         if value is None:
             return fallback
         if isinstance(value, datetime):


### PR DESCRIPTION
## Problem

`sync_vendor_data` forwards `start_date` / `end_date` as raw ISO 8601 strings — that's the on-wire format produced by `periodic_sync_task` and accepted by the public sync endpoint. It calls `strategy.workouts.load_data(db, user_id, **params)` with those strings.

`FitbitWorkouts.load_data` and `.get_workouts_from_api` take \`kwargs.get(\"start_date\") or fallback_datetime\` and pass straight to `get_workouts`, which calls `start_date.strftime(\"%Y-%m-%d\")`. The string doesn't have `.strftime`, so every hourly cron run for any user with a live Fitbit connection crashes with:

```
File \"app/integrations/celery/tasks/sync_vendor_data_task.py\", line 256, in sync_vendor_data
    success = strategy.workouts.load_data(db, user_uuid, **params)
File \"app/services/providers/fitbit/workouts.py\", line 156, in load_data
    activities = self.get_workouts(db, user_id, start_date, end_date)
File \"app/services/providers/fitbit/workouts.py\", line 114, in get_workouts
    \"afterDate\": start_date.strftime(\"%Y-%m-%d\"),
AttributeError: 'str' object has no attribute 'strftime'
```

(Other providers don't hit this because their `load_data` either accepts strings directly or doesn't call `strftime` on them.)

## Fix

Add a `_coerce_to_datetime` helper that accepts either a `datetime` or an ISO 8601 string and returns a `datetime`, with a `fallback` for `None`. Apply at both entry points (`load_data`, `get_workouts_from_api`). `get_workouts` keeps its `datetime` contract — only the entry-point coercion changes.

## Test plan

- [ ] Existing tests pass.
- [ ] Manually invoke `sync_vendor_data` with ISO string `start_date` / `end_date` → no exception, Fitbit activities pulled into the requested window.
- [ ] Same call with `datetime` objects → unchanged behaviour.
- [ ] Same call with `start_date=None` → falls back to 30 days ago, same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved date handling for Fitbit workout syncing so inputs can be either datetimes or ISO‑8601 strings, with consistent fallback defaults applied across fetching and saving flows. This makes syncs more robust, reduces date parsing errors, and ensures consistent behavior between API retrieval and data persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->