### PR TITLE
fix(backend): stop storing Garmin average HR as heart_rate_min

### DIFF
--- a/backend/app/services/providers/garmin/workouts.py
+++ b/backend/app/services/providers/garmin/workouts.py
@@ -154,11 +154,6 @@ class GarminWorkouts(BaseWorkoutsTemplate):
             dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
             return int(dt.timestamp())
         except (ValueError, AttributeError):
-            # If parsing fails, return None or raise error.
-            # For now, let's return None to be safe, or we could raise HTTPException here if we want strict validation.
-            # But since this is a helper, maybe just return None.
-            # Actually, the endpoint was raising HTTPException.
-            # Let's assume the caller handles validation or we just ignore invalid values.
             return None
 
     def _extract_dates(self, start_timestamp: int, end_timestamp: int) -> tuple[datetime, datetime]:
@@ -190,7 +185,8 @@ class GarminWorkouts(BaseWorkoutsTemplate):
         average_cadence = Decimal(str(raw_workout.averageCadence)) if raw_workout.averageCadence is not None else None
 
         return {
-            "heart_rate_min": int(heart_rate_avg) if heart_rate_avg is not None else None,
+            # Garmin activity payloads carry only average and max heart rate
+            "heart_rate_min": None,
             "heart_rate_max": int(heart_rate_max) if heart_rate_max is not None else None,
             "heart_rate_avg": heart_rate_avg,
             "steps_count": steps_count,

--- a/backend/tests/providers/garmin/test_garmin_workouts.py
+++ b/backend/tests/providers/garmin/test_garmin_workouts.py
@@ -124,7 +124,7 @@ class TestGarminWorkouts:
 
         assert metrics["heart_rate_avg"] == Decimal("145")
         assert metrics["heart_rate_max"] == 175
-        assert metrics["heart_rate_min"] == 145
+        assert metrics["heart_rate_min"] is None
         assert metrics["steps_count"] == 8500
         assert metrics["energy_burned"] == Decimal("650")
         assert metrics["distance"] == Decimal("10000")


### PR DESCRIPTION
## Description

Garmin workout normalization stored the average heart rate in `heart_rate_min`:

```python
"heart_rate_min": int(heart_rate_avg) if heart_rate_avg is not None else None,
```

The Garmin activity payload (`ActivityJSON`) only carries `averageHeartRateInBeatsPerMinute` and `maxHeartRateInBeatsPerMinute` - there is no minimum heart rate field. `heart_rate_min` is now stored as `None` instead of a wrong value, until a real source for it exists (e.g. FIT samples).

Also removes a leftover brainstorming comment block in `_parse_timestamp`.

Resolves #1078

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes (ruff + ty pass; the prettier hook fails only without frontend `node_modules`, no frontend files touched)

## Testing Instructions

**Steps to test:**
1. `cd backend && uv run pytest tests/providers/garmin/test_garmin_workouts.py`
2. Ingest a Garmin activity push notification and inspect the stored workout metrics.

**Expected behavior:**

`heart_rate_min` is `None` for Garmin workouts; `heart_rate_avg` and `heart_rate_max` unchanged.

## Additional Notes

Existing rows keep the wrong min value; happy to add a data migration nulling `heart_rate_min` where it equals `heart_rate_avg` for Garmin workouts if maintainers want it in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Garmin workout integration to properly handle heart rate metric data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->