### PR TITLE
refactor: fixed scopes db saving & improved UI

### DIFF
--- a/backend/app/services/providers/garmin/oauth.py
+++ b/backend/app/services/providers/garmin/oauth.py
@@ -53,7 +53,7 @@ class GarminOAuth(BaseOAuthTemplate):
         # Fetch user ID (critical - fail returns all None)
         try:
             user_id_response = httpx.get(
-                f"{self.api_base_url}/wellness-api/rest/user/id",
+                f"{self.api_base_url}/partner-gateway/rest/user/id",
                 headers={"Authorization": f"Bearer {token_response.access_token}"},
                 timeout=30.0,
             )
@@ -66,7 +66,7 @@ class GarminOAuth(BaseOAuthTemplate):
         scope: str | None = None
         try:
             permissions_response = httpx.get(
-                f"{self.api_base_url}/wellness-api/rest/user/permissions",
+                f"{self.api_base_url}/partner-gateway/rest/user/permissions",
                 headers={"Authorization": f"Bearer {token_response.access_token}"},
                 timeout=30.0,
             )

--- a/backend/app/services/providers/templates/base_oauth.py
+++ b/backend/app/services/providers/templates/base_oauth.py
@@ -359,7 +359,7 @@ class BaseOAuthTemplate(ABC):
         provider_user_id = user_info.get("user_id")
         provider_username = user_info.get("username")
 
-        scope = user_info.get("scope")
+        scope = user_info.get("scope") or token_response.scope
 
         token_expires_at = datetime.now(timezone.utc) + timedelta(seconds=token_response.expires_in)
 

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -35,9 +35,12 @@ function TooltipTrigger({
 function TooltipContent({
   className,
   sideOffset = 0,
+  hideArrow = false,
   children,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: React.ComponentProps<typeof TooltipPrimitive.Content> & {
+  hideArrow?: boolean;
+}) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
@@ -50,7 +53,9 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-card fill-card z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        {!hideArrow && (
+          <TooltipPrimitive.Arrow className="bg-card fill-card z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        )}
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/frontend/src/components/user/connection-card.tsx
+++ b/frontend/src/components/user/connection-card.tsx
@@ -363,6 +363,8 @@ export function ConnectionCard({
                       <TooltipContent
                         side="bottom"
                         align="start"
+                        sideOffset={6}
+                        hideArrow
                         className="max-w-xs bg-zinc-900 border border-zinc-700 shadow-xl"
                       >
                         <p className="text-[10px] font-medium text-zinc-500 mb-1.5 uppercase tracking-wide">

--- a/frontend/src/components/user/connection-card.tsx
+++ b/frontend/src/components/user/connection-card.tsx
@@ -5,7 +5,6 @@ import {
   ChevronDown,
   EllipsisVertical,
   History,
-  Info,
   Loader2,
   PlayCircle,
   RefreshCw,
@@ -213,6 +212,15 @@ function parseScopeString(scope: string): string[] {
   return scope.split(/[,\s]+/).filter(Boolean);
 }
 
+// Shorten scope labels for inline display (e.g. ACTIVITY_EXPORT → Activity)
+function formatScopeChip(scope: string): string {
+  return scope
+    .replace(/_(EXPORT|IMPORT|READ|WRITE)$/i, '')
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/^./, (c) => c.toUpperCase());
+}
+
 export function ConnectionCard({
   connection,
   className,
@@ -330,18 +338,48 @@ export function ConnectionCard({
                     })
                   : 'Never'}
               </p>
-              {connection.live_sync_mode && (
-                <div className="mt-1.5">
-                  {connection.live_sync_mode === 'webhook' ? (
-                    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-indigo-500/10 text-indigo-400 border border-indigo-500/20">
-                      <Zap className="h-3 w-3" />
-                      Webhook
-                    </span>
-                  ) : (
-                    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-muted text-muted-foreground border border-border">
-                      <Timer className="h-3 w-3" />
-                      Periodic pull
-                    </span>
+              {(connection.live_sync_mode || scopeItems.length > 0) && (
+                <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                  {connection.live_sync_mode &&
+                    (connection.live_sync_mode === 'webhook' ? (
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-indigo-500/10 text-indigo-400 border border-indigo-500/20">
+                        <Zap className="h-3 w-3" />
+                        Webhook
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-muted text-muted-foreground border border-border">
+                        <Timer className="h-3 w-3" />
+                        Periodic pull
+                      </span>
+                    ))}
+                  {scopeItems.length > 0 && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium bg-muted/60 text-muted-foreground border border-border/60 cursor-default hover:bg-muted hover:text-foreground hover:border-border transition-colors">
+                          {scopeItems.length} scope
+                          {scopeItems.length !== 1 ? 's' : ''}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent
+                        side="bottom"
+                        align="start"
+                        className="max-w-xs bg-zinc-900 border border-zinc-700 shadow-xl"
+                      >
+                        <p className="text-[10px] font-medium text-zinc-500 mb-1.5 uppercase tracking-wide">
+                          Granted permissions
+                        </p>
+                        <div className="flex flex-wrap gap-1">
+                          {scopeItems.map((s) => (
+                            <span
+                              key={s}
+                              className="inline-flex px-1.5 py-0.5 rounded text-[11px] font-medium bg-zinc-800 text-zinc-200 border border-zinc-700"
+                            >
+                              {formatScopeChip(s)}
+                            </span>
+                          ))}
+                        </div>
+                      </TooltipContent>
+                    </Tooltip>
                   )}
                 </div>
               )}
@@ -395,34 +433,6 @@ export function ConnectionCard({
       </CardHeader>
 
       <CardContent className="space-y-4">
-        {/* Show data scope */}
-        {scopeItems.length > 0 && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-default"
-              >
-                <Info className="h-3.5 w-3.5 shrink-0" />
-                <span>Data scope</span>
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" align="start" className="max-w-sm">
-              <div className="flex flex-wrap gap-1 py-0.5">
-                {scopeItems.map((scopeItem) => (
-                  <Badge
-                    key={scopeItem}
-                    variant="secondary"
-                    className="text-[11px] font-normal px-1.5 py-0"
-                  >
-                    {scopeItem}
-                  </Badge>
-                ))}
-              </div>
-            </TooltipContent>
-          </Tooltip>
-        )}
-
         {/* Show backfill progress for Garmin */}
         {isBackfillInProgress && backfillStatus && (
           <div className="space-y-2">


### PR DESCRIPTION
Fixed scopes logging to database at least for Garmin & Oura. Also improved admin panel UI:

<img width="579" height="276" alt="image" src="https://github.com/user-attachments/assets/65890823-41a0-47b5-934c-6f123f89b894" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scope fallback when saving provider connections so granted permissions are retained more reliably.

* **Refactor**
  * Connection card now shows a compact “N scopes” pill in the header with a tooltip listing formatted permission names; the previous expanded Data scope section and info icon were removed.
  * Garmin connection handling updated (no user-facing behavior changes expected).

* **Style**
  * Tooltip rendering refined to optionally hide the arrow for cleaner display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1088?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->