### PR TITLE
docs: add Fitbit and Google Health Connect to the coverage matrix

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -29,7 +29,7 @@ Open-source platform that unifies wearable device data from multiple providers a
 
 ## What It Does
 
-Open Wearables provides a unified API and developer portal to connect and sync data from multiple wearable devices and fitness platforms. Instead of implementing separate integrations for Garmin, Fitbit, Oura, Whoop, Strava, and Apple Health, you can use a single platform to access normalized health data and build intelligent health insights through AI-powered automations.
+Open Wearables provides a unified API and developer portal to connect and sync data from multiple wearable devices and fitness platforms. Instead of implementing separate integrations for Garmin, Fitbit, Oura, Whoop, Strava, Apple Health, and more, you can use a single platform to access normalized health data and build intelligent health insights through AI-powered automations.
 
 **Vision**: Health Insights automations unlock the potential of user data and allow you to drive businesses in a completely new way. By defining conditions in natural language, developers can create intelligent notifications and insights that respond to user health patterns, enabling new types of health applications and services.
 
@@ -52,7 +52,7 @@ Open Wearables provides a unified API and developer portal to connect and sync d
     icon="cloud"
     href="/quickstart"
   >
-    Support for Garmin, Fitbit, Oura, Whoop, Strava, and Apple Health.
+    Support for Garmin, Polar, Suunto, Whoop, Strava, Fitbit, Oura, Ultrahuman, Apple Health, and Google Health Connect.
   </Card>
   <Card
     title="AI Health Assistant"

--- a/docs/providers/coverage.mdx
+++ b/docs/providers/coverage.mdx
@@ -12,7 +12,7 @@ keywords: ["wearable api coverage", "health data types by provider", "wearable d
 "twitter:card": "summary_large_image"
 ---
 
-This guide provides a comprehensive overview of data type support across all integrated wearable providers. Use this matrix to understand what data you can expect when integrating with specific devices.
+This guide gives an overview of data type support across the integrated wearable providers. Use this matrix to understand what data you can expect when integrating with specific devices.
 
 ## Quick Overview
 
@@ -47,7 +47,7 @@ This guide provides a comprehensive overview of data type support across all int
 
 | Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
 |-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
-| `heart_rate` | bpm | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ◐ | ✅ |
+| `heart_rate` | bpm | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | 🔜 | ✅ |
 | `resting_heart_rate` | bpm | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | 🔜 | ❌ | 🔜 | ✅ |
 | `heart_rate_variability_sdnn` | ms | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | `heart_rate_variability_rmssd` | ms | ❌ | ✅ | ◐ | ✅ | ❌ | ✅ | ❌ | ❌ | 🔜 | ✅ |
@@ -56,7 +56,7 @@ This guide provides a comprehensive overview of data type support across all int
 
 <Accordion title="Legend">
   - ✅ **Full support** — Available as time series data
-  - ◐ **Partial** — Currently available only within workout/activity context
+  - ◐ **Partial** — Limited data, only within workout/activity context, or with a known unit caveat
   - 🔜 **Coming soon** — Provider API supports this, processing not yet implemented
   - ❌ **Not available** — Provider does not offer this data type
 </Accordion>
@@ -76,13 +76,13 @@ This guide provides a comprehensive overview of data type support across all int
 
 | Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
 |-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
-| `height` | cm | ✅ | ❌ | 🔜 | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| `height` | cm | ✅ | ❌ | 🔜 | ❌ | ✅ | ✅ | ❌ | ❌ | 🔜 | ✅ |
 | `weight` | kg | ✅ | ✅ | 🔜 | ❌ | ✅ | ✅ | ❌ | ❌ | 🔜 | ✅ |
 | `body_fat_percentage` | % | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 | ✅ |
-| `body_mass_index` | kg/m² | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 | ◐ |
+| `body_mass_index` | kg/m² | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 | ❌ |
 | `lean_body_mass` | kg | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| `body_temperature` | °C | ✅ | ❌ | ◐ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ |
-| `skin_temperature` | °C | ❌ | ✅ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `body_temperature` | °C | ✅ | ❌ | ◐ | ❌ | ❌ | ✅ | ✅ | ❌ | 🔜 | ✅ |
+| `skin_temperature` | °C | ❌ | ✅ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 |
 | `skin_temperature_deviation` | °C | ❌ | ❌ | ◐ | ❌ | ✅ | ❌ | ❌ | ❌ | 🔜 | ❌ |
 | `skin_temperature_trend_deviation` | °C | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
@@ -99,19 +99,20 @@ This guide provides a comprehensive overview of data type support across all int
 
 | Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
 |-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
-| `steps` | count | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ◐ | ✅ |
-| `energy` | kcal | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ◐ | ✅ |
+| `steps` | count | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | 🔜 | ✅ |
+| `energy` | kcal | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | 🔜 | ✅ |
 | `basal_energy` | kcal | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ◐ |
 | `stand_time` | minutes | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `exercise_time` | minutes | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `physical_effort` | score | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 | ❌ | ❌ | ❌ | ❌ |
 | `flights_climbed` | count | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| `hydration` | mL | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 
 ### Activity - Distance
 
 | Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
 |-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
-| `distance_walking_running` | meters | ✅ | ✅ | ✅ | ◐ | ✅ | ❌ | ❌ | ❌ | ◐ | ✅ |
+| `distance_walking_running` | meters | ✅ | ✅ | ✅ | ◐ | ✅ | ❌ | ❌ | ❌ | 🔜 | ✅ |
 | `distance_cycling` | meters | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `distance_swimming` | meters | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `distance_downhill_snow_sports` | meters | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
@@ -143,8 +144,9 @@ This guide provides a comprehensive overview of data type support across all int
 | Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
 |-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
 | `swimming_stroke_count` | count | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `cadence` | rpm | ❌ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| `power` | watts | ❌ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| `cadence` | rpm | ❌ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 |
+| `power` | watts | ❌ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 |
+| `speed` | m/s | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 |
 
 ### Provider-Specific Metrics
 
@@ -174,7 +176,7 @@ Sleep tracking varies significantly across providers. Here's what each provider 
 | Sleep sessions | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
 | Total duration | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
 | Time in bed | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
-| Sleep efficiency | 🔜 | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
+| Sleep efficiency | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
 | **Sleep Stages** | | | | | | | | | | |
 | Stage timestamps | ✅ | ✅ | ✅ | ❌ | ✅ | 🔜 | 🔜 | ❌ | 🔜 | ✅ |
 | Deep sleep | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
@@ -182,11 +184,11 @@ Sleep tracking varies significantly across providers. Here's what each provider 
 | REM sleep | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
 | Awake time | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
 | **Biometrics During Sleep** | | | | | | | | | | |
-| Average heart rate | 🔜 | ✅ | ◐ | ✅ | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Min heart rate | 🔜 | ✅ | ◐ | ✅ | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Average HRV | 🔜 | 🔜 | ❌ | ✅ | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ |
-| SpO2 | 🔜 | 🔜 | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Respiration rate | 🔜 | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Average heart rate | 🔜 | ✅ | ◐ | ✅ | 🔜 | ❌ | ❌ | ❌ | ❌ | 🔜 |
+| Min heart rate | 🔜 | ✅ | ◐ | ✅ | 🔜 | ❌ | ❌ | ❌ | ❌ | 🔜 |
+| Average HRV | 🔜 | 🔜 | ❌ | ✅ | 🔜 | ❌ | ❌ | ❌ | 🔜 | 🔜 |
+| SpO2 | 🔜 | 🔜 | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | 🔜 | 🔜 |
+| Respiration rate | 🔜 | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 | 🔜 |
 | Nap detection | 🔜 | 🔜 | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | 🔜 | ❌ |
 
 <Info>
@@ -207,25 +209,25 @@ All providers that support workouts provide these common fields:
 | Workout type | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
 | Device name | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
 | **Heart Rate** | | | | | | | | | | |
-| Avg heart rate | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ |
-| Max heart rate | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | 🔜 | ✅ |
-| Min heart rate | ✅ | 🔜 | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Avg heart rate | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | 🔜 |
+| Max heart rate | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | 🔜 | 🔜 |
+| Min heart rate | ✅ | 🔜 | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | 🔜 | 🔜 |
 | **Activity Metrics** | | | | | | | | | | |
-| Calories burned | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
-| Distance | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
-| Steps | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| Moving time | 🔜 | 🔜 | 🔜 | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ |
+| Calories burned | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | 🔜 |
+| Distance | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ◐ | 🔜 |
+| Steps | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | 🔜 |
+| Moving time | 🔜 | 🔜 | 🔜 | ✅ | ✅ | ✅ | ❌ | ✅ | 🔜 | ❌ |
 | **Speed & Power** | | | | | | | | | | |
-| Average speed | ✅ | ✅ | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
-| Max speed | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
-| Average watts | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
-| Max watts | 🔜 | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Average speed | ✅ | ✅ | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | 🔜 | 🔜 |
+| Max speed | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | 🔜 |
+| Average watts | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | 🔜 |
+| Max watts | 🔜 | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | 🔜 |
 | **Elevation** | | | | | | | | | | |
-| Total elevation gain | ✅ | ✅ | 🔜 | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ |
-| Elevation high | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
-| Elevation low | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| Total elevation gain | ✅ | ✅ | 🔜 | ✅ | ❌ | ✅ | ❌ | ✅ | 🔜 | 🔜 |
+| Elevation high | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Elevation low | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 | **Other** | | | | | | | | | | |
-| GPS route | ❌ | 🔜 | 🔜 | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| GPS route | ❌ | 🔜 | 🔜 | 🔜 | ❌ | ❌ | ❌ | ❌ | 🔜 | 🔜 |
 
 <Accordion title="Apple Workout Data Note">
   Most workout metrics are supported via HealthKit SDK (heart rate, calories, distance, steps, speed, power, elevation). Moving time and max watts are not yet implemented.
@@ -405,7 +407,8 @@ Key differences and limitations to be aware of when working with each provider:
 
   - Data synced via periodic polling only; the Fitbit Subscriptions API (webhooks) is not yet implemented
   - Workout/activity data only today, fetched from the Activities List API with pagination; backfill defaults to 30 days
-  - Workout metrics populated: avg heart rate, calories, distance, steps, and device name; min/max heart rate, speed, power, and elevation are not populated
+  - Workout metrics populated: avg heart rate, calories, distance, steps, and device name; min/max heart rate, speed, and elevation are offered by the API but not yet processed; power is not available
+  - Workout distance is currently stored as the raw kilometer value from the API; conversion to the platform meter unit is pending
   - Sleep, intraday heart rate, HRV, SpO2, breathing rate, skin temperature, and body measurements are available in the Fitbit Web API but processing is not yet implemented
   - Intraday timeseries requires a Fitbit "Personal" app type or Fitbit approval for server applications
   - 14 activity type ID mappings plus 25 name-based fallbacks to the unified taxonomy; unrecognized activities map to "other"
@@ -414,11 +417,13 @@ Key differences and limitations to be aware of when working with each provider:
 <Accordion title="Google Health Connect">
   **Integration Method:** Push-based via Android SDK (no OAuth)
 
-  - 25+ Health Connect record types mapped to unified series: heart rate, resting HR, HRV, SpO2, blood pressure, respiratory rate, body measurements, steps, calories, distance, power, speed, and cadence
+  - 25+ Health Connect record types mapped to unified series: heart rate, resting HR, HRV, SpO2, blood pressure, respiratory rate, body measurements, steps, calories, and distance
   - Full sleep processing with stages (deep, light, REM, awake), duration, time in bed, efficiency score, and stage timestamps
-  - Workout details include calories, distance, avg/max/min heart rate, avg/max speed, and elevation (gain/high/low)
+  - Workout sessions currently carry duration, type, and start/end times only; heart rate, speed, calorie, and elevation gain aggregates are planned
   - HRV is measured as RMSSD; SDNN is not available
-  - Body fat percentage arrives already in percent; blood glucose arrives in mmol/L and conversion to mg/dL is in review (PR #1123)
+  - Body fat percentage arrives already in percent
+  - Blood glucose arrives in mmol/L; values are stored as received until unit conversion ships
+  - Health Connect basal metabolic rate is a kcal/day rate stored into the kcal `basal_energy` series
   - All Health Connect distance is stored as `distance_walking_running` regardless of activity type
   - No health scores; GPS routes and in-workout sample streams are accepted by the SDK payload but not yet processed
 </Accordion>

--- a/docs/providers/coverage.mdx
+++ b/docs/providers/coverage.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Wearable API Coverage Matrix"
 sidebarTitle: "Coverage Matrix"
-description: "Data types by provider: Apple, Garmin, Polar, Suunto, Oura, Whoop, Ultrahuman, Strava, and Fitbit. OAuth, workouts, sleep, and timeseries support."
+description: "Data types by provider: Apple, Garmin, Polar, Suunto, Oura, Whoop, Ultrahuman, Strava, Fitbit, and Google Health Connect. OAuth, workouts, sleep, and timeseries support."
 keywords: ["wearable api coverage", "health data types by provider", "wearable data types", "provider data support"]
 "og:title": "Wearable API Coverage Matrix | Open Wearables"
-"og:description": "Health data types by provider: Apple, Garmin, Polar, Suunto, Oura, Whoop, Ultrahuman, Strava, Fitbit."
+"og:description": "Health data types by provider: Apple, Garmin, Polar, Suunto, Oura, Whoop, Ultrahuman, Strava, Fitbit, Google Health Connect."
 "og:url": "https://docs.openwearables.io/providers/coverage"
 "og:type": "article"
 "twitter:title": "Wearable API Coverage Matrix | Open Wearables"
-"twitter:description": "Health data types by provider: Apple, Garmin, Polar, Suunto, Oura, Whoop, Ultrahuman, Strava, Fitbit."
+"twitter:description": "Health data types by provider: Apple, Garmin, Polar, Suunto, Oura, Whoop, Ultrahuman, Strava, Fitbit, Google Health Connect."
 "twitter:card": "summary_large_image"
 ---
 
@@ -16,15 +16,15 @@ This guide provides a comprehensive overview of data type support across all int
 
 ## Quick Overview
 
-| Capability | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|------------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| **OAuth** | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Workouts** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| **Sleep** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| **24/7 Data** | ✅ | ✅ | ✅ | ✅ | ✅ | ◐ | ✅ | ❌ |
-| **Timeseries** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ |
-| **Health Scores** | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
-| **Women's Health** | 🔜 | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Capability | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|------------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| **OAuth** | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| **Workouts** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
+| **Sleep** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
+| **24/7 Data** | ✅ | ✅ | ✅ | ✅ | ✅ | ◐ | ✅ | ❌ | 🔜 | ✅ |
+| **Timeseries** | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | 🔜 | ✅ |
+| **Health Scores** | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| **Women's Health** | 🔜 | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 |
 
 <Accordion title="Legend">
   - ✅ **Full support** — Fully implemented and collecting data
@@ -45,14 +45,14 @@ This guide provides a comprehensive overview of data type support across all int
 
 ### Heart & Cardiovascular
 
-| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| `heart_rate` | bpm | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ |
-| `resting_heart_rate` | bpm | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | 🔜 | ❌ |
-| `heart_rate_variability_sdnn` | ms | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| `heart_rate_variability_rmssd` | ms | ❌ | ✅ | ◐ | ✅ | ❌ | ✅ | ❌ | ❌ |
-| `heart_rate_recovery_one_minute` | bpm | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `walking_heart_rate_average` | bpm | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| `heart_rate` | bpm | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ◐ | ✅ |
+| `resting_heart_rate` | bpm | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | 🔜 | ❌ | 🔜 | ✅ |
+| `heart_rate_variability_sdnn` | ms | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| `heart_rate_variability_rmssd` | ms | ❌ | ✅ | ◐ | ✅ | ❌ | ✅ | ❌ | ❌ | 🔜 | ✅ |
+| `heart_rate_recovery_one_minute` | bpm | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `walking_heart_rate_average` | bpm | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 <Accordion title="Legend">
   - ✅ **Full support** — Available as time series data
@@ -63,88 +63,88 @@ This guide provides a comprehensive overview of data type support across all int
 
 ### Blood & Respiratory
 
-| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| `oxygen_saturation` | % | ✅ | ✅ | ◐ | ✅ | ✅ | ✅ | ❌ | ❌ |
-| `blood_glucose` | mg/dL | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `blood_pressure_systolic` | mmHg | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `blood_pressure_diastolic` | mmHg | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `respiratory_rate` | brpm | ✅ | ✅ | ❌ | ❌ | ❌ | 🔜 | ❌ | ❌ |
-| `sleeping_breathing_disturbances` | count | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| `oxygen_saturation` | % | ✅ | ✅ | ◐ | ✅ | ✅ | ✅ | ❌ | ❌ | 🔜 | ✅ |
+| `blood_glucose` | mg/dL | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ◐ |
+| `blood_pressure_systolic` | mmHg | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| `blood_pressure_diastolic` | mmHg | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| `respiratory_rate` | brpm | ✅ | ✅ | ❌ | ❌ | ❌ | 🔜 | ❌ | ❌ | 🔜 | ✅ |
+| `sleeping_breathing_disturbances` | count | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ### Body Composition
 
-| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| `height` | cm | ✅ | ❌ | 🔜 | ❌ | ✅ | ✅ | ❌ | ❌ |
-| `weight` | kg | ✅ | ✅ | 🔜 | ❌ | ✅ | ✅ | ❌ | ❌ |
-| `body_fat_percentage` | % | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `body_mass_index` | kg/m² | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `lean_body_mass` | kg | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `body_temperature` | °C | ✅ | ❌ | ◐ | ❌ | ❌ | ✅ | ✅ | ❌ |
-| `skin_temperature` | °C | ❌ | ✅ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `skin_temperature_deviation` | °C | ❌ | ❌ | ◐ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| `skin_temperature_trend_deviation` | °C | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| `height` | cm | ✅ | ❌ | 🔜 | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| `weight` | kg | ✅ | ✅ | 🔜 | ❌ | ✅ | ✅ | ❌ | ❌ | 🔜 | ✅ |
+| `body_fat_percentage` | % | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 | ✅ |
+| `body_mass_index` | kg/m² | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 | ◐ |
+| `lean_body_mass` | kg | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| `body_temperature` | °C | ✅ | ❌ | ◐ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ |
+| `skin_temperature` | °C | ❌ | ✅ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `skin_temperature_deviation` | °C | ❌ | ❌ | ◐ | ❌ | ✅ | ❌ | ❌ | ❌ | 🔜 | ❌ |
+| `skin_temperature_trend_deviation` | °C | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ### Fitness Metrics
 
-| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| `vo2_max` | mL/kg/min | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ |
-| `cardiovascular_age` | years | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| `six_minute_walk_test_distance` | meters | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `recovery_score` | score | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| `vo2_max` | mL/kg/min | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | 🔜 | ✅ |
+| `cardiovascular_age` | years | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `six_minute_walk_test_distance` | meters | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `recovery_score` | score | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 
 ### Activity - Basic
 
-| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| `steps` | count | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ |
-| `energy` | kcal | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| `basal_energy` | kcal | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `stand_time` | minutes | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `exercise_time` | minutes | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `physical_effort` | score | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 | ❌ | ❌ |
-| `flights_climbed` | count | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| `steps` | count | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ◐ | ✅ |
+| `energy` | kcal | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ◐ | ✅ |
+| `basal_energy` | kcal | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ◐ |
+| `stand_time` | minutes | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `exercise_time` | minutes | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `physical_effort` | score | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 | ❌ | ❌ | ❌ | ❌ |
+| `flights_climbed` | count | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 
 ### Activity - Distance
 
-| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| `distance_walking_running` | meters | ✅ | ✅ | ✅ | ◐ | ✅ | ❌ | ❌ | ❌ |
-| `distance_cycling` | meters | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ |
-| `distance_swimming` | meters | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ |
-| `distance_downhill_snow_sports` | meters | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ |
+| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| `distance_walking_running` | meters | ✅ | ✅ | ✅ | ◐ | ✅ | ❌ | ❌ | ❌ | ◐ | ✅ |
+| `distance_cycling` | meters | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `distance_swimming` | meters | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `distance_downhill_snow_sports` | meters | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ### Activity - Walking Metrics
 
-| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| `walking_step_length` | cm | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `walking_speed` | m/s | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `walking_double_support_percentage` | % | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `walking_asymmetry_percentage` | % | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `walking_steadiness` | % | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `stair_descent_speed` | m/s | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `stair_ascent_speed` | m/s | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| `walking_step_length` | cm | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `walking_speed` | m/s | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `walking_double_support_percentage` | % | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `walking_asymmetry_percentage` | % | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `walking_steadiness` | % | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `stair_descent_speed` | m/s | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `stair_ascent_speed` | m/s | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ### Activity - Running Metrics
 
-| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| `running_power` | watts | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ |
-| `running_speed` | m/s | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ |
-| `running_vertical_oscillation` | cm | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `running_ground_contact_time` | ms | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `running_stride_length` | cm | ✅ | ❌ | ❌ | ◐ | ❌ | ❌ | ❌ | ❌ |
+| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| `running_power` | watts | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `running_speed` | m/s | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `running_vertical_oscillation` | cm | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `running_ground_contact_time` | ms | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `running_stride_length` | cm | ✅ | ❌ | ❌ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ### Activity - Other
 
-| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| `swimming_stroke_count` | count | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ |
-| `cadence` | rpm | ❌ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ |
-| `power` | watts | ❌ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ |
+| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| `swimming_stroke_count` | count | ✅ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `cadence` | rpm | ❌ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| `power` | watts | ❌ | ❌ | ◐ | ◐ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 
 ### Provider-Specific Metrics
 
@@ -158,10 +158,10 @@ These metrics are unique to specific providers and don't have a universal equiva
 
 ### Environmental
 
-| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| `environmental_audio_exposure` | dB | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `headphone_audio_exposure` | dB | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Data Type | Unit | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|-----------|------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| `environmental_audio_exposure` | dB | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `headphone_audio_exposure` | dB | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ---
 
@@ -169,25 +169,25 @@ These metrics are unique to specific providers and don't have a universal equiva
 
 Sleep tracking varies significantly across providers. Here's what each provider offers:
 
-| Feature | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|---------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| Sleep sessions | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Total duration | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Time in bed | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Sleep efficiency | 🔜 | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| **Sleep Stages** | | | | | | | | |
-| Stage timestamps | ✅ | ✅ | ✅ | ❌ | ✅ | 🔜 | 🔜 | ❌ |
-| Deep sleep | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Light sleep | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| REM sleep | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| Awake time | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| **Biometrics During Sleep** | | | | | | | | |
-| Average heart rate | 🔜 | ✅ | ◐ | ✅ | 🔜 | ❌ | ❌ | ❌ |
-| Min heart rate | 🔜 | ✅ | ◐ | ✅ | 🔜 | ❌ | ❌ | ❌ |
-| Average HRV | 🔜 | 🔜 | ❌ | ✅ | 🔜 | ❌ | ❌ | ❌ |
-| SpO2 | 🔜 | 🔜 | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Respiration rate | 🔜 | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Nap detection | 🔜 | 🔜 | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ |
+| Feature | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|---------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| Sleep sessions | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
+| Total duration | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
+| Time in bed | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
+| Sleep efficiency | 🔜 | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
+| **Sleep Stages** | | | | | | | | | | |
+| Stage timestamps | ✅ | ✅ | ✅ | ❌ | ✅ | 🔜 | 🔜 | ❌ | 🔜 | ✅ |
+| Deep sleep | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
+| Light sleep | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
+| REM sleep | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
+| Awake time | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | 🔜 | ✅ |
+| **Biometrics During Sleep** | | | | | | | | | | |
+| Average heart rate | 🔜 | ✅ | ◐ | ✅ | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Min heart rate | 🔜 | ✅ | ◐ | ✅ | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Average HRV | 🔜 | 🔜 | ❌ | ✅ | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ |
+| SpO2 | 🔜 | 🔜 | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Respiration rate | 🔜 | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Nap detection | 🔜 | 🔜 | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | 🔜 | ❌ |
 
 <Info>
   🔜 = Data available from provider API/SDK but processing not yet implemented in Open Wearables.
@@ -199,33 +199,33 @@ Sleep tracking varies significantly across providers. Here's what each provider 
 
 All providers that support workouts provide these common fields:
 
-| Feature | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|---------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| Workout sessions | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Duration | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Start/end time | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Workout type | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Device name | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
-| **Heart Rate** | | | | | | | | |
-| Avg heart rate | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
-| Max heart rate | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
-| Min heart rate | ✅ | 🔜 | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| **Activity Metrics** | | | | | | | | |
-| Calories burned | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Distance | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ |
-| Steps | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Moving time | 🔜 | 🔜 | 🔜 | ✅ | ✅ | ✅ | ❌ | ✅ |
-| **Speed & Power** | | | | | | | | |
-| Average speed | ✅ | ✅ | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ |
-| Max speed | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ |
-| Average watts | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ |
-| Max watts | 🔜 | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ |
-| **Elevation** | | | | | | | | |
-| Total elevation gain | ✅ | ✅ | 🔜 | ✅ | ❌ | ✅ | ❌ | ✅ |
-| Elevation high | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ |
-| Elevation low | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ |
-| **Other** | | | | | | | | |
-| GPS route | ❌ | 🔜 | 🔜 | 🔜 | ❌ | ❌ | ❌ | ❌ |
+| Feature | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|---------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| Workout sessions | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
+| Duration | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
+| Start/end time | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
+| Workout type | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
+| Device name | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| **Heart Rate** | | | | | | | | | | |
+| Avg heart rate | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ |
+| Max heart rate | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | 🔜 | ✅ |
+| Min heart rate | ✅ | 🔜 | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **Activity Metrics** | | | | | | | | | | |
+| Calories burned | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
+| Distance | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ |
+| Steps | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| Moving time | 🔜 | 🔜 | 🔜 | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ |
+| **Speed & Power** | | | | | | | | | | |
+| Average speed | ✅ | ✅ | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| Max speed | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| Average watts | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Max watts | 🔜 | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| **Elevation** | | | | | | | | | | |
+| Total elevation gain | ✅ | ✅ | 🔜 | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ | ✅ |
+| Elevation high | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| Elevation low | ✅ | 🔜 | 🔜 | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| **Other** | | | | | | | | | | |
+| GPS route | ❌ | 🔜 | 🔜 | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 <Accordion title="Apple Workout Data Note">
   Most workout metrics are supported via HealthKit SDK (heart rate, calories, distance, steps, speed, power, elevation). Moving time and max watts are not yet implemented.
@@ -241,16 +241,16 @@ All providers that support workouts provide these common fields:
 
 Health scores are composite metrics that summarize a specific aspect of health into a single number. Open Wearables persists scores natively reported by providers and additionally calculates its own provider-independent scores from raw data.
 
-| Score | Internal | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|-------|:--------:|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| Sleep score | 🔜 | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
-| Readiness score | ❌ | ❌ | ❌ | ◐ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| Activity score | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| Recovery score | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
-| Resilience score | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Stress score | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Body battery | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Strain score | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ |
+| Score | Internal | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|-------|:--------:|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| Sleep score | 🔜 | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Readiness score | ❌ | ❌ | ❌ | ◐ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Activity score | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Recovery score | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Resilience score | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Stress score | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Body battery | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Strain score | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
 
 <Note>
   **Internal scores** are calculated by Open Wearables from raw data, independent of any provider. They are available for any provider that reports the required underlying data.
@@ -266,18 +266,18 @@ Health scores are composite metrics that summarize a specific aspect of health i
 
 Menstrual cycle and reproductive health data. Implemented types are available via the `/events/menstrual-cycles` endpoint and the `menstrual_cycle.created` webhook event.
 
-| Feature | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava |
-|---------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|
-| Menstrual flow / cycle records | 🔜 | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Cycle phase & day in cycle | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Cycle length (logged + predicted) | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Period length | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Fertile window | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Pregnancy tracking | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Basal body temperature | 🔜 | ❌ | ❌ | ❌ | 🔜 | ❌ | ❌ | ❌ |
-| Cervical mucus quality | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Ovulation test result | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Intermenstrual bleeding | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Feature | Apple | Garmin | Polar | Suunto | Oura | Whoop | Ultrahuman | Strava | Fitbit | Health Connect |
+|---------|:-----:|:------:|:-----:|:------:|:----:|:-----:|:----------:|:------:|:------:|:--------------:|
+| Menstrual flow / cycle records | 🔜 | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 |
+| Cycle phase & day in cycle | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Cycle length (logged + predicted) | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Period length | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Fertile window | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Pregnancy tracking | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Basal body temperature | 🔜 | ❌ | ❌ | ❌ | 🔜 | ❌ | ❌ | ❌ | ❌ | 🔜 |
+| Cervical mucus quality | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 |
+| Ovulation test result | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 |
+| Intermenstrual bleeding | 🔜 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | 🔜 |
 
 <Note>
   Garmin MCT data arrives via the `mct` webhook type as daily cycle summaries.
@@ -398,6 +398,29 @@ Key differences and limitations to be aware of when working with each provider:
   - Calories fall back to kilojoules when calorie data is not available from the API
   - Only one webhook subscription allowed per application
   - Webhook must respond with HTTP 200 within 2 seconds; retries up to 3 times on failure
+</Accordion>
+
+<Accordion title="Fitbit">
+  **Integration Method:** OAuth 2.0 with PKCE (pull-based polling)
+
+  - Data synced via periodic polling only; the Fitbit Subscriptions API (webhooks) is not yet implemented
+  - Workout/activity data only today, fetched from the Activities List API with pagination; backfill defaults to 30 days
+  - Workout metrics populated: avg heart rate, calories, distance, steps, and device name; min/max heart rate, speed, power, and elevation are not populated
+  - Sleep, intraday heart rate, HRV, SpO2, breathing rate, skin temperature, and body measurements are available in the Fitbit Web API but processing is not yet implemented
+  - Intraday timeseries requires a Fitbit "Personal" app type or Fitbit approval for server applications
+  - 14 activity type ID mappings plus 25 name-based fallbacks to the unified taxonomy; unrecognized activities map to "other"
+</Accordion>
+
+<Accordion title="Google Health Connect">
+  **Integration Method:** Push-based via Android SDK (no OAuth)
+
+  - 25+ Health Connect record types mapped to unified series: heart rate, resting HR, HRV, SpO2, blood pressure, respiratory rate, body measurements, steps, calories, distance, power, speed, and cadence
+  - Full sleep processing with stages (deep, light, REM, awake), duration, time in bed, efficiency score, and stage timestamps
+  - Workout details include calories, distance, avg/max/min heart rate, avg/max speed, and elevation (gain/high/low)
+  - HRV is measured as RMSSD; SDNN is not available
+  - Body fat percentage arrives already in percent; blood glucose arrives in mmol/L and conversion to mg/dL is in review (PR #1123)
+  - All Health Connect distance is stored as `distance_walking_running` regardless of activity type
+  - No health scores; GPS routes and in-workout sample streams are accepted by the SDK payload but not yet processed
 </Accordion>
 
 ---

--- a/docs/providers/supported.mdx
+++ b/docs/providers/supported.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Supported Wearable Device Integrations"
-description: "9 providers: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Ultrahuman, Apple Health, and Google Health Connect. Cloud OAuth and mobile SDK integrations."
+description: "10 providers: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Oura, Ultrahuman, Apple Health, and Google Health Connect. Cloud OAuth and mobile SDK integrations."
 keywords: ["wearable device integrations", "supported wearables api", "wearable api providers", "open wearables"]
 "og:title": "Supported Wearable Device Integrations | Open Wearables"
-"og:description": "9 providers supported: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Ultrahuman, Apple Health, and Google Health Connect."
+"og:description": "10 providers supported: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Oura, Ultrahuman, Apple Health, and Google Health Connect."
 "og:url": "https://docs.openwearables.io/providers/supported"
 "og:type": "article"
 "twitter:title": "Supported Wearable Device Integrations | Open Wearables"
-"twitter:description": "9 providers supported: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Ultrahuman, Apple Health, and Google Health Connect."
+"twitter:description": "10 providers supported: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Oura, Ultrahuman, Apple Health, and Google Health Connect."
 "twitter:card": "summary_large_image"
 ---
 
@@ -26,7 +26,7 @@ Connect your wearable devices and fitness platforms to Open Wearables. Click on 
 | **Strava** | [Setup Guide →](/providers/strava-api-integration) | Free Strava account required |
 | **Fitbit** | [Setup Guide →](/providers/fitbit-api-integration) | Free Fitbit account required |
 | **Ultrahuman** | [Setup Guide →](/providers/ultrahuman-api-integration) | Ultrahuman Ring Air account required |
-| **Oura Ring** | — | Coming soon |
+| **Oura Ring** | — | Oura account required |
 
 ### SDK-based providers
 

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -56,6 +56,7 @@ The platform supports the following wearable providers:
 - **Suunto** - OAuth + data sync
 - **Whoop** - OAuth + data sync
 - **Strava** - OAuth + webhook sync
+- **Fitbit** - OAuth + pull-based workout sync
 
 **Device/SDK-based:**
 - **Apple Health** - HealthKit integration and XML export support
@@ -200,7 +201,6 @@ An embeddable AI chat widget for user health queries, built on top of the MCP Se
 
 ### Additional Provider Support
 
-- **Fitbit**
 - **Oura**
 - **Coros**
 


### PR DESCRIPTION
## Description

Fitbit and Google Health Connect were supported providers but missing from the coverage matrix - Fitbit was even named in the page frontmatter without having a column. Adds both providers to every provider table (Quick Overview, all Detailed Coverage Matrix sections, Sleep, Workout, Health Scores, Women's Health) plus accordions in Provider Quirks, based on an audit of what the ingestion code actually maps today.

Key decisions, with the code they rest on:

**Fitbit** - workouts only. `strategy.py` registers only oauth and workouts; there is no sleep/247/timeseries module. Workout details populate avg HR, calories, distance, steps, device name (`fitbit/workouts.py`); min/max HR are explicitly None. Everything the Fitbit Web API offers but the code does not process (sleep with stages, intraday HR, HRV, SpO2, breathing rate, skin temp deviation, body metrics, VO2 max) is marked coming-soon, matching the legend definition. Heart rate / steps / energy / distance get the partial symbol since they exist only inside workout records.

**Google Health Connect** - SDK push path (no OAuth). 25+ `ANDROID_*` record types map to unified series in `constants/series_types/sdk/metric_types.py`; full sleep with stages via the shared SDK sleep service; workout details include HR avg/max/min, speed avg/max, and elevation gain/high/low. Marked partial: `blood_glucose` (mmol/L conversion in review, PR #1123), `body_mass_index` (mapped but not a native Health Connect record type - Samsung vocabulary), `basal_energy` (BasalMetabolicRateRecord is a kcal/day rate stored into a kcal series). Workout Steps is not-available: `stepCount` maps as a stat but is absent from the documented Health Connect stat vocabulary.

The Women's Health table landed after the audit (menstrual cycle merge): Fitbit has no public women's health API (not available); Health Connect record types exist for flow/cycle, basal body temperature, cervical mucus, ovulation test, and intermenstrual bleeding but ingestion is not implemented (coming-soon), mirroring the Apple column.

Frontmatter descriptions now include Google Health Connect.

Resolves #1132

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable) - docs only
- [x] New and existing tests pass locally - docs only
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

## Testing Instructions

**Steps to test:**
1. Preview the docs page and check the two new columns render in every table.
2. Cross-check any cell against the cited modules (`backend/app/services/providers/fitbit/`, `backend/app/constants/series_types/sdk/metric_types.py`).

**Expected behavior:**

Every provider table carries Fitbit and Health Connect columns; symbols follow the existing legend semantics (checkmark only where ingestion exists today). All table rows verified to match their header column counts.

## Additional Notes

- Two ingestion findings surfaced during the audit, flagged here rather than silently encoded in the matrix: Fitbit workout distance is stored as the raw Fitbit value (kilometers) without conversion to meters (`fitbit/workouts.py`), unlike Whoop/Strava; and scheduled Fitbit syncs currently fail on string dates - the open PR #1054 fixes that. Happy to file the distance-unit one as an issue.
- If maintainers prefer a separate Samsung Health column (also routed through Health Connect under provider `samsung`), that is a small follow-up; this PR covers the Google column the issue asked for.


## Update after adversarial verification

A second review round cloned the actual Android SDK repo (open_wearables_android_sdk) and checked every cell against what the SDK sends, not just what the backend maps. That overturned several cells from the first pass - commit "docs: correct coverage cells after SDK-level verification":

- Health Connect workout stats (HR avg/max/min, calories, distance, speed, elevation): the SDK's HealthConnectManager sends only a duration stat for HC workouts; the rich workout statistics are emitted solely by the separate Samsung SDK path. Cells corrected to coming-soon (HC offers the data via aggregation). Elevation high/low corrected to not-available (HC has only ElevationGainedRecord).
- Health Connect cadence/power: backend mappings exist but the SDK never reads PowerRecord/SpeedRecord/CyclingPedalingCadenceRecord - the comment in metric_types.py claiming otherwise is wrong against SDK main. Cells corrected to coming-soon.
- Fitbit workout cells corrected from not-available to coming-soon where the Activity Log List API does offer the field (speed, elevationGain, activeDuration, tcxLink GPS export), and timeseries cells corrected from partial to coming-soon (Fitbit ingestion writes zero timeseries; matches the Whoop/Strava convention).
- Added rows for hydration (Health Connect is the only provider with end-to-end ingestion today) and speed; fixed the stale Apple sleep-efficiency cell; aligned sleep-biometrics treatment across SDK providers; BMI corrected to not-available for HC (not a Health Connect data type).
- Sibling docs aligned: roadmap.mdx (Fitbit was still listed as upcoming), supported.mdx (Oura was still "coming soon", provider count), index.mdx provider list.

Known follow-ups deliberately not in this PR: Samsung Health column (routed through the same SDK under provider samsung - the workout statistics wrongly credited to Health Connect in the first pass actually belong there), and the Fitbit distance km-vs-meters code fix (#1138).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded provider coverage to include Fitbit and Google Health Connect across capability matrices (heart, blood, body composition, fitness, activity, sleep, workouts, health scores, women’s health) and added provider-specific integration notes.
  * Updated homepage provider copy to broaden examples.
  * Updated supported providers listing to reflect Oura as supported (count adjusted).
  * Roadmap updated to mark Fitbit as currently available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->