### PR TITLE
fix(backend): persist heart rate on Garmin sleep details

### DIFF
--- a/backend/app/models/sleep_details.py
+++ b/backend/app/models/sleep_details.py
@@ -32,5 +32,8 @@ class SleepDetails(EventRecordDetail):
     sleep_light_minutes: Mapped[int | None]
     sleep_awake_minutes: Mapped[int | None]
 
+    heart_rate_min: Mapped[int | None]
+    heart_rate_avg: Mapped[numeric_5_2 | None]
+
     is_nap: Mapped[bool | None]
     sleep_stages: Mapped[json_binary | None]

--- a/backend/app/schemas/responses/activity/events.py
+++ b/backend/app/schemas/responses/activity/events.py
@@ -69,6 +69,8 @@ class SleepSession(BaseModel):
     efficiency_percent: float | None = None
     stages: SleepStagesSummary | None = None
     sleep_stage_intervals: list[SleepStage] | None = None
+    avg_heart_rate_bpm: int | None = None
+    min_heart_rate_bpm: int | None = None
     is_nap: bool = False
 
 

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -322,6 +322,27 @@ class EventRecordService(
             if eff_denominator > 0:
                 merged_efficiency = Decimal(str(round(eff_numerator / eff_denominator, 2)))
 
+            # Weighted heart rate average, same inclusion rule as efficiency;
+            # minimum heart rate is the min over the sessions that have one.
+            merged_hr_avg: Decimal | None = None
+            hr_numerator = 0.0
+            hr_denominator = 0
+            if adj_detail and adj_detail.heart_rate_avg and adj_in_bed > 0:
+                hr_numerator += float(adj_detail.heart_rate_avg) * adj_in_bed
+                hr_denominator += adj_in_bed
+            if detail.heart_rate_avg and new_in_bed > 0:
+                hr_numerator += float(detail.heart_rate_avg) * new_in_bed
+                hr_denominator += new_in_bed
+            if hr_denominator > 0:
+                merged_hr_avg = Decimal(str(round(hr_numerator / hr_denominator, 2)))
+
+            hr_mins = [
+                value
+                for value in ((adj_detail.heart_rate_min if adj_detail else None), detail.heart_rate_min)
+                if value is not None
+            ]
+            merged_hr_min = min(hr_mins) if hr_mins else None
+
             # Merge sleep_stages: convert DB dicts back to SleepStage, concatenate, sort
             adj_stages_raw = (adj_detail.sleep_stages if adj_detail else None) or []
             adj_stages = [SleepStage.model_validate(s) for s in adj_stages_raw]
@@ -397,6 +418,8 @@ class EventRecordService(
                 "sleep_total_duration_minutes": merged_total,
                 "sleep_time_in_bed_minutes": merged_in_bed,
                 "sleep_efficiency_score": merged_efficiency,
+                "heart_rate_min": merged_hr_min,
+                "heart_rate_avg": merged_hr_avg,
                 "is_nap": bool(adj_detail.is_nap if adj_detail else False) and bool(detail.is_nap or False),
                 "sleep_stages": merged_stages,
             }

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -858,6 +858,10 @@ class EventRecordService(
                 efficiency_percent=float(details.sleep_efficiency_score)
                 if details and details.sleep_efficiency_score
                 else None,
+                avg_heart_rate_bpm=round(details.heart_rate_avg)
+                if details and details.heart_rate_avg is not None
+                else None,
+                min_heart_rate_bpm=details.heart_rate_min if details else None,
                 is_nap=details.is_nap if (details and details.is_nap is not None) else False,
                 sleep_stage_intervals=details.sleep_stages if details else None,  # ty:ignore[invalid-argument-type]
                 stages=SleepStagesSummary(

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -375,10 +375,8 @@ class Garmin247Data(Base247DataTemplate):
             sleep_rem_minutes=stages.get("rem_seconds", 0) // 60,
             sleep_awake_minutes=stages.get("awake_seconds", 0) // 60,
             is_nap=False,
-            heart_rate_avg=Decimal(str(normalized_sleep["avg_heart_rate_bpm"]))
-            if normalized_sleep.get("avg_heart_rate_bpm")
-            else None,
-            heart_rate_min=normalized_sleep.get("min_heart_rate_bpm"),
+            # heart_rate_avg/heart_rate_min are workout-only columns; SleepDetails has
+            # no heart rate fields and rejects them in the ORM constructor (issue #1135).
             sleep_stages=normalized_sleep.get("stage_timestamps"),
         )
 

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -375,8 +375,10 @@ class Garmin247Data(Base247DataTemplate):
             sleep_rem_minutes=stages.get("rem_seconds", 0) // 60,
             sleep_awake_minutes=stages.get("awake_seconds", 0) // 60,
             is_nap=False,
-            # heart_rate_avg/heart_rate_min are workout-only columns; SleepDetails has
-            # no heart rate fields and rejects them in the ORM constructor (issue #1135).
+            heart_rate_avg=Decimal(str(normalized_sleep["avg_heart_rate_bpm"]))
+            if normalized_sleep.get("avg_heart_rate_bpm")
+            else None,
+            heart_rate_min=normalized_sleep.get("min_heart_rate_bpm"),
             sleep_stages=normalized_sleep.get("stage_timestamps"),
         )
 

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -378,7 +378,8 @@ class Garmin247Data(Base247DataTemplate):
             heart_rate_avg=Decimal(str(normalized_sleep["avg_heart_rate_bpm"]))
             if normalized_sleep.get("avg_heart_rate_bpm")
             else None,
-            heart_rate_min=normalized_sleep.get("min_heart_rate_bpm"),
+            # 0 bpm is not a valid minimum; treat it like the absent-avg case above
+            heart_rate_min=normalized_sleep.get("min_heart_rate_bpm") or None,
             sleep_stages=normalized_sleep.get("stage_timestamps"),
         )
 

--- a/backend/migrations/versions/2026_06_10_1941-0d0b052f3b58_add_heart_rate_to_sleep_details.py
+++ b/backend/migrations/versions/2026_06_10_1941-0d0b052f3b58_add_heart_rate_to_sleep_details.py
@@ -1,0 +1,27 @@
+"""add_heart_rate_to_sleep_details
+
+Revision ID: 0d0b052f3b58
+Revises: 264b79d7c541
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0d0b052f3b58"
+down_revision: Union[str, None] = "264b79d7c541"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("sleep_details", sa.Column("heart_rate_min", sa.Integer(), nullable=True))
+    op.add_column("sleep_details", sa.Column("heart_rate_avg", sa.Numeric(precision=5, scale=2), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("sleep_details", "heart_rate_avg")
+    op.drop_column("sleep_details", "heart_rate_min")

--- a/backend/migrations/versions/2026_06_10_1941-0d0b052f3b58_add_heart_rate_to_sleep_details.py
+++ b/backend/migrations/versions/2026_06_10_1941-0d0b052f3b58_add_heart_rate_to_sleep_details.py
@@ -1,7 +1,7 @@
 """add_heart_rate_to_sleep_details
 
 Revision ID: 0d0b052f3b58
-Revises: 264b79d7c541
+Revises: d8a0bc9afdd9
 
 """
 
@@ -12,7 +12,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "0d0b052f3b58"
-down_revision: Union[str, None] = "264b79d7c541"
+down_revision: Union[str, None] = "d8a0bc9afdd9"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/tests/providers/garmin/test_garmin_247.py
+++ b/backend/tests/providers/garmin/test_garmin_247.py
@@ -618,6 +618,82 @@ class TestGarmin247Data:
         assert saved[0].heart_rate_min == 48
         assert saved[0].heart_rate_avg == Decimal("58.00")
 
+    def test_save_sleep_data_zero_heart_rate_not_stored(
+        self,
+        garmin_247: Garmin247Data,
+        db: Session,
+        sample_sleep: dict[str, Any],
+    ) -> None:
+        """0 bpm is not a valid reading; both HR fields stay NULL."""
+        user = UserFactory()
+        sample_sleep["averageHeartRate"] = 0
+        sample_sleep["lowestHeartRate"] = 0
+        normalized, _ = garmin_247.normalize_sleep(sample_sleep, user.id)
+
+        garmin_247.save_sleep_data(db, user.id, normalized)
+
+        saved = db.query(SleepDetails).all()
+        assert len(saved) == 1
+        assert saved[0].heart_rate_min is None
+        assert saved[0].heart_rate_avg is None
+
+    def test_merge_adjacent_sleep_preserves_heart_rate(
+        self,
+        garmin_247: Garmin247Data,
+        db: Session,
+        sample_sleep: dict[str, Any],
+    ) -> None:
+        """Merging adjacent sessions keeps min-of-mins and a time-weighted average."""
+        user = UserFactory()
+
+        first = {**sample_sleep, "averageHeartRate": 70, "lowestHeartRate": 60}
+        normalized_first, _ = garmin_247.normalize_sleep(first, user.id)
+        garmin_247.save_sleep_data(db, user.id, normalized_first)
+
+        # second session starts 30 minutes after the first ends, same duration
+        second = {
+            **sample_sleep,
+            "summaryId": "sleep_456",
+            "startTimeInSeconds": sample_sleep["startTimeInSeconds"] + sample_sleep["durationInSeconds"] + 1800,
+            "averageHeartRate": 50,
+            "lowestHeartRate": 44,
+        }
+        normalized_second, _ = garmin_247.normalize_sleep(second, user.id)
+        garmin_247.save_sleep_data(db, user.id, normalized_second)
+
+        saved = db.query(SleepDetails).all()
+        assert len(saved) == 1
+        assert saved[0].heart_rate_min == 44
+        # equal in-bed durations: weighted average of 70 and 50
+        assert saved[0].heart_rate_avg == Decimal("60.00")
+
+    def test_merge_adjacent_sleep_keeps_heart_rate_from_first_session(
+        self,
+        garmin_247: Garmin247Data,
+        db: Session,
+        sample_sleep: dict[str, Any],
+    ) -> None:
+        """A later HR-less fragment must not erase the persisted heart rate."""
+        user = UserFactory()
+
+        normalized_first, _ = garmin_247.normalize_sleep(sample_sleep, user.id)
+        garmin_247.save_sleep_data(db, user.id, normalized_first)
+
+        second = {
+            **sample_sleep,
+            "summaryId": "sleep_456",
+            "startTimeInSeconds": sample_sleep["startTimeInSeconds"] + sample_sleep["durationInSeconds"] + 1800,
+        }
+        del second["averageHeartRate"]
+        del second["lowestHeartRate"]
+        normalized_second, _ = garmin_247.normalize_sleep(second, user.id)
+        garmin_247.save_sleep_data(db, user.id, normalized_second)
+
+        saved = db.query(SleepDetails).all()
+        assert len(saved) == 1
+        assert saved[0].heart_rate_min == 48
+        assert saved[0].heart_rate_avg == Decimal("58.00")
+
     def test_build_activity_record(self, garmin_247: Garmin247Data) -> None:
         """Test _build_activity_record returns record + detail without DB call."""
         user_id = uuid4()

--- a/backend/tests/providers/garmin/test_garmin_247.py
+++ b/backend/tests/providers/garmin/test_garmin_247.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
-from app.models import SleepDetails
+from app.models import EventRecord, SleepDetails
 from app.repositories.event_record_detail_repository import EventRecordDetailRepository
 from app.repositories.user_connection_repository import UserConnectionRepository
 from app.services.providers.garmin.data_247 import Garmin247Data
@@ -593,6 +593,30 @@ class TestGarmin247Data:
         repo = EventRecordDetailRepository.__new__(EventRecordDetailRepository)
         orm_detail = repo._build_detail(detail, "sleep")
         assert isinstance(orm_detail, SleepDetails)
+        assert orm_detail.heart_rate_min == 48
+        assert orm_detail.heart_rate_avg == Decimal("58")
+
+    def test_save_sleep_data_persists_heart_rate(
+        self,
+        garmin_247: Garmin247Data,
+        db: Session,
+        sample_sleep: dict[str, Any],
+    ) -> None:
+        """Sleep session with heart rate saves and persists the HR aggregates (issue #1135)."""
+        user = UserFactory()
+        normalized, _ = garmin_247.normalize_sleep(sample_sleep, user.id)
+
+        garmin_247.save_sleep_data(db, user.id, normalized)
+
+        saved = (
+            db.query(SleepDetails)
+            .join(EventRecord, EventRecord.id == SleepDetails.record_id)
+            .filter(EventRecord.category == "sleep")
+            .all()
+        )
+        assert len(saved) == 1
+        assert saved[0].heart_rate_min == 48
+        assert saved[0].heart_rate_avg == Decimal("58.00")
 
     def test_build_activity_record(self, garmin_247: Garmin247Data) -> None:
         """Test _build_activity_record returns record + detail without DB call."""

--- a/backend/tests/providers/garmin/test_garmin_247.py
+++ b/backend/tests/providers/garmin/test_garmin_247.py
@@ -9,6 +9,8 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
+from app.models import SleepDetails
+from app.repositories.event_record_detail_repository import EventRecordDetailRepository
 from app.repositories.user_connection_repository import UserConnectionRepository
 from app.services.providers.garmin.data_247 import Garmin247Data
 from app.services.providers.garmin.oauth import GarminOAuth
@@ -577,6 +579,20 @@ class TestGarmin247Data:
         assert record.category == "sleep"
         assert record.type == "sleep_session"
         assert detail.sleep_deep_minutes == 120  # 7200 / 60
+
+    def test_build_sleep_detail_orm_object(self, garmin_247: Garmin247Data, sample_sleep: dict[str, Any]) -> None:
+        """Sleep detail with heart rate present must build a SleepDetails ORM object (issue #1135)."""
+        user_id = uuid4()
+        normalized, _ = garmin_247.normalize_sleep(sample_sleep, user_id)
+        assert normalized.get("min_heart_rate_bpm") is not None  # fixture carries HR
+
+        result = garmin_247._build_sleep_record(user_id, normalized)
+        assert result is not None
+        _, detail = result
+
+        repo = EventRecordDetailRepository.__new__(EventRecordDetailRepository)
+        orm_detail = repo._build_detail(detail, "sleep")
+        assert isinstance(orm_detail, SleepDetails)
 
     def test_build_activity_record(self, garmin_247: Garmin247Data) -> None:
         """Test _build_activity_record returns record + detail without DB call."""


### PR DESCRIPTION
## Description

Garmin sleep sessions failed to save whenever the payload carried heart rate values. `_build_sleep_record` set `heart_rate_avg` / `heart_rate_min` on the sleep `EventRecordDetailCreate`, but `SleepDetails` had no heart rate columns, so `EventRecordDetailRepository._build_detail` raised `TypeError: 'heart_rate_min' is an invalid keyword argument for SleepDetails`. `create_or_merge_sleep` then failed, `save_sleep_data` logged the error, and the entire session (stages, durations, efficiency) was dropped. Garmin sleep summaries include `lowestHeartRate` / `averageHeartRate` for any HR-capable device, so most real Garmin sleep payloads were affected. The bulk path (`bulk_create_details` with `detail_type="sleep"`) fails identically.

Per maintainer feedback, sleep sessions should carry heart rate data, so the fix persists it instead of dropping it:

- `SleepDetails` gains `heart_rate_min` (integer) and `heart_rate_avg` (numeric(5,2)), matching the `WorkoutDetails` column types; migration `0d0b052f3b58` adds them (upgrade and downgrade verified against a scratch database).
- The Garmin sleep mapping is unchanged - the values now land instead of crashing the insert.
- `SleepSession` API response exposes `avg_heart_rate_bpm` / `min_heart_rate_bpm` (null for rows ingested before this fix).

Tests:
- `test_build_sleep_detail_orm_object` drives the actual ORM build with the HR-carrying fixture - fails with `TypeError` on current main, passes here.
- `test_save_sleep_data_persists_heart_rate` does a DB round-trip through `save_sleep_data` and asserts the stored values.

The pre-existing tests passed either way because they stop at the pydantic layer.

Resolves #1135

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes (ruff + ty pass; prettier hook needs frontend `node_modules`, no frontend files touched)

## Testing Instructions

**Steps to test:**
1. `cd backend && uv run alembic upgrade head`
2. `uv run pytest tests/providers/garmin/test_garmin_247.py tests/services/test_event_record_service.py`
3. Optionally: sync a Garmin account whose sleep payloads include `lowestHeartRate` and confirm the session stores and the sleep-sessions endpoint returns `avg_heart_rate_bpm` / `min_heart_rate_bpm`.

**Expected behavior:**

Garmin sleep sessions with heart rate data save successfully and expose the HR aggregates in the API response.


## Update after adversarial review

A skeptic pass with live DB reproduction found two gaps in the first version, both fixed:

- **Adjacent-session merge dropped the new fields.** `create_or_merge_sleep` aggregates every sleep detail field on split-night merges except the two added here - a later HR-less fragment wiped the persisted values, and two HR-carrying fragments kept only the last one's numbers for the whole merged window (reproduced via testcontainers). The merge now takes min-of-mins for `heart_rate_min` and a time-in-bed-weighted average for `heart_rate_avg`, mirroring the existing `sleep_efficiency_score` merge. Two merge-path tests added.
- **0 bpm asymmetry.** The avg gate already dropped 0 but min passed it through, so a degenerate payload would have returned `min_heart_rate_bpm: 0` next to `avg_heart_rate_bpm: null`. Min now gets the same gate; test added.

Also rebased on main and rechained the migration: the menstrual-cycle merge (`d8a0bc9afdd9`) had taken the head this migration originally chained from, which would have produced two alembic heads and broken `upgrade head` on deploy. `down_revision` now points at `d8a0bc9afdd9`; single head verified via ScriptDirectory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sleep sessions now include minimum and average heart-rate metrics alongside other sleep data; merged/adjacent sessions show correct combined heart-rate aggregates.

* **Bug Fixes**
  * Zeroed heart-rate values are not stored and do not overwrite existing heart-rate data.

* **Tests**
  * Added tests validating building, persisting, and merging per-sleep heart-rate aggregates to ensure displayed values remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->