### PR TITLE
feat(backend): add Whoop cycle endpoint for daily strain scores

### DIFF
--- a/backend/app/schemas/model_crud/activities/health_score.py
+++ b/backend/app/schemas/model_crud/activities/health_score.py
@@ -25,7 +25,13 @@ class HealthScoreBase(BaseModel):
         None,
         description="Overall numeric score. Range varies by provider and category — see HEALTH_SCORE_RANGES for scale.",
     )
-    qualifier: str | None = Field(None, description="Textual rating from the provider, e.g. GOOD or EXCELLENT")
+    qualifier: str | None = Field(
+        None,
+        description=(
+            "Textual rating from the provider, e.g. GOOD or EXCELLENT. "
+            "For Whoop strain, 'daily' marks day-level cycle strain vs per-workout strain (null)."
+        ),
+    )
     recorded_at: datetime
     zone_offset: ZoneOffset = None
     components: dict[str, ScoreComponent] | None = None

--- a/backend/app/services/providers/whoop/data_247.py
+++ b/backend/app/services/providers/whoop/data_247.py
@@ -37,7 +37,7 @@ class Whoop247Data(Base247DataTemplate):
         provider_name: str,
         api_base_url: str,
         oauth: BaseOAuthTemplate,
-    ):
+    ) -> None:
         super().__init__(provider_name, api_base_url, oauth)
         self.event_record_repo = EventRecordRepository(EventRecord)
         self.data_source_repo = DataSourceRepository(DataSource)
@@ -964,8 +964,12 @@ class Whoop247Data(Base247DataTemplate):
             user_id=user_id,
             provider=ProviderName.WHOOP,
             category=HealthScoreCategory.STRAIN,
+            # Whoop also emits per-workout strain scores (workouts.py); the qualifier
+            # separates the day-level cycle strain from those.
+            qualifier="daily",
             value=strain,
             recorded_at=recorded_at,
+            zone_offset=raw_cycle.get("timezone_offset"),
             components=components or None,
         )
 

--- a/backend/app/services/providers/whoop/data_247.py
+++ b/backend/app/services/providers/whoop/data_247.py
@@ -30,7 +30,7 @@ from app.utils.structured_logging import log_structured
 
 
 class Whoop247Data(Base247DataTemplate):
-    """Whoop implementation for 247 data (sleep, recovery, activity)."""
+    """Whoop implementation for 247 data (sleep, recovery, cycles, activity)."""
 
     def __init__(
         self,
@@ -982,7 +982,9 @@ class Whoop247Data(Base247DataTemplate):
     ) -> int:
         """Load cycle data from API and save daily strain health scores.
 
-        Returns the number of health scores saved.
+        Returns the number of cycle records normalized into health scores;
+        rows already present in the database are not re-inserted (dedupe via
+        the unique constraint) and are still counted here.
         """
         raw_data = self.get_cycle_data(db, user_id, start_time, end_time)
         health_scores: list[HealthScoreCreate] = []

--- a/backend/app/services/providers/whoop/data_247.py
+++ b/backend/app/services/providers/whoop/data_247.py
@@ -1,4 +1,4 @@
-"""Whoop 247 Data implementation for sleep, recovery, and activity samples."""
+"""Whoop 247 Data implementation for sleep, recovery, cycle, and activity samples."""
 
 from contextlib import suppress
 from datetime import datetime, timedelta, timezone
@@ -73,19 +73,17 @@ class Whoop247Data(Base247DataTemplate):
             headers=headers,
         )
 
-    # -------------------------------------------------------------------------
-    # Sleep Data - Whoop /v2/activity/sleep
-    # -------------------------------------------------------------------------
-
-    def get_sleep_data(
+    def _get_paginated_records(
         self,
         db: DbSession,
         user_id: UUID,
+        endpoint: str,
         start_time: datetime,
         end_time: datetime,
+        task: str,
     ) -> list[dict[str, Any]]:
-        """Fetch sleep data from Whoop API via v2 endpoint with pagination."""
-        all_sleep_data = []
+        """Fetch all records from a paginated Whoop v2 collection endpoint."""
+        all_records: list[dict[str, Any]] = []
         next_token = None
         max_limit = 25  # Whoop API limit
 
@@ -104,18 +102,18 @@ class Whoop247Data(Base247DataTemplate):
                 params["nextToken"] = next_token
 
             try:
-                response = self._make_api_request(db, user_id, "/v2/activity/sleep", params=params)
+                response = self._make_api_request(db, user_id, endpoint, params=params)
                 store_raw_payload(
                     source="api_response",
                     provider="whoop",
                     payload=response,
                     user_id=str(user_id),
-                    trace_id="/v2/activity/sleep",
+                    trace_id=endpoint,
                 )
 
                 # Extract records from response
                 records = response.get("records", []) if isinstance(response, dict) else []
-                all_sleep_data.extend(records)
+                all_records.extend(records)
 
                 # Check for next page
                 next_token = response.get("next_token") if isinstance(response, dict) else None
@@ -128,25 +126,39 @@ class Whoop247Data(Base247DataTemplate):
                 log_structured(
                     self.logger,
                     "error",
-                    f"Error fetching Whoop sleep data: {e}",
+                    f"Error fetching Whoop data from {endpoint}: {e}",
                     provider="whoop",
-                    task="get_sleep_data",
+                    task=task,
                     user_id=str(user_id),
                 )
                 # If we got some data, return what we have; otherwise re-raise
-                if all_sleep_data:
+                if all_records:
                     log_structured(
                         self.logger,
                         "warning",
-                        f"Returning partial sleep data due to error: {e}",
+                        f"Returning partial data from {endpoint} due to error: {e}",
                         provider="whoop",
-                        task="get_sleep_data",
+                        task=task,
                         user_id=str(user_id),
                     )
                     break
                 raise
 
-        return all_sleep_data
+        return all_records
+
+    # -------------------------------------------------------------------------
+    # Sleep Data - Whoop /v2/activity/sleep
+    # -------------------------------------------------------------------------
+
+    def get_sleep_data(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> list[dict[str, Any]]:
+        """Fetch sleep data from Whoop API via v2 endpoint with pagination."""
+        return self._get_paginated_records(db, user_id, "/v2/activity/sleep", start_time, end_time, "get_sleep_data")
 
     def _normalize_sleep_health_score(
         self,
@@ -437,7 +449,7 @@ class Whoop247Data(Base247DataTemplate):
         end_time: datetime | str | None = None,
         is_first_sync: bool = False,
     ) -> dict[str, int]:
-        """Load and save all 247 data types (sleep, recovery, activity).
+        """Load and save all 247 data types (sleep, recovery, cycles, activity).
 
         Args:
             db: Database session
@@ -460,6 +472,7 @@ class Whoop247Data(Base247DataTemplate):
         results = {
             "sleep_sessions_synced": 0,
             "recovery_samples_synced": 0,
+            "cycle_scores_synced": 0,
             "activity_samples_synced": 0,
             "body_measurement_samples_synced": 0,
         }
@@ -485,6 +498,19 @@ class Whoop247Data(Base247DataTemplate):
                 self.logger,
                 "error",
                 f"Failed to sync recovery data: {e}",
+                provider="whoop",
+                task="load_and_save_all",
+                user_id=str(user_id),
+            )
+
+        try:
+            results["cycle_scores_synced"] = self.load_and_save_cycles(db, user_id, start_time, end_time)
+        except Exception as e:
+            db.rollback()
+            log_structured(
+                self.logger,
+                "error",
+                f"Failed to sync cycle data: {e}",
                 provider="whoop",
                 task="load_and_save_all",
                 user_id=str(user_id),
@@ -656,68 +682,7 @@ class Whoop247Data(Base247DataTemplate):
         Returns list of recovery records containing recovery_score, resting_heart_rate,
         hrv_rmssd_milli, spo2_percentage, and skin_temp_celsius.
         """
-        all_recovery_data = []
-        next_token = None
-        max_limit = 25  # Whoop API limit
-
-        # Convert datetimes to ISO 8601 strings
-        start_iso = start_time.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        end_iso = end_time.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-        while True:
-            params: dict[str, Any] = {
-                "start": start_iso,
-                "end": end_iso,
-                "limit": max_limit,
-            }
-
-            if next_token:
-                params["nextToken"] = next_token
-
-            try:
-                response = self._make_api_request(db, user_id, "/v2/recovery", params=params)
-                store_raw_payload(
-                    source="api_response",
-                    provider="whoop",
-                    payload=response,
-                    user_id=str(user_id),
-                    trace_id="/v2/recovery",
-                )
-
-                # Extract records from response
-                records = response.get("records", []) if isinstance(response, dict) else []
-                all_recovery_data.extend(records)
-
-                # Check for next page
-                next_token = response.get("next_token") if isinstance(response, dict) else None
-
-                # Stop if no more records or no next token
-                if not records or not next_token:
-                    break
-
-            except Exception as e:
-                log_structured(
-                    self.logger,
-                    "error",
-                    f"Error fetching Whoop recovery data: {e}",
-                    provider="whoop",
-                    task="get_recovery_data",
-                    user_id=str(user_id),
-                )
-                # If we got some data, return what we have; otherwise re-raise
-                if all_recovery_data:
-                    log_structured(
-                        self.logger,
-                        "warning",
-                        f"Returning partial recovery data due to error: {e}",
-                        provider="whoop",
-                        task="get_recovery_data",
-                        user_id=str(user_id),
-                    )
-                    break
-                raise
-
-        return all_recovery_data
+        return self._get_paginated_records(db, user_id, "/v2/recovery", start_time, end_time, "get_recovery_data")
 
     def _normalize_recovery_health_score(
         self,
@@ -939,6 +904,105 @@ class Whoop247Data(Base247DataTemplate):
             db.commit()
 
         return total_count
+
+    # -------------------------------------------------------------------------
+    # Cycle Data - Whoop /v2/cycle
+    # -------------------------------------------------------------------------
+
+    def get_cycle_data(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> list[dict[str, Any]]:
+        """Fetch cycle (daily strain) data from Whoop API via v2 endpoint with pagination.
+
+        Returns list of cycle records containing strain, kilojoule,
+        average_heart_rate, and max_heart_rate.
+        """
+        return self._get_paginated_records(db, user_id, "/v2/cycle", start_time, end_time, "get_cycle_data")
+
+    def normalize_cycle(
+        self,
+        raw_cycle: dict[str, Any],
+        user_id: UUID,
+    ) -> HealthScoreCreate | None:
+        """Normalize a Whoop cycle record to a daily strain HealthScoreCreate.
+
+        Cycles without an end time are still in progress and their strain is
+        provisional; they are skipped so the unique-constraint dedupe does not
+        lock in a partial value.
+        """
+        if raw_cycle.get("score_state") != "SCORED":
+            return None
+        if not raw_cycle.get("end"):
+            return None
+
+        score = raw_cycle.get("score") or {}
+        strain = score.get("strain")
+        start = raw_cycle.get("start")
+        if strain is None or not start:
+            return None
+
+        try:
+            recorded_at = datetime.fromisoformat(start.replace("Z", "+00:00"))
+        except (ValueError, AttributeError):
+            return None
+
+        components = {
+            k: ScoreComponent(value=v)
+            for k, v in {
+                "kilojoule": score.get("kilojoule"),
+                "average_heart_rate": score.get("average_heart_rate"),
+                "max_heart_rate": score.get("max_heart_rate"),
+            }.items()
+            if v is not None
+        }
+        return HealthScoreCreate(
+            id=uuid4(),
+            user_id=user_id,
+            provider=ProviderName.WHOOP,
+            category=HealthScoreCategory.STRAIN,
+            value=strain,
+            recorded_at=recorded_at,
+            components=components or None,
+        )
+
+    def load_and_save_cycles(
+        self,
+        db: DbSession,
+        user_id: UUID,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> int:
+        """Load cycle data from API and save daily strain health scores.
+
+        Returns the number of health scores saved.
+        """
+        raw_data = self.get_cycle_data(db, user_id, start_time, end_time)
+        health_scores: list[HealthScoreCreate] = []
+
+        for item in raw_data:
+            try:
+                health_score = self.normalize_cycle(item, user_id)
+                if health_score:
+                    health_scores.append(health_score)
+            except Exception as e:
+                log_structured(
+                    self.logger,
+                    "warning",
+                    f"Failed to normalize cycle record: {e}",
+                    provider="whoop",
+                    task="load_and_save_cycles",
+                    user_id=str(user_id),
+                )
+
+        if health_scores:
+            health_score_service.bulk_create(db, health_scores)
+            db.commit()
+
+        return len(health_scores)
 
     # -------------------------------------------------------------------------
     # Activity Samples

--- a/backend/tests/providers/whoop/test_whoop_247.py
+++ b/backend/tests/providers/whoop/test_whoop_247.py
@@ -64,6 +64,8 @@ class TestWhoop247Data:
         assert health_score is not None
         assert health_score.category == HealthScoreCategory.STRAIN
         assert health_score.user_id == user_id
+        assert health_score.qualifier == "daily"
+        assert health_score.zone_offset == "-05:00"
         assert float(health_score.value) == pytest.approx(5.2951527)
         assert health_score.recorded_at == datetime(2024, 1, 15, 2, 25, 44, 774000, tzinfo=timezone.utc)
         assert health_score.components is not None
@@ -86,6 +88,18 @@ class TestWhoop247Data:
     def test_normalize_cycle_missing_strain(self, whoop_247: Whoop247Data, sample_cycle: dict[str, Any]) -> None:
         """Cycle without strain in score is skipped."""
         sample_cycle["score"] = {"kilojoule": 8288.297}
+
+        assert whoop_247.normalize_cycle(sample_cycle, uuid4()) is None
+
+    def test_normalize_cycle_null_score(self, whoop_247: Whoop247Data, sample_cycle: dict[str, Any]) -> None:
+        """SCORED state with a null score object is skipped."""
+        sample_cycle["score"] = None
+
+        assert whoop_247.normalize_cycle(sample_cycle, uuid4()) is None
+
+    def test_normalize_cycle_malformed_start(self, whoop_247: Whoop247Data, sample_cycle: dict[str, Any]) -> None:
+        """Unparseable start timestamp is skipped."""
+        sample_cycle["start"] = "not-a-date"
 
         assert whoop_247.normalize_cycle(sample_cycle, uuid4()) is None
 
@@ -131,3 +145,50 @@ class TestWhoop247Data:
         assert len(saved) == 1
         assert saved[0].category == HealthScoreCategory.STRAIN
         assert float(saved[0].value) == pytest.approx(5.2951527, abs=1e-3)
+
+    def test_load_and_save_cycles_resync_does_not_duplicate(
+        self,
+        db: Session,
+        whoop_247: Whoop247Data,
+        sample_cycle: dict[str, Any],
+    ) -> None:
+        """Re-syncing the same cycle relies on the unique-constraint dedupe."""
+        user = UserFactory()
+        window = (datetime(2024, 1, 1, tzinfo=timezone.utc), datetime(2024, 1, 31, tzinfo=timezone.utc))
+
+        with patch.object(whoop_247, "get_cycle_data", return_value=[sample_cycle]):
+            whoop_247.load_and_save_cycles(db, user.id, *window)
+            whoop_247.load_and_save_cycles(db, user.id, *window)
+
+        assert db.query(HealthScore).filter(HealthScore.user_id == user.id).count() == 1
+
+    def test_get_cycle_data_returns_partial_results_on_later_page_error(
+        self,
+        whoop_247: Whoop247Data,
+        sample_cycle: dict[str, Any],
+    ) -> None:
+        """A failure after the first page returns the records fetched so far."""
+        page_one = {"records": [sample_cycle], "next_token": "token123"}
+
+        with patch.object(whoop_247, "_make_api_request", side_effect=[page_one, RuntimeError("boom")]):
+            records = whoop_247.get_cycle_data(
+                MagicMock(),
+                uuid4(),
+                datetime(2024, 1, 1, tzinfo=timezone.utc),
+                datetime(2024, 1, 31, tzinfo=timezone.utc),
+            )
+
+        assert len(records) == 1
+
+    def test_get_cycle_data_raises_on_first_page_error(self, whoop_247: Whoop247Data) -> None:
+        """A failure on the first page propagates instead of returning empty data."""
+        with (
+            patch.object(whoop_247, "_make_api_request", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError),
+        ):
+            whoop_247.get_cycle_data(
+                MagicMock(),
+                uuid4(),
+                datetime(2024, 1, 1, tzinfo=timezone.utc),
+                datetime(2024, 1, 31, tzinfo=timezone.utc),
+            )

--- a/backend/tests/providers/whoop/test_whoop_247_data.py
+++ b/backend/tests/providers/whoop/test_whoop_247_data.py
@@ -1,0 +1,133 @@
+"""Tests for Whoop 247 data implementation."""
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models import HealthScore
+from app.repositories.user_connection_repository import UserConnectionRepository
+from app.schemas.enums import HealthScoreCategory
+from app.services.providers.whoop.data_247 import Whoop247Data
+from app.services.providers.whoop.oauth import WhoopOAuth
+from tests.factories import UserFactory
+
+
+class TestWhoop247Data:
+    """Tests for Whoop247Data class."""
+
+    @pytest.fixture
+    def whoop_247(self, db: Session) -> Whoop247Data:
+        """Create Whoop247Data instance for testing."""
+        connection_repo = UserConnectionRepository()
+        oauth = WhoopOAuth(
+            user_repo=MagicMock(),
+            connection_repo=connection_repo,
+            provider_name="whoop",
+            api_base_url="https://api.prod.whoop.com/developer",
+        )
+        return Whoop247Data(
+            provider_name="whoop",
+            api_base_url="https://api.prod.whoop.com/developer",
+            oauth=oauth,
+        )
+
+    @pytest.fixture
+    def sample_cycle(self) -> dict[str, Any]:
+        """Sample Whoop cycle record."""
+        return {
+            "id": 93845,
+            "user_id": 10129,
+            "created_at": "2024-01-15T11:25:44.774Z",
+            "updated_at": "2024-01-16T14:25:44.774Z",
+            "start": "2024-01-15T02:25:44.774Z",
+            "end": "2024-01-16T03:25:44.774Z",
+            "timezone_offset": "-05:00",
+            "score_state": "SCORED",
+            "score": {
+                "strain": 5.2951527,
+                "kilojoule": 8288.297,
+                "average_heart_rate": 68,
+                "max_heart_rate": 141,
+            },
+        }
+
+    def test_normalize_cycle_scored(self, whoop_247: Whoop247Data, sample_cycle: dict[str, Any]) -> None:
+        """Scored, completed cycle becomes a strain health score."""
+        user_id = uuid4()
+
+        health_score = whoop_247.normalize_cycle(sample_cycle, user_id)
+
+        assert health_score is not None
+        assert health_score.category == HealthScoreCategory.STRAIN
+        assert health_score.user_id == user_id
+        assert float(health_score.value) == pytest.approx(5.2951527)
+        assert health_score.recorded_at == datetime(2024, 1, 15, 2, 25, 44, 774000, tzinfo=timezone.utc)
+        assert health_score.components is not None
+        assert health_score.components["kilojoule"].value == pytest.approx(8288.297)
+        assert health_score.components["average_heart_rate"].value == 68
+        assert health_score.components["max_heart_rate"].value == 141
+
+    def test_normalize_cycle_unscored(self, whoop_247: Whoop247Data, sample_cycle: dict[str, Any]) -> None:
+        """Unscored cycle is skipped."""
+        sample_cycle["score_state"] = "PENDING_SCORE"
+
+        assert whoop_247.normalize_cycle(sample_cycle, uuid4()) is None
+
+    def test_normalize_cycle_in_progress(self, whoop_247: Whoop247Data, sample_cycle: dict[str, Any]) -> None:
+        """Cycle without end time (still in progress) is skipped."""
+        sample_cycle["end"] = None
+
+        assert whoop_247.normalize_cycle(sample_cycle, uuid4()) is None
+
+    def test_normalize_cycle_missing_strain(self, whoop_247: Whoop247Data, sample_cycle: dict[str, Any]) -> None:
+        """Cycle without strain in score is skipped."""
+        sample_cycle["score"] = {"kilojoule": 8288.297}
+
+        assert whoop_247.normalize_cycle(sample_cycle, uuid4()) is None
+
+    def test_get_cycle_data_paginates(self, whoop_247: Whoop247Data, sample_cycle: dict[str, Any]) -> None:
+        """Cycle fetch follows next_token pagination on /v2/cycle."""
+        page_one = {"records": [sample_cycle], "next_token": "token123"}
+        page_two = {"records": [dict(sample_cycle, id=93846)], "next_token": None}
+
+        with patch.object(whoop_247, "_make_api_request", side_effect=[page_one, page_two]) as mock_request:
+            records = whoop_247.get_cycle_data(
+                MagicMock(),
+                uuid4(),
+                datetime(2024, 1, 1, tzinfo=timezone.utc),
+                datetime(2024, 1, 31, tzinfo=timezone.utc),
+            )
+
+        assert len(records) == 2
+        assert mock_request.call_count == 2
+        first_call = mock_request.call_args_list[0]
+        assert first_call.args[2] == "/v2/cycle"
+        second_call = mock_request.call_args_list[1]
+        assert second_call.kwargs["params"]["nextToken"] == "token123"
+
+    def test_load_and_save_cycles(
+        self,
+        db: Session,
+        whoop_247: Whoop247Data,
+        sample_cycle: dict[str, Any],
+    ) -> None:
+        """Cycle records are saved as strain health scores."""
+        user = UserFactory()
+
+        with patch.object(whoop_247, "get_cycle_data", return_value=[sample_cycle]):
+            count = whoop_247.load_and_save_cycles(
+                db,
+                user.id,
+                datetime(2024, 1, 1, tzinfo=timezone.utc),
+                datetime(2024, 1, 31, tzinfo=timezone.utc),
+            )
+
+        assert count == 1
+        saved = db.query(HealthScore).filter(HealthScore.user_id == user.id).all()
+        assert len(saved) == 1
+        assert saved[0].category == HealthScoreCategory.STRAIN
+        assert float(saved[0].value) == pytest.approx(5.2951527, abs=1e-3)

--- a/docs/providers/coverage.mdx
+++ b/docs/providers/coverage.mdx
@@ -345,7 +345,7 @@ Key differences and limitations to be aware of when working with each provider:
   - Sleep data fully implemented with all stages and efficiency
   - Recovery data fully implemented: recovery score, resting heart rate, HRV (RMSSD), SpO2, skin temperature
   - Body measurements (height, weight) synced from user profile
-  - Strain scores available but not yet implemented
+  - Strain scores implemented: daily strain synced from the cycle endpoint, per-workout strain synced with workouts
 </Accordion>
 
 <Accordion title="Ultrahuman">

--- a/docs/providers/coverage.mdx
+++ b/docs/providers/coverage.mdx
@@ -345,7 +345,7 @@ Key differences and limitations to be aware of when working with each provider:
   - Sleep data fully implemented with all stages and efficiency
   - Recovery data fully implemented: recovery score, resting heart rate, HRV (RMSSD), SpO2, skin temperature
   - Body measurements (height, weight) synced from user profile
-  - Strain scores implemented: daily strain synced from the cycle endpoint, per-workout strain synced with workouts
+  - Strain scores implemented: daily strain synced from the cycle endpoint (health score qualifier `daily`), per-workout strain synced with workouts (qualifier null)
 </Accordion>
 
 <Accordion title="Ultrahuman">

--- a/docs/providers/whoop-api-integration.mdx
+++ b/docs/providers/whoop-api-integration.mdx
@@ -238,7 +238,7 @@ Whoop applies two rate limits by default:
 | Per minute | 100 requests |
 | Per day | 10,000 requests |
 
-**How Open Wearables uses the quota:** Each sync cycle per user makes ~4-7 API requests (workouts, sleep, recovery, and body measurements — each paginated at 25 items per page). With the default polling interval of 1 hour, that's roughly **~120 requests per user per day**. This means the default rate limits comfortably support **~60-80 connected users** per app.
+**How Open Wearables uses the quota:** Each sync cycle per user makes ~5-8 API requests (workouts, sleep, recovery, cycles, and body measurements - each paginated at 25 items per page). With the default polling interval of 1 hour, that's roughly **~140 requests per user per day**. This means the default rate limits comfortably support **~60-70 connected users** per app.
 
 If you need to support more users right now, you can request increased rate limits from Whoop via the [Developer Dashboard](https://developer-dashboard.whoop.com/).
 


### PR DESCRIPTION
## Description

Adds `/v2/cycle` support to the Whoop provider, as requested in #1008. Whoop cycles carry the daily strain score (present even on days without workouts), which was previously never ingested - only per-workout strain was stored.

- `get_cycle_data` fetches cycles with pagination from `/v2/cycle`
- `normalize_cycle` maps a scored cycle to a `HealthScoreCreate` with `category=STRAIN`, `qualifier="daily"`, the cycle's `timezone_offset` as `zone_offset`, and kilojoule / average_heart_rate / max_heart_rate as score components. The qualifier separates day-level cycle strain from the per-workout strain scores `workouts.py` already emits under the same `(provider, category)` - without it, consumers could not tell the two apart.
- `load_and_save_cycles` is wired into `load_and_save_all` (new `cycle_scores_synced` result key)
- Per the issue's suggestion to make the copied code reusable, the identical pagination loops in `get_sleep_data` and `get_recovery_data` were extracted into `_get_paginated_records`, which the new cycle fetch also uses
- `docs/providers/coverage.mdx`: updated the stale "Strain scores available but not yet implemented" line in the Whoop accordion

In-progress cycles (no `end` yet) are skipped: their strain is provisional, and since health score inserts dedupe via `on_conflict_do_nothing`, saving a partial value would lock it in permanently. The completed cycle is picked up on the next sync.

No scope changes needed - `read:cycles` is already in `whoop_default_scope`.

Resolves #1008

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes (ruff + ty pass; prettier hook needs frontend `node_modules`, no frontend files touched)

## Testing Instructions

**Steps to test:**
1. `cd backend && uv run pytest tests/providers/whoop/`
2. Connect a Whoop account and trigger a 247 sync.
3. Check health scores for the user: daily `strain` entries (qualifier `daily`) should appear for each completed cycle, alongside `recovery`.

**Expected behavior:**

One strain health score per completed, scored cycle, with kilojoule and heart rate values as components and the cycle's timezone offset preserved. Unscored or in-progress cycles are skipped. Re-syncing the same window does not duplicate scores (covered by a test).

## Additional Notes

- This should also help with #1113 (strain visible in Whoop app but missing from the dashboard).
- Merge-order heads-up: open PR #1092 (transaction boundaries to callers) rewrites every `db.commit()`/`db.rollback()` in this file to the savepoint/flush pattern. Whichever of the two merges second needs a small rebase; if #1092 lands first I will adapt the cycle block to `begin_nested()`/`flush()`.
- Known limitation, intentionally out of scope: a cycle that is still `PENDING_SCORE` when a sync window passes over it can be missed if it scores only after the next window starts. Padding the cycle fetch window behind `last_synced_at` (dedupe makes re-fetching idempotent) would close that gap; happy to do it here or in a follow-up if desired.
- Related limitation: if Whoop re-scores an already-completed cycle (e.g. after late device data upload), the first saved strain stays in place because health score inserts use `on_conflict_do_nothing`. Fixing that means switching the dedupe to `on_conflict_do_update`, which changes shared `HealthScoreRepository.bulk_create` behavior for all providers - deliberately not done in this PR. The consumer-facing semantics of `daily` strain scores are documented in the `qualifier` field description and `coverage.mdx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Whoop cycle syncing and daily strain score support with paginated fetching and partial-result recovery on downstream errors.

* **Tests**
  * Added tests for cycle normalization, pagination behavior, error recovery, persistence, and idempotent re-syncing to prevent duplicates.

* **Documentation**
  * Updated provider docs and rate-limit guidance to reflect cycle/strain syncing and adjusted request estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->