### PR TITLE
docs: update resilience score

### DIFF
--- a/docs/scores/resilience-score.mdx
+++ b/docs/scores/resilience-score.mdx
@@ -7,7 +7,7 @@ description: A HRV-CV computed by Open Wearables that measures the stability of 
 
 The Resilience Score is an **Open Wearables native score** that measures how stable a user's heart rate variability (HRV) is. It is computed from raw overnight biometric data - not sourced from or influenced by any manufacturer's proprietary score.
 
-HRV-CV during sleep is an established marker of autonomic nervous system resilience: the more stable the overnight HRV, the better the body is recovering and adapting to physiological stress.
+HRV-CV during sleep is an established marker of autonomic nervous system resilience: the more stable the overnight HRV, the better the body is recovering and adapting to physiological stress [1].
 
 | Property   | Value                                                     |
 |------------|-----------------------------------------------------------|
@@ -24,11 +24,12 @@ HRV-CV during sleep is an established marker of autonomic nervous system resilie
 ### Data syncing
 
 - The user must have at least one connected provider that syncs **heart rate data** and **sleep data**.
+- The device must support RMSSD as HRV metric.
 - The device must be **worn during sleep** - overnight HR samples outside of detected sleep windows are excluded from the calculation.
 
 ### Minimum data threshold
 
-A Resilience Score is only computed when there is sufficient data to produce a statistically meaningful result:
+A Resilience Score is only computed when there is sufficient data to produce a meaningful result:
 
 | Requirement                  | Value    |
 |------------------------------|----------|
@@ -42,11 +43,11 @@ If fewer than 5 of the 7 nights have valid overnight HRV recordings, the score i
 
 ## How It Works
 
-### HRV metric selection
+### HRV metric
 
-The score prefers **RMSSD** (Root Mean Square of Successive Differences) as the HRV metric, since it is the most widely available measure of short-term HRV and is reported by most consumer wearables. If no RMSSD data survives the sleep-window filter, the algorithm automatically falls back to **SDNN** (Standard Deviation of Normal-to-Normal intervals).
+The score uses **RMSSD** (Root Mean Square of Successive Differences) as the HRV metric - the most widely available measure of short-term HRV, reported by most consumer wearables. If no RMSSD data survives the sleep-window filter, the score cannot be computed. 
 
-The metric type used (RMSSD or SDNN) is returned in the score response so it can be surfaced in the UI where appropriate.
+The metric type used (RMSSD) is returned in the score response so it can be surfaced in the UI where appropriate.
 
 ### Sleep-window filtering
 
@@ -91,3 +92,5 @@ Each score response includes a day-by-day breakdown of overnight HRV values for 
 ```
 
 Days where the device was not worn during sleep or where insufficient samples were recorded will have `has_data: false`.
+
+[1] Grosicki GJ, Carter JR, Laursen PB, et al. Heart rate variability coefficient of variation during sleep as a digital biomarker that reflects behavior and varies by age and sex. Am J Physiol Heart Circ Physiol. 2026;330(1):H187-H199. doi:10.1152/ajpheart.00738.2025


### PR DESCRIPTION
## Summary

- Removes SDNN fallback — score now requires RMSSD, returns null if unavailable
- Adds device requirement: must support RMSSD as HRV metric
- Minor wording tightening ("statistically meaningful" -> "meaningful", section rename)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the Resilience Score guidance for sleep-based HRV-CV, including an updated footnote reference.
  * Updated the minimum data threshold requirements to explicitly call out RMSSD support and the overnight sleep-window constraint.
  * Refined the HRV metric description to focus on RMSSD and removed the previously stated fallback behavior.
  * Added the corresponding reference entry for the new footnote.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->