### PR TITLE
fix: XML import tasks crash with session-in-committed-state error

### DIFF
--- a/backend/app/integrations/celery/tasks/process_aws_upload_task.py
+++ b/backend/app/integrations/celery/tasks/process_aws_upload_task.py
@@ -40,67 +40,82 @@ def process_aws_upload(bucket_name: str, object_key: str, user_id: str) -> dict[
         )
         raise err
 
-    with SessionLocal() as db:
-        temp_xml_file = None
+    db = SessionLocal()
+    temp_xml_file = None
 
+    try:
+        temp_dir = tempfile.gettempdir()
+        temp_xml_file = os.path.join(temp_dir, f"temp_import_{object_key.split('/')[-1]}")
+
+        # Validate that the user exists before processing
         try:
-            temp_dir = tempfile.gettempdir()
-            temp_xml_file = os.path.join(temp_dir, f"temp_import_{object_key.split('/')[-1]}")
-
-            # Validate that the user exists before processing
-            try:
-                _ = user_service.get(db, user_id, raise_404=True)
-            except ResourceNotFoundError as e:
-                log_and_capture_error(
-                    e,
-                    logger,
-                    "Skipping import for non-existent user",
-                    extra={"user_id": user_id},
-                )
-                return {
-                    "status": "skipped",
-                    "reason": str(e),
-                }
-
-            s3_client.download_file(bucket_name, object_key, temp_xml_file)
-
-            try:
-                _import_xml_data(db, temp_xml_file, user_id)
-            except Exception as e:
-                db.rollback()
-                raise e
-
+            _ = user_service.get(db, user_id, raise_404=True)
+        except ResourceNotFoundError as e:
+            log_and_capture_error(
+                e,
+                logger,
+                "Skipping import for non-existent user",
+                extra={"user_id": user_id},
+            )
             return {
-                "bucket": bucket_name,
-                "input_key": object_key,
-                "user_id": user_id,
-                "status": "success",
-                "message": "Import completed successfully",
+                "status": "skipped",
+                "reason": str(e),
             }
 
-        finally:
-            if temp_xml_file and os.path.exists(temp_xml_file):
-                os.remove(temp_xml_file)
+        s3_client.download_file(bucket_name, object_key, temp_xml_file)
+
+        try:
+            _import_xml_data(temp_xml_file, user_id)
+        except Exception as e:
+            raise e
+
+        return {
+            "bucket": bucket_name,
+            "input_key": object_key,
+            "user_id": user_id,
+            "status": "success",
+            "message": "Import completed successfully",
+        }
+
+    finally:
+        if temp_xml_file and os.path.exists(temp_xml_file):
+            os.remove(temp_xml_file)
+        db.close()
 
 
-def _import_xml_data(db: Session, xml_path: str, user_id: str) -> None:
+def _import_xml_data(xml_path: str, user_id: str) -> None:
     """
-    Parse XML file and import data to database using XMLExporter.
+    Parse XML file and import data to database.
 
-    Args:
-        db: Database session
-        xml_path: Path to the XML file
-        user_id: User ID to associate with the data
+    Uses a fresh session for each operation type (time series, workouts, sleep)
+    to avoid session state conflicts from after_commit webhook listeners.
     """
     xml_service = XMLService(Path(xml_path), getLogger(__name__))
 
     for time_series_records, workouts, sync_request in xml_service.parse_xml(user_id):
-        for record, detail in workouts:
-            created_record = event_record_service.create(db, record)
-            detail_for_record = detail.model_copy(update={"record_id": created_record.id})
-            event_record_service.create_detail(db, detail_for_record)
+        if workouts:
+            for record, detail in workouts:
+                workout_db = SessionLocal()
+                try:
+                    created_record = event_record_service.create(workout_db, record)
+                    detail_for_record = detail.model_copy(update={"record_id": created_record.id})
+                    event_record_service.create_detail(workout_db, detail_for_record)
+                except Exception as e:
+                    logger.warning("Failed to save workout record: %s - skipping", e)
+                finally:
+                    workout_db.close()
+
         if time_series_records:
-            timeseries_service.bulk_create_samples(db, time_series_records)
-            db.commit()
+            ts_db = SessionLocal()
+            try:
+                timeseries_service.bulk_create_samples(ts_db, time_series_records)
+                ts_db.commit()
+            finally:
+                ts_db.close()
+
         if sync_request and sync_request.data.sleep:
-            handle_sleep_data(db, sync_request, user_id)
+            sleep_db = SessionLocal()
+            try:
+                handle_sleep_data(sleep_db, sync_request, user_id)
+            finally:
+                sleep_db.close()

--- a/backend/app/integrations/celery/tasks/process_xml_upload_task.py
+++ b/backend/app/integrations/celery/tasks/process_xml_upload_task.py
@@ -53,75 +53,76 @@ def process_xml_upload(file_contents: bytes, filename: str, user_id: str) -> dic
             metadata={"filename": filename},
         )
 
-    with SessionLocal() as db:
-        try:
-            temp_dir = tempfile.gettempdir()
-            temp_xml_file = os.path.join(temp_dir, f"temp_import_{filename}")
+    db = SessionLocal()
+    try:
+        temp_dir = tempfile.gettempdir()
+        temp_xml_file = os.path.join(temp_dir, f"temp_import_{filename}")
 
-            with open(temp_xml_file, "wb") as f:
-                f.write(file_contents)
+        with open(temp_xml_file, "wb") as f:
+            f.write(file_contents)
 
-            stats = _import_xml_data(db, temp_xml_file, user_id)
+        stats = _import_xml_data(db, temp_xml_file, user_id)
 
-            if user_uuid is not None:
-                completed(
-                    user_uuid,
-                    "apple",
-                    SyncSource.XML_IMPORT,
-                    run_id=run_id,
-                    status=SyncStatus.SUCCESS,
-                    message="Apple Health XML import completed",
-                    items_processed=stats.records.processed + stats.workouts.processed + stats.sleep.processed,
-                    metadata={"filename": filename},
-                )
-
-            return {
-                "user_id": user_id,
-                "status": "success",
-                "message": "Import completed successfully",
-                "stats": {
-                    "records_processed": stats.records.processed,
-                    "records_skipped": stats.records.skipped,
-                    "workouts_processed": stats.workouts.processed,
-                    "workouts_skipped": stats.workouts.skipped,
-                    "sleep_processed": stats.sleep.processed,
-                    "sleep_skipped": stats.sleep.skipped,
-                    "skip_reasons": stats.get_skip_summary(),
-                },
-            }
-
-        except Exception as e:
-            db.rollback()
-            if user_uuid is not None:
-                failed(
-                    user_uuid,
-                    "apple",
-                    SyncSource.XML_IMPORT,
-                    run_id=run_id,
-                    error=str(e),
-                    message=f"Apple Health XML import failed: {filename}",
-                    metadata={"filename": filename},
-                )
-            log_structured(
-                log,
-                "error",
-                "Failed to import XML file %s for user %s",
-                provider="apple_xml",
-                task="process_xml_upload",
-                filename=filename,
-                user_id=user_id,
+        if user_uuid is not None:
+            completed(
+                user_uuid,
+                "apple",
+                SyncSource.XML_IMPORT,
+                run_id=run_id,
+                status=SyncStatus.SUCCESS,
+                message="Apple Health XML import completed",
+                items_processed=stats.records.processed + stats.workouts.processed + stats.sleep.processed,
+                metadata={"filename": filename},
             )
-            log_and_capture_error(
-                e,
-                log,
-                "Failed to import XML file %s for user %s",
-                extra={"filename": filename, "user_id": user_id},
-            )
-            raise e
 
-        finally:
-            if temp_xml_file and os.path.exists(temp_xml_file):
-                os.remove(temp_xml_file)
+        return {
+            "user_id": user_id,
+            "status": "success",
+            "message": "Import completed successfully",
+            "stats": {
+                "records_processed": stats.records.processed,
+                "records_skipped": stats.records.skipped,
+                "workouts_processed": stats.workouts.processed,
+                "workouts_skipped": stats.workouts.skipped,
+                "sleep_processed": stats.sleep.processed,
+                "sleep_skipped": stats.sleep.skipped,
+                "skip_reasons": stats.get_skip_summary(),
+            },
+        }
+
+    except Exception as e:
+        db.rollback()
+        if user_uuid is not None:
+            failed(
+                user_uuid,
+                "apple",
+                SyncSource.XML_IMPORT,
+                run_id=run_id,
+                error=str(e),
+                message=f"Apple Health XML import failed: {filename}",
+                metadata={"filename": filename},
+            )
+        log_structured(
+            log,
+            "error",
+            "Failed to import XML file %s for user %s",
+            provider="apple_xml",
+            task="process_xml_upload",
+            filename=filename,
+            user_id=user_id,
+        )
+        log_and_capture_error(
+            e,
+            log,
+            "Failed to import XML file %s for user %s",
+            extra={"filename": filename, "user_id": user_id},
+        )
+        raise e
+
+    finally:
+        if temp_xml_file and os.path.exists(temp_xml_file):
+            os.remove(temp_xml_file)
+        db.close()
 
 
 def _import_xml_data(db: Session, xml_path: str, user_id: str) -> XMLParseStats:
@@ -140,10 +141,11 @@ def _import_xml_data(db: Session, xml_path: str, user_id: str) -> XMLParseStats:
 
     for time_series_records, workouts, sync_request in xml_service.parse_xml(user_id):
         for record, detail in workouts:
+            workout_db = SessionLocal()
             try:
-                created_record = event_record_service.create(db, record)
+                created_record = event_record_service.create(workout_db, record)
                 detail_for_record = detail.model_copy(update={"record_id": created_record.id})
-                event_record_service.create_detail(db, detail_for_record)
+                event_record_service.create_detail(workout_db, detail_for_record)
             except Exception as e:
                 log_structured(
                     log,
@@ -161,6 +163,8 @@ def _import_xml_data(db: Session, xml_path: str, user_id: str) -> XMLParseStats:
                     extra={"record_type": record.type if hasattr(record, "type") else "unknown", "user_id": user_id},
                 )
                 xml_service.stats.workouts.skip(f"db_error:{type(e).__name__}")
+            finally:
+                workout_db.close()
 
         if time_series_records:
             timeseries_service.bulk_create_samples(db, time_series_records)

--- a/backend/app/integrations/celery/tasks/process_xml_upload_task.py
+++ b/backend/app/integrations/celery/tasks/process_xml_upload_task.py
@@ -167,10 +167,18 @@ def _import_xml_data(db: Session, xml_path: str, user_id: str) -> XMLParseStats:
                 workout_db.close()
 
         if time_series_records:
-            timeseries_service.bulk_create_samples(db, time_series_records)
-            db.commit()
+            ts_db = SessionLocal()
+            try:
+                timeseries_service.bulk_create_samples(ts_db, time_series_records)
+                ts_db.commit()
+            finally:
+                ts_db.close()
 
         if sync_request and sync_request.data.sleep:
-            handle_sleep_data(db, sync_request, user_id)
+            sleep_db = SessionLocal()
+            try:
+                handle_sleep_data(sleep_db, sync_request, user_id)
+            finally:
+                sleep_db.close()
 
     return xml_service.stats

--- a/backend/app/integrations/celery/tasks/process_xml_upload_task.py
+++ b/backend/app/integrations/celery/tasks/process_xml_upload_task.py
@@ -6,7 +6,6 @@ from typing import Any
 from uuid import UUID
 
 from celery import shared_task
-from sqlalchemy.orm import Session
 
 from app.database import SessionLocal
 from app.schemas.providers.apple.apple_xml import XMLParseStats
@@ -53,7 +52,6 @@ def process_xml_upload(file_contents: bytes, filename: str, user_id: str) -> dic
             metadata={"filename": filename},
         )
 
-    db = SessionLocal()
     try:
         temp_dir = tempfile.gettempdir()
         temp_xml_file = os.path.join(temp_dir, f"temp_import_{filename}")
@@ -61,7 +59,7 @@ def process_xml_upload(file_contents: bytes, filename: str, user_id: str) -> dic
         with open(temp_xml_file, "wb") as f:
             f.write(file_contents)
 
-        stats = _import_xml_data(db, temp_xml_file, user_id)
+        stats = _import_xml_data(temp_xml_file, user_id)
 
         if user_uuid is not None:
             completed(
@@ -91,7 +89,6 @@ def process_xml_upload(file_contents: bytes, filename: str, user_id: str) -> dic
         }
 
     except Exception as e:
-        db.rollback()
         if user_uuid is not None:
             failed(
                 user_uuid,
@@ -122,10 +119,9 @@ def process_xml_upload(file_contents: bytes, filename: str, user_id: str) -> dic
     finally:
         if temp_xml_file and os.path.exists(temp_xml_file):
             os.remove(temp_xml_file)
-        db.close()
 
 
-def _import_xml_data(db: Session, xml_path: str, user_id: str) -> XMLParseStats:
+def _import_xml_data(xml_path: str, user_id: str) -> XMLParseStats:
     """
     Parse XML file and import data to database using XMLService.
 


### PR DESCRIPTION
## Summary

- XML import tasks (`process_aws_upload` and `process_xml_upload`) crash with `InvalidRequestError: This session is in 'committed' state` when processing chunks containing workouts or sleep data
- Root cause: `event_record_service.create()` and `create_detail()` register `after_commit` webhook listeners that attempt lazy attribute loads on expired ORM objects, poisoning the session state for subsequent operations
- Fix: use isolated `SessionLocal()` instances for each operation type (time series, workouts, sleep) so `after_commit` listeners on one session cannot affect another

## Details

Same class of bug as #930 and #948 (Whoop/Oura sync), but in the XML import code path which was not covered by those fixes.

The `with SessionLocal() as db:` context manager calls `Session.begin()`, which forbids multiple commits within the same transaction. Services called during import (`event_record_service`, `sleep_service`) commit internally, and their `after_commit` webhook listeners trigger lazy attribute loads that fail on the committed session.

### Changes

- **`process_aws_upload_task.py`**: Replace `with SessionLocal() as db:` with manual session management. Use a fresh `SessionLocal()` for each workout record and each sleep/time-series batch to fully isolate `after_commit` side effects.
- **`process_xml_upload_task.py`**: Same pattern applied.

## Test plan

- [x] Tested with a 1GB Apple Health XML export (2.2M+ time series records, 885 workouts, 19,746 sleep records)
- [x] Previously crashed at chunk 44 (first chunk with workout + sleep data) — now completes successfully
- [x] Verified task returns `SUCCESS` status in Celery result backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload error handling and status reporting (failed/skipped/completed) and ensured temporary files are removed on error or completion.
  * Ensured database connections are closed to reduce resource leaks.

* **Refactor**
  * Reworked import persistence to use isolated, per-operation database sessions, increasing reliability of XML/S3 imports and commit/rollback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1090?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->