### PR TITLE
fix: mount redis volume at /data so persistence works

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -95,7 +95,7 @@ services:
     ports:
       - "${REDIS_PORT:-6379}:6379"
     volumes:
-      - redis_data:/var/lib/redis/data
+      - redis_data:/data
     restart: unless-stopped
 
   svix-server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
     ports:
       - "${REDIS_PORT:-6379}:6379"
     volumes:
-      - redis_data:/var/lib/redis/data
+      - redis_data:/data
 
   svix-server:
     container_name: svix-server__open-wearables


### PR DESCRIPTION
Closes #1126. Spun out of #1111.

The `redis:8` image persists to `/data` (`VOLUME /data`, `WORKDIR /data`), but both compose files mounted the named volume at `/var/lib/redis/data`. As a result `dump.rdb` went to an anonymous volume and every container recreate wiped all redis data, including the svix queue consumer group (see #1111 for the fallout: svix-server never recovers from NOGROUP at runtime, so the delivery stream grows unbounded).

One-line change in each compose file: mount `redis_data:/data`.

Tested locally: `docker compose up -d redis`, `SET persistence_test ok`, `SAVE`, `docker compose down redis`, `up -d redis` again - key survives the recreate and `dump.rdb` is in the `redis_data` volume.

Note for existing deployments: data currently sitting in the anonymous volume at `/data` is not migrated; after this change redis starts from the (previously unused) `redis_data` volume. For dev that is cache/queue state only. Restart svix-server once after applying so it recreates its consumer group.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redis data storage path in deployment configurations for both production and development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->