### PR TITLE
docs(mcp): remove formatted duration fields absent from sleep tool output

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -163,7 +163,6 @@ Get sleep summaries for a user within a date range.
       "start_datetime": "2026-02-03T23:15:00+00:00",
       "end_datetime": "2026-02-04T07:30:00+00:00",
       "duration_minutes": 495,
-      "duration_formatted": "8h 15m",
       "source": "whoop"
     }
   ],
@@ -171,7 +170,6 @@ Get sleep summaries for a user within a date range.
     "total_nights": 7,
     "nights_with_data": 6,
     "avg_duration_minutes": 465,
-    "avg_duration_formatted": "7h 45m",
     "min_duration_minutes": 360,
     "max_duration_minutes": 540
   }


### PR DESCRIPTION
## Description

The `get_sleep_summary` example response in `mcp/README.md` documents `duration_formatted` ("8h 15m") and `avg_duration_formatted` ("7h 45m") fields. The tool implementation in `mcp/app/tools/sleep.py` returns only numeric `*_minutes` values and never produces these fields. Removed the two lines so the example matches the actual output.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable) - docs only
- [x] New and existing tests pass locally - docs only
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

## Testing Instructions

**Steps to test:**
1. Compare the README example with the return value built in `mcp/app/tools/sleep.py` (records list and summary dict).

**Expected behavior:**

Example response fields match the implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example JSON response documentation for the sleep summary tool to reflect the current API response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->