### PR TITLE
feat(backend): centralized unit conversion service (concept for #424)

### DIFF
--- a/backend/app/services/apple/healthkit/import_service.py
+++ b/backend/app/services/apple/healthkit/import_service.py
@@ -32,6 +32,7 @@ from app.schemas.providers.mobile_sdk import (
 from app.schemas.responses.upload import UploadDataResponse
 from app.services.event_record_service import event_record_service
 from app.services.timeseries_service import timeseries_service
+from app.services.unit_conversion import unit_conversion_service
 from app.utils.structured_logging import log_structured
 
 from .device_resolution import extract_device_info
@@ -46,6 +47,7 @@ class ImportService:
         self.log = log
         self.event_record_service = event_record_service
         self.timeseries_service = timeseries_service
+        self.unit_conversion_service = unit_conversion_service
         self.user_connection_repo = UserConnectionRepository()
 
     def _dec(self, value: float | int | Decimal | None) -> Decimal | None:
@@ -127,15 +129,29 @@ class ImportService:
 
             if not series_type:
                 continue
-            # Convert meters -> centimeters for height (both HealthKit and Health Connect report meters)
-            # and ratio (0..1) -> percent for Apple body_fat_percentage (HealthKit HKUnit.percent()).
-            # Android Health Connect's BodyFatRecord.percentage is already in percent, so only scale
-            # body_fat_percentage for provider == "apple" — otherwise Google/Samsung values are stored
-            # ~100x too large.
-            if series_type == SeriesType.height or (
-                series_type == SeriesType.body_fat_percentage and provider == "apple"
-            ):
-                value = value * 100
+
+            # Convert the incoming value to the canonical unit for this series type. The unit
+            # string is usually absent, so UnitConversionService falls back to the per-provider
+            # default source unit (e.g. height in meters, Apple body_fat as a 0..1 ratio).
+            converted = self.unit_conversion_service.convert(
+                series_type=series_type,
+                value=value,
+                provider=provider,
+                unit=rjson.unit,
+            )
+            if converted is None:
+                log_structured(
+                    self.log,
+                    "warning",
+                    "Skipping sample with unrecognized unit for metric",
+                    provider=provider,
+                    action="unit_conversion_skipped",
+                    series_type=series_type.value,
+                    record_type=record_type,
+                    unit=rjson.unit,
+                )
+                continue
+            value = converted
 
             # Extract device info
             device_model, software_version, original_source_name = extract_device_info(rjson.source)

--- a/backend/app/services/unit_conversion.py
+++ b/backend/app/services/unit_conversion.py
@@ -1,0 +1,109 @@
+"""Centralized unit conversion service.
+
+Single source of truth for converting incoming provider values into the canonical
+units defined by ``SERIES_TYPE_DEFINITIONS`` (see ``app/schemas/enums/series_types.py``).
+
+Background: providers report metrics in heterogeneous units, and incoming records
+frequently omit the unit string entirely (``MetricRecord.unit`` is ``str | None`` and is
+empty in practice). Conversion therefore cannot rely solely on a ``(series_type, unit)``
+lookup — when the unit is absent we fall back to a per-provider *default source unit*.
+This keeps the provider-specific knowledge (e.g. Apple sends body fat as a 0..1 ratio
+while Health Connect sends percent) as data in one place rather than scattered ``if``
+branches across importers.
+
+Conversions are ``Decimal``-preserving: each converter multiplies by an integer literal so
+the resulting ``Decimal`` scale matches the previous hardcoded behavior exactly.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Callable
+
+from app.schemas.enums import SeriesType, get_series_type_unit
+
+_UNIT_ABSENT = "__absent__"
+
+
+def _times_100(value: Decimal) -> Decimal:
+    # Integer literal 100 preserves Decimal scale: Decimal("1.7526") * 100 == Decimal("175.2600").
+    return value * 100
+
+
+# Per-provider default source unit (used when the unit string is absent)
+#
+# Encodes the knowledge previously hardcoded in import_service._build_statistic_bundles:
+#   - height is reported in meters by every SDK provider (apple/google/samsung).
+#   - body_fat_percentage is a 0..1 ratio on Apple, but already a percent on Health Connect
+#     (google/samsung), so only Apple needs scaling.
+_PROVIDER_DEFAULT_SOURCE_UNIT: dict[str, dict[SeriesType, str]] = {
+    "apple": {SeriesType.height: "meters", SeriesType.body_fat_percentage: "ratio"},
+    "google": {SeriesType.height: "meters", SeriesType.body_fat_percentage: "percent"},
+    "samsung": {SeriesType.height: "meters", SeriesType.body_fat_percentage: "percent"},
+}
+
+
+# Conversion registry: (series_type, source_unit) -> converter
+# Only NON-canonical source units need an entry. Canonical-unit sources and metrics with no
+# registered conversion fall through to passthrough (value returned unchanged).
+_CONVERSIONS: dict[tuple[SeriesType, str], Callable[[Decimal], Decimal]] = {
+    (SeriesType.height, "meters"): _times_100,
+    (SeriesType.body_fat_percentage, "ratio"): _times_100,
+}
+
+
+class UnitConversionService:
+    """Convert incoming provider values to the canonical unit for their series type."""
+
+    @staticmethod
+    def _normalize_unit(unit: str | None) -> str:
+        if unit is None:
+            return _UNIT_ABSENT
+
+        token = unit.strip()
+
+        return token if token else _UNIT_ABSENT
+
+    def _resolve_source_unit(self, series_type: SeriesType, provider: str, unit_token: str) -> str:
+        """Resolve the effective source unit.
+
+        When the unit is supplied, use it verbatim. When absent, fall back to the per-provider
+        default; if there is no default for this provider/metric, assume the value is already in
+        the canonical unit (passthrough).
+        """
+        if unit_token != _UNIT_ABSENT:
+            return unit_token
+
+        return _PROVIDER_DEFAULT_SOURCE_UNIT.get(provider, {}).get(series_type, get_series_type_unit(series_type))
+
+    def convert(
+        self,
+        series_type: SeriesType,
+        value: Decimal,
+        provider: str,
+        unit: str | None = None,
+    ) -> Decimal | None:
+        """Convert ``value`` to the canonical unit for ``series_type``.
+
+        Returns the converted ``Decimal``, or ``None`` when the incoming unit is present but
+        unrecognized/unexpected for this metric — signalling the caller to log and skip the
+        sample rather than store a wrong-magnitude value.
+        """
+
+        canonical = get_series_type_unit(series_type)
+        unit_token = self._normalize_unit(unit)
+        source_unit = self._resolve_source_unit(series_type, provider, unit_token)
+
+        # If source is already canonical (heart_rate, steps, percent body_fat, ...) -> no change.
+        if source_unit == canonical:
+            return value
+
+        converter = _CONVERSIONS.get((series_type, source_unit))
+        if converter is not None:
+            return converter(value)
+
+        # Present but unrecognized source unit for this metric -> caller logs + skips.
+        return None
+
+
+unit_conversion_service = UnitConversionService()

--- a/backend/tests/utils_tests/test_unit_conversion.py
+++ b/backend/tests/utils_tests/test_unit_conversion.py
@@ -1,0 +1,80 @@
+"""Tests for the centralized unit conversion service.
+
+Pure unit tests (no database). They verify that incoming provider values are converted to
+canonical units, including the per-provider default-source-unit fallback used when the unit
+string is absent, and the log+skip signal (``None``) for unrecognized units.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from app.schemas.enums import SeriesType
+from app.services.unit_conversion import UnitConversionService, unit_conversion_service
+
+
+class TestUnitConversionHeight:
+    """Height is reported in meters by every SDK provider -> stored as centimeters."""
+
+    @pytest.mark.parametrize("provider", ["apple", "google", "samsung"])
+    def test_height_meters_to_cm_unit_absent(self, provider: str) -> None:
+        result = unit_conversion_service.convert(SeriesType.height, Decimal("1.7526"), provider, unit="")
+        # Exact Decimal scale must be preserved (1.7526 * 100 == 175.2600).
+        assert str(result) == "175.2600"
+
+    def test_height_explicit_meters_unit(self) -> None:
+        result = unit_conversion_service.convert(SeriesType.height, Decimal("1.7526"), "apple", unit="meters")
+        assert str(result) == "175.2600"
+
+
+class TestUnitConversionBodyFat:
+    """Body fat is a 0..1 ratio on Apple but already a percent on Health Connect."""
+
+    def test_apple_body_fat_ratio_scaled(self) -> None:
+        result = unit_conversion_service.convert(SeriesType.body_fat_percentage, Decimal("0.304"), "apple", unit="")
+        assert str(result) == "30.400"
+
+    def test_google_body_fat_not_scaled(self) -> None:
+        result = unit_conversion_service.convert(SeriesType.body_fat_percentage, Decimal("30.4"), "google", unit="")
+        assert result == Decimal("30.4")
+
+    def test_samsung_body_fat_not_scaled(self) -> None:
+        result = unit_conversion_service.convert(SeriesType.body_fat_percentage, Decimal("18.5"), "samsung", unit="")
+        assert result == Decimal("18.5")
+
+    def test_explicit_canonical_unit_overrides_provider_default(self) -> None:
+        # An explicit "percent" unit must override Apple's ratio default -> no scaling.
+        result = unit_conversion_service.convert(
+            SeriesType.body_fat_percentage, Decimal("22.0"), "apple", unit="percent"
+        )
+        assert result == Decimal("22.0")
+
+
+class TestUnitConversionPassthrough:
+    """Metrics already in canonical units are returned unchanged."""
+
+    def test_heart_rate_passthrough(self) -> None:
+        result = unit_conversion_service.convert(SeriesType.heart_rate, Decimal("72"), "apple", unit="")
+        assert result == Decimal("72")
+
+    def test_unit_absent_for_unknown_provider_passes_through(self) -> None:
+        # No per-provider default for fitbit -> value assumed canonical -> passthrough.
+        result = unit_conversion_service.convert(SeriesType.height, Decimal("1.75"), "fitbit", unit="")
+        assert result == Decimal("1.75")
+
+
+class TestUnitConversionUnknownUnit:
+    """A present-but-unrecognized unit returns None (caller logs + skips)."""
+
+    def test_unrecognized_unit_returns_none(self) -> None:
+        result = unit_conversion_service.convert(SeriesType.height, Decimal("70"), "apple", unit="inches")
+        assert result is None
+
+    def test_none_unit_uses_provider_default(self) -> None:
+        # unit=None normalizes to absent (not unrecognized) -> provider default applies.
+        result = unit_conversion_service.convert(SeriesType.height, Decimal("1.7526"), "apple", unit=None)
+        assert str(result) == "175.2600"
+
+
+def test_module_singleton_is_unit_conversion_service() -> None:
+    assert isinstance(unit_conversion_service, UnitConversionService)


### PR DESCRIPTION
**Concept implementation for #424 — for discussion/verification, not a finished PR.**

## Scope
Builds \`app/services/unit_conversion.py\` as a single source of truth for converting incoming provider values to canonical units, and migrates the Apple HealthKit \`_build_statistic_bundles\` height/body_fat conversions onto it as a proven reference. Garmin/Oura/Whoop/Suunto/Fitbit and the ms→s duration conversions are intentionally left as follow-ups.

## Design
- **Registry keyed by `(series_type, source_unit)`** with a **per-provider default source unit** fallback. Incoming SDK records usually omit the unit string, so this keeps the Apple-vs-HealthConnect body_fat asymmetry as *data* rather than an `if provider == "apple"` in the importer.
- **Canonical units** come from the existing `SERIES_TYPE_DEFINITIONS` / `get_series_type_unit()` — no second source of truth.
- **Unknown/unexpected unit → log + skip** the sample (no silent wrong-magnitude writes), matching the existing import convention.
- **Behaviour preserved:** `TestSDKImportUnitConversion` stays green **unchanged**; new pure unit tests cover the service directly.

## Unit assumptions verified against platform docs
- Apple body fat is a 0–1 ratio (`HKUnit percentUnit // % (0.0 - 1.0)`) → ×100 to percent.
- Health Connect `Percentage` is already 0–100 → no scaling.
- Height is meters on both Apple and Health Connect → ×100 to cm.

## Open question
Unknown-unit policy: **log + skip** (current) vs **raise**. Worth deciding before extending to the other providers.

## Follow-ups (out of scope here)
Garmin weight (g→kg), Oura/Whoop height, Suunto balance/SpO2/joules→kcal, Fitbit/Whoop/Apple duration (ms→s), plus unit-string alias/case handling and an optional strict mode.