### PR TITLE
fix(frontend): empty-state hint for provider priorities list

### DIFF
--- a/frontend/src/routes/_authenticated/settings/-priorities-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/-priorities-tab.tsx
@@ -336,16 +336,23 @@ export function PrioritiesTab() {
         </div>
 
         <div className="p-4 space-y-2">
-          {localOrder.map((provider, index) => (
-            <ProviderItem
-              key={provider.provider}
-              provider={provider}
-              index={index}
-              total={localOrder.length}
-              onMoveUp={() => handleMoveUp(index)}
-              onMoveDown={() => handleMoveDown(index)}
-            />
-          ))}
+          {localOrder.length === 0 ? (
+            <p className="px-4 py-8 text-sm text-muted-foreground text-center">
+              Providers will appear here as soon as their data starts flowing
+              in.
+            </p>
+          ) : (
+            localOrder.map((provider, index) => (
+              <ProviderItem
+                key={provider.provider}
+                provider={provider}
+                index={index}
+                total={localOrder.length}
+                onMoveUp={() => handleMoveUp(index)}
+                onMoveDown={() => handleMoveDown(index)}
+              />
+            ))
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Description

Temporary frontend fix for #1190: when the provider priorities list is empty, show a hint that providers appear once their data starts flowing in - instead of a confusing blank card. The proper backend fix (returning all supported providers) will follow.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

### Frontend Changes

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

## Testing Instructions

**Steps to test:**
1. Open Settings → Priorities with a fresh instance that has no synced data yet.
2. Look at the "Provider Priorities" → "Priority Order" card.

**Expected behavior:**
Instead of an empty card, the card shows: "Providers will appear here as soon as their data starts flowing in."

## Screenshots

<img width="1220" height="836" alt="image" src="https://github.com/user-attachments/assets/e8a82317-672e-4a81-b8e4-787652db29bc" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The priorities section in settings now displays an empty-state message when no priorities are configured, replacing the blank list view and providing clearer guidance to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->