### PR TITLE
fix(backend): null workout heart_rate_min rows copied from average HR

### DIFF
--- a/backend/scripts/data_migrations/null_bogus_workout_heart_rate_min.py
+++ b/backend/scripts/data_migrations/null_bogus_workout_heart_rate_min.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Null workout heart_rate_min values that actually hold the average heart rate.
+
+Garmin activity payloads carry no minimum heart rate, but until PR #1121 the
+Garmin workout normalizer wrote heart_rate_min = int(heart_rate_avg). Polar had
+the same bug until PR #1041. Both providers therefore have workout_details rows
+where heart_rate_min is a copy of the average, not a minimum.
+
+Selection is deliberately narrow:
+- Garmin averages are integers in the API, so every bogus row satisfies
+  heart_rate_min = heart_rate_avg exactly. Exact equality also protects
+  SDK-imported rows that were attributed to provider 'garmin' via source
+  inference but carry a genuine HealthKit minimum.
+- Polar averages may be fractional, so bogus rows satisfy
+  heart_rate_min = floor(heart_rate_avg) (the int() truncation).
+
+heart_rate_avg and heart_rate_max are genuine and stay untouched. Rows written
+after the fixes have heart_rate_min NULL and are not matched.
+
+Usage (inside Docker):
+    docker compose exec app uv run python scripts/data_migrations/null_bogus_workout_heart_rate_min.py --dry-run
+    docker compose exec app uv run python scripts/data_migrations/null_bogus_workout_heart_rate_min.py
+"""
+
+import argparse
+
+from sqlalchemy import text
+
+from app.database import SessionLocal
+
+_PREDICATE = """
+    wd.heart_rate_min IS NOT NULL
+    AND wd.heart_rate_avg IS NOT NULL
+    AND (
+        (ds.provider = 'garmin' AND wd.heart_rate_min = wd.heart_rate_avg)
+        OR (ds.provider = 'polar' AND wd.heart_rate_min = FLOOR(wd.heart_rate_avg))
+    )
+    AND er.category = 'workout'
+"""
+
+_AFFECTED_COUNT = text(f"""
+    SELECT COUNT(*)
+    FROM workout_details wd
+    JOIN event_record er ON er.id = wd.record_id
+    JOIN data_source ds ON ds.id = er.data_source_id
+    WHERE {_PREDICATE}
+""")
+
+_SAMPLE_ROWS = text(f"""
+    SELECT wd.record_id, ds.provider, wd.heart_rate_min, wd.heart_rate_avg, wd.heart_rate_max, er.start_datetime
+    FROM workout_details wd
+    JOIN event_record er ON er.id = wd.record_id
+    JOIN data_source ds ON ds.id = er.data_source_id
+    WHERE {_PREDICATE}
+    ORDER BY er.start_datetime DESC
+    LIMIT 20
+""")
+
+_UPDATE = text(f"""
+    UPDATE workout_details wd
+    SET heart_rate_min = NULL
+    FROM event_record er
+    JOIN data_source ds ON ds.id = er.data_source_id
+    WHERE er.id = wd.record_id
+      AND {_PREDICATE}
+""")
+
+
+def main(dry_run: bool) -> None:
+    with SessionLocal() as db:
+        count = db.execute(_AFFECTED_COUNT).scalar()
+
+        if count == 0:
+            print("No affected rows - nothing to do.")
+            return
+
+        print(f"Workout rows with heart_rate_min copied from the average: {count}")
+
+        rows = db.execute(_SAMPLE_ROWS).fetchall()
+        print(f"\n{'Record ID':<38} {'Provider':<10} {'Min':>5} {'Avg':>8} {'Max':>5}  Start")
+        print("-" * 90)
+        for row in rows:
+            hr_max = row.heart_rate_max if row.heart_rate_max is not None else "-"
+            print(
+                f"{row.record_id!s:<38} {row.provider:<10} {row.heart_rate_min:>5} "
+                f"{row.heart_rate_avg:>8.2f} {hr_max:>5}  {row.start_datetime}"
+            )
+        if count > 20:
+            print(f"  ... and {count - 20} more")
+
+        if dry_run:
+            print("\nDry run - no changes made.")
+            return
+
+        result = db.execute(_UPDATE)
+        db.commit()
+        print(f"\nUpdated {result.rowcount} row(s).")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Preview affected rows without updating")
+    args = parser.parse_args()
+    main(dry_run=args.dry_run)

--- a/backend/scripts/start/app.sh
+++ b/backend/scripts/start/app.sh
@@ -37,6 +37,12 @@ echo 'Running body_fat_percentage normalization...'
 uv run python scripts/data_migrations/normalize_body_fat_percentage.py \
     || echo "Warning: body_fat_percentage normalization failed — will retry on next startup."
 
+# TODO: Remove this after ~2026-08-01 once all deployments have migrated.
+# Nulls workout heart_rate_min values copied from average HR (Garmin pre-#1121, Polar pre-#1041); no-op once cleaned.
+echo 'Running workout heart_rate_min cleanup...'
+uv run python scripts/data_migrations/null_bogus_workout_heart_rate_min.py \
+    || echo "Warning: workout heart_rate_min cleanup failed - will retry on next startup."
+
 # Initialize archival settings
 echo 'Initializing archival settings...'
 uv run python scripts/init/seed_archival_settings.py


### PR DESCRIPTION
## Description

Follow-up to #1121 (issue #1078). That PR stopped writing the average heart rate into `workout_details.heart_rate_min` for Garmin workouts, but every row created before the fix still carries the copied average. Polar had the identical bug (`heart_rate_min = int(hr_avg)`) until the refactor in #1041, so its pre-refactor rows are equally affected.

Adds `backend/scripts/data_migrations/null_bogus_workout_heart_rate_min.py` following the existing convention in that directory (`--dry-run` preview, sample listing, single guarded UPDATE).

Selection is deliberately narrow:

- `provider = 'garmin' AND heart_rate_min = heart_rate_avg` - Garmin averages are integers in the API (`averageHeartRateInBeatsPerMinute: int`), so every bogus row matches exactly. Exact equality (rather than `floor`) also protects SDK-imported rows attributed to provider `garmin` via source inference that carry a genuine HealthKit minimum.
- `provider = 'polar' AND heart_rate_min = FLOOR(heart_rate_avg)` - Polar averages may be fractional, matching the old `int()` truncation.
- `category = 'workout'` only; Garmin sleep minimum HR is genuine and lives elsewhere.
- `heart_rate_avg` and `heart_rate_max` are genuine and untouched. Post-fix rows have `heart_rate_min` NULL and are not matched.

No other provider ever wrote a copied average: Suunto, Apple XML, and the mobile SDK write genuine minimums; Fitbit, Strava, Whoop, Oura, Ultrahuman never set the field.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable) - verified against a scratch database, see below
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes (ruff passes; prettier hook needs frontend `node_modules`, no frontend files touched)

## Testing Instructions

**Steps to test:**
1. `docker compose exec app uv run python scripts/data_migrations/null_bogus_workout_heart_rate_min.py --dry-run`
2. Review the listed rows, then run without `--dry-run`.

**Expected behavior:**

Only Garmin workout rows with `heart_rate_min = heart_rate_avg` and Polar workout rows with `heart_rate_min = floor(heart_rate_avg)` get `heart_rate_min` set to NULL. Re-running reports nothing to do.

Verified against a scratch database migrated to head with seven fixture rows: Garmin bogus (nulled), Garmin distinct-min (kept), Garmin post-fix NULL (untouched), Polar bogus fractional avg (nulled), Polar distinct-min (kept), Suunto constant-HR min == avg (kept, provider filter), Garmin sleep-category row (kept). Re-run after the update found no affected rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected inaccurate minimum heart rate values for Garmin and Polar workout records; affected entries have been identified and cleared.
* **Chores**
  * Added an automated data-cleanup step at startup to apply the fixes. The cleanup reports affected counts and sample rows and can be run in a non-destructive mode for verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->