### PR TITLE
docs: note developer program is on hold

### DIFF
--- a/docs/providers/garmin-api-integration.mdx
+++ b/docs/providers/garmin-api-integration.mdx
@@ -15,6 +15,12 @@ keywords: ["garmin api", "garmin connect api", "garmin health data", "garmin api
 **Garmin API giving you a headache?** We feel your pain - that's exactly why we created Open Wearables. Pop into our [Discord](https://discord.gg/qrcfFnNE6H) if you have questions or want to discover how Open Wearables can solve your problems.
 </Note>
 
+<Warning>
+**The Garmin Connect Developer Program is currently on hold.** Garmin has suspended the developer program and there is no information on when it will be resumed. This means you **cannot create a new developer account at this time**. Existing accounts continue to work normally - only new sign-ups are blocked.
+
+**Need Garmin integration anyway?** With the Open Wearables [custom deployment offer](https://openwearables.io/custom-deployment), the Garmin developer application can be managed for you, which unlocks the integration. Reach out to us on [Discord](https://discord.gg/qrcfFnNE6H) or at [hello@openwearables.io](mailto:hello@openwearables.io) to learn more.
+</Warning>
+
 ## Overview
 
 Garmin Connect provides access to comprehensive fitness and health data from Garmin devices through their Wellness API. The integration supports activities, daily summaries, sleep data, body composition, and more.
@@ -54,6 +60,10 @@ Once you get access to the Developer Portal, you’ll find the full docs, includ
     Garmin access is approval-based. To apply, submit the official form:
 
     - [Garmin Connect Developer Program Access Request Form](https://www.garmin.com/en-US/forms/GarminConnectDeveloperAccess/)
+
+    <Warning>
+    **The developer program is currently suspended by Garmin**, with no announced resumption date - you cannot create a new developer account right now. Existing accounts still work. If you can't get access this way, the Open Wearables [custom deployment offer](https://openwearables.io/custom-deployment) can manage the Garmin developer application on your behalf and unlock the integration - reach out at [hello@openwearables.io](mailto:hello@openwearables.io).
+    </Warning>
 
     <Note>
     **Tips to avoid rejection:**


### PR DESCRIPTION
## Description

The Garmin Connect Developer Program is currently suspended - you can't create a new developer account right now (existing accounts still work). 

The docs still walked people through an application flow that won't go anywhere, so this adds clear warnings about the hold and points to the custom deployment offer as a way to get the integration unlocked. Closes #1117.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code

## Testing Instructions

**Steps to test:**
1. Open `docs/providers/garmin-api-integration.mdx` (or the rendered docs page).
2. Check the warning below the intro note and the one in the "Apply for Garmin developer access" step.

**Expected behavior:**
Both warnings explain the program is on hold, that new accounts can't be created (existing ones still work), and link to the [custom deployment offer](https://openwearables.io/custom-deployment) / hello@openwearables.io.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Garmin API integration documentation with status warnings regarding the Garmin Connect Developer Program
  * Added notifications about developer account creation limitations and available support resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->