### PR TITLE
Fire sleep.created on all committed saves (match docstring contract)

### DIFF
--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -209,41 +209,45 @@ class EventRecordService(
         first, and the old record is deleted only after a successful insert — so a failure
         never loses the original data.
         """
-        result, inserted, final_detail = self._create_or_merge_sleep_inner(
+                result, inserted, final_detail = self._create_or_merge_sleep_inner(
             db_session, user_id, record, detail, threshold_minutes
         )
-        if inserted:
-            eff = final_detail.sleep_efficiency_score
-            has_stages = any(
-                [
-                    final_detail.sleep_awake_minutes,
-                    final_detail.sleep_light_minutes,
-                    final_detail.sleep_deep_minutes,
-                    final_detail.sleep_rem_minutes,
-                ]
-            )
-            on_sleep_created(
-                record_id=result.id,
-                user_id=user_id,
-                provider=record.provider or record.source_name,
-                device=record.device_model,
-                start_time=result.start_datetime.isoformat(),
-                end_time=result.end_datetime.isoformat(),
-                zone_offset=record.zone_offset,
-                duration_seconds=result.duration_seconds,
-                efficiency_percent=float(eff) if eff is not None else None,
-                stages={
-                    "awake_minutes": final_detail.sleep_awake_minutes,
-                    "light_minutes": final_detail.sleep_light_minutes,
-                    "deep_minutes": final_detail.sleep_deep_minutes,
-                    "rem_minutes": final_detail.sleep_rem_minutes,
-                }
-                if has_stages
-                else None,
-                is_nap=final_detail.is_nap,
-            )
+        eff = final_detail.sleep_efficiency_score
+        has_stages = any(
+            [
+                final_detail.sleep_awake_minutes,
+                final_detail.sleep_light_minutes,
+                final_detail.sleep_deep_minutes,
+                final_detail.sleep_rem_minutes,
+            ]
+        )
+        # Fire on every committed save (new or merged) per the SLEEP_CREATED
+        # docstring: "A new (or merged) sleep session was saved."
+        # Pre-fix: `if inserted:` gated the webhook, so the three merge-path
+        # returns (re-ingestion, same-window merge, constraint collision) saved
+        # detail changes silently without notifying subscribers.
+        on_sleep_created(
+            record_id=result.id,
+            user_id=user_id,
+            provider=record.provider or record.source_name,
+            device=record.device_model,
+            start_time=result.start_datetime.isoformat(),
+            end_time=result.end_datetime.isoformat(),
+            zone_offset=record.zone_offset,
+            duration_seconds=result.duration_seconds,
+            efficiency_percent=float(eff) if eff is not None else None,
+            stages={
+                "awake_minutes": final_detail.sleep_awake_minutes,
+                "light_minutes": final_detail.sleep_light_minutes,
+                "deep_minutes": final_detail.sleep_deep_minutes,
+                "rem_minutes": final_detail.sleep_rem_minutes,
+            }
+            if has_stages
+            else None,
+            is_nap=final_detail.is_nap,
+            is_merge=not inserted,
+        )
         return result
-
     def _create_or_merge_sleep_inner(
         self,
         db_session: DbSession,

--- a/backend/app/services/outgoing_webhooks/events.py
+++ b/backend/app/services/outgoing_webhooks/events.py
@@ -7,6 +7,7 @@ happens in the worker process.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import re
 from typing import Any
@@ -115,7 +116,15 @@ def on_sleep_created(
     efficiency_percent: float | None = None,
     stages: dict[str, int | None] | None = None,
     is_nap: bool | None = None,
+    is_merge: bool = False,
 ) -> None:
+    # Hash mutable fields into the idempotency_key so successive merged saves
+    # of the same record produce distinct Svix events (per SLEEP_CREATED
+    # description: "A new (or merged) sleep session was saved.") while
+    # genuine retries of the same payload still dedupe.
+    rev = hashlib.md5(
+        f"{start_time}|{end_time}|{duration_seconds}|{efficiency_percent}|{stages}|{is_nap}".encode()
+    ).hexdigest()[:12]
     _dispatch(
         WebhookEventType.SLEEP_CREATED,
         {
@@ -131,12 +140,12 @@ def on_sleep_created(
                 "efficiency_percent": efficiency_percent,
                 "stages": stages,
                 "is_nap": is_nap,
+                "is_merge": is_merge,
             },
         },
-        idempotency_key=f"sleep.created.{record_id}",
+        idempotency_key=f"sleep.created.{record_id}.{rev}",
         channels=[f"user.{user_id}"],
     )
-
 
 def on_timeseries_batch_saved(
     *,


### PR DESCRIPTION
## Problem

`SLEEP_CREATED`'s description in `event_types.py` reads *"A new (or merged) sleep session was saved."* and the module docstring is explicit that there's no update/patch flow. But `event_record_service.create_or_merge_sleep` (line 211) only fires `on_sleep_created` when `inserted=True`, which skips three merge-path returns inside `_create_or_merge_sleep_inner`:

- Line 285 — re-ingestion (same `external_id`): detail replaced with fresh values, then `return adjacent, False, detail`.
- Line 366 — `same_window` merge: detail updated in-place, `return adjacent, False, detail`.
- Line 378 — constraint collision treated as same-window: same outcome, `return adjacent, False, detail`.

All three modify the database. None fire the webhook.

## Real-world impact

In a production deployment, a freshly-paired WHOOP user has 91 sleep-category `HealthScore` rows but only 1 `EventRecord`. That single record fired `sleep.created` once; every subsequent WHOOP backfill night merged into it via the same-window / external_id paths and was silently swallowed. Subscribers see one stale snapshot.

## Fix

1. **`event_record_service.create_or_merge_sleep`** — drop the `if inserted:` gate. Fire `on_sleep_created` on every committed save, passing `is_merge=not inserted` so consumers can distinguish fresh vs. merged saves.
2. **`outgoing_webhooks/events.on_sleep_created`** — accept the new `is_merge: bool = False` kwarg, include it in the payload, and hash the mutable fields into the `idempotency_key`. Preserves Svix dedup for genuine retries of identical payloads while still producing distinct delivery attempts for successive merges of the same record.

No new event type, no `*_UPDATED` flow — stays inside the project's documented "created-only" design.

## Test plan

I have not added tests in this PR — happy to follow up once you can point me at the test scaffolding (e.g. `tests/services/event_record_service/...`). Suggested assertions:

- Fresh insert → `on_sleep_created(is_merge=False)`; idempotency_key contains content hash.
- Re-ingestion (same `external_id`) with modified detail → `on_sleep_created(is_merge=True)` with different idempotency_key.
- No-op re-ingestion (byte-identical detail) → same idempotency_key (Svix-side dedup still works for retries).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sleep session webhooks now dispatch for both newly created and merged sessions, ensuring comprehensive tracking of all sleep data modifications without gaps.
  * Webhook event payloads now explicitly identify whether each update resulted from a create or merge operation, providing clear visibility into how sleep records are being modified and synchronized.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1089?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->