### PR TITLE
docs: drop "| Open Wearables" suffix from page titles

### DIFF
--- a/docs/api-reference/guides/sync-status-stream.mdx
+++ b/docs/api-reference/guides/sync-status-stream.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Live Sync Status (SSE) | Open Wearables"
+title: "Live Sync Status (SSE)"
 sidebarTitle: "Live Sync Status"
 description: "Stream real-time sync lifecycle events for a user via Server-Sent Events. Track when pulls, webhooks, SDK uploads, Apple Health imports, and Garmin backfills start, progress, and complete."
 keywords: ["sync status", "server-sent events", "SSE", "real-time sync", "sync progress", "open wearables"]

--- a/docs/api-reference/guides/webhooks.mdx
+++ b/docs/api-reference/guides/webhooks.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Outgoing Webhooks | Open Wearables"
+title: "Outgoing Webhooks"
 sidebarTitle: "Outgoing Webhooks"
 description: "Receive real-time notifications when health data arrives for your users. Register HTTPS endpoints, filter by event type or user, verify signatures, and debug delivery."
 keywords: ["open wearables webhooks", "health data webhooks", "wearable data real-time", "webhook event types", "webhook signature verification"]


### PR DESCRIPTION
## Description

Two docs pages had `| Open Wearables` baked into their `title:` frontmatter while every other page keeps the title clean. 

<img width="1140" height="833" alt="image" src="https://github.com/user-attachments/assets/67f56b2e-dd33-434a-9802-c87842cff277" />


This drops the suffix so the visible page titles are consistent across the docs. 

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code

## Testing Instructions

**Steps to test:**
1. Open `docs/api-reference/guides/sync-status-stream.mdx` and `docs/api-reference/guides/webhooks.mdx`.
2. Check the `title:` field in the frontmatter.

**Expected behavior:**
Titles read "Live Sync Status (SSE)" and "Outgoing Webhooks" - no `| Open Wearables` suffix.