### PR TITLE
feat(frontend): add Data Explorer page to browse all stored data points

### DIFF
--- a/frontend/src/components/data-explorer/scores-explorer.tsx
+++ b/frontend/src/components/data-explorer/scores-explorer.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react';
+import { Gauge } from 'lucide-react';
+import { useHealthScores } from '@/hooks/api/use-health';
+import { useDateRange } from '@/hooks/use-date-range';
+import {
+  DateRangeSelector,
+  type DateRangeValue,
+} from '@/components/ui/date-range-selector';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
+import { formatDate } from '@/lib/utils/format';
+import { formatLabel, formatValue } from './utils';
+
+const PAGE_SIZE = 50;
+
+interface ScoresExplorerProps {
+  userId: string;
+}
+
+export function ScoresExplorer({ userId }: ScoresExplorerProps) {
+  const [range, setRange] = useState<DateRangeValue>(90);
+  const [page, setPage] = useState(0);
+  const { startDate, endDate } = useDateRange(range);
+
+  useEffect(() => {
+    setPage(0);
+  }, [range]);
+
+  const { data, isLoading, isFetching } = useHealthScores(userId, {
+    start_date: startDate,
+    end_date: endDate,
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
+  });
+
+  const scores = data?.data ?? [];
+  const hasMore = data?.pagination?.has_more ?? false;
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-card/40 p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <h3 className="text-sm font-medium text-foreground">Health Scores</h3>
+        <DateRangeSelector value={range} onChange={setRange} />
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      ) : scores.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border/60 bg-muted/10 p-12 text-center">
+          <Gauge className="mx-auto h-8 w-8 text-muted-foreground/40" />
+          <p className="mt-2 text-sm text-muted-foreground">
+            No health scores in the last {range} days. Try a wider date range.
+          </p>
+        </div>
+      ) : (
+        <>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Recorded</TableHead>
+                <TableHead>Category</TableHead>
+                <TableHead className="text-right">Score</TableHead>
+                <TableHead>Qualifier</TableHead>
+                <TableHead>Provider</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {scores.map((score) => (
+                <TableRow key={score.id}>
+                  <TableCell className="whitespace-nowrap py-2.5 text-muted-foreground">
+                    {formatDate(score.recorded_at)}
+                  </TableCell>
+                  <TableCell className="py-2.5">
+                    {formatLabel(score.category)}
+                  </TableCell>
+                  <TableCell className="py-2.5 text-right font-medium tabular-nums">
+                    {formatValue(score.value)}
+                  </TableCell>
+                  <TableCell className="py-2.5 capitalize text-muted-foreground">
+                    {score.qualifier ?? '—'}
+                  </TableCell>
+                  <TableCell className="py-2.5 text-muted-foreground">
+                    {formatLabel(score.provider)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          {(page > 0 || hasMore) && (
+            <div className="mt-4 flex items-center justify-end gap-2 border-t border-border/60 pt-4">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page === 0 || isFetching}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!hasMore || isFetching}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/data-explorer/sleep-explorer.tsx
+++ b/frontend/src/components/data-explorer/sleep-explorer.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+import { Moon } from 'lucide-react';
+import { useSleepSessions } from '@/hooks/api/use-health';
+import { useDateRange } from '@/hooks/use-date-range';
+import { useCursorPagination } from '@/hooks/use-cursor-pagination';
+import { CursorPagination } from '@/components/common/cursor-pagination';
+import {
+  DateRangeSelector,
+  type DateRangeValue,
+} from '@/components/ui/date-range-selector';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { formatDate, formatDuration, formatPercent } from '@/lib/utils/format';
+import { formatSource } from './utils';
+
+interface SleepExplorerProps {
+  userId: string;
+}
+
+export function SleepExplorer({ userId }: SleepExplorerProps) {
+  const [range, setRange] = useState<DateRangeValue>(90);
+  const { startDate, endDate } = useDateRange(range);
+  const pagination = useCursorPagination();
+  const { reset } = pagination;
+
+  useEffect(() => {
+    reset();
+  }, [range, reset]);
+
+  const { data, isLoading, isFetching } = useSleepSessions(userId, {
+    start_date: startDate,
+    end_date: endDate,
+    limit: 50,
+    cursor: pagination.currentCursor ?? undefined,
+  });
+
+  const sessions = data?.data ?? [];
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-card/40 p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <h3 className="text-sm font-medium text-foreground">Sleep Sessions</h3>
+        <DateRangeSelector value={range} onChange={setRange} />
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      ) : sessions.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border/60 bg-muted/10 p-12 text-center">
+          <Moon className="mx-auto h-8 w-8 text-muted-foreground/40" />
+          <p className="mt-2 text-sm text-muted-foreground">
+            No sleep sessions in the last {range} days. Try a wider date range.
+          </p>
+        </div>
+      ) : (
+        <>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Start</TableHead>
+                <TableHead>End</TableHead>
+                <TableHead>In Bed</TableHead>
+                <TableHead>Asleep</TableHead>
+                <TableHead>Efficiency</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Source</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sessions.map((session) => (
+                <TableRow key={session.id}>
+                  <TableCell className="whitespace-nowrap py-2.5 text-muted-foreground">
+                    {formatDate(session.start_time)}
+                  </TableCell>
+                  <TableCell className="whitespace-nowrap py-2.5 text-muted-foreground">
+                    {formatDate(session.end_time)}
+                  </TableCell>
+                  <TableCell className="py-2.5 tabular-nums">
+                    {formatDuration(session.duration_seconds)}
+                  </TableCell>
+                  <TableCell className="py-2.5 tabular-nums">
+                    {formatDuration(session.sleep_duration_seconds)}
+                  </TableCell>
+                  <TableCell className="py-2.5 tabular-nums">
+                    {formatPercent(session.efficiency_percent)}
+                  </TableCell>
+                  <TableCell className="py-2.5">
+                    {session.is_nap ? 'Nap' : 'Night'}
+                  </TableCell>
+                  <TableCell className="py-2.5 text-muted-foreground">
+                    {formatSource(session.source)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          <CursorPagination
+            currentPage={pagination.currentPage}
+            hasPrevPage={pagination.hasPrevPage}
+            hasNextPage={data?.pagination?.has_more ?? false}
+            isFetching={isFetching}
+            onPrevPage={pagination.goToPrevPage}
+            onNextPage={() =>
+              pagination.goToNextPage(data?.pagination?.next_cursor ?? null)
+            }
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/data-explorer/timeseries-explorer.tsx
+++ b/frontend/src/components/data-explorer/timeseries-explorer.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Database } from 'lucide-react';
+import { useTimeSeries, useUserDataSummary } from '@/hooks/api/use-health';
+import { useDateRange } from '@/hooks/use-date-range';
+import { useCursorPagination } from '@/hooks/use-cursor-pagination';
+import { CursorPagination } from '@/components/common/cursor-pagination';
+import {
+  DateRangeSelector,
+  type DateRangeValue,
+} from '@/components/ui/date-range-selector';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+import { formatDate, formatNumber } from '@/lib/utils/format';
+import { formatLabel, formatSource, formatValue } from './utils';
+
+interface TimeseriesExplorerProps {
+  userId: string;
+}
+
+export function TimeseriesExplorer({ userId }: TimeseriesExplorerProps) {
+  const { data: summary, isLoading: isSummaryLoading } =
+    useUserDataSummary(userId);
+  const [selectedType, setSelectedType] = useState<string | null>(null);
+  const [range, setRange] = useState<DateRangeValue>(30);
+  const { startDate, endDate } = useDateRange(range);
+  const pagination = useCursorPagination();
+  const { reset } = pagination;
+
+  useEffect(() => {
+    reset();
+  }, [selectedType, range, reset]);
+
+  const typeEntries = useMemo(
+    () =>
+      Object.entries(summary?.series_type_counts ?? {}).sort(
+        (a, b) => b[1] - a[1]
+      ),
+    [summary]
+  );
+
+  const { data, isLoading, isFetching } = useTimeSeries(userId, {
+    start_time: startDate,
+    end_time: endDate,
+    ...(selectedType ? { types: [selectedType] } : {}),
+    limit: 50,
+    cursor: pagination.currentCursor ?? undefined,
+  });
+
+  const samples = data?.data ?? [];
+  const hasNextPage = data?.pagination?.has_more ?? false;
+  const nextCursor = data?.pagination?.next_cursor ?? null;
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[280px_1fr]">
+      {/* Series type list */}
+      <div className="rounded-xl border border-border/60 bg-card/40 p-3">
+        <h3 className="mb-2 px-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          Series Types
+        </h3>
+        {isSummaryLoading ? (
+          <div className="space-y-2 px-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-8 w-full" />
+            ))}
+          </div>
+        ) : (
+          <nav className="max-h-[32rem] space-y-0.5 overflow-y-auto">
+            <TypeButton
+              label="All types"
+              count={summary?.total_data_points ?? 0}
+              isActive={selectedType === null}
+              onClick={() => setSelectedType(null)}
+            />
+            {typeEntries.map(([code, count]) => (
+              <TypeButton
+                key={code}
+                label={formatLabel(code)}
+                count={count}
+                isActive={selectedType === code}
+                onClick={() => setSelectedType(code)}
+              />
+            ))}
+          </nav>
+        )}
+      </div>
+
+      {/* Samples table */}
+      <div className="rounded-xl border border-border/60 bg-card/40 p-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+          <h3 className="text-sm font-medium text-foreground">
+            {selectedType ? formatLabel(selectedType) : 'All Data Points'}
+          </h3>
+          <DateRangeSelector value={range} onChange={setRange} />
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <Skeleton key={i} className="h-10 w-full" />
+            ))}
+          </div>
+        ) : samples.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border/60 bg-muted/10 p-12 text-center">
+            <Database className="mx-auto h-8 w-8 text-muted-foreground/40" />
+            <p className="mt-2 text-sm text-muted-foreground">
+              No data points in the last {range} days. Try a wider date range.
+            </p>
+          </div>
+        ) : (
+          <>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Timestamp</TableHead>
+                  <TableHead>Type</TableHead>
+                  <TableHead className="text-right">Value</TableHead>
+                  <TableHead>Unit</TableHead>
+                  <TableHead>Source</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {samples.map((sample, i) => (
+                  <TableRow key={`${sample.timestamp}-${sample.type}-${i}`}>
+                    <TableCell className="whitespace-nowrap py-2.5 text-muted-foreground">
+                      {formatDate(sample.timestamp)}
+                    </TableCell>
+                    <TableCell className="py-2.5">
+                      {formatLabel(sample.type)}
+                    </TableCell>
+                    <TableCell className="py-2.5 text-right font-medium tabular-nums">
+                      {formatValue(sample.value)}
+                    </TableCell>
+                    <TableCell className="py-2.5 text-muted-foreground">
+                      {sample.unit}
+                    </TableCell>
+                    <TableCell className="py-2.5 text-muted-foreground">
+                      {formatSource(sample.source)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            <CursorPagination
+              currentPage={pagination.currentPage}
+              hasPrevPage={pagination.hasPrevPage}
+              hasNextPage={hasNextPage}
+              isFetching={isFetching}
+              onPrevPage={pagination.goToPrevPage}
+              onNextPage={() => pagination.goToNextPage(nextCursor)}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TypeButton({
+  label,
+  count,
+  isActive,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  isActive: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
+        isActive
+          ? 'bg-muted text-foreground'
+          : 'text-muted-foreground hover:bg-card/60 hover:text-foreground/90'
+      )}
+    >
+      <span className="truncate">{label}</span>
+      <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+        {formatNumber(count)}
+      </span>
+    </button>
+  );
+}

--- a/frontend/src/components/data-explorer/user-picker.tsx
+++ b/frontend/src/components/data-explorer/user-picker.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { Search, X } from 'lucide-react';
+import { useUser, useUsers } from '@/hooks/api/use-users';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { UserRead } from '@/lib/api/types';
+
+interface UserPickerProps {
+  selectedUserId: string | undefined;
+  onSelect: (userId: string | undefined) => void;
+}
+
+function userDisplayName(user: UserRead): string {
+  const name = [user.first_name, user.last_name].filter(Boolean).join(' ');
+  return name || user.email || user.external_user_id || user.id;
+}
+
+export function UserPicker({ selectedUserId, onSelect }: UserPickerProps) {
+  const [input, setInput] = useState('');
+  const [search, setSearch] = useState('');
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setSearch(input.trim()), 250);
+    return () => clearTimeout(timer);
+  }, [input]);
+
+  const { data: selectedUser } = useUser(selectedUserId ?? '');
+  const { data: results, isFetching } = useUsers({
+    search: search || undefined,
+    limit: 8,
+  });
+
+  if (selectedUserId) {
+    const name = selectedUser ? userDisplayName(selectedUser) : '…';
+    return (
+      <div className="flex items-center justify-between rounded-xl border border-border/60 bg-card/40 px-4 py-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border/60 bg-muted/40 text-xs font-bold text-foreground/70">
+            {name.charAt(0).toUpperCase()}
+          </div>
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium text-foreground">
+              {name}
+            </p>
+            <p className="truncate font-mono text-xs text-muted-foreground">
+              {selectedUserId}
+            </p>
+          </div>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onSelect(undefined)}
+          className="gap-1 text-xs text-muted-foreground"
+        >
+          <X className="h-3 w-3" />
+          Change user
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative max-w-xl">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder="Search users by name, email, or external ID..."
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setOpen(false)}
+          className="pl-9"
+        />
+      </div>
+      {open && (
+        <div className="absolute z-10 mt-1 w-full overflow-hidden rounded-lg border border-border/60 bg-popover shadow-lg">
+          {isFetching && !results ? (
+            <div className="space-y-2 p-3">
+              <Skeleton className="h-8 w-full" />
+              <Skeleton className="h-8 w-full" />
+            </div>
+          ) : results && results.items.length > 0 ? (
+            <ul>
+              {results.items.map((user) => (
+                <li key={user.id}>
+                  <button
+                    type="button"
+                    // onMouseDown fires before the input's onBlur closes the list
+                    onMouseDown={() => {
+                      onSelect(user.id);
+                      setInput('');
+                    }}
+                    className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left transition-colors hover:bg-card/60"
+                  >
+                    <span className="truncate text-sm text-foreground">
+                      {userDisplayName(user)}
+                    </span>
+                    <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                      {user.id.slice(0, 8)}…
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="p-3 text-sm text-muted-foreground">No users found.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/data-explorer/utils.ts
+++ b/frontend/src/components/data-explorer/utils.ts
@@ -1,0 +1,26 @@
+import type { SourceMetadata } from '@/lib/api/types';
+
+/** Format a snake_case code (series type, provider, workout type) for display. */
+export function formatLabel(code: string | null | undefined): string {
+  if (!code) return '—';
+  return code.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Format a source (provider + optional device) for display. */
+export function formatSource(
+  source:
+    | SourceMetadata
+    | { provider: string; device?: string | null }
+    | null
+    | undefined
+): string {
+  if (!source) return '—';
+  const provider = formatLabel(source.provider);
+  return source.device ? `${provider} · ${source.device}` : provider;
+}
+
+/** Format a numeric sample value with at most 2 decimal places. */
+export function formatValue(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '—';
+  return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}

--- a/frontend/src/components/data-explorer/workouts-explorer.tsx
+++ b/frontend/src/components/data-explorer/workouts-explorer.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import { Dumbbell } from 'lucide-react';
+import { useWorkouts } from '@/hooks/api/use-health';
+import { useDateRange } from '@/hooks/use-date-range';
+import { useCursorPagination } from '@/hooks/use-cursor-pagination';
+import { CursorPagination } from '@/components/common/cursor-pagination';
+import {
+  DateRangeSelector,
+  type DateRangeValue,
+} from '@/components/ui/date-range-selector';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  formatCalories,
+  formatDate,
+  formatDistance,
+  formatDuration,
+  formatHeartRate,
+} from '@/lib/utils/format';
+import { formatLabel, formatSource } from './utils';
+
+interface WorkoutsExplorerProps {
+  userId: string;
+}
+
+export function WorkoutsExplorer({ userId }: WorkoutsExplorerProps) {
+  const [range, setRange] = useState<DateRangeValue>(90);
+  const { startDate, endDate } = useDateRange(range);
+  const pagination = useCursorPagination();
+  const { reset } = pagination;
+
+  useEffect(() => {
+    reset();
+  }, [range, reset]);
+
+  const { data, isLoading, isFetching } = useWorkouts(userId, {
+    start_date: startDate,
+    end_date: endDate,
+    limit: 50,
+    cursor: pagination.currentCursor ?? undefined,
+    sort_order: 'desc',
+  });
+
+  const workouts = data?.data ?? [];
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-card/40 p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <h3 className="text-sm font-medium text-foreground">Workouts</h3>
+        <DateRangeSelector value={range} onChange={setRange} />
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </div>
+      ) : workouts.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border/60 bg-muted/10 p-12 text-center">
+          <Dumbbell className="mx-auto h-8 w-8 text-muted-foreground/40" />
+          <p className="mt-2 text-sm text-muted-foreground">
+            No workouts in the last {range} days. Try a wider date range.
+          </p>
+        </div>
+      ) : (
+        <>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Start</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Duration</TableHead>
+                <TableHead>Distance</TableHead>
+                <TableHead>Calories</TableHead>
+                <TableHead>Avg HR</TableHead>
+                <TableHead>Source</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {workouts.map((workout) => (
+                <TableRow key={workout.id}>
+                  <TableCell className="whitespace-nowrap py-2.5 text-muted-foreground">
+                    {formatDate(workout.start_time)}
+                  </TableCell>
+                  <TableCell className="py-2.5">
+                    {formatLabel(workout.type)}
+                  </TableCell>
+                  <TableCell className="py-2.5 tabular-nums">
+                    {formatDuration(workout.duration_seconds)}
+                  </TableCell>
+                  <TableCell className="py-2.5 tabular-nums">
+                    {formatDistance(workout.distance_meters)}
+                  </TableCell>
+                  <TableCell className="py-2.5 tabular-nums">
+                    {formatCalories(workout.calories_kcal)}
+                  </TableCell>
+                  <TableCell className="py-2.5 tabular-nums">
+                    {formatHeartRate(workout.avg_heart_rate_bpm)}
+                  </TableCell>
+                  <TableCell className="py-2.5 text-muted-foreground">
+                    {formatSource(workout.source)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          <CursorPagination
+            currentPage={pagination.currentPage}
+            hasPrevPage={pagination.hasPrevPage}
+            hasNextPage={data?.pagination?.has_more ?? false}
+            isFetching={isFetching}
+            onPrevPage={pagination.goToPrevPage}
+            onNextPage={() =>
+              pagination.goToNextPage(data?.pagination?.next_cursor ?? null)
+            }
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/simple-sidebar.tsx
+++ b/frontend/src/components/layout/simple-sidebar.tsx
@@ -8,6 +8,7 @@ import {
   ExternalLink,
   Webhook,
   RefreshCw,
+  Database,
 } from 'lucide-react';
 import logotype from '@/logotype.svg';
 import { cn } from '@/lib/utils';
@@ -25,6 +26,11 @@ const menuItems = [
     title: 'Users',
     url: ROUTES.users,
     icon: Users,
+  },
+  {
+    title: 'Data Explorer',
+    url: ROUTES.dataExplorer,
+    icon: Database,
   },
   {
     title: 'Webhooks',

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -135,6 +135,8 @@ export interface TimeSeriesSample {
   type: string;
   value: number;
   unit: string;
+  zone_offset?: string | null;
+  source?: SourceMetadata | null;
 }
 
 export interface TimeSeriesParams {

--- a/frontend/src/lib/constants/routes.ts
+++ b/frontend/src/lib/constants/routes.ts
@@ -10,6 +10,7 @@ export const ROUTES = {
   dashboard: '/dashboard',
   users: '/users',
   user: '/users/$userId',
+  dataExplorer: '/data-explorer',
   webhooks: '/webhooks',
   syncs: '/syncs',
   settings: '/settings',

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as AuthenticatedWebhooksRouteImport } from './routes/_authenticat
 import { Route as AuthenticatedUsersRouteImport } from './routes/_authenticated/users'
 import { Route as AuthenticatedSyncsRouteImport } from './routes/_authenticated/syncs'
 import { Route as AuthenticatedSettingsRouteImport } from './routes/_authenticated/settings'
+import { Route as AuthenticatedDataExplorerRouteImport } from './routes/_authenticated/data-explorer'
 import { Route as AuthenticatedDashboardRouteImport } from './routes/_authenticated/dashboard'
 import { Route as AuthenticatedWebhooksIndexRouteImport } from './routes/_authenticated/webhooks/index'
 import { Route as AuthenticatedUsersIndexRouteImport } from './routes/_authenticated/users/index'
@@ -91,6 +92,12 @@ const AuthenticatedSettingsRoute = AuthenticatedSettingsRouteImport.update({
   path: '/settings',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedDataExplorerRoute =
+  AuthenticatedDataExplorerRouteImport.update({
+    id: '/data-explorer',
+    path: '/data-explorer',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedDashboardRoute = AuthenticatedDashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
@@ -153,6 +160,7 @@ export interface FileRoutesByFullPath {
   '/register': typeof RegisterRoute
   '/reset-password': typeof ResetPasswordRoute
   '/dashboard': typeof AuthenticatedDashboardRoute
+  '/data-explorer': typeof AuthenticatedDataExplorerRoute
   '/settings': typeof AuthenticatedSettingsRoute
   '/syncs': typeof AuthenticatedSyncsRouteWithChildren
   '/users': typeof AuthenticatedUsersRouteWithChildren
@@ -176,6 +184,7 @@ export interface FileRoutesByTo {
   '/register': typeof RegisterRoute
   '/reset-password': typeof ResetPasswordRoute
   '/dashboard': typeof AuthenticatedDashboardRoute
+  '/data-explorer': typeof AuthenticatedDataExplorerRoute
   '/settings': typeof AuthenticatedSettingsRoute
   '/widget/connect': typeof WidgetConnectRoute
   '/users/$userId': typeof AuthenticatedUsersUserIdRoute
@@ -197,6 +206,7 @@ export interface FileRoutesById {
   '/register': typeof RegisterRoute
   '/reset-password': typeof ResetPasswordRoute
   '/_authenticated/dashboard': typeof AuthenticatedDashboardRoute
+  '/_authenticated/data-explorer': typeof AuthenticatedDataExplorerRoute
   '/_authenticated/settings': typeof AuthenticatedSettingsRoute
   '/_authenticated/syncs': typeof AuthenticatedSyncsRouteWithChildren
   '/_authenticated/users': typeof AuthenticatedUsersRouteWithChildren
@@ -222,6 +232,7 @@ export interface FileRouteTypes {
     | '/register'
     | '/reset-password'
     | '/dashboard'
+    | '/data-explorer'
     | '/settings'
     | '/syncs'
     | '/users'
@@ -245,6 +256,7 @@ export interface FileRouteTypes {
     | '/register'
     | '/reset-password'
     | '/dashboard'
+    | '/data-explorer'
     | '/settings'
     | '/widget/connect'
     | '/users/$userId'
@@ -265,6 +277,7 @@ export interface FileRouteTypes {
     | '/register'
     | '/reset-password'
     | '/_authenticated/dashboard'
+    | '/_authenticated/data-explorer'
     | '/_authenticated/settings'
     | '/_authenticated/syncs'
     | '/_authenticated/users'
@@ -333,7 +346,7 @@ declare module '@tanstack/react-router' {
     '/_authenticated': {
       id: '/_authenticated'
       path: ''
-      fullPath: ''
+      fullPath: '/'
       preLoaderRoute: typeof AuthenticatedRouteImport
       parentRoute: typeof rootRouteImport
     }
@@ -377,6 +390,13 @@ declare module '@tanstack/react-router' {
       path: '/settings'
       fullPath: '/settings'
       preLoaderRoute: typeof AuthenticatedSettingsRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/data-explorer': {
+      id: '/_authenticated/data-explorer'
+      path: '/data-explorer'
+      fullPath: '/data-explorer'
+      preLoaderRoute: typeof AuthenticatedDataExplorerRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/dashboard': {
@@ -493,6 +513,7 @@ const AuthenticatedWebhooksRouteWithChildren =
 
 interface AuthenticatedRouteChildren {
   AuthenticatedDashboardRoute: typeof AuthenticatedDashboardRoute
+  AuthenticatedDataExplorerRoute: typeof AuthenticatedDataExplorerRoute
   AuthenticatedSettingsRoute: typeof AuthenticatedSettingsRoute
   AuthenticatedSyncsRoute: typeof AuthenticatedSyncsRouteWithChildren
   AuthenticatedUsersRoute: typeof AuthenticatedUsersRouteWithChildren
@@ -501,6 +522,7 @@ interface AuthenticatedRouteChildren {
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedDashboardRoute: AuthenticatedDashboardRoute,
+  AuthenticatedDataExplorerRoute: AuthenticatedDataExplorerRoute,
   AuthenticatedSettingsRoute: AuthenticatedSettingsRoute,
   AuthenticatedSyncsRoute: AuthenticatedSyncsRouteWithChildren,
   AuthenticatedUsersRoute: AuthenticatedUsersRouteWithChildren,

--- a/frontend/src/routes/_authenticated/data-explorer.tsx
+++ b/frontend/src/routes/_authenticated/data-explorer.tsx
@@ -1,0 +1,110 @@
+import { useState } from 'react';
+import { createFileRoute } from '@tanstack/react-router';
+import { Database, Dumbbell, Gauge, Moon, UserSearch } from 'lucide-react';
+import { PageHeader } from '@/components/ui/page-header';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { UserPicker } from '@/components/data-explorer/user-picker';
+import { TimeseriesExplorer } from '@/components/data-explorer/timeseries-explorer';
+import { WorkoutsExplorer } from '@/components/data-explorer/workouts-explorer';
+import { SleepExplorer } from '@/components/data-explorer/sleep-explorer';
+import { ScoresExplorer } from '@/components/data-explorer/scores-explorer';
+import { useUserDataSummary } from '@/hooks/api/use-health';
+import { formatNumber } from '@/lib/utils/format';
+
+interface DataExplorerSearch {
+  userId?: string;
+}
+
+export const Route = createFileRoute('/_authenticated/data-explorer')({
+  component: DataExplorerPage,
+  validateSearch: (search: Record<string, unknown>): DataExplorerSearch => ({
+    userId:
+      typeof search.userId === 'string' && search.userId
+        ? search.userId
+        : undefined,
+  }),
+});
+
+function DataExplorerPage() {
+  const { userId } = Route.useSearch();
+  const navigate = Route.useNavigate();
+
+  const setUserId = (id: string | undefined) => {
+    navigate({ search: { userId: id }, replace: true });
+  };
+
+  return (
+    <div className="space-y-6 p-6 md:p-8">
+      <PageHeader
+        title="Data Explorer"
+        description="Browse every data point collected for a user — raw samples, workouts, sleep sessions, and health scores."
+      />
+
+      <UserPicker selectedUserId={userId} onSelect={setUserId} />
+
+      {userId ? (
+        <ExplorerContent userId={userId} />
+      ) : (
+        <div className="rounded-xl border border-dashed border-border/60 bg-muted/10 p-16 text-center">
+          <UserSearch className="mx-auto h-10 w-10 text-muted-foreground/40" />
+          <p className="mt-3 text-sm text-muted-foreground">
+            Select a user above to explore their data.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ExplorerContent({ userId }: { userId: string }) {
+  const [tab, setTab] = useState('timeseries');
+  const { data: summary } = useUserDataSummary(userId);
+
+  return (
+    <Tabs value={tab} onValueChange={setTab}>
+      <TabsList>
+        <TabsTrigger value="timeseries" className="gap-2">
+          <Database className="h-3.5 w-3.5" />
+          Data Points
+          <TabCount value={summary?.total_data_points} />
+        </TabsTrigger>
+        <TabsTrigger value="workouts" className="gap-2">
+          <Dumbbell className="h-3.5 w-3.5" />
+          Workouts
+          <TabCount value={summary?.total_workouts} />
+        </TabsTrigger>
+        <TabsTrigger value="sleep" className="gap-2">
+          <Moon className="h-3.5 w-3.5" />
+          Sleep
+          <TabCount value={summary?.total_sleep_events} />
+        </TabsTrigger>
+        <TabsTrigger value="scores" className="gap-2">
+          <Gauge className="h-3.5 w-3.5" />
+          Health Scores
+        </TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="timeseries">
+        <TimeseriesExplorer userId={userId} />
+      </TabsContent>
+      <TabsContent value="workouts">
+        <WorkoutsExplorer userId={userId} />
+      </TabsContent>
+      <TabsContent value="sleep">
+        <SleepExplorer userId={userId} />
+      </TabsContent>
+      <TabsContent value="scores">
+        <ScoresExplorer userId={userId} />
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+function TabCount({ value }: { value: number | undefined }) {
+  if (value === undefined) return null;
+  return (
+    <span className="rounded-full border border-border/60 bg-muted/40 px-1.5 py-0.5 text-[10px] tabular-nums text-muted-foreground">
+      {formatNumber(value)}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a new **Data Explorer** page (`/data-explorer`) to the dashboard, linked from the sidebar, for inspecting every data point stored for a user.
- User search with debounced lookup; the selected user is kept in the URL (`?userId=...`) so views are shareable.
- Four tabs built entirely on existing per-user APIs:
  - **Data Points** — sidebar inventory of every series type with counts (from `GET /summaries/data`), plus an "All types" view; raw samples table (timestamp, value, unit, source) via `GET /timeseries` with date-range presets and cursor pagination.
  - **Workouts** — `GET /events/workouts` with cursor pagination.
  - **Sleep** — `GET /events/sleep` sessions with in-bed/asleep/efficiency/nap columns.
  - **Health Scores** — `GET /health-scores` with offset pagination.
- Extends the frontend `TimeSeriesSample` type with `source` and `zone_offset`, which the backend already returns.
- No backend changes; reuses existing hooks (`useUserDataSummary`, `useTimeSeries`, `useWorkouts`, `useSleepSessions`, `useHealthScores`), `useCursorPagination`, `DateRangeSelector`, and shadcn `Table`/`Tabs`.

## Test plan

- [ ] Open `/data-explorer` from the sidebar and search/select a user
- [ ] Verify series type inventory matches the user's Data Summary counts
- [ ] Browse raw samples for a dense type (e.g. heart rate) and page through results
- [ ] Switch date ranges (7d–365d) and confirm pagination resets
- [ ] Check Workouts, Sleep, and Health Scores tabs render and paginate
- [ ] Confirm `?userId=` deep link restores the selected user
- [x] `pnpm run build`, `tsc --noEmit`, `lint:fix`, `format` all pass

## Pancake Recipe

A short stack worth syncing your wearable for — these clock in fluffy, golden, and slightly tangy.

**Ingredients (makes ~10 pancakes)**
- 250 g all-purpose flour
- 2 tbsp sugar
- 2 tsp baking powder
- 1/2 tsp baking soda
- 1/2 tsp fine salt
- 350 ml buttermilk (or milk + 1 tbsp lemon juice, rested 10 min)
- 2 eggs, separated
- 40 g melted butter, plus more for the pan
- 1 tsp vanilla extract
- Zest of half a lemon

**Steps**
1. Whisk flour, sugar, baking powder, baking soda, and salt in a large bowl.
2. In a second bowl, whisk buttermilk, egg yolks, melted butter, vanilla, and lemon zest.
3. Pour the wet mix into the dry and stir until *just* combined — a few lumps are your friends; overmixing makes rubber, not pancakes.
4. Beat the egg whites to soft peaks and gently fold them in. This is the fluff engine.
5. Rest the batter 10 minutes while a heavy pan warms over medium heat.
6. Butter the pan lightly, ladle in ~80 ml of batter per pancake, and wait for bubbles to form and pop across the surface (~2 min).
7. Flip once, cook another 60–90 seconds until golden, and resist the urge to press down.
8. Stack, crown with butter and maple syrup (blueberries optional but encouraged), and serve while your resting heart rate is still low.

**Your chef: Fable 5**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Data Explorer page with tabbed navigation displaying health data across workouts, sleep sessions, health scores, and timeseries measurements
- User selection and account switching capability within the data explorer interface
- Date range filtering and cursor-based pagination controls available on all data views
- Count badges showing activity summary statistics per health data category

<!-- end of auto-generated comment: release notes by coderabbit.ai -->