### PR TITLE
fix: update last_synced_at on webhook receive

### DIFF
--- a/backend/app/services/providers/oura/webhook_handler.py
+++ b/backend/app/services/providers/oura/webhook_handler.py
@@ -232,6 +232,8 @@ class OuraWebhookHandler(BaseWebhookHandler):
             object_id=notification.object_id,
         )
 
+        self.connection_repo.update_last_synced_at(db, connection)
+
         count = self._dispatch_data_type(db, notification, user_id)
 
         if count is None:

--- a/backend/app/services/providers/polar/webhook_handler.py
+++ b/backend/app/services/providers/polar/webhook_handler.py
@@ -208,6 +208,8 @@ class PolarWebhookHandler(BaseWebhookHandler):
         path = urlparse(event.url).path
         user_id = connection.user_id
 
+        self.connection_repo.update_last_synced_at(db, connection)
+
         log_structured(
             logger,
             "info",

--- a/backend/app/services/providers/strava/webhook_handler.py
+++ b/backend/app/services/providers/strava/webhook_handler.py
@@ -269,6 +269,8 @@ class StravaWebhookHandler(BaseWebhookHandler):
 
         user_id: UUID = connection.user_id
 
+        self.connection_repo.update_last_synced_at(db, connection)
+
         if aspect_type == "delete":
             return self._handle_activity_delete(db, user_id, object_id, trace_id)
 

--- a/backend/app/services/providers/whoop/webhook_handler.py
+++ b/backend/app/services/providers/whoop/webhook_handler.py
@@ -202,6 +202,8 @@ class WhoopWebhookHandler(BaseWebhookHandler):
             resource_id=resource_id,
         )
 
+        self.connection_repo.update_last_synced_at(db, connection)
+
         if notification.type.is_delete_type:
             return self._handle_deleted(db, notification.type, user_id, resource_id)
         if notification.type.is_update_type:


### PR DESCRIPTION
Resolves #1143 :


> This part of code:
> 
> ```python
>     connection = self.connection_repo.get_active_connection(db, uid, "garmin")
>     if connection:
>         self.connection_repo.update_last_synced_at(db, connection)
> ```
> 
> For updating last_synced_at field in user connection in webhook handlers is only implemented for Garmin and Suunto. The issue here is that we have webhooks also implemented for:
> 
> - Whoop
> - Oura
> - Polar
> - Strava
> 
> So basically, we need to copy this part in the correct place in webhook handler for each of those, or maybe handle this somewhere in the base webhook handler methods?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook event processors for Oura, Polar, Strava, and Whoop data providers now properly record synchronization timestamps when handling incoming webhook notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->