### PR TITLE
fix(backend): convert Fitbit workout distance from kilometers to meters

### DIFF
--- a/backend/app/services/providers/fitbit/workouts.py
+++ b/backend/app/services/providers/fitbit/workouts.py
@@ -55,7 +55,9 @@ class FitbitWorkouts(BaseWorkoutsTemplate):
             "heart_rate_avg": Decimal(str(hr_avg)) if hr_avg is not None else None,
             "steps_count": int(steps) if steps is not None else None,
             "energy_burned": Decimal(str(calories)) if calories is not None else None,
-            "distance": Decimal(str(distance)) if distance is not None else None,
+            # Fitbit reports distance in kilometers (no Accept-Language header is sent,
+            # so responses are always metric); the platform stores meters.
+            "distance": Decimal(str(distance)) * 1000 if distance is not None else None,
         }
 
     def _normalize_workout(

--- a/backend/tests/providers/fitbit/test_fitbit_workouts.py
+++ b/backend/tests/providers/fitbit/test_fitbit_workouts.py
@@ -53,7 +53,7 @@ def test_normalize_workout_detail_metrics(fitbit_workouts: FitbitWorkouts) -> No
 
     assert detail.heart_rate_avg == Decimal("155")
     assert detail.energy_burned == Decimal("500")
-    assert detail.distance == Decimal("10.0")
+    assert detail.distance == Decimal("10000.0")  # Fitbit sends kilometers, stored as meters
 
 
 def test_normalize_workout_missing_heart_rate(fitbit_workouts: FitbitWorkouts) -> None:


### PR DESCRIPTION
## Description

Fitbit workout distance was stored as the raw API value, which is kilometers, while the platform stores distance in meters (`coverage.mdx` unit table; Whoop stores `distance_meter`, Garmin `distanceInMeters`, Strava meters). A 10 km run was stored as `10.0` and then relabeled as meters by every consumer: API responses, the webhook `distance_meters` payload field, and the dashboard - all off by 1000x.

Units cannot be anything other than kilometers here: Fitbit selects the unit system purely from the per-request `Accept-Language` header (en_US -> miles, absent or anything else -> metric), and the backend sends no `Accept-Language` on any request (`api_client.py` sends only Authorization + Accept). So a flat x1000 conversion at normalization is sufficient; the response's `distanceUnit` field stays untouched as a potential future guard.

The existing test asserted the bug (`detail.distance == Decimal("10.0")` for a 10 km activity); updated to assert `10000.0`.

Resolves #1138

## Notes

Existing rows are not migrated here. Distinguishing km-stored Fitbit rows is provider-scoped and unambiguous (`provider = 'fitbit'` rows written before this fix are all kilometers), so a follow-up backfill in the style of `null_bogus_workout_heart_rate_min.py` (x1000 for fitbit workout rows below a sanity threshold) is straightforward - happy to add it here or separately. Worth noting Fitbit syncs are currently broken on main for scheduled runs (string-date crash, open PR #1054), which limits how much affected data exists.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed) - the coverage matrix PR #1137 documents the caveat and can flip the cell once this merges

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes (ruff + ty pass; prettier hook needs frontend `node_modules`, no frontend files touched)

## Testing Instructions

**Steps to test:**
1. `cd backend && uv run pytest tests/providers/fitbit/`
2. Sync a Fitbit account and compare a workout's stored `distance` against the Fitbit app value.

**Expected behavior:**

A 10 km Fitbit activity stores `distance = 10000` meters; `distance_meters` in webhook payloads and API responses is correct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fitbit workout distance metrics are now correctly normalized to meters, ensuring accurate distance tracking and reporting in your fitness data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->