### PR TITLE
fix(docs): update GitHub repository links in iOS SDK documentation

### DIFF
--- a/docs/sdk/ios/index.mdx
+++ b/docs/sdk/ios/index.mdx
@@ -18,7 +18,7 @@ The Open Wearables iOS SDK (`OpenWearablesHealthSDK`) is a native Swift SDK for 
 
 This is the **core native implementation** that powers health data sync on iOS. The [Flutter SDK](/sdk/flutter) uses this SDK under the hood as a wrapper.
 
-<Card title="GitHub Repository" icon="github" href="https://github.com/the-momentum/OpenWearablesHealthSDK">
+<Card title="GitHub Repository" icon="github" href="https://github.com/the-momentum/open_wearables_ios_sdk">
   View source code, report issues, and contribute to the iOS SDK.
 </Card>
 
@@ -53,7 +53,7 @@ This is the **core native implementation** that powers health data sync on iOS. 
 
     ```swift
     dependencies: [
-        .package(url: "https://github.com/the-momentum/OpenWearablesHealthSDK.git", from: "0.8.0")
+        .package(url: "https://github.com/the-momentum/open_wearables_ios_sdk", from: "0.13.0")
     ]
     ```
 
@@ -293,7 +293,7 @@ sdk.requestAuthorization(types: [.steps, .heartRate, .sleep, .workout]) { grante
   <Card title="Integration Guide" icon="arrow-right" href="/sdk/ios/integration">
     Complete step-by-step integration guide.
   </Card>
-  <Card title="API Reference" icon="code" href="https://github.com/the-momentum/OpenWearablesHealthSDK">
+  <Card title="API Reference" icon="code" href="https://github.com/the-momentum/open_wearables_ios_sdk">
     Full API documentation on GitHub.
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Description

Fixed reference link to iOS SDK. 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated iOS SDK documentation links to point to the new GitHub repository for the iOS SDK, including package manager dependencies and API reference resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1064?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->