### PR TITLE
feat(backend): add average_cadence support for Garmin

### DIFF
--- a/backend/app/schemas/model_crud/activities/event_record.py
+++ b/backend/app/schemas/model_crud/activities/event_record.py
@@ -22,6 +22,7 @@ class EventRecordMetrics(TypedDict, total=False):
     moving_time_seconds: int | None
     total_elevation_gain: Decimal | None
     average_speed: Decimal | None
+    average_cadence: Decimal | None
     average_watts: Decimal | None
     elev_high: Decimal | None
     elev_low: Decimal | None

--- a/backend/app/schemas/model_crud/activities/event_record_detail.py
+++ b/backend/app/schemas/model_crud/activities/event_record_detail.py
@@ -21,6 +21,7 @@ class EventRecordDetailBase(BaseModel):
     max_watts: Decimal | None = None
 
     average_speed: Decimal | None = None
+    average_cadence: Decimal | None = None
     average_watts: Decimal | None = None
 
     moving_time_seconds: int | None = None

--- a/backend/app/schemas/providers/garmin/activity_import.py
+++ b/backend/app/schemas/providers/garmin/activity_import.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel, ConfigDict
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, model_validator
 
 
 class ActivityJSON(BaseModel):
@@ -29,8 +31,24 @@ class ActivityJSON(BaseModel):
     activityName: str | None = None
     startTimeOffsetInSeconds: int | None = None
     averageSpeedInMetersPerSecond: float | None = None
+    averageRunCadenceInStepsPerMinute: float | None = None
+    averageBikingCadenceInRevPerMinute: float | None = None
+    averageSwimCadenceInStrokesPerMinute: float | None = None
     isWebUpload: bool | None = None
     manual: bool | None = None
+
+    averageCadence: float | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _unify_cadence(cls, data: Any) -> Any:
+        data.setdefault(
+            "averageCadence",
+            data.get("averageRunCadenceInStepsPerMinute")
+            or data.get("averageBikingCadenceInRevPerMinute")
+            or data.get("averageSwimCadenceInStrokesPerMinute"),
+        )
+        return data
 
 
 class RootJSON(BaseModel):

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -939,6 +939,11 @@ class Garmin247Data(Base247DataTemplate):
         max_hr = raw_activity.get("maxHeartRateInBeatsPerMinute")
         elevation_gain = raw_activity.get("elevationGainInMeters")
         avg_speed = raw_activity.get("averageSpeedInMetersPerSecond")
+        avg_cadence = (
+            raw_activity.get("averageRunCadenceInStepsPerMinute")
+            or raw_activity.get("averageBikingCadenceInRevPerMinute")
+            or raw_activity.get("averageSwimCadenceInStrokesPerMinute")
+        )
 
         detail = EventRecordDetailCreate(
             record_id=record_id,
@@ -948,6 +953,7 @@ class Garmin247Data(Base247DataTemplate):
             heart_rate_max=max_hr,
             total_elevation_gain=Decimal(str(elevation_gain)) if elevation_gain is not None else None,
             average_speed=Decimal(str(avg_speed)) if avg_speed is not None else None,
+            average_cadence=Decimal(str(avg_cadence)) if avg_cadence is not None else None,
         )
 
         return record, detail

--- a/backend/app/services/providers/garmin/workouts.py
+++ b/backend/app/services/providers/garmin/workouts.py
@@ -187,6 +187,8 @@ class GarminWorkouts(BaseWorkoutsTemplate):
 
         distance = Decimal(str(raw_workout.distanceInMeters)) if raw_workout.distanceInMeters is not None else None
 
+        average_cadence = Decimal(str(raw_workout.averageCadence)) if raw_workout.averageCadence is not None else None
+
         return {
             "heart_rate_min": int(heart_rate_avg) if heart_rate_avg is not None else None,
             "heart_rate_max": int(heart_rate_max) if heart_rate_max is not None else None,
@@ -194,6 +196,7 @@ class GarminWorkouts(BaseWorkoutsTemplate):
             "steps_count": steps_count,
             "energy_burned": energy_burned,
             "distance": distance,
+            "average_cadence": average_cadence,
         }
 
     def _normalize_workout(

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -926,7 +926,7 @@ wheels = [
 
 [[package]]
 name = "open-wearables"
-version = "0.1.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Resolves #541 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Average cadence metrics are now captured and displayed for running, cycling, and swimming activities imported from Garmin devices, providing insights into exercise efficiency across different activity types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1080?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->