### PR TITLE
fix(backend): convert Health Connect blood glucose from mmol/L to mg/dL

### DIFF
--- a/backend/app/services/apple/healthkit/import_service.py
+++ b/backend/app/services/apple/healthkit/import_service.py
@@ -37,6 +37,10 @@ from app.utils.structured_logging import log_structured
 from .device_resolution import extract_device_info
 from .sleep_service import handle_sleep_data
 
+# Health Connect's own mg/dL converter uses exactly 18.0, so values written to HC
+# in mg/dL round-trip with a ~0.1% offset under this factor.
+MMOL_L_TO_MG_DL = Decimal("18.0182")
+
 
 class ImportService:
     def __init__(
@@ -139,7 +143,7 @@ class ImportService:
 
             # Health Connect reports blood glucose in mmol/L; the series unit is mg/dL.
             if series_type == SeriesType.blood_glucose and (rjson.unit or "").lower().startswith("mmol"):
-                value = value * Decimal("18.0182")
+                value = value * MMOL_L_TO_MG_DL
 
             # Extract device info
             device_model, software_version, original_source_name = extract_device_info(rjson.source)

--- a/backend/app/services/apple/healthkit/import_service.py
+++ b/backend/app/services/apple/healthkit/import_service.py
@@ -137,6 +137,10 @@ class ImportService:
             ):
                 value = value * 100
 
+            # Health Connect reports blood glucose in mmol/L; the series unit is mg/dL.
+            if series_type == SeriesType.blood_glucose and (rjson.unit or "").lower().startswith("mmol"):
+                value = value * Decimal("18.0182")
+
             # Extract device info
             device_model, software_version, original_source_name = extract_device_info(rjson.source)
 

--- a/backend/tests/integrations/test_apple_sdk_import.py
+++ b/backend/tests/integrations/test_apple_sdk_import.py
@@ -343,64 +343,6 @@ class TestAppleSDKImport:
 
         assert result["records_saved"] >= 0
 
-    def test_health_connect_blood_glucose_converted_to_mg_dl(
-        self,
-        import_service: ImportService,
-    ) -> None:
-        """Health Connect reports glucose in mmol/L; stored value must be mg/dL."""
-        payload: dict[str, Any] = {
-            "provider": "samsung",
-            "sdkVersion": "1.0.0",
-            "syncTimestamp": "2025-04-10T12:00:00Z",
-            "data": {
-                "records": [
-                    {
-                        "id": "11111111-1111-1111-1111-111111111111",
-                        "type": "BLOOD_GLUCOSE",
-                        "unit": "mmol/L",
-                        "value": 6.111,
-                        "startDate": "2025-04-10T11:00:00Z",
-                        "endDate": "2025-04-10T11:00:00Z",
-                    }
-                ]
-            },
-        }
-        request = SDKSyncRequest(**payload)
-
-        samples = import_service._build_statistic_bundles(request, str(uuid4()))
-
-        assert len(samples) == 1
-        assert samples[0].series_type == SeriesType.blood_glucose
-        assert float(samples[0].value) == pytest.approx(110.1, abs=0.1)
-
-    def test_healthkit_blood_glucose_stored_unchanged(
-        self,
-        import_service: ImportService,
-    ) -> None:
-        """HealthKit already reports glucose in mg/dL; value must not be scaled."""
-        payload: dict[str, Any] = {
-            **SDK_ENVELOPE,
-            "data": {
-                "records": [
-                    {
-                        "id": "22222222-2222-2222-2222-222222222222",
-                        "type": "HKQuantityTypeIdentifierBloodGlucose",
-                        "unit": "mg/dL",
-                        "value": 105,
-                        "startDate": "2025-04-10T11:00:00Z",
-                        "endDate": "2025-04-10T11:00:00Z",
-                    }
-                ]
-            },
-        }
-        request = SDKSyncRequest(**payload)
-
-        samples = import_service._build_statistic_bundles(request, str(uuid4()))
-
-        assert len(samples) == 1
-        assert samples[0].series_type == SeriesType.blood_glucose
-        assert samples[0].value == Decimal("105")
-
     def test_import_empty_payload(
         self,
         db: Session,
@@ -615,11 +557,11 @@ class TestSDKImportUnitConversion:
         return ImportService(log=logging.getLogger("test"))
 
     @staticmethod
-    def _record(metric_type: str, value: float) -> dict[str, Any]:
+    def _record(metric_type: str, value: float, unit: str | None = "") -> dict[str, Any]:
         return {
             "id": f"test-{metric_type}",
             "type": metric_type,
-            "unit": "",
+            "unit": unit,
             "value": value,
             "startDate": "2025-04-10T12:00:00Z",
             "endDate": "2025-04-10T12:00:00Z",
@@ -718,3 +660,46 @@ class TestSDKImportUnitConversion:
         assert len(samples) == 1
         assert samples[0].series_type == SeriesType.height
         assert samples[0].value == Decimal("175.2600")
+
+    @pytest.mark.parametrize(
+        ("unit", "expected"),
+        [
+            ("mmol/L", Decimal("110.1092202")),
+            ("MMOL/L", Decimal("110.1092202")),
+            (None, Decimal("6.111")),
+            ("", Decimal("6.111")),
+        ],
+    )
+    def test_health_connect_blood_glucose_unit_handling(
+        self,
+        import_service: ImportService,
+        unit: str | None,
+        expected: Decimal,
+    ) -> None:
+        """Health Connect glucose arrives in mmol/L and must be stored as mg/dL; only a mmol unit converts."""
+        user_id = str(uuid4())
+        request = self._build_request(
+            "samsung",
+            [self._record("BLOOD_GLUCOSE", 6.111, unit=unit)],
+        )
+        samples = import_service._build_statistic_bundles(request, user_id)
+
+        assert len(samples) == 1
+        assert samples[0].series_type == SeriesType.blood_glucose
+        assert samples[0].value == expected
+
+    def test_healthkit_blood_glucose_not_scaled(
+        self,
+        import_service: ImportService,
+    ) -> None:
+        """HealthKit reports glucose in mg/dL — stored unchanged."""
+        user_id = str(uuid4())
+        request = self._build_request(
+            "apple",
+            [self._record("HKQuantityTypeIdentifierBloodGlucose", 105, unit="mg/dL")],
+        )
+        samples = import_service._build_statistic_bundles(request, user_id)
+
+        assert len(samples) == 1
+        assert samples[0].series_type == SeriesType.blood_glucose
+        assert samples[0].value == Decimal("105")

--- a/backend/tests/integrations/test_apple_sdk_import.py
+++ b/backend/tests/integrations/test_apple_sdk_import.py
@@ -343,6 +343,64 @@ class TestAppleSDKImport:
 
         assert result["records_saved"] >= 0
 
+    def test_health_connect_blood_glucose_converted_to_mg_dl(
+        self,
+        import_service: ImportService,
+    ) -> None:
+        """Health Connect reports glucose in mmol/L; stored value must be mg/dL."""
+        payload: dict[str, Any] = {
+            "provider": "samsung",
+            "sdkVersion": "1.0.0",
+            "syncTimestamp": "2025-04-10T12:00:00Z",
+            "data": {
+                "records": [
+                    {
+                        "id": "11111111-1111-1111-1111-111111111111",
+                        "type": "BLOOD_GLUCOSE",
+                        "unit": "mmol/L",
+                        "value": 6.111,
+                        "startDate": "2025-04-10T11:00:00Z",
+                        "endDate": "2025-04-10T11:00:00Z",
+                    }
+                ]
+            },
+        }
+        request = SDKSyncRequest(**payload)
+
+        samples = import_service._build_statistic_bundles(request, str(uuid4()))
+
+        assert len(samples) == 1
+        assert samples[0].series_type == SeriesType.blood_glucose
+        assert float(samples[0].value) == pytest.approx(110.1, abs=0.1)
+
+    def test_healthkit_blood_glucose_stored_unchanged(
+        self,
+        import_service: ImportService,
+    ) -> None:
+        """HealthKit already reports glucose in mg/dL; value must not be scaled."""
+        payload: dict[str, Any] = {
+            **SDK_ENVELOPE,
+            "data": {
+                "records": [
+                    {
+                        "id": "22222222-2222-2222-2222-222222222222",
+                        "type": "HKQuantityTypeIdentifierBloodGlucose",
+                        "unit": "mg/dL",
+                        "value": 105,
+                        "startDate": "2025-04-10T11:00:00Z",
+                        "endDate": "2025-04-10T11:00:00Z",
+                    }
+                ]
+            },
+        }
+        request = SDKSyncRequest(**payload)
+
+        samples = import_service._build_statistic_bundles(request, str(uuid4()))
+
+        assert len(samples) == 1
+        assert samples[0].series_type == SeriesType.blood_glucose
+        assert samples[0].value == Decimal("105")
+
     def test_import_empty_payload(
         self,
         db: Session,

--- a/backend/tests/integrations/test_apple_sdk_import.py
+++ b/backend/tests/integrations/test_apple_sdk_import.py
@@ -692,7 +692,7 @@ class TestSDKImportUnitConversion:
         self,
         import_service: ImportService,
     ) -> None:
-        """HealthKit reports glucose in mg/dL — stored unchanged."""
+        """HealthKit reports glucose in mg/dL - stored unchanged."""
         user_id = str(uuid4())
         request = self._build_request(
             "apple",


### PR DESCRIPTION
## Description

Blood glucose values synced from Android via Health Connect arrive in mmol/L (Health Connect's canonical unit for `BloodGlucoseRecord`), but `_build_statistic_bundles` stored them verbatim while the `blood_glucose` series unit is `mg_dl`. A 110 mg/dL reading was stored as 6.111.

The conversion is gated on the unit string the SDK already sends (`unit` starts with `mmol`, case-insensitive), so SDK paths that send mg/dL (the iOS SDK reads glucose with a fixed mg/dL HKUnit) and any other source already sending mg/dL are unaffected. The factor lives in a module constant `MMOL_L_TO_MG_DL = Decimal("18.0182")`.

Tests live in `TestSDKImportUnitConversion` next to the existing body-fat/height conversion tests: parametrized over `mmol/L` / `MMOL/L` (converted, exact `Decimal("110.1092202")`) and `None` / `""` (stored unchanged), plus a HealthKit mg/dL passthrough test.

Resolves #1119

## Notes

- Conversion factor 18.0182 mg/dL per mmol/L - the standard clinical convention (inverse of the rounded 0.0555 mmol/L-per-mg/dL factor). Health Connect's own internal mg/dL converter uses exactly 18.0, so values written to HC in mg/dL round-trip with a ~0.1% offset under this factor (max ~0.25 mg/dL at 250 mg/dL). Noted in a code comment.
- **Scope:** this fixes the mobile SDK ingestion path only. The Apple Health XML export path (`apple_xml/xml_service.py`) has the same class of bug for users whose Health app displays glucose in mmol/L (Apple writes the export in the display unit, e.g. `unit="mmol<180.15588...>/L"`); that path never reads the record's unit attribute. Filed separately so it can be fixed for all affected series types at once rather than special-cased here.
- This touches the same block as #1114 and the same territory as #1120. If #1114 lands first I will move this case into its `_normalize_unit` helper (it then needs the record's `unit` passed in). For #1120: its registry needs a `(blood_glucose, mmol/L)` entry plus unit-token normalization, since it currently skips samples with unrecognized units.
- **Existing data:** mmol-stored rows are not migrated here, and value-range heuristics are not safe for glucose (genuine severe-hypoglycemia readings below 30 mg/dL exist, and mmol values can be missed above range cutoffs). The reliable repair path is re-deriving the affected samples from stored raw payloads (`store_raw_payload` keeps the original records incl. the `unit` field), matching on `external_id`. Happy to add that migration on request, here or as a follow-up.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes (ruff + ty pass; prettier hook needs frontend `node_modules`, no frontend files touched)

## Testing Instructions

**Steps to test:**
1. `cd backend && uv run pytest tests/integrations/test_apple_sdk_import.py`
2. Sync a Health Connect payload containing a `BLOOD_GLUCOSE` record with `unit: "mmol/L"` and inspect the stored sample.

**Expected behavior:**

Stored `blood_glucose` value is in mg/dL (6.111 mmol/L -> 110.1092202); HealthKit mg/dL values unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic unit conversion for blood glucose measurements during health data imports. Values are now consistently converted to mg/dL regardless of the source unit format.

* **Tests**
  * Expanded test coverage to verify blood glucose import and unit conversion functionality works correctly across different input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->