### PR TITLE
ci: add manual Docker Hub image publish workflow

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -10,9 +10,9 @@ on:
         required: false
         default: ""
       vite_api_url:
-        description: "Frontend only: API URL baked into the build at compile time."
+        description: "Frontend only: API URL baked into the build. Leave empty to use the repo variable VITE_API_URL, falling back to http://localhost:8000."
         required: false
-        default: "https://api.openwearables.mntm.dev"
+        default: ""
 
 jobs:
   publish:
@@ -27,13 +27,10 @@ jobs:
             context: ./backend
             dockerfile: ./backend/Dockerfile
             image: themomentum/open-wearables-backend
-            build-args: ""
           - name: frontend
             context: ./frontend
             dockerfile: ./frontend/Dockerfile
             image: themomentum/open-wearables-frontend
-            build-args: |
-              VITE_API_URL=${{ inputs.vite_api_url }}
     steps:
       - uses: actions/checkout@v4
 
@@ -64,6 +61,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: ${{ matrix.build-args }}
+          # Frontend only: pick per-run input, else repo variable VITE_API_URL, else localhost.
+          build-args: ${{ matrix.name == 'frontend' && format('VITE_API_URL={0}', inputs.vite_api_url || vars.VITE_API_URL || 'http://localhost:8000') || '' }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -58,6 +58,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # No API URL is baked in: the frontend reads it at runtime from the
-          # container's API_URL env var. See frontend/src/lib/api/runtime-config.ts.
+          # container's VITE_API_URL env var. See frontend/src/lib/api/runtime-config.ts.
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           images: ${{ matrix.image }}
           tags: |
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha
             type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
 

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,69 @@
+name: Publish Docker images
+
+# Manually triggered build & push of the production images to Docker Hub.
+# Run it from the GitHub UI: Actions -> "Publish Docker images" -> Run workflow.
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Extra image tag to push (in addition to `latest` and the commit SHA). Leave empty to skip."
+        required: false
+        default: ""
+      vite_api_url:
+        description: "Frontend only: API URL baked into the build at compile time."
+        required: false
+        default: "https://api.openwearables.mntm.dev"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: backend
+            context: ./backend
+            dockerfile: ./backend/Dockerfile
+            image: themomentum/open-wearables-backend
+            build-args: ""
+          - name: frontend
+            context: ./frontend
+            dockerfile: ./frontend/Dockerfile
+            image: themomentum/open-wearables-frontend
+            build-args: |
+              VITE_API_URL=${{ inputs.vite_api_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Derive image tags & labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=raw,value=latest
+            type=sha
+            type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+
+      - name: Build and push ${{ matrix.name }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ matrix.build-args }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -9,10 +9,6 @@ on:
         description: "Extra image tag to push (in addition to `latest` and the commit SHA). Leave empty to skip."
         required: false
         default: ""
-      vite_api_url:
-        description: "Frontend only: API URL baked into the build. Leave empty to use the repo variable VITE_API_URL, falling back to http://localhost:8000."
-        required: false
-        default: ""
 
 jobs:
   publish:
@@ -61,7 +57,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # Frontend only: pick per-run input, else repo variable VITE_API_URL, else localhost.
-          build-args: ${{ matrix.name == 'frontend' && format('VITE_API_URL={0}', inputs.vite_api_url || vars.VITE_API_URL || 'http://localhost:8000') || '' }}
+          # No API URL is baked in: the frontend reads it at runtime from the
+          # container's API_URL env var. See frontend/src/lib/api/runtime-config.ts.
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/docs/deployment/docker-images.mdx
+++ b/docs/deployment/docker-images.mdx
@@ -1,0 +1,91 @@
+---
+title: "Docker Images"
+description: "Run Open Wearables from the prebuilt Docker Hub images and point the frontend at any backend at runtime"
+---
+
+## Overview
+
+Open Wearables publishes two production images to Docker Hub:
+
+| Image | Service | Port |
+|-------|---------|------|
+| `themomentum/open-wearables-backend` | FastAPI API + Celery worker/beat/flower | `8000` |
+| `themomentum/open-wearables-frontend` | React frontend (TanStack Start, served by Nitro) | `3000` |
+
+The single backend image runs the API, worker, beat, and flower — the command is supplied by your orchestrator (`scripts/start/app.sh`, `worker.sh`, `beat.sh`, `flower.sh`), exactly as in `docker-compose.yml`.
+
+## Configuring the frontend API URL at runtime
+
+<Note>
+  **What changed:** the frontend used to bake `VITE_API_URL` into the JavaScript bundle at build time, which meant a prebuilt image could only ever talk to one backend. The API URL is now resolved at **runtime**, so the **same published image** works against any backend without rebuilding.
+</Note>
+
+Set `VITE_API_URL` as an environment variable on the frontend container. The Nitro server reads it at startup and injects it into the served HTML before the app loads:
+
+```bash
+docker run -p 3000:3000 \
+  -e VITE_API_URL=https://api.client1.com \
+  themomentum/open-wearables-frontend:latest
+```
+
+The same image with a different value points at a different backend — no rebuild:
+
+```bash
+docker run -p 3000:3000 \
+  -e VITE_API_URL=https://api.client2.com \
+  themomentum/open-wearables-frontend:latest
+```
+
+If `VITE_API_URL` is not set, it falls back to `http://localhost:8000`.
+
+<Note>
+  `VITE_API_URL` is a single variable used for both build-time (Vite inlines `import.meta.env`) and runtime configuration. When the same variable is set both in an `.env` file and via the container's `environment:`, the container environment wins — so runtime always overrides any baked-in value.
+</Note>
+
+### How it works
+
+Because the frontend is server-rendered (TanStack Start on Nitro), the value travels from the container env to the browser like this:
+
+1. The Nitro server reads `process.env.VITE_API_URL` at request time.
+2. It injects `window.__APP_CONFIG__ = { apiUrl: "..." }` into the HTML `<head>` before the app hydrates.
+3. The API client reads that value. (Resolution order: injected runtime value → `VITE_API_URL` baked at build → `http://localhost:8000`.)
+
+The logic lives in `frontend/src/lib/api/runtime-config.ts`.
+
+## Example: deploying one client
+
+For a client served at `client1.com` with its API at `api.client1.com`:
+
+```yaml
+services:
+  frontend:
+    image: themomentum/open-wearables-frontend:latest
+    environment:
+      - VITE_API_URL=https://api.client1.com
+    ports:
+      - "3000:3000"
+
+  backend:
+    image: themomentum/open-wearables-backend:latest
+    command: scripts/start/app.sh
+    env_file:
+      - ./config/.env
+    ports:
+      - "8000:8000"
+```
+
+The backend reads all of its configuration from the environment at runtime (`config/.env`), so its image needs no per-client rebuild either.
+
+## Publishing the images
+
+Images are built and pushed manually via the **Publish Docker images** GitHub Actions workflow (`.github/workflows/publish-images.yml`):
+
+1. Go to **Actions → Publish Docker images → Run workflow**.
+2. Both images are built and pushed, tagged with the commit SHA, plus `latest` when run from `main`, plus any optional tag you provide.
+
+The workflow requires two repository secrets: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` (a Docker Hub access token with Read & Write scope). No API URL is baked into the frontend image — it is always configured at runtime as described above.
+
+## Related Guides
+
+- [Deploy to Railway](/deployment/railway) - One-click managed deployment
+- [Raw Payloads Storage](/dev-guides/raw-payload-storage) - Backend runtime configuration example

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -95,6 +95,7 @@
           {
             "group": "Deployment",
             "pages": [
+              "deployment/docker-images",
               "deployment/railway"
             ]
           },

--- a/frontend/src/lib/api/config.ts
+++ b/frontend/src/lib/api/config.ts
@@ -1,5 +1,7 @@
+import { resolveApiUrl } from './runtime-config';
+
 export const API_CONFIG = {
-  baseUrl: import.meta.env.VITE_API_URL || 'http://localhost:8000',
+  baseUrl: resolveApiUrl(),
   timeout: 30000, // 30 seconds
   retryAttempts: 3,
   retryDelay: 1000, // 1 second

--- a/frontend/src/lib/api/runtime-config.ts
+++ b/frontend/src/lib/api/runtime-config.ts
@@ -7,15 +7,16 @@ declare global {
 }
 
 /**
- * Resolve the backend API base URL.
+ * Resolve the backend API base URL from a single env var: VITE_API_URL.
  *
- * The URL is configured at *runtime*, not baked at build time, so a single
- * prebuilt image can point at any backend (e.g. https://api.client1.com)
- * without rebuilding. Order of precedence:
+ * The same name works both at build time (Vite inlines import.meta.env) and at
+ * runtime (the container's VITE_API_URL env var), so a prebuilt image can point
+ * at any backend (e.g. https://api.client1.com) without rebuilding. Order of
+ * precedence:
  *
  *   1. Browser: window.__APP_CONFIG__.apiUrl, injected into the SSR HTML from
- *      the container's API_URL env var (see routes/__root.tsx).
- *   2. SSR server (Nitro runtime): the API_URL / VITE_API_URL env var.
+ *      the container's VITE_API_URL env var (see routes/__root.tsx).
+ *   2. SSR server (Nitro runtime): process.env.VITE_API_URL.
  *   3. VITE_API_URL baked at build time (dev / opt-in build-time config).
  *   4. http://localhost:8000.
  */
@@ -29,12 +30,7 @@ export function resolveApiUrl(): string {
   }
 
   const env = typeof process !== 'undefined' ? process.env : undefined;
-  return (
-    env?.API_URL ||
-    env?.VITE_API_URL ||
-    import.meta.env.VITE_API_URL ||
-    FALLBACK_API_URL
-  );
+  return env?.VITE_API_URL || import.meta.env.VITE_API_URL || FALLBACK_API_URL;
 }
 
 /**

--- a/frontend/src/lib/api/runtime-config.ts
+++ b/frontend/src/lib/api/runtime-config.ts
@@ -1,0 +1,48 @@
+const FALLBACK_API_URL = 'http://localhost:8000';
+
+declare global {
+  interface Window {
+    __APP_CONFIG__?: { apiUrl?: string };
+  }
+}
+
+/**
+ * Resolve the backend API base URL.
+ *
+ * The URL is configured at *runtime*, not baked at build time, so a single
+ * prebuilt image can point at any backend (e.g. https://api.client1.com)
+ * without rebuilding. Order of precedence:
+ *
+ *   1. Browser: window.__APP_CONFIG__.apiUrl, injected into the SSR HTML from
+ *      the container's API_URL env var (see routes/__root.tsx).
+ *   2. SSR server (Nitro runtime): the API_URL / VITE_API_URL env var.
+ *   3. VITE_API_URL baked at build time (dev / opt-in build-time config).
+ *   4. http://localhost:8000.
+ */
+export function resolveApiUrl(): string {
+  if (typeof window !== 'undefined') {
+    return (
+      window.__APP_CONFIG__?.apiUrl ||
+      import.meta.env.VITE_API_URL ||
+      FALLBACK_API_URL
+    );
+  }
+
+  const env = typeof process !== 'undefined' ? process.env : undefined;
+  return (
+    env?.API_URL ||
+    env?.VITE_API_URL ||
+    import.meta.env.VITE_API_URL ||
+    FALLBACK_API_URL
+  );
+}
+
+/**
+ * Inline script that publishes the runtime config to the browser before the
+ * app bundle hydrates. Rendered into the SSR document head/body.
+ */
+export function runtimeConfigScript(): string {
+  const config = { apiUrl: resolveApiUrl() };
+  // JSON.stringify + escape `<` so the value can't break out of the <script>.
+  return `window.__APP_CONFIG__ = ${JSON.stringify(config).replace(/</g, '\\u003c')};`;
+}

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -9,6 +9,7 @@ import { ReactQueryDevtoolsPanel } from '@tanstack/react-query-devtools';
 import { TanStackDevtools } from '@tanstack/react-devtools';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@/lib/query/client';
+import { runtimeConfigScript } from '@/lib/api/runtime-config';
 import { Toaster } from '@/components/ui/sonner';
 
 import appCss from '../styles.css?url';
@@ -102,6 +103,12 @@ function RootComponent() {
     <html lang="en" className="dark">
       <head>
         <HeadContent />
+        {/* Runtime config: injects the API URL from the container env before
+            the app hydrates, so one prebuilt image works against any backend. */}
+        <script
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: runtimeConfigScript() }}
+        />
       </head>
       <body>
         <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## What

Adds `.github/workflows/publish-images.yml` — a manually triggered (`workflow_dispatch`) workflow that builds the production backend and frontend images and pushes them to Docker Hub:

- `themomentum/open-wearables-backend`
- `themomentum/open-wearables-frontend`

## How it works

- Builds both images in a matrix (backend + frontend) using buildx with GitHub Actions layer cache
- Tags each image with `latest`, `sha-<commit>`, and an optional manual tag passed at dispatch time
- Bakes `VITE_API_URL` into the frontend build (default `https://api.openwearables.mntm.dev`, overridable on dispatch — it is compiled into the static bundle, not read at runtime)
- The single backend image serves app / worker / beat / flower, matching the existing compose setup (the `Dockerfile` has no `CMD`; the command is supplied by compose)

## Required setup before first run

Add two repository secrets (Settings → Secrets and variables → Actions):

- `DOCKERHUB_USERNAME` — `themomentum`
- `DOCKERHUB_TOKEN` — a Docker Hub access token with Read & Write scope

## Verification

Both images were built locally with the exact CI context, dockerfile and build-args:

- Backend image builds successfully (306 MB)
- Frontend image builds successfully (171 MB); confirmed the prod `VITE_API_URL` is baked into the emitted bundle
- `actionlint` passes on the workflow

## Scope

Image publish only — no production deploy / SSH / prod compose is included, per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime-configurable frontend API base URL that can be provided from container/runtime settings before app hydration.
* **Chores**
  * Added a manually triggered GitHub Actions workflow to build and publish backend and frontend Docker images to Docker Hub, with optional tag input and commit-based tagging.
* **Documentation**
  * Added deployment documentation for the prebuilt Docker images, including ports and example run/configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->