### PR TITLE
refactor: move transaction boundaries from services/repos to callers

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -85,6 +85,7 @@ def _get_db_dependency() -> Iterator[Session]:
     db = SessionLocal()
     try:
         yield db
+        db.commit()
     except Exception as exc:
         db.rollback()
         raise exc

--- a/backend/app/integrations/celery/tasks/archival_task.py
+++ b/backend/app/integrations/celery/tasks/archival_task.py
@@ -36,6 +36,7 @@ def run_daily_archival() -> dict:
     with SessionLocal() as db:
         try:
             summary = archival_service.run_daily_archival(db)
+            db.commit()
             logger.info("Daily archival completed: %s", summary)
             return summary
         except Exception:

--- a/backend/app/integrations/celery/tasks/finalize_stale_sleep_task.py
+++ b/backend/app/integrations/celery/tasks/finalize_stale_sleep_task.py
@@ -41,6 +41,7 @@ def finalize_stale_sleeps() -> None:
 
                     if now - end_time >= timedelta(minutes=settings.sleep_end_gap_minutes):
                         finish_sleep(db, user_id, state)
+                        db.commit()
                 finally:
                     with contextlib.suppress(Exception):
                         lock.release()

--- a/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
+++ b/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
@@ -114,6 +114,8 @@ def process_sdk_upload(
             db, content, content_type, user_id, batch_id=batch_id
         ).model_dump()
 
+        db.commit()
+
         # Log processing completion with results
         log_structured(
             logger,

--- a/backend/app/integrations/celery/tasks/seed_data_task.py
+++ b/backend/app/integrations/celery/tasks/seed_data_task.py
@@ -27,5 +27,6 @@ def generate_seed_data(request_data: dict) -> dict:
             logger.info("Seed data generation completed: %s", summary)
             return summary
         except Exception:
+            db.rollback()
             logger.exception("Seed data generation failed")
             raise

--- a/backend/app/integrations/celery/tasks/seed_data_task.py
+++ b/backend/app/integrations/celery/tasks/seed_data_task.py
@@ -23,6 +23,7 @@ def generate_seed_data(request_data: dict) -> dict:
     with SessionLocal() as db:
         try:
             summary = seed_data_service.generate(db, config)
+            db.commit()
             logger.info("Seed data generation completed: %s", summary)
             return summary
         except Exception:

--- a/backend/app/integrations/celery/tasks/sync_vendor_data_task.py
+++ b/backend/app/integrations/celery/tasks/sync_vendor_data_task.py
@@ -312,6 +312,7 @@ def sync_vendor_data(
                     if not is_historical:
                         user_connection_repo.update_last_synced_at(db, connection)
 
+                    db.commit()
                     result.providers_synced[provider_name] = provider_result
                     log_structured(
                         logger,

--- a/backend/app/integrations/celery/tasks/webhook_push_task.py
+++ b/backend/app/integrations/celery/tasks/webhook_push_task.py
@@ -41,7 +41,9 @@ def process_webhook_push(
         if strategy.webhooks is None:
             raise ValueError(f"Provider '{provider_name}' has no webhook handler")
         with SessionLocal() as db:
-            return strategy.webhooks.process_payload(db, payload, request_trace_id)
+            result = strategy.webhooks.process_payload(db, payload, request_trace_id)
+            db.commit()
+            return result
     except ValueError as exc:
         # Configuration error (unknown provider, missing handler) — retrying won't help.
         log_structured(

--- a/backend/app/repositories/archival_repository.py
+++ b/backend/app/repositories/archival_repository.py
@@ -36,7 +36,7 @@ class ArchivalSettingRepository:
         setting = self.get(db)
         setting.archive_after_days = archive_after_days
         setting.delete_after_days = delete_after_days
-        db.commit()
+        db.flush()
         db.refresh(setting)
         return setting
 
@@ -260,7 +260,7 @@ class DataPointSeriesArchiveRepository:
             )
             total_deleted += deleted_count
 
-            db.commit()
+            db.flush()
 
         return total_deleted
 
@@ -277,7 +277,7 @@ class DataPointSeriesArchiveRepository:
             )
             .delete(synchronize_session=False)
         )
-        db.commit()
+        db.flush()
         return deleted
 
     def delete_live_before(self, db: DbSession, cutoff_date: date) -> int:
@@ -318,7 +318,7 @@ class DataPointSeriesArchiveRepository:
                 break
 
             total_deleted += deleted
-            db.commit()
+            db.flush()
 
         return total_deleted
 

--- a/backend/app/repositories/data_point_series_repository.py
+++ b/backend/app/repositories/data_point_series_repository.py
@@ -182,14 +182,15 @@ class DataPointSeriesRepository(
             # NOTE: Caller should commit - allows batching multiple operations
 
     def try_commit(self, db_session: DbSession, creation: DataPointSeries) -> DataPointSeries:
+        nested = db_session.begin_nested()
         try:
-            db_session.commit()
+            db_session.flush()
+            nested.commit()
             db_session.refresh(creation)
             return creation
         except SQLAIntegrityError as e:
+            nested.rollback()
             if isinstance(e.orig, UniqueViolation):
-                db_session.rollback()
-
                 # Query for existing record using the unique constraint fields
                 existing = (
                     db_session.query(self.model)

--- a/backend/app/repositories/event_record_detail_repository.py
+++ b/backend/app/repositories/event_record_detail_repository.py
@@ -52,7 +52,7 @@ class EventRecordDetailRepository(
         """Create a detail record using the appropriate polymorphic model."""
         detail = self._build_detail(creator, detail_type)
         db_session.add(detail)
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(detail)
         return detail
 

--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -123,19 +123,21 @@ class EventRecordRepository(
             )
             .delete(synchronize_session=False)
         )
-        db_session.commit()
+        db_session.flush()
         return deleted
 
     @handle_exceptions
     def create(self, db_session: DbSession, creator: EventRecordCreate) -> EventRecord:
         data_source_id, creation = self._build_creation(db_session, creator)
+        nested = db_session.begin_nested()
         try:
             db_session.add(creation)
-            db_session.commit()
+            db_session.flush()
+            nested.commit()
             db_session.refresh(creation)
             return creation
         except IntegrityError:
-            db_session.rollback()
+            nested.rollback()
             if existing := self._fetch_existing(db_session, data_source_id, creation):
                 return existing
             raise

--- a/backend/app/repositories/invitation_repository.py
+++ b/backend/app/repositories/invitation_repository.py
@@ -57,7 +57,7 @@ class InvitationRepository(CrudRepository[Invitation, InvitationCreateInternal, 
     ) -> Invitation:
         """Update invitation status."""
         invitation.status = status
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(invitation)
         return invitation
 
@@ -70,6 +70,6 @@ class InvitationRepository(CrudRepository[Invitation, InvitationCreateInternal, 
         """Accept invitation and create developer in a single atomic transaction."""
         db_session.add(developer)
         invitation.status = InvitationStatus.ACCEPTED
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(developer)
         return developer

--- a/backend/app/repositories/provider_settings_repository.py
+++ b/backend/app/repositories/provider_settings_repository.py
@@ -35,7 +35,7 @@ class ProviderSettingsRepository:
             .returning(ProviderSetting)
         )
         setting = db.execute(stmt).scalar_one()
-        db.commit()
+        db.flush()
         return setting
 
     def ensure_all_providers_exist(
@@ -64,7 +64,7 @@ class ProviderSettingsRepository:
             elif existing[provider].live_sync_mode is None and default_mode is not None:
                 existing[provider].live_sync_mode = default_mode
 
-        db.commit()
+        db.flush()
 
     def get_webhook_secret(self, db: DbSession, provider: ProviderName) -> str | None:
         """Return the stored webhook signing secret for a provider, or None."""
@@ -80,7 +80,7 @@ class ProviderSettingsRepository:
             .on_conflict_do_update(index_elements=["provider"], set_={"webhook_secret": secret})
         )
         db.execute(stmt)
-        db.commit()
+        db.flush()
 
     def bulk_update(self, db: DbSession, updates: dict[str, bool]) -> None:
         """Bulk update is_enabled for multiple providers."""
@@ -96,4 +96,4 @@ class ProviderSettingsRepository:
             )
             db.execute(stmt)
 
-        db.commit()
+        db.flush()

--- a/backend/app/repositories/refresh_token_repository.py
+++ b/backend/app/repositories/refresh_token_repository.py
@@ -17,7 +17,7 @@ class RefreshTokenRepository:
     def create(self, db_session: DbSession, token: RefreshToken) -> RefreshToken:
         """Create a new refresh token."""
         db_session.add(token)
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(token)
         return token
 
@@ -39,7 +39,7 @@ class RefreshTokenRepository:
     def revoke_token(self, db_session: DbSession, token: RefreshToken) -> RefreshToken:
         """Revoke a single refresh token."""
         token.revoked_at = datetime.now(timezone.utc)
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(token)
         return token
 
@@ -52,7 +52,7 @@ class RefreshTokenRepository:
             .values(revoked_at=now)
         )
         result = cast(CursorResult[tuple[()]], db_session.execute(stmt))
-        db_session.commit()
+        db_session.flush()
         return result.rowcount or 0
 
     def revoke_all_for_developer(self, db_session: DbSession, developer_id: UUID) -> int:
@@ -64,13 +64,13 @@ class RefreshTokenRepository:
             .values(revoked_at=now)
         )
         result = cast(CursorResult[tuple[()]], db_session.execute(stmt))
-        db_session.commit()
+        db_session.flush()
         return result.rowcount or 0
 
     def update_last_used(self, db_session: DbSession, token: RefreshToken) -> RefreshToken:
         """Update the last_used_at timestamp of a token."""
         token.last_used_at = datetime.now(timezone.utc)
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(token)
         return token
 

--- a/backend/app/repositories/repositories.py
+++ b/backend/app/repositories/repositories.py
@@ -25,7 +25,7 @@ class CrudRepository[
         creation_data = creator.model_dump()
         creation = self.model(**creation_data)
         db_session.add(creation)
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(creation)
         return creation
 
@@ -63,13 +63,13 @@ class CrudRepository[
         for field_name, field_value in updater_data.items():
             setattr(originator, field_name, field_value)
         db_session.add(originator)
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(originator)
         return originator
 
     def delete(self, db_session: DbSession, originator: ModelType) -> ModelType:
         db_session.delete(originator)
-        db_session.commit()
+        db_session.flush()
         return originator
 
     def delete_flush(self, db_session: DbSession, originator: ModelType) -> None:

--- a/backend/app/repositories/user_connection_repository.py
+++ b/backend/app/repositories/user_connection_repository.py
@@ -247,7 +247,7 @@ class UserConnectionRepository(CrudRepository[UserConnection, UserConnectionCrea
                 ),
             ),
         )
-        db_session.commit()
+        db_session.flush()
         return result.rowcount
 
     def mark_as_revoked(self, db_session: DbSession, connection: UserConnection) -> UserConnection:
@@ -255,7 +255,7 @@ class UserConnectionRepository(CrudRepository[UserConnection, UserConnectionCrea
         connection.status = ConnectionStatus.REVOKED
         connection.updated_at = datetime.now(timezone.utc)
         db_session.add(connection)
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(connection)
         return connection
 
@@ -264,7 +264,7 @@ class UserConnectionRepository(CrudRepository[UserConnection, UserConnectionCrea
         connection.scope = scope
         connection.updated_at = datetime.now(timezone.utc)
         db_session.add(connection)
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(connection)
         return connection
 
@@ -284,7 +284,7 @@ class UserConnectionRepository(CrudRepository[UserConnection, UserConnectionCrea
         connection.token_expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
         connection.updated_at = datetime.now(timezone.utc)
         db_session.add(connection)
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(connection)
         return connection
 
@@ -315,7 +315,7 @@ class UserConnectionRepository(CrudRepository[UserConnection, UserConnectionCrea
         connection.status = ConnectionStatus.ACTIVE
         connection.updated_at = datetime.now(timezone.utc)
         db_session.add(connection)
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(connection)
         return connection
 
@@ -323,7 +323,7 @@ class UserConnectionRepository(CrudRepository[UserConnection, UserConnectionCrea
         """Update the last synced timestamp."""
         connection.last_synced_at = datetime.now(timezone.utc)
         db_session.add(connection)
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(connection)
         return connection
 
@@ -368,7 +368,7 @@ class UserConnectionRepository(CrudRepository[UserConnection, UserConnectionCrea
                 existing.status = ConnectionStatus.ACTIVE
                 existing.updated_at = datetime.now(timezone.utc)
                 db_session.add(existing)
-                db_session.commit()
+                db_session.flush()
                 db_session.refresh(existing)
             return existing
 
@@ -385,6 +385,6 @@ class UserConnectionRepository(CrudRepository[UserConnection, UserConnectionCrea
             updated_at=datetime.now(timezone.utc),
         )
         db_session.add(connection)
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(connection)
         return connection

--- a/backend/app/repositories/user_invitation_code_repository.py
+++ b/backend/app/repositories/user_invitation_code_repository.py
@@ -28,7 +28,7 @@ class UserInvitationCodeRepository(CrudRepository[UserInvitationCode, UserInvita
     def mark_redeemed(self, db_session: DbSession, invitation_code: UserInvitationCode) -> UserInvitationCode:
         """Mark an invitation code as redeemed."""
         invitation_code.redeemed_at = datetime.now(timezone.utc)
-        db_session.commit()
+        db_session.flush()
         db_session.refresh(invitation_code)
         return invitation_code
 
@@ -46,4 +46,4 @@ class UserInvitationCodeRepository(CrudRepository[UserInvitationCode, UserInvita
             .values(revoked_at=now)
         )
         db_session.execute(stmt)
-        db_session.commit()
+        db_session.flush()

--- a/backend/app/services/apple/healthkit/import_service.py
+++ b/backend/app/services/apple/healthkit/import_service.py
@@ -291,8 +291,8 @@ class ImportService:
             self.timeseries_service.bulk_create_samples(db_session, samples)
             records_saved += len(samples)
 
-        # Commit all workout and timeseries changes in one transaction
-        db_session.commit()
+        # Flush all workout and timeseries changes (caller commits)
+        db_session.flush()
 
         # Process sleep (count sleep segments from input)
         if request.data.sleep:

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -288,7 +288,7 @@ class EventRecordService(
                         self._local_sleep_date(adjacent.start_datetime, adjacent.zone_offset),
                     },
                 )
-                db_session.commit()
+                db_session.flush()
                 return adjacent, False, detail
 
             adj_detail: SleepDetails | None = adjacent.detail if isinstance(adjacent.detail, SleepDetails) else None
@@ -416,7 +416,7 @@ class EventRecordService(
                     user_id,
                     {self._local_sleep_date(adjacent.start_datetime, adjacent.zone_offset)},
                 )
-                db_session.commit()
+                db_session.flush()
                 return adjacent, False, detail
 
             record = record.model_copy(
@@ -443,7 +443,7 @@ class EventRecordService(
                     user_id,
                     {self._local_sleep_date(adjacent.start_datetime, adjacent.zone_offset)},
                 )
-                db_session.commit()
+                db_session.flush()
                 return adjacent, False, detail
 
             merged_final_detail = detail.model_copy(update={"record_id": created_record.id, **merged_detail_fields})
@@ -462,7 +462,7 @@ class EventRecordService(
                     self._local_sleep_date(created_record.start_datetime, created_record.zone_offset),
                 },
             )
-            db_session.commit()
+            db_session.flush()
             return created_record, True, merged_final_detail
 
         created_record = self.crud.create_and_flush(db_session, record)
@@ -472,7 +472,7 @@ class EventRecordService(
             new_detail,
             detail_type="sleep",
         )
-        db_session.commit()
+        db_session.flush()
         return created_record, True, new_detail
 
     @staticmethod

--- a/backend/app/services/priority_service.py
+++ b/backend/app/services/priority_service.py
@@ -42,7 +42,7 @@ class PriorityService:
         priority: int,
     ) -> ProviderPriorityResponse:
         result = self.priority_repo.upsert(db_session, provider, priority)
-        db_session.commit()
+        db_session.flush()
         return ProviderPriorityResponse.model_validate(result)
 
     @handle_exceptions
@@ -53,7 +53,7 @@ class PriorityService:
     ) -> ProviderPriorityListResponse:
         priorities_tuples = [(p.provider, p.priority) for p in update.priorities]
         results = self.priority_repo.bulk_update(db_session, priorities_tuples)
-        db_session.commit()
+        db_session.flush()
         return ProviderPriorityListResponse(items=[ProviderPriorityResponse.model_validate(p) for p in results])
 
     @handle_exceptions
@@ -96,7 +96,7 @@ class PriorityService:
         priority: int,
     ) -> DeviceTypePriorityResponse:
         result = self.device_type_priority_repo.upsert(db_session, device_type, priority)
-        db_session.commit()
+        db_session.flush()
         return DeviceTypePriorityResponse.model_validate(result)
 
     @handle_exceptions
@@ -107,7 +107,7 @@ class PriorityService:
     ) -> DeviceTypePriorityListResponse:
         priorities_tuples = [(p.device_type, p.priority) for p in update.priorities]
         results = self.device_type_priority_repo.bulk_update(db_session, priorities_tuples)
-        db_session.commit()
+        db_session.flush()
         return DeviceTypePriorityListResponse(items=[DeviceTypePriorityResponse.model_validate(p) for p in results])
 
     def get_priority_data_source_ids(

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -530,6 +530,7 @@ class Garmin247Data(Base247DataTemplate):
             self.data_point_repo.bulk_create(db, samples)
         if health_scores:
             health_score_service.bulk_create(db, health_scores)
+        if samples or health_scores:
             db.flush()
         return len(samples)
 

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -530,7 +530,7 @@ class Garmin247Data(Base247DataTemplate):
             self.data_point_repo.bulk_create(db, samples)
         if health_scores:
             health_score_service.bulk_create(db, health_scores)
-            db.commit()
+            db.flush()
         return len(samples)
 
     def _collect_heart_rate_samples(
@@ -1077,7 +1077,7 @@ class Garmin247Data(Base247DataTemplate):
             self.data_point_repo.bulk_create(db, samples)
         if score := self._normalize_body_battery_health_score(user_id, raw_stress):
             health_score_service.bulk_create(db, [score])
-            db.commit()
+            db.flush()
         return len(samples)
 
     # -------------------------------------------------------------------------
@@ -1776,7 +1776,7 @@ class Garmin247Data(Base247DataTemplate):
 
         if all_health_scores:
             health_score_service.bulk_create(db, all_health_scores)
-            db.commit()
+            db.flush()
 
         return count
 

--- a/backend/app/services/providers/garmin/webhook_handler.py
+++ b/backend/app/services/providers/garmin/webhook_handler.py
@@ -159,7 +159,7 @@ class GarminWebhookHandler(BaseWebhookHandler):
         well_result = self._process_wellness(db, payload, errors, synced_user_ids, users_with_new_success, trace_id)
 
         # --- commit + update last_synced_at ------------------------------
-        db.commit()
+        db.flush()
 
         for uid in synced_user_ids:
             with contextlib.suppress(Exception):

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -267,7 +267,7 @@ class Oura247Data(Base247DataTemplate):
             timeseries_service.bulk_create_samples(db, samples)
         if health_scores:
             health_score_service.bulk_create(db, health_scores)
-            db.commit()
+            db.flush()
         return len(samples)
 
     # -------------------------------------------------------------------------
@@ -344,7 +344,7 @@ class Oura247Data(Base247DataTemplate):
 
         if samples:
             timeseries_service.bulk_create_samples(db, samples)
-            db.commit()
+            db.flush()
         return len(samples)
 
     # -------------------------------------------------------------------------
@@ -492,7 +492,7 @@ class Oura247Data(Base247DataTemplate):
             timeseries_service.bulk_create_samples(db, samples)
         if health_scores:
             health_score_service.bulk_create(db, health_scores)
-            db.commit()
+            db.flush()
         return len(samples)
 
     # -------------------------------------------------------------------------
@@ -792,7 +792,7 @@ class Oura247Data(Base247DataTemplate):
         """Save daily sleep scores via health_score_service."""
         if normalized:
             health_score_service.bulk_create(db, normalized)
-            db.commit()
+            db.flush()
         return len(normalized)
 
     # -------------------------------------------------------------------------
@@ -880,7 +880,7 @@ class Oura247Data(Base247DataTemplate):
 
         if samples:
             timeseries_service.bulk_create_samples(db, samples)
-            db.commit()
+            db.flush()
         return len(samples)
 
     # -------------------------------------------------------------------------
@@ -950,7 +950,7 @@ class Oura247Data(Base247DataTemplate):
 
         if samples:
             timeseries_service.bulk_create_samples(db, samples)
-            db.commit()
+            db.flush()
         return len(samples)
 
     # -------------------------------------------------------------------------
@@ -1041,7 +1041,7 @@ class Oura247Data(Base247DataTemplate):
 
         if samples:
             timeseries_service.bulk_create_samples(db, samples)
-            db.commit()
+            db.flush()
         return len(samples)
 
     # -------------------------------------------------------------------------
@@ -1100,7 +1100,7 @@ class Oura247Data(Base247DataTemplate):
 
         if samples:
             timeseries_service.bulk_create_samples(db, samples)
-            db.commit()
+            db.flush()
         return len(samples)
 
     # -------------------------------------------------------------------------

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -671,11 +671,12 @@ class Oura247Data(Base247DataTemplate):
                 sleep_stages=normalized_sleep.get("stage_timestamps", []),
             )
 
+            savepoint = db.begin_nested()
             try:
                 event_record_service.create_or_merge_sleep(db, user_id, record, detail, settings.sleep_end_gap_minutes)
                 count += 1
             except Exception as e:
-                db.rollback()
+                savepoint.rollback()
                 log_structured(
                     self.logger,
                     "error",
@@ -1172,10 +1173,11 @@ class Oura247Data(Base247DataTemplate):
 
         results: dict[str, int] = {}
         for data_type, fn in tasks.items():
+            savepoint = db.begin_nested()
             try:
                 results[data_type] = fn()
             except Exception as e:
-                db.rollback()
+                savepoint.rollback()
                 results[data_type] = 0
                 log_structured(
                     self.logger,

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -267,6 +267,7 @@ class Oura247Data(Base247DataTemplate):
             timeseries_service.bulk_create_samples(db, samples)
         if health_scores:
             health_score_service.bulk_create(db, health_scores)
+        if samples or health_scores:
             db.flush()
         return len(samples)
 
@@ -492,6 +493,7 @@ class Oura247Data(Base247DataTemplate):
             timeseries_service.bulk_create_samples(db, samples)
         if health_scores:
             health_score_service.bulk_create(db, health_scores)
+        if samples or health_scores:
             db.flush()
         return len(samples)
 

--- a/backend/app/services/providers/polar/data_247.py
+++ b/backend/app/services/providers/polar/data_247.py
@@ -1033,7 +1033,7 @@ class Polar247Data(Base247DataTemplate):
         for data_type, fn in tasks.items():
             try:
                 results[data_type] = fn()
-                db.commit()
+                db.flush()
             except Exception as e:
                 db.rollback()
                 results[data_type] = 0

--- a/backend/app/services/providers/polar/data_247.py
+++ b/backend/app/services/providers/polar/data_247.py
@@ -1031,11 +1031,12 @@ class Polar247Data(Base247DataTemplate):
 
         results: dict[str, int] = {}
         for data_type, fn in tasks.items():
+            savepoint = db.begin_nested()
             try:
                 results[data_type] = fn()
                 db.flush()
             except Exception as e:
-                db.rollback()
+                savepoint.rollback()
                 results[data_type] = 0
                 log_and_capture_error(
                     e,

--- a/backend/app/services/providers/suunto/data_247.py
+++ b/backend/app/services/providers/suunto/data_247.py
@@ -754,6 +754,6 @@ class Suunto247Data(Base247DataTemplate):
         # not committed within their individual save methods. Sleep and recovery
         # commit per-record via crud.create/try_commit, but bulk_create_samples
         # defers commit to the caller intentionally for batching efficiency.
-        db.commit()
+        db.flush()
 
         return results

--- a/backend/app/services/providers/suunto/webhook_handler.py
+++ b/backend/app/services/providers/suunto/webhook_handler.py
@@ -195,7 +195,7 @@ class SuuntoWebhookHandler(BaseWebhookHandler):
             result["status"] = "unknown_event_type"
 
         self.connection_repo.update_last_synced_at(db, connection)
-        db.commit()
+        db.flush()
 
         return result
 

--- a/backend/app/services/providers/whoop/data_247.py
+++ b/backend/app/services/providers/whoop/data_247.py
@@ -427,6 +427,7 @@ class Whoop247Data(Base247DataTemplate):
                 )
         if health_scores:
             health_score_service.bulk_create(db, health_scores)
+        if count or health_scores:
             db.flush()
         return count
 

--- a/backend/app/services/providers/whoop/data_247.py
+++ b/backend/app/services/providers/whoop/data_247.py
@@ -408,6 +408,7 @@ class Whoop247Data(Base247DataTemplate):
         count = 0
         health_scores: list[HealthScoreCreate] = []
         for item in raw_data:
+            savepoint = db.begin_nested()
             try:
                 normalized, health_score = self.normalize_sleep(item, user_id)
                 self.save_sleep_data(db, user_id, normalized)
@@ -415,7 +416,7 @@ class Whoop247Data(Base247DataTemplate):
                 if health_score:
                     health_scores.append(health_score)
             except Exception as e:
-                db.rollback()
+                savepoint.rollback()
                 log_structured(
                     self.logger,
                     "warning",
@@ -464,10 +465,11 @@ class Whoop247Data(Base247DataTemplate):
             "body_measurement_samples_synced": 0,
         }
 
+        savepoint = db.begin_nested()
         try:
             results["sleep_sessions_synced"] = self.load_and_save_sleep(db, user_id, start_time, end_time)
         except Exception as e:
-            db.rollback()
+            savepoint.rollback()
             log_structured(
                 self.logger,
                 "error",
@@ -477,10 +479,11 @@ class Whoop247Data(Base247DataTemplate):
                 user_id=str(user_id),
             )
 
+        savepoint = db.begin_nested()
         try:
             results["recovery_samples_synced"] = self.load_and_save_recovery(db, user_id, start_time, end_time)
         except Exception as e:
-            db.rollback()
+            savepoint.rollback()
             log_structured(
                 self.logger,
                 "error",
@@ -490,10 +493,11 @@ class Whoop247Data(Base247DataTemplate):
                 user_id=str(user_id),
             )
 
+        savepoint = db.begin_nested()
         try:
             results["body_measurement_samples_synced"] = self.load_and_save_body_measurement(db, user_id)
         except Exception as e:
-            db.rollback()
+            savepoint.rollback()
             log_structured(
                 self.logger,
                 "error",
@@ -917,6 +921,7 @@ class Whoop247Data(Base247DataTemplate):
         health_scores: list[HealthScoreCreate] = []
 
         for item in raw_data:
+            savepoint = db.begin_nested()
             try:
                 normalized, health_score = self.normalize_recovery(item, user_id)
                 if normalized:  # Skip unscored records
@@ -924,7 +929,7 @@ class Whoop247Data(Base247DataTemplate):
                     if health_score:
                         health_scores.append(health_score)
             except Exception as e:
-                db.rollback()
+                savepoint.rollback()
                 log_structured(
                     self.logger,
                     "warning",

--- a/backend/app/services/providers/whoop/data_247.py
+++ b/backend/app/services/providers/whoop/data_247.py
@@ -426,7 +426,7 @@ class Whoop247Data(Base247DataTemplate):
                 )
         if health_scores:
             health_score_service.bulk_create(db, health_scores)
-            db.commit()
+            db.flush()
         return count
 
     def load_and_save_all(
@@ -636,7 +636,7 @@ class Whoop247Data(Base247DataTemplate):
 
         if samples_to_create:
             timeseries_service.bulk_create_samples(db, samples_to_create)
-            db.commit()
+            db.flush()
 
         return len(samples_to_create)
 
@@ -852,7 +852,7 @@ class Whoop247Data(Base247DataTemplate):
 
         if samples_to_create:
             timeseries_service.bulk_create_samples(db, samples_to_create)
-            db.commit()
+            db.flush()
 
         return len(samples_to_create)
 
@@ -936,7 +936,7 @@ class Whoop247Data(Base247DataTemplate):
 
         if health_scores:
             health_score_service.bulk_create(db, health_scores)
-            db.commit()
+            db.flush()
 
         return total_count
 

--- a/backend/app/services/providers/whoop/workouts.py
+++ b/backend/app/services/providers/whoop/workouts.py
@@ -418,11 +418,12 @@ class WhoopWorkouts(BaseWorkoutsTemplate):
                     strain_scores.append(strain_score)
 
         if strain_scores:
+            savepoint = db.begin_nested()
             try:
                 health_score_service.bulk_create(db, strain_scores)
                 db.flush()
             except Exception:
-                db.rollback()
+                savepoint.rollback()
                 raise
 
         return count

--- a/backend/app/services/providers/whoop/workouts.py
+++ b/backend/app/services/providers/whoop/workouts.py
@@ -420,7 +420,7 @@ class WhoopWorkouts(BaseWorkoutsTemplate):
         if strain_scores:
             try:
                 health_score_service.bulk_create(db, strain_scores)
-                db.commit()
+                db.flush()
             except Exception:
                 db.rollback()
                 raise

--- a/backend/app/services/seed_data/service.py
+++ b/backend/app/services/seed_data/service.py
@@ -228,7 +228,7 @@ class SeedDataService:
                         health_score_service.bulk_create(db, scores)
                         summary["health_scores"] += len(scores)
 
-            db.commit()
+            db.flush()
             logger.info(
                 "Seed user %d/%d created (workouts=%d, sleeps=%d, ts=%d, health_scores=%d)",
                 user_num,

--- a/backend/app/utils/duplicates.py
+++ b/backend/app/utils/duplicates.py
@@ -20,15 +20,17 @@ def handle_duplicates(func: Callable[..., T]) -> Callable[..., T | None]:
 
     @wraps(func)
     def wrapper(*args, **kwargs) -> T | None:
+        db_session = args[1]
+        nested = db_session.begin_nested()
         try:
-            return func(*args, **kwargs)
+            result = func(*args, **kwargs)
+            nested.commit()
+            return result
         except SQLAIntegrityError as e:
+            nested.rollback()
             if isinstance(e.orig, UniqueViolation):
                 model = args[0].model
-                db_session = args[1]
                 creator = args[2]
-
-                db_session.rollback()
 
                 creator_data = creator.model_dump()
                 mapper = inspect(model)


### PR DESCRIPTION
## Summary

- Replace all mid-flow `db.commit()` calls in repositories and services with `db.flush()`, moving transaction ownership to callers (FastAPI request lifecycle, Celery tasks)
- This is the architectural fix for the session-state poisoning described in #948 and #930 — resolves the root cause rather than working around it per-provider

## Problem

Services and repositories called `db.commit()` internally (~63 sites). When multiple services ran in sequence within a single session, `after_commit` webhook listeners triggered lazy attribute loads on expired ORM objects, poisoning the session with `InvalidRequestError: This session is in 'committed' state`.

Previous fixes (#1022) added `db.rollback()` in except blocks per-provider. This PR eliminates the root cause.

## Changes

**Transaction boundary moved to callers (2 patterns):**
- `_get_db_dependency()` auto-commits after yielding the session (FastAPI requests)
- Celery tasks commit explicitly at their transaction boundaries

**Repositories — `commit()` → `flush()` (15 files):**
- Base `repositories.py`, `event_record_repository.py`, `event_record_detail_repository.py`, `provider_settings_repository.py`, `data_point_series_repository.py`, `user_invitation_code_repository.py`, `user_connection_repository.py`, `archival_repository.py`, `invitation_repository.py`, `refresh_token_repository.py`

**IntegrityError handling — savepoint pattern:**
- `handle_duplicates` decorator wraps calls in `begin_nested()` savepoint
- `event_record_repository.create()` and `data_point_series_repository.try_commit()` use explicit savepoints

**Services — `commit()` → `flush()` (15 files):**
- `event_record_service.py`, `priority_service.py`, `import_service.py`, `seed_data/service.py`
- All provider data_247 services (Oura, Whoop, Garmin, Polar, Suunto)
- Webhook handlers (Garmin, Suunto)

## Test plan

- [x] Tested with 1GB Apple Health XML import (2.2M time series, 885 workouts, 27,443 sleep records)
- [x] All 44 chunks processed with zero session state errors
- [x] Previously crashed at chunk 44 with `InvalidRequestError`

Closes #948, closes #930

🐇

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence in background jobs so changes are reliably saved before tasks finish, reducing lost or inconsistent data.
  * Reduced risk of cascading failures during sync/import by isolating errors to individual items or steps.

* **Refactor**
  * Standardized transaction handling across services and repositories for more predictable, resilient data operations and clearer ownership of commits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/the-momentum/open-wearables/pull/1092?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->