### PR TITLE
feat(backend): map INDOOR_CYCLING, JUMP_ROPE, KICKBOXING_MARTIAL_ARTS

### DIFF
--- a/backend/app/constants/workout_types/polar.py
+++ b/backend/app/constants/workout_types/polar.py
@@ -13,6 +13,7 @@ POLAR_WORKOUT_TYPE_MAPPINGS: list[tuple[str, str | None, WorkoutType]] = [
     ("CYCLING", "CYCLING_ROAD", WorkoutType.CYCLING),
     ("CYCLING", "CYCLING_MOUNTAIN", WorkoutType.MOUNTAIN_BIKING),
     ("CYCLING", "CYCLING_INDOOR", WorkoutType.INDOOR_CYCLING),
+    ("CYCLING", "INDOOR_CYCLING", WorkoutType.INDOOR_CYCLING),
     ("OTHER", "CYCLING_MOUNTAIN_BIKE", WorkoutType.MOUNTAIN_BIKING),
     ("OTHER", "CYCLING_CYCLOCROSS", WorkoutType.CYCLOCROSS),
     # Swimming - sport="SWIMMING" or "OTHER"
@@ -37,6 +38,7 @@ POLAR_WORKOUT_TYPE_MAPPINGS: list[tuple[str, str | None, WorkoutType]] = [
     # Strength & Gym - sport="STRENGTH_TRAINING" or "OTHER"
     ("STRENGTH_TRAINING", None, WorkoutType.STRENGTH_TRAINING),
     ("OTHER", "FITNESS_CARDIO", WorkoutType.CARDIO_TRAINING),
+    ("OTHER", "JUMP_ROPE", WorkoutType.CARDIO_TRAINING),
     ("OTHER", "FITNESS_ELLIPTICAL", WorkoutType.ELLIPTICAL),
     ("OTHER", "FITNESS_INDOOR_ROWING", WorkoutType.ROWING_MACHINE),
     ("OTHER", "FITNESS_STAIR_CLIMBING", WorkoutType.STAIR_CLIMBING),
@@ -77,6 +79,7 @@ POLAR_WORKOUT_TYPE_MAPPINGS: list[tuple[str, str | None, WorkoutType]] = [
     # Combat Sports - sport="OTHER"
     ("OTHER", "COMBAT_SPORTS_BOXING", WorkoutType.BOXING),
     ("OTHER", "COMBAT_SPORTS_MARTIAL_ARTS", WorkoutType.MARTIAL_ARTS),
+    ("OTHER", "KICKBOXING_MARTIAL_ARTS", WorkoutType.BOXING),
     # Outdoor Activities - sport="OTHER"
     ("OTHER", "OUTDOOR_CLIMBING", WorkoutType.ROCK_CLIMBING),
     ("OTHER", "INDOOR_CLIMBING", WorkoutType.INDOOR_CLIMBING),

--- a/backend/tests/providers/polar/test_polar_workouts.py
+++ b/backend/tests/providers/polar/test_polar_workouts.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from sqlalchemy.orm import Session
 
+from app.constants.workout_types.polar import get_unified_workout_type
 from app.schemas.enums import WorkoutType
 from app.schemas.providers.polar import ExerciseJSON as PolarExerciseJSON
 from app.services.providers.polar.workouts import PolarWorkouts
@@ -561,3 +562,16 @@ class TestPolarWorkoutsDataLoading:
 
         # Assert
         assert result == 0
+
+
+class TestGetUnifiedWorkoutType:
+    @pytest.mark.parametrize(
+        ("sport", "detailed", "expected"),
+        [
+            ("CYCLING", "INDOOR_CYCLING", WorkoutType.INDOOR_CYCLING),
+            ("OTHER", "JUMP_ROPE", WorkoutType.CARDIO_TRAINING),
+            ("OTHER", "KICKBOXING_MARTIAL_ARTS", WorkoutType.BOXING),
+        ],
+    )
+    def test_mappings(self, sport: str, detailed: str, expected: WorkoutType) -> None:
+        assert get_unified_workout_type(sport, detailed) == expected


### PR DESCRIPTION
## Summary

Three Polar sports were resolving to the wrong unified type. Confirmed against **real Polar AccessLink `/v3/exercises` data** (device: Polar Beat):

| Polar `sport` | `detailed_sport_info` | Was | Now |
|---|---|---|---|
| `CYCLING` | `INDOOR_CYCLING` | `CYCLING` (fell through) | `INDOOR_CYCLING` |
| `OTHER` | `JUMP_ROPE` | `GENERIC` | `CARDIO_TRAINING` |
| `OTHER` | `KICKBOXING_MARTIAL_ARTS` | `GENERIC` | `BOXING` |

- Only `CYCLING_INDOOR` was mapped to `INDOOR_CYCLING`; Polar actually emits `INDOOR_CYCLING`, so indoor rides were landing on plain `CYCLING`.
- `jump rope -> CARDIO_TRAINING` and `kickboxing -> BOXING` match the convention already used by every other provider (`apple_sdk`, `apple_xml`, `garmin`, `oura`, `suunto`, `whoop`).

All three `detailed_sport_info` strings are taken verbatim from live AccessLink responses, not guessed.

## Test plan

- [x] Added `TestGetUnifiedWorkoutType::test_mappings` covering the three values.
- [x] Existing mappings unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved workout classification for Polar imports by recognizing indoor cycling, jump rope, and kickboxing activities.
* **Tests**
  * Added unit tests to ensure these Polar activity variants map to the correct unified workout types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->