### PR TITLE
fix(backend): report accurate Suunto sleep sync stats, skip unsaveable sessions

### DIFF
--- a/backend/app/services/providers/suunto/data_247.py
+++ b/backend/app/services/providers/suunto/data_247.py
@@ -229,8 +229,13 @@ class Suunto247Data(Base247DataTemplate):
         db: DbSession,
         user_id: UUID,
         normalized_sleep: dict[str, Any],
-    ) -> None:
-        """Save normalized sleep data as EventRecord + SleepDetails."""
+    ) -> bool:
+        """Save normalized sleep data as EventRecord + SleepDetails.
+
+        Returns ``True`` if the session was persisted and ``False`` if it was
+        skipped (no usable start/end window) or the underlying service raised, so
+        the sync loop can report accurate saved/skipped counts.
+        """
         sleep_id: UUID = normalized_sleep["id"]
 
         start_dt = parse_iso_datetime(normalized_sleep.get("start_time"))
@@ -245,7 +250,7 @@ class Suunto247Data(Base247DataTemplate):
                 task="save_sleep_data",
                 user_id=str(user_id),
             )
-            return
+            return False
 
         # EventRecord
         record = EventRecordCreate(
@@ -294,9 +299,10 @@ class Suunto247Data(Base247DataTemplate):
                 task="save_sleep_data",
                 user_id=str(user_id),
             )
-            return
+            return False
 
         self._persist_resting_heart_rate(db, user_id, normalized_sleep, end_dt)
+        return True
 
     def _persist_resting_heart_rate(
         self,
@@ -691,16 +697,24 @@ class Suunto247Data(Base247DataTemplate):
         user_id: UUID,
         start_time: datetime,
         end_time: datetime,
-    ) -> int:
-        """Load sleep data from API and save to database."""
+    ) -> tuple[int, int]:
+        """Load sleep data from API and save to database.
+
+        Returns ``(saved, skipped)`` so callers can distinguish a real sync from
+        one where every fetched session was dropped (e.g. unusable windows).
+        """
         raw_data = self.get_sleep_data(db, user_id, start_time, end_time)
-        count = 0
+        saved = 0
+        skipped = 0
         for item in raw_data:
             try:
                 normalized = self.normalize_sleep(item, user_id)
-                self.save_sleep_data(db, user_id, normalized)
-                count += 1
+                if self.save_sleep_data(db, user_id, normalized):
+                    saved += 1
+                else:
+                    skipped += 1
             except Exception as e:
+                skipped += 1
                 log_structured(
                     self.logger,
                     "warning",
@@ -709,7 +723,7 @@ class Suunto247Data(Base247DataTemplate):
                     task="load_and_save_sleep",
                     user_id=str(user_id),
                 )
-        return count
+        return saved, skipped
 
     def load_and_save_all(
         self,
@@ -733,6 +747,7 @@ class Suunto247Data(Base247DataTemplate):
 
         results: dict[str, int] = {
             "sleep_sessions_synced": 0,
+            "sleep_sessions_skipped": 0,
             "recovery_samples_synced": 0,
             "activity_samples_synced": 0,
             "daily_activity_synced": 0,
@@ -740,7 +755,9 @@ class Suunto247Data(Base247DataTemplate):
 
         # 1. Sleep sessions → EventRecord + SleepDetails
         try:
-            results["sleep_sessions_synced"] = self.load_and_save_sleep(db, user_id, start_dt, end_dt)
+            saved, skipped = self.load_and_save_sleep(db, user_id, start_dt, end_dt)
+            results["sleep_sessions_synced"] = saved
+            results["sleep_sessions_skipped"] = skipped
         except Exception as e:
             log_structured(
                 self.logger,

--- a/backend/app/services/providers/suunto/webhook_handler.py
+++ b/backend/app/services/providers/suunto/webhook_handler.py
@@ -250,8 +250,8 @@ class SuuntoWebhookHandler(BaseWebhookHandler):
         for sample in samples:
             try:
                 normalized = self.suunto_247.normalize_sleep(sample, user_id)
-                self.suunto_247.save_sleep_data(db, user_id, normalized)
-                saved += 1
+                if self.suunto_247.save_sleep_data(db, user_id, normalized):
+                    saved += 1
             except Exception as exc:
                 log_structured(
                     logger,

--- a/backend/tests/providers/suunto/test_suunto_247.py
+++ b/backend/tests/providers/suunto/test_suunto_247.py
@@ -3,6 +3,7 @@
 from collections.abc import Generator
 from datetime import datetime, timezone
 from decimal import Decimal
+from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -142,3 +143,72 @@ class TestSuuntoRestingHeartRatePersistence:
         timeseries_service_mock.bulk_create_samples.assert_called_once()
         db.rollback.assert_called_once()
         db.commit.assert_not_called()
+
+
+def _normalized_sleep(**overrides: Any) -> dict[str, Any]:
+    """A normalized sleep dict shaped exactly as ``normalize_sleep`` emits one."""
+    base: dict[str, Any] = {
+        "id": uuid4(),
+        "suunto_sleep_id": 1780782000,
+        "start_time": "2026-06-06T23:40:00+02:00",
+        "end_time": "2026-06-07T06:12:00+02:00",
+        "duration_seconds": 23520,
+        "efficiency_percent": 77,
+        "is_nap": False,
+        "min_heart_rate_bpm": None,
+        "stages": {"deep_seconds": 7320, "light_seconds": 10950, "rem_seconds": 5220, "awake_seconds": 30},
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSuuntoSleepSyncStats:
+    """The sleep sync loop must skip unsaveable sessions and report accurate
+    (saved, skipped) counts, so a fully-dropped backfill is never reported as a
+    successful sync."""
+
+    @patch("app.services.providers.suunto.data_247.event_record_service")
+    def test_save_sleep_data_reports_success(self, mock_event: MagicMock, data_247: Suunto247Data) -> None:
+        assert data_247.save_sleep_data(MagicMock(), uuid4(), _normalized_sleep()) is True
+        mock_event.create_or_merge_sleep.assert_called_once()
+
+    @patch("app.services.providers.suunto.data_247.event_record_service")
+    def test_save_sleep_data_reports_skip_for_missing_window(
+        self, mock_event: MagicMock, data_247: Suunto247Data
+    ) -> None:
+        skipped = data_247.save_sleep_data(MagicMock(), uuid4(), _normalized_sleep(start_time=None, end_time=None))
+
+        assert skipped is False
+        mock_event.create_or_merge_sleep.assert_not_called()
+
+    @patch("app.services.providers.suunto.data_247.event_record_service")
+    def test_load_and_save_sleep_counts_saved_and_skipped(self, mock_event: MagicMock, data_247: Suunto247Data) -> None:
+        saveable = {
+            "timestamp": "2026-06-06T23:40:00+02:00",
+            "entryData": {
+                "BedtimeStart": "2026-06-06T23:40:00+02:00",
+                "BedtimeEnd": "2026-06-07T06:12:00+02:00",
+                "Duration": 23520.0,
+                "SleepId": 1,
+            },
+        }
+        unsaveable = {"timestamp": "2026-06-07T13:00:00+02:00", "entryData": {"Duration": 0.0, "SleepId": 2}}
+
+        with patch.object(data_247, "get_sleep_data", return_value=[saveable, unsaveable]):
+            saved, skipped = data_247.load_and_save_sleep(
+                MagicMock(), uuid4(), datetime.now(timezone.utc), datetime.now(timezone.utc)
+            )
+
+        assert (saved, skipped) == (1, 1)
+
+    def test_load_and_save_all_surfaces_skipped_count(self, data_247: Suunto247Data) -> None:
+        with (
+            patch.object(data_247, "load_and_save_sleep", return_value=(2, 3)),
+            patch.object(data_247, "load_and_save_recovery", return_value=0),
+            patch.object(data_247, "get_activity_samples", return_value=[]),
+            patch.object(data_247, "get_daily_activity_statistics", return_value=[]),
+        ):
+            results = data_247.load_and_save_all(MagicMock(), uuid4())
+
+        assert results["sleep_sessions_synced"] == 2
+        assert results["sleep_sessions_skipped"] == 3


### PR DESCRIPTION
load_and_save_sleep counted every fetched session as synced, including the ones save_sleep_data silently dropped for a missing start/end window, so a backfill that persisted nothing still reported a full sleep_sessions_synced count. save_sleep_data now returns whether it persisted; the REST loop and the SLEEP_CREATED webhook count only real saves, load_and_save_sleep returns (saved, skipped), and load_and_save_all surfaces sleep_sessions_skipped.

## Description

<!-- Provide a brief summary of your changes. What problem does this solve? -->

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [ ] `pnpm run lint` passes
- [ ] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds

## Testing Instructions

<!-- Describe how reviewers can test your changes -->

**Steps to test:**
1.
2.
3.

**Expected behavior:**



## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->



## Additional Notes

<!-- Any additional context or information reviewers should know -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Suunto sleep synchronization reporting by accurately distinguishing between sessions that were successfully saved and those that were skipped (including cases with missing timing data).
  * Updated sync statistics to correctly reflect both saved and skipped sleep sessions.
* **Tests**
  * Added test coverage to verify sleep persistence outcomes and ensure aggregated sync/skipped counters are reported correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->