### PR TITLE
feat(backend): Strava workout_details segments (laps & km splits)

### DIFF
--- a/backend/app/constants/workout_segments.py
+++ b/backend/app/constants/workout_segments.py
@@ -1,0 +1,7 @@
+from enum import StrEnum
+
+
+class SegmentKind(StrEnum):
+    LAP = "lap"
+    SPLIT = "split"
+    LENGTH = "length"

--- a/backend/app/repositories/event_record_detail_repository.py
+++ b/backend/app/repositories/event_record_detail_repository.py
@@ -32,6 +32,8 @@ class EventRecordDetailRepository(
         """Construct the polymorphic ORM object without touching the session."""
         creation_data = creator.model_dump(exclude_none=True)
         if detail_type == "workout":
+            if creator.segments:
+                creation_data["segments"] = [s.model_dump(mode="json") for s in creator.segments]
             return cast(EventRecordDetail, WorkoutDetails(**creation_data))
         if detail_type == "sleep":
             # sleep_stages contains datetime fields that JSONB cannot serialize directly;
@@ -127,6 +129,8 @@ class EventRecordDetailRepository(
             # Serialize sleep_stages datetimes to ISO strings for JSONB storage
             if detail_type == "sleep" and data.get("sleep_stages"):
                 data["sleep_stages"] = [s.model_dump(mode="json") for s in creator.sleep_stages]  # ty:ignore[not-iterable]
+            if detail_type == "workout" and data.get("segments"):
+                data["segments"] = [s.model_dump(mode="json") for s in creator.segments]  # ty:ignore[not-iterable]
             # Filter to keep only columns present in the target model
             filtered_data = {k: v for k, v in data.items() if k in valid_columns}
             child_values.append(filtered_data)

--- a/backend/app/schemas/model_crud/activities/__init__.py
+++ b/backend/app/schemas/model_crud/activities/__init__.py
@@ -36,6 +36,7 @@ from .personal_record import (
     PersonalRecordUpdate,
 )
 from .sleep import SleepStage
+from .workout_segment import WorkoutSegment
 
 __all__ = [
     # DataPointSeries (rename from timeseries maybe)
@@ -65,6 +66,8 @@ __all__ = [
     "PersonalRecordResponse",
     # Sleep
     "SleepStage",
+    # WorkoutSegment
+    "WorkoutSegment",
     # HealthScore
     "ScoreComponent",
     "HealthScoreBase",

--- a/backend/app/schemas/model_crud/activities/event_record_detail.py
+++ b/backend/app/schemas/model_crud/activities/event_record_detail.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from pydantic import BaseModel
 
 from .sleep import SleepStage
+from .workout_segment import WorkoutSegment
 
 
 class EventRecordDetailBase(BaseModel):
@@ -29,6 +30,8 @@ class EventRecordDetailBase(BaseModel):
 
     elev_high: Decimal | None = None
     elev_low: Decimal | None = None
+
+    segments: list[WorkoutSegment] | None = None
 
     # Sleep-specific fields
     sleep_total_duration_minutes: int | None = None

--- a/backend/app/schemas/model_crud/activities/workout_segment.py
+++ b/backend/app/schemas/model_crud/activities/workout_segment.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+from app.constants.workout_segments import SegmentKind
+
+
+class WorkoutSegment(BaseModel):
+    """A sub-activity breakdown (lap, split or pool length) stored inside the JSONB column."""
+
+    kind: SegmentKind
+    index: int
+    distance_meters: float | None = None
+    duration_seconds: int | None = None
+    moving_time_seconds: int | None = None
+    average_speed: float | None = None
+    average_heartrate: float | None = None
+    max_heartrate: int | None = None
+    average_cadence: float | None = None
+    average_watts: float | None = None
+    total_elevation_gain: float | None = None

--- a/backend/app/schemas/providers/strava/activity_import.py
+++ b/backend/app/schemas/providers/strava/activity_import.py
@@ -13,6 +13,36 @@ class StravaGearJSON(BaseModel):
     distance: int
 
 
+class StravaLapJSON(BaseModel):
+    """A single Strava lap from a DetailedActivity's ``laps`` array."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    lap_index: int
+    distance: float | None = None  # meters
+    elapsed_time: int | None = None  # seconds
+    moving_time: int | None = None  # seconds
+    average_speed: float | None = None  # meters/second
+    average_heartrate: float | None = None
+    max_heartrate: float | None = None
+    average_cadence: float | None = None
+    average_watts: float | None = None
+    total_elevation_gain: float | None = None
+
+
+class StravaSplitJSON(BaseModel):
+    """A single auto per-kilometre split from a DetailedActivity's ``splits_metric`` array."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    split: int  # 1-based split index
+    distance: float | None = None  # meters
+    elapsed_time: int | None = None  # seconds
+    moving_time: int | None = None  # seconds
+    average_speed: float | None = None  # meters/second
+    average_heartrate: float | None = None
+
+
 class ActivityJSON(BaseModel):
     """Strava activity data from API responses or webhook fetches.
 
@@ -71,3 +101,7 @@ class ActivityJSON(BaseModel):
     start_date_local: str | None = None  # ISO 8601 local
     timezone: str | None = None
     utc_offset: float | None = None
+
+    # Sub-activity breakdown (DetailedActivity only)
+    laps: list[StravaLapJSON] | None = None
+    splits_metric: list[StravaSplitJSON] | None = None

--- a/backend/app/schemas/responses/activity/events.py
+++ b/backend/app/schemas/responses/activity/events.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-from app.schemas.model_crud.activities import SleepStage
+from app.schemas.model_crud.activities import SleepStage, WorkoutSegment
 from app.schemas.utils import SourceMetadata
 
 from .data_point_responses import TimeSeriesSample
@@ -26,6 +26,7 @@ class Workout(BaseModel):
     max_heart_rate_bpm: int | None = None
     avg_pace_sec_per_km: int | float | None = None
     elevation_gain_meters: float | None = None
+    segments: list[WorkoutSegment] | None = None
 
 
 class WorkoutDetailed(Workout):

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -31,6 +31,7 @@ from app.schemas.model_crud.activities import (
     EventRecordUpdate,
     HealthScoreCreate,
     ScoreComponent,
+    WorkoutSegment,
 )
 from app.schemas.model_crud.activities.sleep import SleepStage
 from app.schemas.responses.activity import SleepSession, SleepStagesSummary, Workout, WorkoutDetailed
@@ -700,6 +701,7 @@ class EventRecordService(
                 elevation_gain_meters=float(details.total_elevation_gain)
                 if details and details.total_elevation_gain
                 else None,
+                segments=[WorkoutSegment(**s) for s in details.segments] if details and details.segments else None,
             )
             data.append(workout)
 
@@ -765,6 +767,7 @@ class EventRecordService(
             if details and details.total_elevation_gain
             else None,
             heart_rate_samples=[],  # TODO: Fetch from DataPointSeries if needed
+            segments=[WorkoutSegment(**s) for s in details.segments] if details and details.segments else None,
         )
 
     @handle_exceptions

--- a/backend/app/services/providers/strava/workouts.py
+++ b/backend/app/services/providers/strava/workouts.py
@@ -4,6 +4,7 @@ from typing import Any, Iterable
 from uuid import UUID, uuid4
 
 from app.config import settings
+from app.constants.workout_segments import SegmentKind
 from app.constants.workout_types import get_unified_strava_workout_type
 from app.database import DbSession
 from app.schemas.enums import WorkoutType
@@ -11,6 +12,7 @@ from app.schemas.model_crud.activities import (
     EventRecordCreate,
     EventRecordDetailCreate,
     EventRecordMetrics,
+    WorkoutSegment,
 )
 from app.schemas.providers.strava import ActivityJSON as StravaActivityJSON
 from app.services.event_record_service import event_record_service
@@ -224,10 +226,45 @@ class StravaWorkouts(BaseWorkoutsTemplate):
 
         detail = EventRecordDetailCreate(
             record_id=workout_id,
+            segments=self._build_segments(raw_workout),
             **metrics,
         )
 
         return record, detail
+
+    def _build_segments(self, raw_workout: StravaActivityJSON) -> list[WorkoutSegment] | None:
+        """Build lap-kind segments — manual/device laps when set, else auto per-km splits (#1076)."""
+        laps = raw_workout.laps or []
+        splits = raw_workout.splits_metric or []
+        if len(laps) > 1 or (laps and not splits):
+            return [
+                WorkoutSegment(
+                    kind=SegmentKind.LAP,
+                    index=lap.lap_index,
+                    distance_meters=lap.distance,
+                    duration_seconds=lap.elapsed_time,
+                    moving_time_seconds=lap.moving_time,
+                    average_speed=lap.average_speed,
+                    average_heartrate=lap.average_heartrate,
+                    max_heartrate=int(lap.max_heartrate) if lap.max_heartrate is not None else None,
+                    average_cadence=lap.average_cadence,
+                    average_watts=lap.average_watts,
+                    total_elevation_gain=lap.total_elevation_gain,
+                )
+                for lap in laps
+            ]
+        return [
+            WorkoutSegment(
+                kind=SegmentKind.LAP,
+                index=split.split,
+                distance_meters=split.distance,
+                duration_seconds=split.elapsed_time,
+                moving_time_seconds=split.moving_time,
+                average_speed=split.average_speed,
+                average_heartrate=split.average_heartrate,
+            )
+            for split in splits
+        ] or None
 
     def _build_bundles(
         self,

--- a/backend/tests/providers/strava/conftest.py
+++ b/backend/tests/providers/strava/conftest.py
@@ -1,0 +1,20 @@
+"""Strava provider test configuration.
+
+Overrides session-scoped DB fixtures for pure unit tests that don't need a database.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def engine() -> MagicMock:
+    """Override engine fixture — strava unit tests don't need a database."""
+    return MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def set_factory_session() -> None:
+    """Override autouse DB fixture — strava unit tests don't use factory-boy."""
+    return  # override: suppress DB fixture for unit tests

--- a/backend/tests/providers/strava/test_strava_segments.py
+++ b/backend/tests/providers/strava/test_strava_segments.py
@@ -1,0 +1,107 @@
+"""Tests for Strava lap/split → workout segments mapping (#1076)."""
+
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.constants.workout_segments import SegmentKind
+from app.schemas.providers.strava import ActivityJSON as StravaActivityJSON
+from app.services.providers.strava.workouts import StravaWorkouts
+
+_SINGLE_LAP = [{"lap_index": 1, "distance": 15354.1, "elapsed_time": 4327}]
+
+_MANUAL_LAPS = [
+    {
+        "lap_index": 1,
+        "distance": 400.0,
+        "elapsed_time": 90,
+        "moving_time": 90,
+        "average_speed": 4.44,
+        "average_heartrate": 150.0,
+        "max_heartrate": 168.0,
+        "average_watts": 280.0,
+    },
+    {"lap_index": 2, "distance": 200.0, "elapsed_time": 75, "average_heartrate": 130.0},
+    {"lap_index": 3, "distance": 400.0, "elapsed_time": 88, "average_heartrate": 152.0},
+]
+
+_SPLITS = [
+    {
+        "split": 1,
+        "distance": 1001.9,
+        "elapsed_time": 349,
+        "moving_time": 330,
+        "average_speed": 3.04,
+        "average_heartrate": 127.5,
+    },
+    {
+        "split": 2,
+        "distance": 1000.0,
+        "elapsed_time": 293,
+        "moving_time": 293,
+        "average_speed": 3.41,
+        "average_heartrate": 142.0,
+    },
+]
+
+
+def _activity(**overrides: Any) -> StravaActivityJSON:
+    base = {
+        "id": 98765,
+        "name": "Morning Run",
+        "type": "Run",
+        "sport_type": "Run",
+        "start_date": "2024-01-15T08:00:00Z",
+        "elapsed_time": 3600,
+        "utc_offset": 3600.0,
+    }
+    return StravaActivityJSON(**{**base, **overrides})
+
+
+@pytest.fixture
+def strava_workouts() -> StravaWorkouts:
+    return StravaWorkouts(
+        workout_repo=MagicMock(),
+        connection_repo=MagicMock(),
+        provider_name="strava",
+        api_base_url="https://www.strava.com",
+        oauth=MagicMock(),
+    )
+
+
+def test_segments_use_auto_km_splits_when_no_manual_laps(strava_workouts: StravaWorkouts) -> None:
+    """A single (whole-activity) lap → segments come from the auto per-km splits, kind=lap."""
+    segments = strava_workouts._build_segments(_activity(laps=_SINGLE_LAP, splits_metric=_SPLITS))
+    assert segments is not None
+    assert len(segments) == 2
+    assert all(s.kind == SegmentKind.LAP for s in segments)
+    assert segments[0].index == 1
+    assert segments[0].distance_meters == 1001.9
+    assert segments[0].duration_seconds == 349
+    assert segments[0].average_heartrate == 127.5
+
+
+def test_segments_prefer_manual_laps_when_set(strava_workouts: StravaWorkouts) -> None:
+    """Multiple manual/device laps win over auto splits (kind=lap), carrying power."""
+    segments = strava_workouts._build_segments(_activity(laps=_MANUAL_LAPS, splits_metric=_SPLITS))
+    assert segments is not None
+    assert len(segments) == 3
+    assert all(s.kind == SegmentKind.LAP for s in segments)
+    assert segments[0].distance_meters == 400.0
+    assert segments[0].max_heartrate == 168
+    assert segments[0].average_watts == 280.0
+
+
+def test_segments_none_without_laps_or_splits(strava_workouts: StravaWorkouts) -> None:
+    """No laps and no splits → no segments."""
+    assert strava_workouts._build_segments(_activity()) is None
+
+
+def test_normalize_workout_attaches_segments(strava_workouts: StravaWorkouts) -> None:
+    """_normalize_workout puts the lap segments on the detail."""
+    _record, detail = strava_workouts._normalize_workout(_activity(laps=_SINGLE_LAP, splits_metric=_SPLITS), uuid4())
+    assert detail.segments is not None
+    assert len(detail.segments) == 2
+    assert detail.segments[0].kind == SegmentKind.LAP

--- a/docs/providers/strava-api-integration.mdx
+++ b/docs/providers/strava-api-integration.mdx
@@ -31,11 +31,15 @@ Strava provides access to activity/workout data through their API. The integrati
 | Data Type | Support |
 |-----------|---------|
 | Workouts / Activities | Yes |
+| Workout segments (laps & km splits) | Yes |
+| Per-sample streams (HR, speed, cadence, power) | Yes |
 | Sleep | No |
 | Daily summaries (247 data) | No |
 | Body composition | No |
 
 Strava is an activity-focused platform — it does not provide continuous health monitoring data like sleep, HRV, or daily summaries.
+
+Workout **segments** are stored on `workout_details.segments` as `lap`-kind entries: the activity's manual/device laps when set (intervals), otherwise Strava's auto per-kilometre splits (`splits_metric`). Each segment carries distance, duration, average speed and heart rate (laps additionally carry cadence and power).
 
 ### Data delivery
 


### PR DESCRIPTION
Part of #1076 (laps slice — does **not** fully close the issue; swim lengths and the split kind are follow-ups).

## Report

Populates the `workout_details.segments` JSONB column (added in #1079) with
Strava sub-activity breakdowns, as `lap`-kind `WorkoutSegment`s — matching the
issue's `lap (km splits or manual)`:

- multiple manual/device `laps[]` when the athlete set them (intervals), else
- Strava's auto per-kilometre `splits_metric[]`.

One source is chosen per activity so segments never overlap/double-count.
Segments are exposed on the workout `Workout` response (list + detailed), so
consumers can read them via `GET /users/{id}/events/workouts`.

Verified locally on a real Strava activity: a 15.4 km run (single whole-activity
lap) yields 16 `lap`-kind segments from `splits_metric`, stored in
`workout_details.segments` and returned by the list endpoint.

## Scope / follow-ups

- ✅ `lap` kind (manual laps + auto km splits) for Strava.
- ⛔ Swim lengths (`length` kind) and `split` (run/walk/interval) are **not**
  included here — the column + GIN index already support them; left for
  follow-ups (and other providers, cf. #953, #1065).

## Notes

- `WorkoutSegment` mirrors the `SleepStage` pattern (typed model + `SegmentKind`
  enum, JSONB-serialised in the detail repository like `sleep_stages`). No
  migration — the column and GIN index already exist (#1079).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workouts now include segment data (laps and metric splits) with granular metrics such as distance, duration, moving time, average/maximum heart rate, average cadence, power output, and elevation gain.
  * Enhanced Strava integration to import workout segments for richer activity details.

* **Documentation**
  * Updated documentation to reflect newly supported Strava workout segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->