### PR TITLE
feat(integrations): emit resting_heart_rate series from sleep HRMin

### DIFF
--- a/backend/app/services/providers/suunto/data_247.py
+++ b/backend/app/services/providers/suunto/data_247.py
@@ -28,10 +28,10 @@ from app.schemas.model_crud.activities import (
 )
 from app.services.event_record_service import event_record_service
 from app.services.health_score_service import health_score_service
-from app.services.timeseries_service import timeseries_service
 from app.services.providers.api_client import make_authenticated_request
 from app.services.providers.templates.base_247_data import Base247DataTemplate
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
+from app.services.timeseries_service import timeseries_service
 from app.utils.dates import parse_datetime_or_default, parse_iso_datetime
 from app.utils.structured_logging import log_structured
 
@@ -307,16 +307,8 @@ class Suunto247Data(Base247DataTemplate):
     ) -> None:
         """Emit a resting_heart_rate data point from the sleep session's HRMin.
 
-        Suunto does not expose a dedicated resting-HR endpoint; the lowest
-        sustained heart rate during a full sleep session is the sports-science
-        equivalent. Naps are excluded, too short for a representative RHR.
-
-        Backfill policy: no separate migration. `_persist_resting_heart_rate`
-        runs from `save_sleep_data`, so any historical sleep record reprocessed
-        by the standard `load_and_save_sleep` backfill (or a replayed Suunto
-        webhook) emits its RHR retroactively. `data_point_series` upserts on
-        `(data_source_id, series_type_definition_id, recorded_at)`, so reruns
-        are idempotent.
+        Suunto exposes no dedicated resting-HR endpoint; HRMin during a full
+        sleep session is the sports-science equivalent. Naps excluded.
         """
         if normalized_sleep.get("is_nap"):
             return

--- a/backend/app/services/providers/suunto/data_247.py
+++ b/backend/app/services/providers/suunto/data_247.py
@@ -323,9 +323,7 @@ class Suunto247Data(Base247DataTemplate):
             recorded_at=recorded_at,
             value=Decimal(str(rhr)),
             series_type=SeriesType.resting_heart_rate,
-            external_id=str(normalized_sleep["suunto_sleep_id"])
-            if normalized_sleep.get("suunto_sleep_id")
-            else None,
+            external_id=str(normalized_sleep["suunto_sleep_id"]) if normalized_sleep.get("suunto_sleep_id") else None,
         )
         try:
             timeseries_service.bulk_create_samples(db, [sample])

--- a/backend/app/services/providers/suunto/data_247.py
+++ b/backend/app/services/providers/suunto/data_247.py
@@ -28,10 +28,10 @@ from app.schemas.model_crud.activities import (
 )
 from app.services.event_record_service import event_record_service
 from app.services.health_score_service import health_score_service
+from app.services.timeseries_service import timeseries_service
 from app.services.providers.api_client import make_authenticated_request
 from app.services.providers.templates.base_247_data import Base247DataTemplate
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
-from app.services.timeseries_service import timeseries_service
 from app.utils.dates import parse_datetime_or_default, parse_iso_datetime
 from app.utils.structured_logging import log_structured
 
@@ -292,6 +292,60 @@ class Suunto247Data(Base247DataTemplate):
                 f"Error saving sleep record {sleep_id}: {e}",
                 provider="suunto",
                 task="save_sleep_data",
+                user_id=str(user_id),
+            )
+            return
+
+        self._persist_resting_heart_rate(db, user_id, normalized_sleep, end_dt)
+
+    def _persist_resting_heart_rate(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        normalized_sleep: dict[str, Any],
+        recorded_at: datetime,
+    ) -> None:
+        """Emit a resting_heart_rate data point from the sleep session's HRMin.
+
+        Suunto does not expose a dedicated resting-HR endpoint; the lowest
+        sustained heart rate during a full sleep session is the sports-science
+        equivalent. Naps are excluded, too short for a representative RHR.
+
+        Backfill policy: no separate migration. `_persist_resting_heart_rate`
+        runs from `save_sleep_data`, so any historical sleep record reprocessed
+        by the standard `load_and_save_sleep` backfill (or a replayed Suunto
+        webhook) emits its RHR retroactively. `data_point_series` upserts on
+        `(data_source_id, series_type_definition_id, recorded_at)`, so reruns
+        are idempotent.
+        """
+        if normalized_sleep.get("is_nap"):
+            return
+        rhr = normalized_sleep.get("min_heart_rate_bpm")
+        if rhr is None:
+            return
+
+        sample = TimeSeriesSampleCreate(
+            id=uuid4(),
+            user_id=user_id,
+            source=self.provider_name,
+            recorded_at=recorded_at,
+            value=Decimal(str(rhr)),
+            series_type=SeriesType.resting_heart_rate,
+            external_id=str(normalized_sleep["suunto_sleep_id"])
+            if normalized_sleep.get("suunto_sleep_id")
+            else None,
+        )
+        try:
+            timeseries_service.bulk_create_samples(db, [sample])
+            db.commit()
+        except Exception as e:
+            db.rollback()
+            log_structured(
+                self.logger,
+                "error",
+                f"Failed to persist resting_heart_rate from sleep: {e}",
+                provider="suunto",
+                task="persist_resting_heart_rate",
                 user_id=str(user_id),
             )
 

--- a/backend/tests/providers/suunto/test_suunto_247.py
+++ b/backend/tests/providers/suunto/test_suunto_247.py
@@ -1,0 +1,132 @@
+"""Tests for Suunto247Data — focused on resting_heart_rate emission from sleep."""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.schemas.enums import SeriesType
+from app.services.providers.suunto.data_247 import Suunto247Data
+from app.services.providers.suunto.strategy import SuuntoStrategy
+
+
+@pytest.fixture
+def data_247() -> Suunto247Data:
+    return SuuntoStrategy().data_247
+
+
+@pytest.fixture
+def base_sleep() -> dict:
+    return {
+        "id": uuid4(),
+        "user_id": uuid4(),
+        "provider": "suunto",
+        "is_nap": False,
+        "min_heart_rate_bpm": 52.0,
+        "suunto_sleep_id": 12345,
+    }
+
+
+@pytest.fixture
+def timeseries_service_mock():
+    with patch(
+        "app.services.providers.suunto.data_247.timeseries_service",
+    ) as mock:
+        yield mock
+
+
+class TestSuuntoSleepNormalization:
+    def test_normalize_sleep_extracts_hr_extremes(self, data_247: Suunto247Data) -> None:
+        raw = {
+            "timestamp": "2026-05-17T02:13:00.000+02:00",
+            "entryData": {
+                "BedtimeStart": "2026-05-17T02:13:00.000+02:00",
+                "BedtimeEnd": "2026-05-17T09:19:00.000+02:00",
+                "Duration": 25560.0,
+                "DeepSleepDuration": 5610.0,
+                "LightSleepDuration": 17970.0,
+                "REMSleepDuration": 1710.0,
+                "HRAvg": 67.0,
+                "HRMin": 52.0,
+                "SleepQualityScore": 75,
+                "IsNap": False,
+                "SleepId": 1778976780,
+            },
+        }
+        result = data_247.normalize_sleep(raw, uuid4())
+
+        assert result["avg_heart_rate_bpm"] == 67.0
+        assert result["min_heart_rate_bpm"] == 52.0
+        assert result["is_nap"] is False
+
+
+class TestSuuntoRestingHeartRatePersistence:
+    def test_emits_rhr_sample_for_non_nap_sleep_with_hr_min(
+        self,
+        data_247: Suunto247Data,
+        base_sleep: dict,
+        timeseries_service_mock: MagicMock,
+    ) -> None:
+        db = MagicMock()
+        recorded_at = datetime(2026, 5, 17, 9, 19, tzinfo=timezone.utc)
+
+        data_247._persist_resting_heart_rate(db, base_sleep["user_id"], base_sleep, recorded_at)
+
+        timeseries_service_mock.bulk_create_samples.assert_called_once()
+        samples = timeseries_service_mock.bulk_create_samples.call_args[0][1]
+        assert len(samples) == 1
+        sample = samples[0]
+        assert sample.series_type == SeriesType.resting_heart_rate
+        assert sample.value == Decimal("52.0")
+        assert sample.recorded_at == recorded_at
+        assert sample.user_id == base_sleep["user_id"]
+        assert sample.source == "suunto"
+        assert sample.external_id == "12345"
+        db.commit.assert_called_once()
+
+    def test_skips_nap_sessions(
+        self,
+        data_247: Suunto247Data,
+        base_sleep: dict,
+        timeseries_service_mock: MagicMock,
+    ) -> None:
+        base_sleep["is_nap"] = True
+
+        data_247._persist_resting_heart_rate(
+            MagicMock(), base_sleep["user_id"], base_sleep, datetime.now(timezone.utc),
+        )
+
+        timeseries_service_mock.bulk_create_samples.assert_not_called()
+
+    def test_skips_when_hr_min_missing(
+        self,
+        data_247: Suunto247Data,
+        base_sleep: dict,
+        timeseries_service_mock: MagicMock,
+    ) -> None:
+        base_sleep["min_heart_rate_bpm"] = None
+
+        data_247._persist_resting_heart_rate(
+            MagicMock(), base_sleep["user_id"], base_sleep, datetime.now(timezone.utc),
+        )
+
+        timeseries_service_mock.bulk_create_samples.assert_not_called()
+
+    def test_swallows_service_errors_and_rolls_back(
+        self,
+        data_247: Suunto247Data,
+        base_sleep: dict,
+        timeseries_service_mock: MagicMock,
+    ) -> None:
+        timeseries_service_mock.bulk_create_samples.side_effect = RuntimeError("db down")
+        db = MagicMock()
+
+        data_247._persist_resting_heart_rate(
+            db, base_sleep["user_id"], base_sleep, datetime.now(timezone.utc),
+        )
+
+        timeseries_service_mock.bulk_create_samples.assert_called_once()
+        db.rollback.assert_called_once()
+        db.commit.assert_not_called()

--- a/backend/tests/providers/suunto/test_suunto_247.py
+++ b/backend/tests/providers/suunto/test_suunto_247.py
@@ -15,7 +15,9 @@ from app.services.providers.suunto.strategy import SuuntoStrategy
 
 @pytest.fixture
 def data_247() -> Suunto247Data:
-    return SuuntoStrategy().data_247
+    instance = SuuntoStrategy().data_247
+    assert isinstance(instance, Suunto247Data)
+    return instance
 
 
 @pytest.fixture
@@ -96,7 +98,10 @@ class TestSuuntoRestingHeartRatePersistence:
         base_sleep["is_nap"] = True
 
         data_247._persist_resting_heart_rate(
-            MagicMock(), base_sleep["user_id"], base_sleep, datetime.now(timezone.utc),
+            MagicMock(),
+            base_sleep["user_id"],
+            base_sleep,
+            datetime.now(timezone.utc),
         )
 
         timeseries_service_mock.bulk_create_samples.assert_not_called()
@@ -110,7 +115,10 @@ class TestSuuntoRestingHeartRatePersistence:
         base_sleep["min_heart_rate_bpm"] = None
 
         data_247._persist_resting_heart_rate(
-            MagicMock(), base_sleep["user_id"], base_sleep, datetime.now(timezone.utc),
+            MagicMock(),
+            base_sleep["user_id"],
+            base_sleep,
+            datetime.now(timezone.utc),
         )
 
         timeseries_service_mock.bulk_create_samples.assert_not_called()
@@ -125,7 +133,10 @@ class TestSuuntoRestingHeartRatePersistence:
         db = MagicMock()
 
         data_247._persist_resting_heart_rate(
-            db, base_sleep["user_id"], base_sleep, datetime.now(timezone.utc),
+            db,
+            base_sleep["user_id"],
+            base_sleep,
+            datetime.now(timezone.utc),
         )
 
         timeseries_service_mock.bulk_create_samples.assert_called_once()

--- a/backend/tests/providers/suunto/test_suunto_247.py
+++ b/backend/tests/providers/suunto/test_suunto_247.py
@@ -1,5 +1,6 @@
 """Tests for Suunto247Data — focused on resting_heart_rate emission from sleep."""
 
+from collections.abc import Generator
 from datetime import datetime, timezone
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
@@ -30,7 +31,7 @@ def base_sleep() -> dict:
 
 
 @pytest.fixture
-def timeseries_service_mock():
+def timeseries_service_mock() -> Generator[MagicMock, None, None]:
     with patch(
         "app.services.providers.suunto.data_247.timeseries_service",
     ) as mock:


### PR DESCRIPTION
## Why

Suunto's API does not expose a dedicated resting-HR endpoint (no field in `/247samples/recovery`, none in `/247samples/activity`). Consumers that rely on `SeriesType.resting_heart_rate` therefore see no data for Suunto users, while Garmin and Whoop publish it from their daily summaries.

## What

The lowest sustained heart rate during a full sleep session (`HRMin` on `/247samples/sleep`) is the sports-science equivalent of resting HR. Whenever a non-nap sleep record is saved, emit a `resting_heart_rate` `DataPointSeries`
point - same shape as Garmin's daily RHR signal.

Naps are excluded (too short to be representative). Repository errors are logged but do not break the sleep save path.

## Test plan

- `tests/providers/suunto/test_suunto_247.py` covers:
  - HRMin / HRAvg extraction in `normalize_sleep`
  - RHR persistence for non-nap sleeps
  - Skip on nap
  - Skip when `HRMin` is null
  - Swallow repo errors without breaking sleep save
- Full Suunto provider suite still green (`pytest tests/providers/suunto tests/integrations/test_suunto_import.py` → 59 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sleep ingestion now persists a derived resting heart rate sample per session (uses session min HR, recorded at session end; optional external ID; naps are skipped).

* **Bug Fixes / Improvements**
  * If saving the sleep record fails, derived samples are not created; persistence errors are logged and trigger a rollback when sample saving fails.

* **Tests**
  * Added tests for sleep normalization, emitting/skipping resting HR samples, handling missing HR, and error/rollback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1055?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->