### PR TITLE
feat(backend): Garmin workout samples

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -88,6 +88,11 @@ class Settings(BaseSettings):
     # Will default to false in a future release.
     historical_sync_on_connect: bool = True
 
+    # Whether to ingest per-second workout samples (speed, cadence, power, GPS, etc.) into
+    # data_point_series on workout webhook arrival. Significantly increases DB storage.
+    # Per-provider granularity will be added via ProviderSetting in a future release.
+    ingest_workout_samples: bool = False
+
     # SCORE SETTINGS
     score_backfill_days: int = 30  # How far back the missing-score query looks
     sleep_score_interval_seconds: int = 600  # How often to run the fill-missing-scores task (default: 10 min)

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -1796,6 +1796,7 @@ class Garmin247Data(Base247DataTemplate):
                             try:
                                 all_samples.extend(self._build_activity_samples(user_id, item))
                             except Exception as e:
+                                activity_id = item.get("activityId") or item.get("summary", {}).get("activityId")
                                 log_structured(
                                     self.logger,
                                     "warning",
@@ -1803,7 +1804,7 @@ class Garmin247Data(Base247DataTemplate):
                                     provider="garmin",
                                     task="process_items_batch",
                                     user_id=str(user_id),
-                                    activity_id=item.get("activityId"),
+                                    activity_id=activity_id,
                                     error=str(e),
                                 )
                     case "moveIQActivities":

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -29,6 +29,16 @@ from app.services.providers.templates.base_oauth import BaseOAuthTemplate
 from app.utils.dates import offset_to_iso
 from app.utils.structured_logging import log_structured
 
+# activityDetails.samples[] field → SeriesType mapping.
+# Only includes types already seeded in series_type_definition.
+# GPS/elevation (elevation, latitude, longitude) excluded until #1074.
+_ACTIVITY_SAMPLE_FIELD_MAP: list[tuple[str, SeriesType]] = [
+    ("heartRate", SeriesType.heart_rate),
+    ("speedMetersPerSecond", SeriesType.speed),
+    ("stepsPerMinute", SeriesType.cadence),
+    ("powerInWatts", SeriesType.power),
+]
+
 
 class Garmin247Data(Base247DataTemplate):
     """Garmin implementation for 247 data (sleep, dailies, epochs, body composition).
@@ -958,6 +968,46 @@ class Garmin247Data(Base247DataTemplate):
 
         return record, detail
 
+    def _build_activity_samples(
+        self,
+        user_id: UUID,
+        raw_activity_details: dict[str, Any],
+    ) -> list[TimeSeriesSampleCreate]:
+        """Build per-second data_point_series rows from activityDetails.samples[].
+
+        Called only when settings.ingest_workout_samples is True.
+        Failures here must never reach the caller — wrap in try/except at call site.
+        """
+        samples = raw_activity_details.get("samples", [])
+        if not samples:
+            return []
+
+        summary = raw_activity_details.get("summary", {})
+        zone_offset = offset_to_iso(summary.get("startTimeOffsetInSeconds"))
+
+        result: list[TimeSeriesSampleCreate] = []
+        for sample in samples:
+            ts = sample.get("startTimeInSeconds")
+            if ts is None:
+                continue
+            recorded_at = datetime.fromtimestamp(ts, tz=timezone.utc)
+            for field, series_type in _ACTIVITY_SAMPLE_FIELD_MAP:
+                value = sample.get(field)
+                if value is None:
+                    continue
+                result.append(
+                    TimeSeriesSampleCreate(
+                        id=uuid4(),
+                        user_id=user_id,
+                        source=self.provider_name,
+                        recorded_at=recorded_at,
+                        zone_offset=zone_offset,
+                        value=Decimal(str(value)),
+                        series_type=series_type,
+                    )
+                )
+        return result
+
     def save_activity_data(
         self,
         db: DbSession,
@@ -1729,12 +1779,33 @@ class Garmin247Data(Base247DataTemplate):
                             all_sleep_details.append(detail)
                         if health_score:
                             all_health_scores.append(health_score)
-                    case "activities" | "activityDetails":
+                    case "activities":
                         result = self._build_activity_record(user_id, item)
                         if result:
                             record, detail = result
                             all_records.append(record)
                             all_workout_details.append(detail)
+                    case "activityDetails":
+                        # activityDetails items nest summary data one level deeper
+                        result = self._build_activity_record(user_id, item.get("summary", {}))
+                        if result:
+                            record, detail = result
+                            all_records.append(record)
+                            all_workout_details.append(detail)
+                        if settings.ingest_workout_samples:
+                            try:
+                                all_samples.extend(self._build_activity_samples(user_id, item))
+                            except Exception as e:
+                                log_structured(
+                                    self.logger,
+                                    "warning",
+                                    "Failed to build activity samples, skipping",
+                                    provider="garmin",
+                                    task="process_items_batch",
+                                    user_id=str(user_id),
+                                    activity_id=item.get("activityId"),
+                                    error=str(e),
+                                )
                     case "moveIQActivities":
                         record = self._build_moveiq_record(user_id, item)
                         if record:

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -65,6 +65,9 @@ RESILIENCE_SCORE_INTERVAL_SECONDS=600  # How often to run the fill-missing-resil
 # Set to false once your integration calls POST /sync/{provider}/users/{user_id}/sync/historical explicitly.
 # Will default to false in a future release.
 HISTORICAL_SYNC_ON_CONNECT=true
+# Ingest per-second workout samples (speed, cadence, power, GPS, elevation) into data_point_series
+# on workout webhook arrival. Increases DB storage significantly — disabled by default.
+INGEST_WORKOUT_SAMPLES=false
 
 #--- OUTGOING WEBHOOKS (Svix) ---#
 # Self-hosted Svix server URL (default matches docker-compose.yml)


### PR DESCRIPTION
Resolves #1081

## Report
Storage impact (measured, 30-day Garmin history, 82 workouts, single user):

data_point_series: +248k rows — speed (69k), cadence (49k), power (47k), additional per-workout heart_rate (84k)
Per user: ~48 MB → ~114 MB (+138%)
Average: ~2 900 rows/workout across 4 series types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-second workout sample ingestion on workout webhook arrival, controllable via the INGEST_WORKOUT_SAMPLES flag (disabled by default). When enabled, captures detailed per-second metrics such as speed, cadence, power, GPS, and elevation. Enabling increases database storage usage.

* **Chores**
  * Example configuration updated to include the new INGEST_WORKOUT_SAMPLES flag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1082?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->