### PR TITLE
fix: convert walking units from healthkit

### DIFF
--- a/backend/app/services/apple/healthkit/import_service.py
+++ b/backend/app/services/apple/healthkit/import_service.py
@@ -110,6 +110,25 @@ class ImportService:
 
             yield record, detail, time_series_samples
 
+    def _normalize_unit(self, series_type: SeriesType, value: Decimal, provider: str | None = None) -> Decimal:
+        match series_type:
+            # meters → cm
+            case SeriesType.height | SeriesType.walking_step_length:
+                return value * 100
+            # 0-1 fraction → percent (body_fat only for Apple; Health Connect already reports percent)
+            case SeriesType.body_fat_percentage if provider == "apple":
+                return value * 100
+            # HealthKit walking metrics returned as 0-1 fraction, DB stores percent
+            # apple-only metrics, so no need to check if provider is apple
+            case (
+                SeriesType.walking_double_support_percentage
+                | SeriesType.walking_asymmetry_percentage
+                | SeriesType.walking_steadiness
+            ):
+                return value * 100
+            case _:
+                return value
+
     def _build_statistic_bundles(
         self,
         request: SDKSyncRequest,
@@ -163,25 +182,6 @@ class ImportService:
         max_v = max(values)
         avg_v = sum(values, Decimal("0")) / Decimal(len(values))
         return min_v, max_v, avg_v
-
-    def _normalize_unit(self, series_type: SeriesType, value: Decimal, provider: str | None = None) -> Decimal:
-        match series_type:
-            # meters → cm
-            case SeriesType.height | SeriesType.walking_step_length:
-                return value * 100
-            # 0-1 fraction → percent (body_fat only for Apple; Health Connect already reports percent)
-            case SeriesType.body_fat_percentage if provider == "apple":
-                return value * 100
-            # HealthKit walking metrics returned as 0-1 fraction, DB stores percent
-            # apple-only metrics, so no need to check if provider is apple
-            case (
-                SeriesType.walking_double_support_percentage
-                | SeriesType.walking_asymmetry_percentage
-                | SeriesType.walking_steadiness
-            ):
-                return value * 100
-            case _:
-                return value
 
     def _extract_metrics_from_workout_stats(
         self,

--- a/backend/app/services/apple/healthkit/import_service.py
+++ b/backend/app/services/apple/healthkit/import_service.py
@@ -127,15 +127,7 @@ class ImportService:
 
             if not series_type:
                 continue
-            # Convert meters -> centimeters for height (both HealthKit and Health Connect report meters)
-            # and ratio (0..1) -> percent for Apple body_fat_percentage (HealthKit HKUnit.percent()).
-            # Android Health Connect's BodyFatRecord.percentage is already in percent, so only scale
-            # body_fat_percentage for provider == "apple" — otherwise Google/Samsung values are stored
-            # ~100x too large.
-            if series_type == SeriesType.height or (
-                series_type == SeriesType.body_fat_percentage and provider == "apple"
-            ):
-                value = value * 100
+            value = self._normalize_unit(series_type, value, provider)
 
             # Extract device info
             device_model, software_version, original_source_name = extract_device_info(rjson.source)
@@ -172,6 +164,25 @@ class ImportService:
         avg_v = sum(values, Decimal("0")) / Decimal(len(values))
         return min_v, max_v, avg_v
 
+    def _normalize_unit(self, series_type: SeriesType, value: Decimal, provider: str | None = None) -> Decimal:
+        match series_type:
+            # meters → cm
+            case SeriesType.height | SeriesType.walking_step_length:
+                return value * 100
+            # 0-1 fraction → percent (body_fat only for Apple; Health Connect already reports percent)
+            case SeriesType.body_fat_percentage if provider == "apple":
+                return value * 100
+            # HealthKit walking metrics returned as 0-1 fraction, DB stores percent
+            # apple-only metrics, so no need to check if provider is apple
+            case (
+                SeriesType.walking_double_support_percentage
+                | SeriesType.walking_asymmetry_percentage
+                | SeriesType.walking_steadiness
+            ):
+                return value * 100
+            case _:
+                return value
+
     def _extract_metrics_from_workout_stats(
         self,
         stats: list[WorkoutStatistic] | None,
@@ -199,46 +210,43 @@ class ImportService:
             if value is None or stat.type is None:
                 continue
 
-            # series type conversion only happens for metrics that are not in EventRecordMetrics
             series_type = get_series_type_from_workout_statistic_type(stat.type)
-
             if series_type:
-                sample = TimeSeriesSampleCreate(
-                    id=uuid4(),
-                    external_id=None,
-                    user_id=user_uuid,
-                    source=source_name,
-                    device_model=device_model,
-                    software_version=software_version,
-                    provider=provider,
-                    recorded_at=end_date,
-                    zone_offset=zone_offset,
-                    value=value,
-                    series_type=series_type,
+                time_series_samples.append(
+                    TimeSeriesSampleCreate(
+                        id=uuid4(),
+                        external_id=None,
+                        user_id=user_uuid,
+                        source=source_name,
+                        device_model=device_model,
+                        software_version=software_version,
+                        provider=provider,
+                        recorded_at=end_date,
+                        zone_offset=zone_offset,
+                        value=value,
+                        series_type=series_type,
+                    )
                 )
-                time_series_samples.append(sample)
                 continue
 
-            # duration is not a part of EventRecordMetrics, however it is sent as a workout statistic
-            if stat.type in (WorkoutStatisticType.DURATION, WorkoutStatisticType.TOTAL_DURATION):
-                duration = float(value) / 1000 if stat.unit == "ms" else float(value)
-                continue
-
-            if stat.type in (
-                WorkoutStatisticType.ACTIVE_ENERGY_BURNED,
-                WorkoutStatisticType.BASAL_ENERGY_BURNED,
-                WorkoutStatisticType.CALORIES,
-                WorkoutStatisticType.TOTAL_CALORIES,
-            ):
-                stats_dict["energy_burned"] += value
-                continue
-
-            detail_field = get_detail_field_from_workout_statistic_type(stat.type)
-            if detail_field:
-                # Apple SDK may send fractional Decimals for integer fields (e.g. stepCount)
-                if detail_field in ("steps_count", "moving_time_seconds"):
-                    value = int(value)
-                stats_dict[detail_field] = value
+            match stat.type:
+                # duration is sent as a workout statistic but stored separately
+                case WorkoutStatisticType.DURATION | WorkoutStatisticType.TOTAL_DURATION:
+                    duration = float(value) / 1000 if stat.unit == "ms" else float(value)
+                case (
+                    WorkoutStatisticType.ACTIVE_ENERGY_BURNED
+                    | WorkoutStatisticType.BASAL_ENERGY_BURNED
+                    | WorkoutStatisticType.CALORIES
+                    | WorkoutStatisticType.TOTAL_CALORIES
+                ):
+                    stats_dict["energy_burned"] += value
+                case _:
+                    detail_field = get_detail_field_from_workout_statistic_type(stat.type)
+                    if detail_field:
+                        # Apple SDK may send fractional Decimals for integer fields (e.g. stepCount)
+                        if detail_field in ("steps_count", "moving_time_seconds"):
+                            value = int(value)
+                        stats_dict[detail_field] = value
 
         return EventRecordMetrics(**stats_dict), time_series_samples, duration
 

--- a/backend/scripts/data_migrations/normalize_apple_walking_metrics.py
+++ b/backend/scripts/data_migrations/normalize_apple_walking_metrics.py
@@ -42,7 +42,9 @@ def _count_query(value_filter: str) -> TextClause:
         SELECT COUNT(*)
         FROM data_point_series dps
         JOIN series_type_definition std ON std.id = dps.series_type_definition_id
+        JOIN data_source ds ON ds.id = dps.data_source_id
         WHERE std.code = :code
+          AND ds.provider = 'apple'
           AND {value_filter}
     """)  # noqa: S608
 
@@ -54,6 +56,7 @@ def _sample_query(value_filter: str) -> TextClause:
         JOIN series_type_definition std ON std.id = dps.series_type_definition_id
         JOIN data_source ds ON ds.id = dps.data_source_id
         WHERE std.code = :code
+          AND ds.provider = 'apple'
           AND {value_filter}
         ORDER BY dps.recorded_at DESC
         LIMIT 10
@@ -64,9 +67,11 @@ def _update_query(value_filter: str) -> TextClause:
     return text(f"""
         UPDATE data_point_series dps
         SET value = dps.value * 100
-        FROM series_type_definition std
+        FROM series_type_definition std, data_source ds
         WHERE std.id = dps.series_type_definition_id
+          AND ds.id = dps.data_source_id
           AND std.code = :code
+          AND ds.provider = 'apple'
           AND {value_filter}
     """)  # noqa: S608
 

--- a/backend/scripts/data_migrations/normalize_apple_walking_metrics.py
+++ b/backend/scripts/data_migrations/normalize_apple_walking_metrics.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Fix Apple HealthKit walking metrics stored in wrong units.
+
+HealthKit returns walking percentages as a 0-1 fraction (using HKUnit.percent())
+and walking_step_length in meters, but the DB unit column says "percent" / "cm".
+This script multiplies all affected values by 100 to correct the stored data.
+
+Affected series types:
+  - walking_double_support_percentage  (issue #1105)
+  - walking_asymmetry_percentage
+  - walking_steadiness
+  - walking_step_length                (issue #1106)
+
+The filter on each UPDATE is intentionally narrow so the script is safe to re-run
+after the ingestion fix is deployed (new rows will already be in the correct range).
+
+Usage (inside Docker):
+    docker compose exec app uv run python scripts/data_migrations/normalize_apple_walking_metrics.py --dry-run
+    docker compose exec app uv run python scripts/data_migrations/normalize_apple_walking_metrics.py
+"""
+
+import argparse
+
+from sqlalchemy import TextClause, text
+
+from app.database import SessionLocal
+
+# (series_type_code, value_filter, description)
+# value_filter keeps the UPDATE idempotent once the ingestion fix is live:
+#   - fractions are < 1; corrected percent values are 0–100
+#   - meters are < 10; corrected cm values are 30–150
+MIGRATIONS = [
+    ("walking_double_support_percentage", "dps.value < 1", "0-1 fraction → percent"),
+    ("walking_asymmetry_percentage", "dps.value < 1", "0-1 fraction → percent"),
+    ("walking_steadiness", "dps.value < 1", "0-1 fraction → percent"),
+    ("walking_step_length", "dps.value < 10", "meters → cm"),
+]
+
+
+def _count_query(value_filter: str) -> TextClause:
+    return text(f"""
+        SELECT COUNT(*)
+        FROM data_point_series dps
+        JOIN series_type_definition std ON std.id = dps.series_type_definition_id
+        WHERE std.code = :code
+          AND {value_filter}
+    """)  # noqa: S608
+
+
+def _sample_query(value_filter: str) -> TextClause:
+    return text(f"""
+        SELECT dps.id, dps.value, dps.value * 100 AS corrected, ds.provider, dps.recorded_at
+        FROM data_point_series dps
+        JOIN series_type_definition std ON std.id = dps.series_type_definition_id
+        JOIN data_source ds ON ds.id = dps.data_source_id
+        WHERE std.code = :code
+          AND {value_filter}
+        ORDER BY dps.recorded_at DESC
+        LIMIT 10
+    """)  # noqa: S608
+
+
+def _update_query(value_filter: str) -> TextClause:
+    return text(f"""
+        UPDATE data_point_series dps
+        SET value = dps.value * 100
+        FROM series_type_definition std
+        WHERE std.id = dps.series_type_definition_id
+          AND std.code = :code
+          AND {value_filter}
+    """)  # noqa: S608
+
+
+def main(dry_run: bool) -> None:
+    with SessionLocal() as db:
+        any_affected = False
+
+        for code, value_filter, description in MIGRATIONS:
+            count = db.execute(_count_query(value_filter), {"code": code}).scalar()
+            if count == 0:
+                print(f"{code}: no affected rows — skipping.")
+                continue
+
+            any_affected = True
+            print(f"\n{code} ({description}): {count} row(s) to fix")
+
+            rows = db.execute(_sample_query(value_filter), {"code": code}).fetchall()
+            print(f"  {'ID':<38} {'Provider':<12} {'Current':>10} {'Corrected':>10}  Recorded at")
+            print("  " + "-" * 90)
+            for row in rows:
+                print(
+                    f"  {row.id!s:<38} {row.provider:<12} {row.value:>10.4f} {row.corrected:>10.4f}  {row.recorded_at}"
+                )
+            if count > 10:
+                print(f"  ... and {count - 10} more")
+
+            if not dry_run:
+                result = db.execute(_update_query(value_filter), {"code": code})
+                print(f"  Updated {result.rowcount} row(s).")
+
+        if not any_affected:
+            print("No affected rows across all metrics — nothing to do.")
+            return
+
+        if dry_run:
+            print("\nDry run — no changes made.")
+            return
+
+        db.commit()
+        print("\nAll updates committed.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Preview affected rows without updating")
+    args = parser.parse_args()
+    main(dry_run=args.dry_run)

--- a/backend/scripts/start/app.sh
+++ b/backend/scripts/start/app.sh
@@ -49,6 +49,12 @@ echo 'Running workout heart_rate_min cleanup...'
 uv run python scripts/data_migrations/null_bogus_workout_heart_rate_min.py \
     || echo "Warning: workout heart_rate_min cleanup failed - will retry on next startup."
 
+# TODO: Remove this after ~2026-08-01 once all deployments have migrated.
+# Multiplies Apple HealthKit walking metrics stored as fractions/meters (issues #1105, #1106); no-op if already corrected.
+echo 'Running Apple walking metrics normalization...'
+uv run python scripts/data_migrations/normalize_apple_walking_metrics.py \
+    || echo "Warning: Apple walking metrics normalization failed — will retry on next startup."
+
 # Initialize archival settings
 echo 'Initializing archival settings...'
 uv run python scripts/init/seed_archival_settings.py


### PR DESCRIPTION
## Description

- walking_double_support_percentage stored as fraction but unit says percent
- walking_step_length values in meters but unit says cm
- asymmetry percentage too

Resolves #1105 
Resolves #1106

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Apple Health data import to apply consistent unit normalization for metric values (including height, walking step length, and percentage-style walking stats).
* **Bug Fixes / Data Migration**
  * Added a safe, idempotent migration to correct previously mis-normalized Apple walking metrics (fractions→percent and meters→cm), with dry-run support.
* **Chore**
  * Updated backend startup to run the walking-metrics normalization step as a non-fatal action, helping bring existing data into line sooner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->