### PR TITLE
chore: increase Oura log verbosity

### DIFF
--- a/backend/app/integrations/celery/tasks/webhook_push_task.py
+++ b/backend/app/integrations/celery/tasks/webhook_push_task.py
@@ -17,7 +17,6 @@ from fastapi import HTTPException
 from app.database import SessionLocal
 from app.schemas.sync_status import SyncStatus
 from app.services import sync_status_service
-from app.schemas.enums.provider import ProviderName
 from app.services.providers.factory import ProviderFactory
 from app.utils.structured_logging import log_structured
 
@@ -130,41 +129,6 @@ def _emit_webhook_sync_status(provider_name: str, result: Any) -> None:
         logger.debug("Failed to emit webhook sync status: %s", exc, exc_info=True)
 
 
-def extract_payload_user_id(provider_name: str, payload: dict[str, Any]) -> str | None:
-    """Best-effort extraction of the provider's user identifier from a webhook payload.
-
-    The key differs per provider (Oura/Whoop/Polar use ``user_id``, Strava uses
-    ``owner_id``, Suunto uses ``username``, Garmin nests ``userId`` per item).
-    Returns ``None`` when no identifier is present.
-    """
-    try:
-        provider = ProviderName(provider_name)
-    except ValueError:
-        return None
-
-    match provider:
-        case ProviderName.OURA | ProviderName.WHOOP | ProviderName.POLAR:
-            uid = payload.get("user_id")
-            return str(uid) if uid is not None else None
-        case ProviderName.STRAVA:
-            uid = payload.get("owner_id")
-            return str(uid) if uid is not None else None
-        case ProviderName.SUUNTO:
-            return payload.get("username")
-        case ProviderName.GARMIN:
-            # Garmin batches items under data-type keys; userId lives per item.
-            user_ids = {
-                str(item["userId"])
-                for items in payload.values()
-                if isinstance(items, list)
-                for item in items
-                if isinstance(item, dict) and item.get("userId")
-            }
-            return ",".join(sorted(user_ids)) or None
-        case _:
-            return None
-
-
 @shared_task(
     bind=True,
     acks_late=True,
@@ -181,13 +145,16 @@ def process_webhook_push(
     process_payload() with a fresh DB session. Retries up to 3 times on
     unexpected infrastructure errors.
     """
+    handler = None
+    provider_user_id: str | None = None
     try:
-        factory = ProviderFactory()
-        strategy = factory.get_provider(provider_name)
-        if strategy.webhooks is None:
+        strategy = ProviderFactory().get_provider(provider_name)
+        handler = strategy.webhooks
+        if handler is None:
             raise ValueError(f"Provider '{provider_name}' has no webhook handler")
+        provider_user_id = handler.extract_user_id(payload)
         with SessionLocal() as db:
-            result = strategy.webhooks.process_payload(db, payload, request_trace_id)
+            result = handler.process_payload(db, payload, request_trace_id)
         _emit_webhook_sync_status(provider_name, result)
         return result
     except ValueError as exc:
@@ -198,7 +165,7 @@ def process_webhook_push(
             "Webhook push task aborted — configuration error",
             provider=provider_name,
             trace_id=request_trace_id,
-            provider_user_id=extract_payload_user_id(provider_name, payload),
+            provider_user_id=provider_user_id,
             error=str(exc),
         )
         raise
@@ -212,7 +179,7 @@ def process_webhook_push(
                 "Webhook push task skipped — upstream non-retriable response",
                 provider=provider_name,
                 trace_id=request_trace_id,
-                provider_user_id=extract_payload_user_id(provider_name, payload),
+                provider_user_id=provider_user_id,
                 upstream_status=exc.status_code,
                 error=str(exc.detail),
             )
@@ -227,7 +194,7 @@ def process_webhook_push(
             "Webhook push task failed, scheduling retry",
             provider=provider_name,
             trace_id=request_trace_id,
-            provider_user_id=extract_payload_user_id(provider_name, payload),
+            provider_user_id=provider_user_id,
             upstream_status=exc.status_code,
             error=str(exc.detail),
             attempt=self.request.retries,
@@ -241,7 +208,7 @@ def process_webhook_push(
             "Webhook push task failed, scheduling retry",
             provider=provider_name,
             trace_id=request_trace_id,
-            provider_user_id=extract_payload_user_id(provider_name, payload),
+            provider_user_id=provider_user_id,
             error=str(exc),
             attempt=self.request.retries,
             max_retries=self.max_retries,

--- a/backend/app/integrations/celery/tasks/webhook_push_task.py
+++ b/backend/app/integrations/celery/tasks/webhook_push_task.py
@@ -212,6 +212,7 @@ def process_webhook_push(
                 "Webhook push task skipped — upstream non-retriable response",
                 provider=provider_name,
                 trace_id=request_trace_id,
+                provider_user_id=extract_payload_user_id(provider_name, payload),
                 upstream_status=exc.status_code,
                 error=str(exc.detail),
             )
@@ -226,6 +227,7 @@ def process_webhook_push(
             "Webhook push task failed, scheduling retry",
             provider=provider_name,
             trace_id=request_trace_id,
+            provider_user_id=extract_payload_user_id(provider_name, payload),
             upstream_status=exc.status_code,
             error=str(exc.detail),
             attempt=self.request.retries,

--- a/backend/app/integrations/celery/tasks/webhook_push_task.py
+++ b/backend/app/integrations/celery/tasks/webhook_push_task.py
@@ -17,6 +17,7 @@ from fastapi import HTTPException
 from app.database import SessionLocal
 from app.schemas.sync_status import SyncStatus
 from app.services import sync_status_service
+from app.schemas.enums.provider import ProviderName
 from app.services.providers.factory import ProviderFactory
 from app.utils.structured_logging import log_structured
 
@@ -129,6 +130,41 @@ def _emit_webhook_sync_status(provider_name: str, result: Any) -> None:
         logger.debug("Failed to emit webhook sync status: %s", exc, exc_info=True)
 
 
+def extract_payload_user_id(provider_name: str, payload: dict[str, Any]) -> str | None:
+    """Best-effort extraction of the provider's user identifier from a webhook payload.
+
+    The key differs per provider (Oura/Whoop/Polar use ``user_id``, Strava uses
+    ``owner_id``, Suunto uses ``username``, Garmin nests ``userId`` per item).
+    Returns ``None`` when no identifier is present.
+    """
+    try:
+        provider = ProviderName(provider_name)
+    except ValueError:
+        return None
+
+    match provider:
+        case ProviderName.OURA | ProviderName.WHOOP | ProviderName.POLAR:
+            uid = payload.get("user_id")
+            return str(uid) if uid is not None else None
+        case ProviderName.STRAVA:
+            uid = payload.get("owner_id")
+            return str(uid) if uid is not None else None
+        case ProviderName.SUUNTO:
+            return payload.get("username")
+        case ProviderName.GARMIN:
+            # Garmin batches items under data-type keys; userId lives per item.
+            user_ids = {
+                str(item["userId"])
+                for items in payload.values()
+                if isinstance(items, list)
+                for item in items
+                if isinstance(item, dict) and item.get("userId")
+            }
+            return ",".join(sorted(user_ids)) or None
+        case _:
+            return None
+
+
 @shared_task(
     bind=True,
     acks_late=True,
@@ -162,6 +198,7 @@ def process_webhook_push(
             "Webhook push task aborted — configuration error",
             provider=provider_name,
             trace_id=request_trace_id,
+            payload_user_id=extract_payload_user_id(provider_name, payload),
             error=str(exc),
         )
         raise
@@ -202,6 +239,7 @@ def process_webhook_push(
             "Webhook push task failed, scheduling retry",
             provider=provider_name,
             trace_id=request_trace_id,
+            payload_user_id=extract_payload_user_id(provider_name, payload),
             error=str(exc),
             attempt=self.request.retries,
             max_retries=self.max_retries,

--- a/backend/app/integrations/celery/tasks/webhook_push_task.py
+++ b/backend/app/integrations/celery/tasks/webhook_push_task.py
@@ -198,7 +198,7 @@ def process_webhook_push(
             "Webhook push task aborted — configuration error",
             provider=provider_name,
             trace_id=request_trace_id,
-            payload_user_id=extract_payload_user_id(provider_name, payload),
+            provider_user_id=extract_payload_user_id(provider_name, payload),
             error=str(exc),
         )
         raise
@@ -239,7 +239,7 @@ def process_webhook_push(
             "Webhook push task failed, scheduling retry",
             provider=provider_name,
             trace_id=request_trace_id,
-            payload_user_id=extract_payload_user_id(provider_name, payload),
+            provider_user_id=extract_payload_user_id(provider_name, payload),
             error=str(exc),
             attempt=self.request.retries,
             max_retries=self.max_retries,

--- a/backend/app/services/providers/garmin/webhook_handler.py
+++ b/backend/app/services/providers/garmin/webhook_handler.py
@@ -77,6 +77,17 @@ class GarminWebhookHandler(BaseWebhookHandler):
         self.garmin_247 = garmin_247
         self.connection_repo = UserConnectionRepository()
 
+    def extract_user_id(self, payload: dict[str, Any]) -> str | None:
+        """Garmin batches items under data-type keys; userId lives per item."""
+        user_ids = {
+            str(item["userId"])
+            for items in payload.values()
+            if isinstance(items, list)
+            for item in items
+            if isinstance(item, dict) and item.get("userId")
+        }
+        return ",".join(sorted(user_ids)) or None
+
     # ------------------------------------------------------------------
     # BaseWebhookHandler interface
     # ------------------------------------------------------------------

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -45,7 +45,7 @@ from app.services.providers.templates.base_oauth import BaseOAuthTemplate
 from app.services.raw_payload_storage import store_raw_payload
 from app.services.timeseries_service import timeseries_service
 from app.utils.dates import offset_to_iso
-from app.utils.structured_logging import log_structured
+from app.utils.structured_logging import LogContext, log_structured
 
 
 class Oura247Data(Base247DataTemplate):
@@ -252,8 +252,10 @@ class Oura247Data(Base247DataTemplate):
         db: DbSession,
         user_id: UUID,
         normalized: tuple[dict[str, list[dict[str, Any]]], list[HealthScoreCreate]],
+        log_ctx: LogContext | None = None,
     ) -> int:
         """Save daily activity data as DataPointSeries and health scores."""
+        provider_user_id, trace_id = log_ctx or LogContext()
         activity_samples, health_scores = normalized
         samples: list[TimeSeriesSampleCreate] = []
         for key, series_type in ACTIVITY_SERIES.items():
@@ -279,6 +281,8 @@ class Oura247Data(Base247DataTemplate):
                         metric=key,
                         error=str(e),
                         user_id=str(user_id),
+                        provider_user_id=provider_user_id,
+                        trace_id=trace_id,
                     )
 
         counts = WriteCounts(0, 0)
@@ -336,8 +340,10 @@ class Oura247Data(Base247DataTemplate):
         db: DbSession,
         user_id: UUID,
         normalized: list[tuple[datetime, float]],
+        log_ctx: LogContext | None = None,
     ) -> int:
         """Save daily cardiovascular age data as DataPointSeries."""
+        provider_user_id, trace_id = log_ctx or LogContext()
         samples: list[TimeSeriesSampleCreate] = []
 
         for recorded_at, value in normalized:
@@ -360,6 +366,8 @@ class Oura247Data(Base247DataTemplate):
                     action="oura_cardiovascular_age_save_error",
                     error=str(e),
                     user_id=str(user_id),
+                    provider_user_id=provider_user_id,
+                    trace_id=trace_id,
                 )
 
         counts = WriteCounts(0, 0)
@@ -470,8 +478,10 @@ class Oura247Data(Base247DataTemplate):
         db: DbSession,
         user_id: UUID,
         normalized: tuple[list[dict[str, Any]], list[HealthScoreCreate]],
+        log_ctx: LogContext | None = None,
     ) -> int:
         """Save normalized readiness data as DataPointSeries and health scores."""
+        provider_user_id, trace_id = log_ctx or LogContext()
         recovery_metrics, health_scores = normalized
 
         metrics = list(READINESS_SERIES.items())
@@ -504,6 +514,8 @@ class Oura247Data(Base247DataTemplate):
                             field=field_name,
                             error=str(e),
                             user_id=str(user_id),
+                            provider_user_id=provider_user_id,
+                            trace_id=trace_id,
                         )
 
         counts = WriteCounts(0, 0)
@@ -621,8 +633,10 @@ class Oura247Data(Base247DataTemplate):
         db: DbSession,
         user_id: UUID,
         normalized_items: list[dict[str, Any]],
+        log_ctx: LogContext | None = None,
     ) -> int:
         """Save normalized sleep data to database as EventRecord with SleepDetails."""
+        provider_user_id, trace_id = log_ctx or LogContext()
         count = 0
         for normalized_sleep in normalized_items:
             sleep_id = normalized_sleep["id"]
@@ -652,6 +666,8 @@ class Oura247Data(Base247DataTemplate):
                     action="oura_sleep_skip",
                     sleep_id=str(sleep_id),
                     user_id=str(user_id),
+                    provider_user_id=provider_user_id,
+                    trace_id=trace_id,
                 )
                 continue
 
@@ -711,6 +727,8 @@ class Oura247Data(Base247DataTemplate):
                     sleep_id=str(sleep_id),
                     error=str(e),
                     user_id=str(user_id),
+                    provider_user_id=provider_user_id,
+                    trace_id=trace_id,
                 )
 
             hr: OuraIntervalData | None = normalized_sleep.get("heart_rate")
@@ -753,6 +771,8 @@ class Oura247Data(Base247DataTemplate):
                         sleep_id=str(sleep_id),
                         error=str(e),
                         user_id=str(user_id),
+                        provider_user_id=provider_user_id,
+                        trace_id=trace_id,
                     )
 
             avg_breath = normalized_sleep.get("average_breath")
@@ -782,6 +802,8 @@ class Oura247Data(Base247DataTemplate):
                         sleep_id=str(sleep_id),
                         error=str(e),
                         user_id=str(user_id),
+                        provider_user_id=provider_user_id,
+                        trace_id=trace_id,
                     )
 
         return count
@@ -880,8 +902,10 @@ class Oura247Data(Base247DataTemplate):
         db: DbSession,
         user_id: UUID,
         raw_data: list[dict[str, Any]],
+        log_ctx: LogContext | None = None,
     ) -> int:
         """Save SpO2 data as DataPointSeries."""
+        provider_user_id, trace_id = log_ctx or LogContext()
         samples: list[TimeSeriesSampleCreate] = []
         for item in raw_data:
             day = item.get("day")
@@ -915,6 +939,8 @@ class Oura247Data(Base247DataTemplate):
                         action="oura_spo2_save_error",
                         error=str(e),
                         user_id=str(user_id),
+                        provider_user_id=provider_user_id,
+                        trace_id=trace_id,
                     )
 
             bdi = item.get("breathing_disturbance_index")
@@ -938,6 +964,8 @@ class Oura247Data(Base247DataTemplate):
                         action="oura_bdi_save_error",
                         error=str(e),
                         user_id=str(user_id),
+                        provider_user_id=provider_user_id,
+                        trace_id=trace_id,
                     )
 
         counts = WriteCounts(0, 0)
@@ -1132,8 +1160,10 @@ class Oura247Data(Base247DataTemplate):
         db: DbSession,
         user_id: UUID,
         raw_data: list[dict[str, Any]],
+        log_ctx: LogContext | None = None,
     ) -> int:
         """Save Vo2 data as DataPointSeries."""
+        provider_user_id, trace_id = log_ctx or LogContext()
         samples: list[TimeSeriesSampleCreate] = []
         for item in raw_data:
             vo2_max = item.get("vo2_max")
@@ -1161,6 +1191,8 @@ class Oura247Data(Base247DataTemplate):
                     action="oura_vo2_save_error",
                     error=str(e),
                     user_id=str(user_id),
+                    provider_user_id=provider_user_id,
+                    trace_id=trace_id,
                 )
 
         counts = WriteCounts(0, 0)

--- a/backend/app/services/providers/oura/webhook_handler.py
+++ b/backend/app/services/providers/oura/webhook_handler.py
@@ -314,7 +314,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
                 data_type=data_type,
                 event_type=notification.event_type,
             )
-            return None
+            return 0
 
         if data_type == "workout":
             return self.workouts.save_by_id(db, user_id, object_id)

--- a/backend/app/services/providers/oura/webhook_handler.py
+++ b/backend/app/services/providers/oura/webhook_handler.py
@@ -361,4 +361,15 @@ class OuraWebhookHandler(BaseWebhookHandler):
             case "vo2_max":
                 return self.data_247.save_vo2_data(db, user_id, docs, log_ctx)
             case _:
+                log_structured(
+                    logger,
+                    "warning",
+                    "Unhandled Oura data type",
+                    provider="oura",
+                    trace_id=trace_id,
+                    user_id=str(user_id),
+                    provider_user_id=notification.user_id,
+                    data_type=data_type,
+                    event_type=notification.event_type,
+                )
                 return None

--- a/backend/app/services/providers/oura/webhook_handler.py
+++ b/backend/app/services/providers/oura/webhook_handler.py
@@ -71,6 +71,8 @@ _COLLECTION_NAME: dict[str, str] = {
 class OuraWebhookHandler(BaseWebhookHandler):
     """Webhook handler for Oura notify-only events."""
 
+    user_id_field = "user_id"
+
     def __init__(self, data_247: Oura247Data, workouts: OuraWorkouts) -> None:
         super().__init__("oura")
         self.data_247 = data_247

--- a/backend/app/services/providers/oura/webhook_handler.py
+++ b/backend/app/services/providers/oura/webhook_handler.py
@@ -151,6 +151,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
             "Enqueued Oura webhook processing task",
             provider="oura",
             trace_id=request_trace_id,
+            oura_user_id=oura_user_id,
             task_id=getattr(task, "id", None),
         )
 
@@ -187,6 +188,16 @@ class OuraWebhookHandler(BaseWebhookHandler):
         try:
             notification = OuraWebhookNotification(**payload)
         except (ValidationError, TypeError) as exc:
+            log_structured(
+                logger,
+                "warning",
+                "Invalid Oura webhook payload",
+                provider="oura",
+                trace_id=trace_id,
+                oura_user_id=payload.get("user_id", "unknown"),
+                data_type=payload.get("data_type", "unknown"),
+                error=str(exc),
+            )
             return {"status": "error", "error": f"Invalid payload: {exc}"}
 
         if notification.event_type == "delete":
@@ -196,6 +207,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
                 "Ignoring Oura delete event",
                 provider="oura",
                 trace_id=trace_id,
+                oura_user_id=notification.user_id,
                 data_type=notification.data_type,
             )
             return {"status": "ignored", "reason": "delete_event"}
@@ -234,7 +246,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
 
         self.connection_repo.update_last_synced_at(db, connection)
 
-        count = self._dispatch_data_type(db, notification, user_id)
+        count = self._dispatch_data_type(db, notification, user_id, trace_id)
 
         if count is None:
             log_structured(
@@ -245,6 +257,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
                 trace_id=trace_id,
                 data_type=notification.data_type,
                 user_id=str(user_id),
+                oura_user_id=notification.user_id,
             )
             return {
                 "status": "ignored",
@@ -284,11 +297,23 @@ class OuraWebhookHandler(BaseWebhookHandler):
         db: DbSession,
         notification: OuraWebhookNotification,
         user_id: UUID,
+        trace_id: str,
     ) -> int | None:
         data_type = notification.data_type
         object_id = notification.object_id
 
         if not object_id:
+            log_structured(
+                logger,
+                "warning",
+                "Oura webhook missing object_id; skipping fetch",
+                provider="oura",
+                trace_id=trace_id,
+                user_id=str(user_id),
+                oura_user_id=notification.user_id,
+                data_type=data_type,
+                event_type=notification.event_type,
+            )
             return None
 
         if data_type == "workout":
@@ -297,6 +322,17 @@ class OuraWebhookHandler(BaseWebhookHandler):
         collection = _COLLECTION_NAME.get(data_type, data_type)
         raw = self.data_247._make_api_request(db, user_id, f"/v2/usercollection/{collection}/{object_id}")
         if not raw or not isinstance(raw, dict):
+            log_structured(
+                logger,
+                "warning",
+                "Oura object fetch returned no data",
+                provider="oura",
+                trace_id=trace_id,
+                user_id=str(user_id),
+                oura_user_id=notification.user_id,
+                data_type=data_type,
+                object_id=object_id,
+            )
             return 0
 
         docs = [raw]

--- a/backend/app/services/providers/oura/webhook_handler.py
+++ b/backend/app/services/providers/oura/webhook_handler.py
@@ -45,7 +45,7 @@ from app.services.providers.oura.data_247 import Oura247Data
 from app.services.providers.oura.workouts import OuraWorkouts
 from app.services.providers.templates.base_webhook_handler import BaseWebhookHandler
 from app.services.raw_payload_storage import store_raw_payload
-from app.utils.structured_logging import log_structured
+from app.utils.structured_logging import LogContext, log_structured
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +129,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
         request_trace_id = str(uuid4())[:8]
         event_type = payload.get("event_type", "unknown")
         data_type = payload.get("data_type", "unknown")
-        oura_user_id = payload.get("user_id", "unknown")
+        provider_user_id = payload.get("user_id", "unknown")
 
         log_structured(
             logger,
@@ -139,7 +139,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
             trace_id=request_trace_id,
             event_type=event_type,
             data_type=data_type,
-            oura_user_id=oura_user_id,
+            provider_user_id=provider_user_id,
         )
 
         store_raw_payload(source="webhook", provider="oura", payload=payload, trace_id=request_trace_id)
@@ -151,7 +151,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
             "Enqueued Oura webhook processing task",
             provider="oura",
             trace_id=request_trace_id,
-            oura_user_id=oura_user_id,
+            provider_user_id=provider_user_id,
             task_id=getattr(task, "id", None),
         )
 
@@ -194,7 +194,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
                 "Invalid Oura webhook payload",
                 provider="oura",
                 trace_id=trace_id,
-                oura_user_id=payload.get("user_id", "unknown"),
+                provider_user_id=payload.get("user_id", "unknown"),
                 data_type=payload.get("data_type", "unknown"),
                 error=str(exc),
             )
@@ -207,7 +207,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
                 "Ignoring Oura delete event",
                 provider="oura",
                 trace_id=trace_id,
-                oura_user_id=notification.user_id,
+                provider_user_id=notification.user_id,
                 data_type=notification.data_type,
             )
             return {"status": "ignored", "reason": "delete_event"}
@@ -220,7 +220,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
                 "No connection found for Oura user",
                 provider="oura",
                 trace_id=trace_id,
-                oura_user_id=notification.user_id,
+                provider_user_id=notification.user_id,
                 data_type=notification.data_type,
             )
             return {
@@ -238,7 +238,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
             provider="oura",
             trace_id=trace_id,
             user_id=str(user_id),
-            oura_user_id=notification.user_id,
+            provider_user_id=notification.user_id,
             data_type=notification.data_type,
             event_type=notification.event_type,
             object_id=notification.object_id,
@@ -257,7 +257,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
                 trace_id=trace_id,
                 data_type=notification.data_type,
                 user_id=str(user_id),
-                oura_user_id=notification.user_id,
+                provider_user_id=notification.user_id,
             )
             return {
                 "status": "ignored",
@@ -273,7 +273,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
             action="oura_webhook_complete",
             trace_id=trace_id,
             user_id=str(user_id),
-            oura_user_id=notification.user_id,
+            provider_user_id=notification.user_id,
             data_type=notification.data_type,
             event_type=notification.event_type,
             records_saved=int(count),
@@ -310,7 +310,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
                 provider="oura",
                 trace_id=trace_id,
                 user_id=str(user_id),
-                oura_user_id=notification.user_id,
+                provider_user_id=notification.user_id,
                 data_type=data_type,
                 event_type=notification.event_type,
             )
@@ -329,7 +329,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
                 provider="oura",
                 trace_id=trace_id,
                 user_id=str(user_id),
-                oura_user_id=notification.user_id,
+                provider_user_id=notification.user_id,
                 data_type=data_type,
                 object_id=object_id,
             )
@@ -337,22 +337,28 @@ class OuraWebhookHandler(BaseWebhookHandler):
 
         docs = [raw]
 
+        log_ctx = LogContext(provider_user_id=notification.user_id, trace_id=trace_id)
+
         match data_type:
             case "sleep" | "daily_sleep":
-                return self.data_247.save_sleep_data(db, user_id, self.data_247.normalize_sleeps(docs, user_id))
+                return self.data_247.save_sleep_data(
+                    db, user_id, self.data_247.normalize_sleeps(docs, user_id), log_ctx
+                )
             case "daily_readiness":
-                return self.data_247.save_readiness_data(db, user_id, self.data_247.normalize_readiness(docs, user_id))
+                return self.data_247.save_readiness_data(
+                    db, user_id, self.data_247.normalize_readiness(docs, user_id), log_ctx
+                )
             case "daily_activity":
                 return self.data_247.save_activity_data(
-                    db, user_id, self.data_247.normalize_activity_samples(docs, user_id)
+                    db, user_id, self.data_247.normalize_activity_samples(docs, user_id), log_ctx
                 )
             case "daily_spo2":
-                return self.data_247.save_spo2_data(db, user_id, docs)
+                return self.data_247.save_spo2_data(db, user_id, docs, log_ctx)
             case "daily_cardiovascular_age":
                 return self.data_247.save_cardiovascular_age_data(
-                    db, user_id, self.data_247.normalize_cardiovascular_age_samples(docs, user_id)
+                    db, user_id, self.data_247.normalize_cardiovascular_age_samples(docs, user_id), log_ctx
                 )
             case "vo2_max":
-                return self.data_247.save_vo2_data(db, user_id, docs)
+                return self.data_247.save_vo2_data(db, user_id, docs, log_ctx)
             case _:
                 return None

--- a/backend/app/services/providers/polar/webhook_handler.py
+++ b/backend/app/services/providers/polar/webhook_handler.py
@@ -62,6 +62,8 @@ _PROCESS_PUSH_TASK = "app.integrations.celery.tasks.webhook_push_task.process_we
 class PolarWebhookHandler(BaseWebhookHandler):
     """Webhook handler for Polar AccessLink notify-only events."""
 
+    user_id_field = "user_id"
+
     def __init__(self, workouts: "PolarWorkouts | None" = None, data_247: "Polar247Data | None" = None) -> None:
         super().__init__("polar")
         self.connection_repo = UserConnectionRepository()

--- a/backend/app/services/providers/strava/webhook_handler.py
+++ b/backend/app/services/providers/strava/webhook_handler.py
@@ -61,6 +61,8 @@ _PROCESS_PUSH_TASK = "app.integrations.celery.tasks.webhook_push_task.process_we
 class StravaWebhookHandler(BaseWebhookHandler):
     """Webhook handler for Strava notify-only events."""
 
+    user_id_field = "owner_id"
+
     def __init__(self, workouts: StravaWorkouts) -> None:
         super().__init__("strava")
         self.workouts = workouts

--- a/backend/app/services/providers/suunto/webhook_handler.py
+++ b/backend/app/services/providers/suunto/webhook_handler.py
@@ -52,6 +52,8 @@ class SuuntoWebhookHandler(BaseWebhookHandler):
     the ``X-HMAC-SHA256-Signature`` request header.
     """
 
+    user_id_field = "username"
+
     def __init__(self, suunto_workouts: SuuntoWorkouts, suunto_247: Suunto247Data) -> None:
         super().__init__("suunto")
         self.suunto_workouts = suunto_workouts

--- a/backend/app/services/providers/templates/base_webhook_handler.py
+++ b/backend/app/services/providers/templates/base_webhook_handler.py
@@ -66,9 +66,20 @@ class BaseWebhookHandler(ABC):
       standard *verify → parse → dispatch* sequence is insufficient.
     """
 
+    #: Top-level webhook-payload key holding the provider-side user id.
+    #: Override extract_user_id() instead when it isn't a flat field (e.g. Garmin).
+    user_id_field: str | None = None
+
     def __init__(self, provider_name: str) -> None:
         self.provider_name = provider_name
         self.logger = logging.getLogger(self.__class__.__name__)
+
+    def extract_user_id(self, payload: dict[str, Any]) -> str | None:
+        """Best-effort provider-side user id from a raw webhook payload (for log correlation)."""
+        if not self.user_id_field:
+            return None
+        value = payload.get(self.user_id_field)
+        return str(value) if value is not None else None
 
     # ------------------------------------------------------------------
     # Abstract interface

--- a/backend/app/services/providers/whoop/webhook_handler.py
+++ b/backend/app/services/providers/whoop/webhook_handler.py
@@ -54,6 +54,8 @@ _PROCESS_PUSH_TASK = "app.integrations.celery.tasks.webhook_push_task.process_we
 class WhoopWebhookHandler(BaseWebhookHandler):
     """Webhook handler for Whoop notify-only events."""
 
+    user_id_field = "user_id"
+
     def __init__(self, data_247: Whoop247Data, workouts: WhoopWorkouts) -> None:
         super().__init__("whoop")
         self.data_247 = data_247

--- a/backend/app/services/sync_status_service.py
+++ b/backend/app/services/sync_status_service.py
@@ -40,6 +40,7 @@ from app.schemas.sync_status import (
     SyncStatusEvent,
 )
 from app.utils.sse import format_comment, format_event
+from app.utils.structured_logging import log_structured
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +81,42 @@ def emit(event: SyncStatusEvent) -> None:
     Failures are logged but never raised — sync flow must not be blocked
     by Redis problems.
     """
+    # Mirror the SSE event into the structured logs so sync outcome metadata
+    # (status, item counts, inserted/updated split, message) is queryable in the
+    # deployment logs, not only on the frontend stream.
+    match event.status:
+        case SyncStatus.FAILED:
+            level = "error"
+        case SyncStatus.PARTIAL:
+            level = "warning"
+        case _:
+            level = "info"
+    extra = {
+        key: value
+        for key, value in {
+            "items_processed": event.items_processed,
+            "items_total": event.items_total,
+            "inserted": event.metadata.get("inserted"),
+            "updated": event.metadata.get("updated"),
+            "detail": event.message,
+            "error": event.error,
+        }.items()
+        if value is not None
+    }
+    log_structured(
+        logger,
+        level,
+        "Sync status",
+        provider=event.provider,
+        action="sync_status",
+        status=str(event.status),
+        source=str(event.source),
+        stage=str(event.stage),
+        run_id=event.run_id,
+        user_id=str(event.user_id),
+        **extra,
+    )
+
     try:
         client = get_redis_client()
         payload = event.model_dump_json()

--- a/backend/app/utils/structured_logging.py
+++ b/backend/app/utils/structured_logging.py
@@ -3,10 +3,22 @@
 import json
 import sys
 from logging import Logger
-from typing import Any
+from typing import Any, NamedTuple
 from uuid import UUID
 
 from app.utils.context import trace_id_var
+
+
+class LogContext(NamedTuple):
+    """Per-request log fields threaded into downstream fetch/save logs.
+
+    Lets callers pass the provider-side user id and trace id as a single
+    argument instead of threading two separate params through every signature.
+    Unpack at the top of a method:  ``provider_user_id, trace_id = log_ctx or LogContext()``.
+    """
+
+    provider_user_id: str | None = None
+    trace_id: str | None = None
 
 
 def json_serial(obj: Any) -> str:
@@ -61,7 +73,7 @@ def log_structured(
         Vercel: Filter by JSON attributes in dashboard
         GCP: Use Cloud Logging filters with jsonPayload.batch_id="abc-123"
     """
-    if "trace_id" not in attributes:
+    if attributes.get("trace_id") is None:
         tid = trace_id_var.get()
         if tid:
             attributes["trace_id"] = tid


### PR DESCRIPTION
## Description

Add `LogCtx` named tuple to be passed further along - containing traec id and provider user id for searching through logs, can also be used further for logging in other providers

Also adds logging in more places, to prevent silent returns with no warnings - also for debugging purposes

Resolves #1184 

## Checklist

### General

- [xx] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / Improvements**
  * Added best-effort provider user-id extraction to webhook handling and standardized the payload field mapping across supported providers.
  * Extended structured logging with a shared context for `trace_id` and provider user identifiers, including clearer webhook and sync status diagnostics.
* **Bug Fixes**
  * Improved trace ID handling to preserve caller-supplied values.
  * Enhanced Oura webhook processing logs and no-op behavior when payloads are invalid or fetched data is empty/invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->