### PR TITLE
fix(backend): widen data_source.source to VARCHAR(100)

### DIFF
--- a/backend/app/models/data_source.py
+++ b/backend/app/models/data_source.py
@@ -5,7 +5,7 @@ from sqlalchemy import Index, text
 from sqlalchemy.orm import Mapped
 
 from app.database import BaseDbModel
-from app.mappings import FKUser, FKUserConnection, OneToMany, PrimaryKey, str_32, str_50, str_100, str_255
+from app.mappings import FKUser, FKUserConnection, OneToMany, PrimaryKey, str_32, str_50, str_100
 from app.schemas.enums import ProviderName
 
 if TYPE_CHECKING:
@@ -39,10 +39,14 @@ class DataSource(BaseDbModel):
     user_connection_id: Mapped[FKUserConnection]
     device_model: Mapped[str_100 | None]
     software_version: Mapped[str_50 | None]
-    # Apple HealthKit source bundle ids look like "com.apple.health.<UUID>"
-    # (53 chars), so 50 is too short and aborts SDK imports — see migration
-    # 264b79d7c541. 255 fits reverse-DNS bundle identifiers comfortably.
-    source: Mapped[str_255 | None]
+    # Apple HealthKit tags on-device data with source bundle ids like
+    # "com.apple.health.<UUID>" (53 chars), so 50 is too short and aborts SDK
+    # imports - see migration 264b79d7c541. Populated by ensure_data_source()
+    # in app/repositories/data_source_repository.py. Apple documents no max
+    # length for HKSource.bundleIdentifier (it is an app bundle id or a device
+    # UUID, see https://developer.apple.com/documentation/healthkit/hksource/bundleidentifier);
+    # 100 fits the observed identifiers and matches the other str_100 columns.
+    source: Mapped[str_100 | None]
     device_type: Mapped[str_32 | None]
     original_source_name: Mapped[str_100 | None]
 

--- a/backend/app/models/data_source.py
+++ b/backend/app/models/data_source.py
@@ -5,7 +5,7 @@ from sqlalchemy import Index, text
 from sqlalchemy.orm import Mapped
 
 from app.database import BaseDbModel
-from app.mappings import FKUser, FKUserConnection, OneToMany, PrimaryKey, str_32, str_50, str_100
+from app.mappings import FKUser, FKUserConnection, OneToMany, PrimaryKey, str_32, str_50, str_100, str_255
 from app.schemas.enums import ProviderName
 
 if TYPE_CHECKING:
@@ -39,7 +39,10 @@ class DataSource(BaseDbModel):
     user_connection_id: Mapped[FKUserConnection]
     device_model: Mapped[str_100 | None]
     software_version: Mapped[str_50 | None]
-    source: Mapped[str_50 | None]
+    # Apple HealthKit source bundle ids look like "com.apple.health.<UUID>"
+    # (53 chars), so 50 is too short and aborts SDK imports — see migration
+    # 264b79d7c541. 255 fits reverse-DNS bundle identifiers comfortably.
+    source: Mapped[str_255 | None]
     device_type: Mapped[str_32 | None]
     original_source_name: Mapped[str_100 | None]
 

--- a/backend/migrations/versions/2026_06_04_1806-264b79d7c541_widen_data_source_source_to_100.py
+++ b/backend/migrations/versions/2026_06_04_1806-264b79d7c541_widen_data_source_source_to_100.py
@@ -1,4 +1,4 @@
-"""widen_data_source_source_to_255
+"""widen_data_source_source_to_100
 
 Revision ID: 264b79d7c541
 Revises: 2d316787b998
@@ -21,12 +21,12 @@ def upgrade() -> None:
     # Apple HealthKit tags on-device sleep/records with a source bundle
     # identifier of the form "com.apple.health.<UUID>" (53 chars), which
     # overflows the old VARCHAR(50) and aborts the whole SDK import batch.
-    # Widen to 255 to comfortably fit reverse-DNS bundle identifiers.
+    # Widen to 100 to fit the observed reverse-DNS bundle identifiers.
     op.alter_column(
         "data_source",
         "source",
         existing_type=sa.String(length=50),
-        type_=sa.String(length=255),
+        type_=sa.String(length=100),
         existing_nullable=True,
     )
 
@@ -35,7 +35,7 @@ def downgrade() -> None:
     op.alter_column(
         "data_source",
         "source",
-        existing_type=sa.String(length=255),
+        existing_type=sa.String(length=100),
         type_=sa.String(length=50),
         existing_nullable=True,
     )

--- a/backend/migrations/versions/2026_06_04_1806-264b79d7c541_widen_data_source_source_to_255.py
+++ b/backend/migrations/versions/2026_06_04_1806-264b79d7c541_widen_data_source_source_to_255.py
@@ -1,0 +1,41 @@
+"""widen_data_source_source_to_255
+
+Revision ID: 264b79d7c541
+Revises: 2d316787b998
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "264b79d7c541"
+down_revision: Union[str, None] = "2d316787b998"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Apple HealthKit tags on-device sleep/records with a source bundle
+    # identifier of the form "com.apple.health.<UUID>" (53 chars), which
+    # overflows the old VARCHAR(50) and aborts the whole SDK import batch.
+    # Widen to 255 to comfortably fit reverse-DNS bundle identifiers.
+    op.alter_column(
+        "data_source",
+        "source",
+        existing_type=sa.String(length=50),
+        type_=sa.String(length=255),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "data_source",
+        "source",
+        existing_type=sa.String(length=255),
+        type_=sa.String(length=50),
+        existing_nullable=True,
+    )

--- a/backend/tests/repositories/test_data_source_repository.py
+++ b/backend/tests/repositories/test_data_source_repository.py
@@ -1,0 +1,60 @@
+"""
+Tests for DataSourceRepository.
+
+Regression coverage for the ``data_source.source`` column width: Apple
+HealthKit tags on-device data with a source bundle identifier of the form
+``com.apple.health.<UUID>`` (53 chars). This overflowed the previous
+``VARCHAR(50)`` and aborted the entire SDK import batch with
+``StringDataRightTruncation``, so no Apple sleep/records were ever saved.
+The column is now ``VARCHAR(255)``.
+"""
+
+from sqlalchemy.orm import Session
+
+from app.models import DataSource
+from app.repositories.data_source_repository import DataSourceRepository
+from app.schemas.enums import ProviderName
+from tests.factories import UserFactory
+
+# Realistic Apple HealthKit source bundle id: "com.apple.health." + a UUID.
+APPLE_HEALTH_SOURCE = "com.apple.health.ED447642-08FD-4E45-AF20-633C02C83170"
+
+
+class TestDataSourceRepository:
+    """Test suite for DataSourceRepository."""
+
+    def test_apple_health_source_bundle_id_persists(self, db: Session) -> None:
+        """A 53-char Apple source bundle id imports without truncation.
+
+        Exercises ``ensure_data_source`` (the SDK import path that failed) and
+        asserts the full identifier round-trips — this would raise
+        ``StringDataRightTruncation`` against the old ``VARCHAR(50)`` column.
+        """
+        # Arrange: a source longer than the old 50-char limit.
+        assert len(APPLE_HEALTH_SOURCE) > 50
+        user = UserFactory()
+        repo = DataSourceRepository(DataSource)
+
+        # Act
+        created = repo.ensure_data_source(
+            db,
+            user_id=user.id,
+            provider=ProviderName.APPLE,
+            device_model="Watch7,5",
+            source=APPLE_HEALTH_SOURCE,
+        )
+        db.commit()
+        db.expire_all()
+
+        # Assert: stored intact, retrievable by its full identity.
+        assert created.source == APPLE_HEALTH_SOURCE
+        stored = repo.get_by_identity(
+            db,
+            user_id=user.id,
+            provider=ProviderName.APPLE,
+            device_model="Watch7,5",
+            source=APPLE_HEALTH_SOURCE,
+        )
+        assert stored is not None
+        assert stored.source == APPLE_HEALTH_SOURCE
+        assert len(stored.source) == len(APPLE_HEALTH_SOURCE)

--- a/backend/tests/repositories/test_data_source_repository.py
+++ b/backend/tests/repositories/test_data_source_repository.py
@@ -6,7 +6,7 @@ HealthKit tags on-device data with a source bundle identifier of the form
 ``com.apple.health.<UUID>`` (53 chars). This overflowed the previous
 ``VARCHAR(50)`` and aborted the entire SDK import batch with
 ``StringDataRightTruncation``, so no Apple sleep/records were ever saved.
-The column is now ``VARCHAR(255)``.
+The column is now ``VARCHAR(100)``.
 """
 
 from sqlalchemy.orm import Session


### PR DESCRIPTION
## Description

Apple HealthKit tags on-device data with a **source bundle identifier** of the form `com.apple.health.<UUID>` — e.g. `com.apple.health.ED447642-08FD-4E45-AF20-633C02C83170`, which is **53 characters**. The `data_source.source` column was `VARCHAR(50)`, so inserting it raised `StringDataRightTruncation` and rolled back the **entire** SDK import batch (`-> HTTP 400`).

The practical effect: **Apple sleep records are never saved** — sleep samples carry that long `com.apple.health.<UUID>` source — while steps / heart-rate / workouts come through fine because they're tagged with short sources like `Apple Watch` / `iPhone`. This is the root cause of #1002 (`sleep_record_save_error`, `value too long for type character varying(50)`).

This PR widens `data_source.source` to `VARCHAR(255)` (model + Alembic migration) — comfortably fitting reverse-DNS bundle identifiers — and adds a regression test.

**Changes**
- `app/models/data_source.py` — `source` mapped type `str_50 -> str_255` (`str_255` already existed in `app/mappings.py`).
- `migrations/versions/2026_06_04_1806-264b79d7c541_widen_data_source_source_to_255.py` — new migration; `alter_column` 50 → 255, with a symmetric downgrade.
- `tests/repositories/test_data_source_repository.py` — regression test importing a 53-char Apple source via `ensure_data_source`.

Fixes #1002

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes (ruff check, ruff format, ty — all green on the changed files)

## Testing Instructions

**Steps to test:**
1. `cd backend`
2. Run the regression test (it exercises the real `ensure_data_source` import path):
   ```bash
   ENV=test SECRET_KEY=… MASTER_KEY=… \
   TEST_DATABASE_URL=postgresql+psycopg://…/open_wearables_test \
   uv run pytest tests/repositories/test_data_source_repository.py -v
   ```
3. Apply the migration against a database and confirm the column width:
   ```bash
   uv run alembic upgrade head
   # SELECT character_maximum_length FROM information_schema.columns
   #   WHERE table_name='data_source' AND column_name='source';  -> 255
   ```

**Expected behavior:**

A 53-char Apple source bundle id (`com.apple.health.<UUID>`) imports and round-trips intact. Against the old `VARCHAR(50)` the same test raises the exact production error — `StringDataRightTruncation: value too long for type character varying(50)` — so it's a true regression guard. The Alembic migration is reversible (verified up → down → up; `source` goes 50 → 255 → 50 → 255).

## Additional Notes

- Reproduced on a self-hosted deployment: Apple Watch activity/steps/HR/workouts synced, but `summaries/sleep` returned `sample_count: 0` because every sleep batch 400'd on this truncation. After widening the column and re-syncing, 60+ sleep sessions imported and the summaries endpoint returns them.
- Scope: this fixes the `source` truncation that blocks sleep. #1002 also notes body/measurement data not appearing; no truncation error was logged for that, so it may be a separate issue and isn't addressed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Source identifiers can now be stored in full without truncation, preventing data loss on certain integrations.

* **Tests**
  * Added regression test to verify source identifier persistence across system restarts.

* **Chores**
  * Database schema updated to increase source field capacity from 50 to 100 characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->