### PR TITLE
feat: auto-deploy ow-poc to fly on merge to main, gated on checks

### DIFF
--- a/.github/workflows/fly_deploy.yml
+++ b/.github/workflows/fly_deploy.yml
@@ -1,0 +1,75 @@
+name: Fly Deploy (ow-poc)
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+jobs:
+  gate:
+    name: Wait for all checks to pass
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      checks: read
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RUN_ID: ${{ job.check_run_id }}
+        with:
+          # wait for every check from OTHER workflows on this commit to
+          # succeed or skip before allowing the deploy to proceed. Checks in
+          # our own workflow run (gate/deploy) are excluded by check-suite id
+          # — they are downstream of this job and would otherwise deadlock
+          # the wait.
+          script: |
+            core.info('failed/completed/total:');
+            const runId = parseInt(process.env.RUN_ID);
+            while (true) {
+                const ref = context.sha;
+                const jobs = await github.paginate(
+                    github.rest.checks.listForRef,
+                    { ...context.repo, ref, per_page: 100 }
+                );
+                const thisRun = jobs.filter(j => j.id === runId);
+                if (thisRun.length !== 1) {
+                    const jobsJSON = JSON.stringify(jobs);
+                    core.info(`No match for ${runId} in ${jobsJSON}`);
+                    core.setFailed(`runId lookup failed`);
+                    break;
+                }
+                const suiteId = thisRun[0].check_suite.id;
+                const others = jobs.filter(j => j.check_suite.id !== suiteId);
+
+                const completed = others.filter(j => j.status === 'completed');
+                const failed = completed.filter(j => j.conclusion !== 'success' && j.conclusion !== 'skipped');
+                core.info(`${failed.length}/${completed.length}/${others.length}`)
+
+                if (failed.length) {
+                    for(var j of failed) {
+                        core.setFailed(`${j.name} ${j.conclusion}: ${j.html_url}`);
+                    }
+                    break;
+                } else if (completed.length == others.length) {
+                    break;
+                }
+                await new Promise((r) => setTimeout(r, 5 * 1000));
+            }
+
+  deploy:
+    name: ow-poc app
+    needs: gate
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # 1.6
+    - name: Deploy
+      working-directory: backend
+      run: flyctl deploy -a ow-poc --remote-only

--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ CLAUDE.local.md
 
 # Exception: AI tool configs that should be tracked
 !.gemini/settings.json
+
+# Local planning docs / issue drafts (never committed)
+docs/specs/

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -1,0 +1,43 @@
+# Fly.io app for Open Wearables (TCP fork)
+# Deploy from this directory: cd backend && flyctl deploy
+
+app = "ow-poc"
+primary_region = "ewr"
+
+[build]
+  dockerfile = "Dockerfile"
+
+# Three process types share the same image, each runs a different start script.
+# Fly creates one machine per process type by default.
+[processes]
+  app = "bash scripts/start/app.sh"
+  worker = "bash scripts/start/worker.sh"
+  beat = "bash scripts/start/beat.sh"
+
+# Only the `app` process accepts inbound HTTPS.
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [[http_service.checks]]
+    interval = "15s"
+    timeout = "5s"
+    grace_period = "30s"
+    method = "GET"
+    path = "/"
+
+# VM sizing for the API process (larger because it serves requests).
+[[vm]]
+  size = "shared-cpu-2x"
+  memory = "1024mb"
+  processes = ["app"]
+
+# Smaller VMs for background processes.
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+  processes = ["worker", "beat"]


### PR DESCRIPTION
Commit the fly.toml that defined the manual May 27 deploy and add a gated CI deploy job so ow-poc.fly.dev stays in lockstep with main.

Closes jupyterhealth/jupyterhealth-exchange#504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established continuous deployment workflow for backend service with automatic validation before deployment
  * Configured deployment platform with health checks, multi-process support, and regional infrastructure setup
  * Updated repository ignore patterns to properly track configuration settings while excluding local planning documents

<!-- end of auto-generated comment: release notes by coderabbit.ai -->