### PR TITLE
feat(backend): Garmin support for workout segments (laps, swim lengths etc)

### DIFF
--- a/backend/app/repositories/event_record_detail_repository.py
+++ b/backend/app/repositories/event_record_detail_repository.py
@@ -1,7 +1,7 @@
-from typing import Literal, cast
+from typing import Any, Literal, cast
 from uuid import UUID
 
-from sqlalchemy import Table
+from sqlalchemy import Table, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
 
@@ -155,3 +155,16 @@ class EventRecordDetailRepository(
         if detail is not None:
             db_session.delete(detail)
             db_session.flush()
+
+    def update_workout_fields(
+        self,
+        db_session: DbSession,
+        record_id: UUID,
+        fields: dict[str, Any],
+    ) -> None:
+        """Patch one or more columns on the workout_details row for the given record.
+
+        Intended for JSONB fields (segments, hr_zones, power_zones) that are
+        written separately from the initial bulk insert.
+        """
+        db_session.execute(update(WorkoutDetails).where(WorkoutDetails.record_id == record_id).values(**fields))

--- a/backend/app/repositories/event_record_detail_repository.py
+++ b/backend/app/repositories/event_record_detail_repository.py
@@ -166,5 +166,6 @@ class EventRecordDetailRepository(
 
         Intended for JSONB fields (segments, hr_zones, power_zones) that are
         written separately from the initial bulk insert.
+        NOTE: Caller is responsible for committing or flushing the transaction.
         """
         db_session.execute(update(WorkoutDetails).where(WorkoutDetails.record_id == record_id).values(**fields))

--- a/backend/app/schemas/model_crud/activities/event_record_detail.py
+++ b/backend/app/schemas/model_crud/activities/event_record_detail.py
@@ -42,6 +42,8 @@ class EventRecordDetailBase(BaseModel):
 
     sleep_stages: list[SleepStage] | None = None
 
+    segments: list[dict] | None = None
+
 
 class EventRecordDetailCreate(EventRecordDetailBase):
     """Schema for creating an event record detail entry."""

--- a/backend/app/services/fit_parser.py
+++ b/backend/app/services/fit_parser.py
@@ -80,7 +80,7 @@ def parse_fit_file(
 ) -> FitParseResult:
     result = FitParseResult()
     dev_fields_seen: set[str] = set()
-    lap_index = split_index = length_index = 0
+    _seg_counters: dict[str, int] = {k: 0 for k in _SEGMENT_KINDS}
 
     with fitdecode.FitReader(io.BytesIO(data)) as fit:
         for frame in fit:
@@ -109,23 +109,13 @@ def parse_fit_file(
                             )
                         )
 
-            elif frame.name == "lap":
-                seg = _extract_lap(frame, lap_index)
+            elif frame.name in _SEGMENT_KINDS:
+                numeric, enums = _SEGMENT_KINDS[frame.name]
+                idx = _seg_counters[frame.name]
+                seg = _extract_segment(frame, frame.name, idx, numeric, enums)
                 if seg.get("elapsed_seconds") is not None:
                     result.segments.append(seg)
-                lap_index += 1
-
-            elif frame.name == "split":
-                seg = _extract_split(frame, split_index)
-                if seg.get("elapsed_seconds") is not None:
-                    result.segments.append(seg)
-                split_index += 1
-
-            elif frame.name == "length":
-                seg = _extract_length(frame, length_index)
-                if seg.get("elapsed_seconds") is not None:
-                    result.segments.append(seg)
-                length_index += 1
+                _seg_counters[frame.name] = idx + 1
 
     result.developer_fields_found = sorted(dev_fields_seen)
     logger.debug(
@@ -141,11 +131,58 @@ def parse_fit_file(
 # Segment extraction helpers
 # ---------------------------------------------------------------------------
 
+# Field specs for each segment kind:
+#   numeric: (fit_field_name, output_key, scale) — scale applied before rounding
+#   enums:   (fit_field_name, output_key)        — stored as str()
+
+_LAP_NUMERIC: tuple[tuple[str, str, float], ...] = (
+    ("total_distance", "distance_meters", 1.0),
+    ("avg_heart_rate", "avg_heart_rate", 1.0),
+    ("max_heart_rate", "max_heart_rate", 1.0),
+    ("avg_speed", "avg_speed", 1.0),
+    ("max_speed", "max_speed", 1.0),
+    ("avg_power", "avg_power", 1.0),
+    ("max_power", "max_power", 1.0),
+    ("normalized_power", "normalized_power", 1.0),
+    ("avg_cadence", "avg_cadence", 1.0),
+    ("total_strides", "total_strides", 1.0),
+    ("total_ascent", "total_ascent", 1.0),
+    ("total_descent", "total_descent", 1.0),
+    # FIT stores in mm; output in cm
+    ("avg_vertical_oscillation", "avg_vertical_oscillation", 0.1),
+    ("avg_step_length", "avg_step_length", 0.1),
+    # fitdecode auto-applies scale=100; value already in %
+    ("avg_vertical_ratio", "avg_vertical_ratio", 1.0),
+    ("avg_stance_time", "avg_stance_time", 1.0),
+    ("avg_stance_time_balance", "avg_stance_time_balance", 1.0),
+)
+
+_SPLIT_NUMERIC: tuple[tuple[str, str, float], ...] = (
+    ("total_distance", "distance_meters", 1.0),
+    ("avg_speed", "avg_speed", 1.0),
+)
+_SPLIT_ENUMS: tuple[tuple[str, str], ...] = (("split_type", "split_type"),)
+
+_LENGTH_NUMERIC: tuple[tuple[str, str, float], ...] = (
+    ("total_strokes", "total_strokes", 1.0),
+    ("avg_speed", "avg_speed", 1.0),
+)
+_LENGTH_ENUMS: tuple[tuple[str, str], ...] = (
+    ("swim_stroke", "swim_stroke"),
+    ("length_type", "length_type"),
+)
+
+# Dispatch map: frame.name → (numeric_fields, enum_fields)
+_SEGMENT_KINDS: dict[str, tuple] = {
+    "lap": (_LAP_NUMERIC, ()),
+    "split": (_SPLIT_NUMERIC, _SPLIT_ENUMS),
+    "length": (_LENGTH_NUMERIC, _LENGTH_ENUMS),
+}
+
 
 def _field_val(frame: fitdecode.FitDataMessage, name: str) -> Any:
     try:
-        v = frame.get_value(name)
-        return v if v is not None else None
+        return frame.get_value(name)
     except KeyError:
         return None
 
@@ -166,71 +203,27 @@ def _iso(v: Any) -> str | None:
     return ts.isoformat()
 
 
-def _copy(seg: dict, frame: fitdecode.FitDataMessage, fit_name: str, out_name: str, scale: float = 1.0) -> None:
-    v = _field_val(frame, fit_name)
-    if v is not None:
-        seg[out_name] = _r2(float(v) * scale)
-
-
-def _extract_lap(frame: fitdecode.FitDataMessage, index: int) -> dict:
+def _extract_segment(
+    frame: fitdecode.FitDataMessage,
+    kind: str,
+    index: int,
+    numeric: tuple[tuple[str, str, float], ...],
+    enums: tuple[tuple[str, str], ...] = (),
+) -> dict:
     seg: dict = {
-        "kind": "lap",
+        "kind": kind,
         "index": index,
         "start_time": _iso(_field_val(frame, "start_time")),
         "elapsed_seconds": _r2(_field_val(frame, "total_elapsed_time")),
     }
-    _copy(seg, frame, "total_distance", "distance_meters")
-    _copy(seg, frame, "avg_heart_rate", "avg_heart_rate")
-    _copy(seg, frame, "max_heart_rate", "max_heart_rate")
-    _copy(seg, frame, "avg_speed", "avg_speed")
-    _copy(seg, frame, "max_speed", "max_speed")
-    _copy(seg, frame, "avg_power", "avg_power")
-    _copy(seg, frame, "max_power", "max_power")
-    _copy(seg, frame, "normalized_power", "normalized_power")
-    _copy(seg, frame, "avg_cadence", "avg_cadence")
-    _copy(seg, frame, "total_strides", "total_strides")
-    _copy(seg, frame, "total_ascent", "total_ascent")
-    _copy(seg, frame, "total_descent", "total_descent")
-    # FIT stores these in mm; store as cm
-    _copy(seg, frame, "avg_vertical_oscillation", "avg_vertical_oscillation", 0.1)
-    _copy(seg, frame, "avg_step_length", "avg_step_length", 0.1)
-    # fitdecode auto-applies scale for these (already in %)
-    _copy(seg, frame, "avg_vertical_ratio", "avg_vertical_ratio")
-    _copy(seg, frame, "avg_stance_time", "avg_stance_time")
-    _copy(seg, frame, "avg_stance_time_balance", "avg_stance_time_balance")
-    return {k: v for k, v in seg.items() if v is not None}
-
-
-def _extract_split(frame: fitdecode.FitDataMessage, index: int) -> dict:
-    seg: dict = {
-        "kind": "split",
-        "index": index,
-        "start_time": _iso(_field_val(frame, "start_time")),
-        "elapsed_seconds": _r2(_field_val(frame, "total_elapsed_time")),
-    }
-    _copy(seg, frame, "total_distance", "distance_meters")
-    _copy(seg, frame, "avg_speed", "avg_speed")
-    split_type = _field_val(frame, "split_type")
-    if split_type is not None:
-        seg["split_type"] = str(split_type)
-    return {k: v for k, v in seg.items() if v is not None}
-
-
-def _extract_length(frame: fitdecode.FitDataMessage, index: int) -> dict:
-    seg: dict = {
-        "kind": "length",
-        "index": index,
-        "start_time": _iso(_field_val(frame, "start_time")),
-        "elapsed_seconds": _r2(_field_val(frame, "total_elapsed_time")),
-    }
-    _copy(seg, frame, "total_strokes", "total_strokes")
-    _copy(seg, frame, "avg_speed", "avg_speed")
-    swim_stroke = _field_val(frame, "swim_stroke")
-    if swim_stroke is not None:
-        seg["swim_stroke"] = str(swim_stroke)
-    length_type = _field_val(frame, "length_type")
-    if length_type is not None:
-        seg["length_type"] = str(length_type)
+    for fit_name, out_name, scale in numeric:
+        v = _field_val(frame, fit_name)
+        if v is not None:
+            seg[out_name] = _r2(v * scale)
+    for fit_name, out_name in enums:
+        v = _field_val(frame, fit_name)
+        if v is not None:
+            seg[out_name] = str(v)
     return {k: v for k, v in seg.items() if v is not None}
 
 

--- a/backend/app/services/fit_parser.py
+++ b/backend/app/services/fit_parser.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
+from typing import Any
 from uuid import UUID, uuid4
 
 import fitdecode
@@ -21,8 +22,6 @@ logger = logging.getLogger(__name__)
 # fit_fields is ordered: first field present in the record message wins.
 # This lets us prefer enhanced_* variants (FIT 2.0 float) over their uint16
 # base equivalents without duplicating logic in the parser.
-#
-# GPS and environmental fields are commented out pending series type seeds (#1074).
 # ---------------------------------------------------------------------------
 
 _SEMICIRCLES_TO_DEGREES: float = 180.0 / (2**31)
@@ -69,7 +68,7 @@ _RECORD_FIELD_MAP: tuple[_FieldMapping, ...] = (
 @dataclass
 class FitParseResult:
     samples: list[TimeSeriesSampleCreate] = field(default_factory=list)
-    workout_steps: list[dict] = field(default_factory=list)  # pending #1076
+    segments: list[dict] = field(default_factory=list)
     developer_fields_found: list[str] = field(default_factory=list)
 
 
@@ -81,38 +80,163 @@ def parse_fit_file(
 ) -> FitParseResult:
     result = FitParseResult()
     dev_fields_seen: set[str] = set()
+    lap_index = split_index = length_index = 0
 
     with fitdecode.FitReader(io.BytesIO(data)) as fit:
         for frame in fit:
-            if not isinstance(frame, fitdecode.FitDataMessage) or frame.name != "record":
+            if not isinstance(frame, fitdecode.FitDataMessage):
                 continue
 
-            ts = _timestamp(frame)
-            if ts is None:
-                continue
-
-            for f in frame.fields:
-                if f.field is None and f.name not in (None, "unknown"):
-                    dev_fields_seen.add(str(f.name))
-
-            for mapping in _RECORD_FIELD_MAP:
-                if (value := _extract(frame, mapping)) is not None:
-                    result.samples.append(
-                        TimeSeriesSampleCreate(
-                            id=uuid4(),
-                            user_id=user_id,
-                            data_source_id=data_source_id,
-                            source=source,
-                            recorded_at=ts,
-                            zone_offset=None,
-                            value=value,
-                            series_type=mapping.series_type,
+            if frame.name == "record":
+                ts = _timestamp(frame)
+                if ts is None:
+                    continue
+                for f in frame.fields:
+                    if f.field is None and f.name not in (None, "unknown"):
+                        dev_fields_seen.add(str(f.name))
+                for mapping in _RECORD_FIELD_MAP:
+                    if (value := _extract(frame, mapping)) is not None:
+                        result.samples.append(
+                            TimeSeriesSampleCreate(
+                                id=uuid4(),
+                                user_id=user_id,
+                                data_source_id=data_source_id,
+                                source=source,
+                                recorded_at=ts,
+                                zone_offset=None,
+                                value=value,
+                                series_type=mapping.series_type,
+                            )
                         )
-                    )
+
+            elif frame.name == "lap":
+                seg = _extract_lap(frame, lap_index)
+                if seg.get("elapsed_seconds") is not None:
+                    result.segments.append(seg)
+                lap_index += 1
+
+            elif frame.name == "split":
+                seg = _extract_split(frame, split_index)
+                if seg.get("elapsed_seconds") is not None:
+                    result.segments.append(seg)
+                split_index += 1
+
+            elif frame.name == "length":
+                seg = _extract_length(frame, length_index)
+                if seg.get("elapsed_seconds") is not None:
+                    result.segments.append(seg)
+                length_index += 1
 
     result.developer_fields_found = sorted(dev_fields_seen)
-    logger.debug("FIT parsed: %d samples, dev_fields=%s", len(result.samples), result.developer_fields_found or "none")
+    logger.debug(
+        "FIT parsed: %d samples, %d segments, dev_fields=%s",
+        len(result.samples),
+        len(result.segments),
+        result.developer_fields_found or "none",
+    )
     return result
+
+
+# ---------------------------------------------------------------------------
+# Segment extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _field_val(frame: fitdecode.FitDataMessage, name: str) -> Any:
+    try:
+        v = frame.get_value(name)
+        return v if v is not None else None
+    except KeyError:
+        return None
+
+
+def _r2(v: Any) -> float | None:
+    if v is None:
+        return None
+    try:
+        return round(float(v), 2)
+    except (TypeError, ValueError):
+        return None
+
+
+def _iso(v: Any) -> str | None:
+    if not isinstance(v, datetime):
+        return None
+    ts = v if v.tzinfo else v.replace(tzinfo=timezone.utc)
+    return ts.isoformat()
+
+
+def _copy(seg: dict, frame: fitdecode.FitDataMessage, fit_name: str, out_name: str, scale: float = 1.0) -> None:
+    v = _field_val(frame, fit_name)
+    if v is not None:
+        seg[out_name] = _r2(float(v) * scale)
+
+
+def _extract_lap(frame: fitdecode.FitDataMessage, index: int) -> dict:
+    seg: dict = {
+        "kind": "lap",
+        "index": index,
+        "start_time": _iso(_field_val(frame, "start_time")),
+        "elapsed_seconds": _r2(_field_val(frame, "total_elapsed_time")),
+    }
+    _copy(seg, frame, "total_distance", "distance_meters")
+    _copy(seg, frame, "avg_heart_rate", "avg_heart_rate")
+    _copy(seg, frame, "max_heart_rate", "max_heart_rate")
+    _copy(seg, frame, "avg_speed", "avg_speed")
+    _copy(seg, frame, "max_speed", "max_speed")
+    _copy(seg, frame, "avg_power", "avg_power")
+    _copy(seg, frame, "max_power", "max_power")
+    _copy(seg, frame, "normalized_power", "normalized_power")
+    _copy(seg, frame, "avg_cadence", "avg_cadence")
+    _copy(seg, frame, "total_strides", "total_strides")
+    _copy(seg, frame, "total_ascent", "total_ascent")
+    _copy(seg, frame, "total_descent", "total_descent")
+    # FIT stores these in mm; store as cm
+    _copy(seg, frame, "avg_vertical_oscillation", "avg_vertical_oscillation", 0.1)
+    _copy(seg, frame, "avg_step_length", "avg_step_length", 0.1)
+    # fitdecode auto-applies scale for these (already in %)
+    _copy(seg, frame, "avg_vertical_ratio", "avg_vertical_ratio")
+    _copy(seg, frame, "avg_stance_time", "avg_stance_time")
+    _copy(seg, frame, "avg_stance_time_balance", "avg_stance_time_balance")
+    return {k: v for k, v in seg.items() if v is not None}
+
+
+def _extract_split(frame: fitdecode.FitDataMessage, index: int) -> dict:
+    seg: dict = {
+        "kind": "split",
+        "index": index,
+        "start_time": _iso(_field_val(frame, "start_time")),
+        "elapsed_seconds": _r2(_field_val(frame, "total_elapsed_time")),
+    }
+    _copy(seg, frame, "total_distance", "distance_meters")
+    _copy(seg, frame, "avg_speed", "avg_speed")
+    split_type = _field_val(frame, "split_type")
+    if split_type is not None:
+        seg["split_type"] = str(split_type)
+    return {k: v for k, v in seg.items() if v is not None}
+
+
+def _extract_length(frame: fitdecode.FitDataMessage, index: int) -> dict:
+    seg: dict = {
+        "kind": "length",
+        "index": index,
+        "start_time": _iso(_field_val(frame, "start_time")),
+        "elapsed_seconds": _r2(_field_val(frame, "total_elapsed_time")),
+    }
+    _copy(seg, frame, "total_strokes", "total_strokes")
+    _copy(seg, frame, "avg_speed", "avg_speed")
+    swim_stroke = _field_val(frame, "swim_stroke")
+    if swim_stroke is not None:
+        seg["swim_stroke"] = str(swim_stroke)
+    length_type = _field_val(frame, "length_type")
+    if length_type is not None:
+        seg["length_type"] = str(length_type)
+    return {k: v for k, v in seg.items() if v is not None}
+
+
+# ---------------------------------------------------------------------------
+# Record message helpers
+# ---------------------------------------------------------------------------
 
 
 def _timestamp(frame: fitdecode.FitDataMessage) -> datetime | None:

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -9,8 +9,13 @@ from uuid import UUID, uuid4
 from app.config import settings
 from app.constants.sleep import SleepStageType
 from app.database import DbSession
-from app.models import DataPointSeries, EventRecord, WorkoutDetails
-from app.repositories import DataSourceRepository, EventRecordRepository, UserConnectionRepository
+from app.models import DataPointSeries, EventRecord, EventRecordDetail
+from app.repositories import (
+    DataSourceRepository,
+    EventRecordDetailRepository,
+    EventRecordRepository,
+    UserConnectionRepository,
+)
 from app.repositories.data_point_series_repository import DataPointSeriesRepository
 from app.schemas.enums import HealthScoreCategory, ProviderName, SeriesType
 from app.schemas.model_crud.activities import (
@@ -75,6 +80,7 @@ class Garmin247Data(Base247DataTemplate):
     ):
         super().__init__(provider_name, api_base_url, oauth)
         self.event_record_repo = EventRecordRepository(EventRecord)
+        self.event_record_detail_repo = EventRecordDetailRepository(EventRecordDetail)
         self.data_source_repo = DataSourceRepository()
         self.connection_repo = UserConnectionRepository()
         self.data_point_repo = DataPointSeriesRepository(DataPointSeries)
@@ -1745,9 +1751,7 @@ class Garmin247Data(Base247DataTemplate):
                 activity_id=activity_id,
             )
             return
-        db.query(WorkoutDetails).filter(WorkoutDetails.record_id == record.id).update(
-            {"segments": segments}, synchronize_session=False
-        )
+        self.event_record_detail_repo.update_workout_fields(db, record.id, {"segments": segments})
 
     # -------------------------------------------------------------------------
     # Batch Processing (for webhook handlers)
@@ -1853,6 +1857,9 @@ class Garmin247Data(Base247DataTemplate):
                     case "activityFiles":
                         if item.get("fileType") != "FIT":
                             continue
+                        # FIT is always downloaded: segments (laps/splits/lengths) are core
+                        # workout data, like avg_hr or distance, not a feature flag concern.
+                        # activityDetails is also always processed without a flag.
                         callback_url = item.get("callbackURL")
                         if not callback_url:
                             continue
@@ -1899,7 +1906,19 @@ class Garmin247Data(Base247DataTemplate):
                             )
                             continue
                         if fit_result.segments:
-                            self._save_segments(db, user_id, activity_id, fit_result.segments)
+                            try:
+                                self._save_segments(db, user_id, activity_id, fit_result.segments)
+                            except Exception as e:
+                                log_structured(
+                                    self.logger,
+                                    "warning",
+                                    "Failed to save segments",
+                                    provider="garmin",
+                                    task="process_items_batch",
+                                    user_id=str(user_id),
+                                    activity_id=activity_id,
+                                    error=str(e),
+                                )
                         fit_samples: list[TimeSeriesSampleCreate] = []
                         if settings.ingest_workout_samples:
                             fit_samples = [

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -9,7 +9,7 @@ from uuid import UUID, uuid4
 from app.config import settings
 from app.constants.sleep import SleepStageType
 from app.database import DbSession
-from app.models import DataPointSeries, EventRecord
+from app.models import DataPointSeries, EventRecord, WorkoutDetails
 from app.repositories import DataSourceRepository, EventRecordRepository, UserConnectionRepository
 from app.repositories.data_point_series_repository import DataPointSeriesRepository
 from app.schemas.enums import HealthScoreCategory, ProviderName, SeriesType
@@ -1720,6 +1720,35 @@ class Garmin247Data(Base247DataTemplate):
         # TODO: Implement proper MCT storage if needed
         return 0
 
+    def _save_segments(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        activity_id: str,
+        segments: list[dict],
+    ) -> None:
+        """Update workout_details.segments for the event_record matching activity_id.
+
+        No-op if the event_record doesn't exist yet (activityFiles arrived before
+        activityDetails). activityDetails is always processed first within the same
+        webhook because WELLNESS_TYPES orders it before activityFiles.
+        """
+        record = self.event_record_repo.get_by_external_id(db, user_id, activity_id, source=self.provider_name)
+        if record is None:
+            log_structured(
+                self.logger,
+                "warning",
+                "No event_record found for activityFiles — segments not saved",
+                provider="garmin",
+                task="_save_segments",
+                user_id=str(user_id),
+                activity_id=activity_id,
+            )
+            return
+        db.query(WorkoutDetails).filter(WorkoutDetails.record_id == record.id).update(
+            {"segments": segments}, synchronize_session=False
+        )
+
     # -------------------------------------------------------------------------
     # Batch Processing (for webhook handlers)
     # -------------------------------------------------------------------------
@@ -1824,8 +1853,6 @@ class Garmin247Data(Base247DataTemplate):
                     case "activityFiles":
                         if item.get("fileType") != "FIT":
                             continue
-                        if not settings.ingest_workout_samples and not settings.store_fit_files:
-                            continue
                         callback_url = item.get("callbackURL")
                         if not callback_url:
                             continue
@@ -1857,34 +1884,39 @@ class Garmin247Data(Base247DataTemplate):
                             user_id=str(user_id),
                             activity_id=activity_id,
                         )
+                        try:
+                            fit_result = parse_fit_file(fit_bytes, user_id, source=self.provider_name)
+                        except Exception as e:
+                            log_structured(
+                                self.logger,
+                                "warning",
+                                "Failed to parse FIT file",
+                                provider="garmin",
+                                task="process_items_batch",
+                                user_id=str(user_id),
+                                activity_id=activity_id,
+                                error=str(e),
+                            )
+                            continue
+                        if fit_result.segments:
+                            self._save_segments(db, user_id, activity_id, fit_result.segments)
+                        fit_samples: list[TimeSeriesSampleCreate] = []
                         if settings.ingest_workout_samples:
-                            try:
-                                fit_result = parse_fit_file(fit_bytes, user_id, source=self.provider_name)
-                                fit_samples = [
-                                    s for s in fit_result.samples if s.series_type not in _ACTIVITY_DETAILS_SERIES_TYPES
-                                ]
-                                all_samples.extend(fit_samples)
-                                log_structured(
-                                    self.logger,
-                                    "info",
-                                    "Parsed FIT file",
-                                    provider="garmin",
-                                    task="process_items_batch",
-                                    user_id=str(user_id),
-                                    activity_id=activity_id,
-                                    samples=len(fit_samples),
-                                )
-                            except Exception as e:
-                                log_structured(
-                                    self.logger,
-                                    "warning",
-                                    "Failed to parse FIT file",
-                                    provider="garmin",
-                                    task="process_items_batch",
-                                    user_id=str(user_id),
-                                    activity_id=activity_id,
-                                    error=str(e),
-                                )
+                            fit_samples = [
+                                s for s in fit_result.samples if s.series_type not in _ACTIVITY_DETAILS_SERIES_TYPES
+                            ]
+                            all_samples.extend(fit_samples)
+                        log_structured(
+                            self.logger,
+                            "info",
+                            "Parsed FIT file",
+                            provider="garmin",
+                            task="process_items_batch",
+                            user_id=str(user_id),
+                            activity_id=activity_id,
+                            segments=len(fit_result.segments),
+                            samples=len(fit_samples),
+                        )
 
                     case "moveIQActivities":
                         record = self._build_moveiq_record(user_id, item)

--- a/backend/tests/fixtures/fit_builder.py
+++ b/backend/tests/fixtures/fit_builder.py
@@ -79,18 +79,38 @@ class _Field(NamedTuple):
     size: int
 
 
-# Definition message: one record per layout (local_mesg_type=0, global=20)
-def _definition_msg(fields: list[_Field]) -> bytes:
-    header = 0x40  # definition, local_mesg_type=0
-    # reserved(1) | architecture=LE(1) | global_mesg_num(2) | num_fields(1)
-    body = struct.pack("<BBHB", 0x00, 0x00, 20, len(fields))
+# Lap message (global_mesg_num=19) fields used here:
+#   253  timestamp          uint32  (FIT epoch seconds — end of lap)
+#     2  start_time         uint32  (FIT epoch seconds)
+#     7  total_elapsed_time uint32  (raw = seconds * 1000; fitdecode applies scale=1000)
+#     9  total_distance     uint32  (raw = meters * 100; fitdecode applies scale=100)
+#    15  avg_heart_rate     uint8   (bpm)
+#    16  max_heart_rate     uint8   (bpm)
+
+_LAP_FIELDS: list[_Field] = [
+    _Field(253, _UINT32, 4),
+    _Field(2, _UINT32, 4),
+    _Field(7, _UINT32, 4),
+    _Field(9, _UINT32, 4),
+    _Field(15, _UINT8, 1),
+    _Field(16, _UINT8, 1),
+]
+
+
+def _definition_msg(fields: list[_Field], local_type: int = 0, global_num: int = 20) -> bytes:
+    """Build a FIT definition message.
+
+    local_type 0 = record (global 20), local_type 1 = lap (global 19).
+    """
+    header = 0x40 | local_type
+    body = struct.pack("<BBHB", 0x00, 0x00, global_num, len(fields))
     for f in fields:
         body += struct.pack("BBB", f.def_num, f.size, f.base_type)
     return bytes([header]) + body
 
 
-def _data_msg(fields: list[_Field], values: list[int]) -> bytes:
-    header = 0x00  # data, local_mesg_type=0
+def _data_msg(fields: list[_Field], values: list[int], local_type: int = 0) -> bytes:
+    header = local_type
     body = b""
     for f, v in zip(fields, values):
         signed = f.base_type in (_SINT8, _SINT32)
@@ -101,6 +121,21 @@ def _data_msg(fields: list[_Field], values: list[int]) -> bytes:
         elif f.size == 4:
             body += struct.pack("<i" if signed else "<I", v)
     return bytes([header]) + body
+
+
+def _lap_messages(laps: list[tuple[int, int, int, int, int, int]]) -> bytes:
+    """Build definition + data messages for a list of laps (local_type=1, global=19).
+
+    Each lap: (start_ts, end_ts, elapsed_seconds, distance_meters, avg_hr, max_hr)
+    """
+    out = _definition_msg(_LAP_FIELDS, local_type=1, global_num=19)
+    for start_ts, end_ts, elapsed_s, distance_m, avg_hr, max_hr in laps:
+        out += _data_msg(
+            _LAP_FIELDS,
+            [end_ts, start_ts, elapsed_s * 1000, distance_m * 100, avg_hr, max_hr],
+            local_type=1,
+        )
+    return out
 
 
 def _fit_file(messages: bytes) -> bytes:
@@ -118,12 +153,12 @@ def _fit_file(messages: bytes) -> bytes:
 
 
 def make_running_fit(n_records: int = 20) -> bytes:
-    """Synthetic running activity: full sensor set including GPS and running dynamics."""
+    """Synthetic running activity: full sensor set including GPS, running dynamics, and 2 laps."""
     lat = int(50.0 * _DEG_TO_SEMICIRCLES)  # 50°N
     lon = int(20.0 * _DEG_TO_SEMICIRCLES)  # 20°E
     alt_raw = int((200.0 + 500) * 5)  # 200 m → raw enhanced_altitude
 
-    fields = [
+    record_fields = [
         _Field(253, _UINT32, 4),  # timestamp
         _Field(0, _SINT32, 4),  # position_lat (semicircles)
         _Field(1, _SINT32, 4),  # position_long (semicircles)
@@ -139,10 +174,10 @@ def make_running_fit(n_records: int = 20) -> bytes:
         _Field(84, _UINT16, 2),  # stance_time_balance (raw = % * 100)
     ]
     start_ts = _fit_ts(datetime(2025, 6, 1, 8, 0, 0, tzinfo=timezone.utc))
-    messages = _definition_msg(fields)
+    messages = _definition_msg(record_fields)
     for i in range(n_records):
         messages += _data_msg(
-            fields,
+            record_fields,
             [
                 start_ts + i,
                 lat,
@@ -159,6 +194,14 @@ def make_running_fit(n_records: int = 20) -> bytes:
                 4950,  # stance_time_balance: 49.5%
             ],
         )
+    # Two laps splitting the activity evenly
+    half = n_records // 2
+    messages += _lap_messages(
+        [
+            (start_ts, start_ts + half, half, half * 3, 152, 160),  # lap 0: ~3 m/s
+            (start_ts + half, start_ts + n_records, half, half * 3, 156, 164),  # lap 1
+        ]
+    )
     return _fit_file(messages)
 
 

--- a/backend/tests/services/test_fit_parser.py
+++ b/backend/tests/services/test_fit_parser.py
@@ -109,6 +109,39 @@ class TestSwimming:
         assert {s.series_type for s in swimming.samples} == {SeriesType.heart_rate}
 
 
+class TestSegments:
+    def test_running_has_two_laps(self, running: FitParseResult) -> None:
+        laps = [s for s in running.segments if s["kind"] == "lap"]
+        assert len(laps) == 2
+
+    def test_lap_required_fields(self, running: FitParseResult) -> None:
+        for lap in running.segments:
+            assert lap["kind"] == "lap"
+            assert isinstance(lap["index"], int)
+            assert lap["elapsed_seconds"] > 0
+            assert lap["start_time"] is not None
+
+    def test_lap_has_distance_and_hr(self, running: FitParseResult) -> None:
+        lap = running.segments[0]
+        assert "distance_meters" in lap
+        assert lap["distance_meters"] > 0
+        assert "avg_heart_rate" in lap
+        assert 40 <= lap["avg_heart_rate"] <= 220
+        assert "max_heart_rate" in lap
+        assert lap["max_heart_rate"] >= lap["avg_heart_rate"]
+
+    def test_lap_indices_sequential(self, running: FitParseResult) -> None:
+        laps = [s for s in running.segments if s["kind"] == "lap"]
+        indices = [lap["index"] for lap in laps]
+        assert indices == list(range(len(laps)))
+
+    def test_cycling_no_segments(self, cycling: FitParseResult) -> None:
+        assert cycling.segments == []
+
+    def test_swimming_no_segments(self, swimming: FitParseResult) -> None:
+        assert swimming.segments == []
+
+
 class TestInvalidInput:
     def test_empty_bytes_returns_no_samples(self) -> None:
         assert parse_fit_file(b"", uuid4(), uuid4()).samples == []


### PR DESCRIPTION
Resolves #1076 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FIT files now yield workout segments (laps/splits) with metrics (elapsed time, distance, heart rate) and those segments are persisted to activity details.
  * Event record details now expose an optional segments field.

* **Improvements**
  * FIT parsing always runs, reports segment/sample counts, and better avoids duplicating existing activity time-series.

* **Tests**
  * Added tests validating segment extraction for running/cycling/swimming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->