### PR TITLE
fix(backend): persist blood pressure from Garmin webhooks

### DIFF
--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -1320,12 +1320,15 @@ class Garmin247Data(Base247DataTemplate):
     ) -> list[TimeSeriesSampleCreate]:
         """Build time series samples from blood pressure data (no DB interaction)."""
         samples: list[TimeSeriesSampleCreate] = []
-        measurement_ts = raw_bp.get("measurementTimestampGMT", 0)
+        # Garmin's bloodPressures webhook carries the timestamp as
+        # measurementTimeInSeconds (same as bodyComps). Fall back to the
+        # legacy field names for safety.
+        measurement_ts = (
+            raw_bp.get("measurementTimeInSeconds")
+            or raw_bp.get("measurementTimestampGMT")
+            or raw_bp.get("startTimeInSeconds", 0)
+        )
         summary_id = raw_bp.get("summaryId")
-
-        # Try alternative timestamp field
-        if not measurement_ts:
-            measurement_ts = raw_bp.get("startTimeInSeconds", 0)
 
         if not measurement_ts:
             return samples

--- a/backend/tests/providers/garmin/test_garmin_247.py
+++ b/backend/tests/providers/garmin/test_garmin_247.py
@@ -103,6 +103,19 @@ class TestGarmin247Data:
             "muscleMassInGrams": 35000,
         }
 
+    @pytest.fixture
+    def sample_blood_pressure(self) -> dict[str, Any]:
+        """Sample Garmin blood pressure webhook item."""
+        return {
+            "summaryId": "sd60a3665-6a31b950",
+            "systolic": 112,
+            "diastolic": 73,
+            "pulse": 69,
+            "sourceType": "MANUAL",
+            "measurementTimeInSeconds": 1781643600,
+            "measurementTimeOffsetInSeconds": -18000,  # -05:00
+        }
+
     # -------------------------------------------------------------------------
     # Helper Method Tests
     # -------------------------------------------------------------------------
@@ -541,6 +554,31 @@ class TestGarmin247Data:
         """Test _build_body_comp_samples returns empty for missing timestamp."""
         user_id = uuid4()
         samples = garmin_247._build_body_comp_samples(user_id, {"weightInGrams": 75000})
+        assert samples == []
+
+    def test_build_blood_pressure_samples(
+        self, garmin_247: Garmin247Data, sample_blood_pressure: dict[str, Any]
+    ) -> None:
+        """Test _build_blood_pressure_samples reads the webhook timestamp field."""
+        from app.schemas.enums.series_types import SeriesType
+
+        user_id = uuid4()
+        samples = garmin_247._build_blood_pressure_samples(user_id, sample_blood_pressure)
+
+        assert len(samples) == 2  # systolic + diastolic
+        by_type = {s.series_type: s for s in samples}
+        assert by_type[SeriesType.blood_pressure_systolic].value == Decimal("112")
+        assert by_type[SeriesType.blood_pressure_diastolic].value == Decimal("73")
+
+        systolic = by_type[SeriesType.blood_pressure_systolic]
+        assert systolic.recorded_at == datetime(2026, 6, 16, 21, 0, tzinfo=timezone.utc)
+        assert systolic.zone_offset == "-05:00"
+        assert systolic.external_id == "sd60a3665-6a31b950"
+
+    def test_build_blood_pressure_samples_missing_timestamp(self, garmin_247: Garmin247Data) -> None:
+        """Test _build_blood_pressure_samples returns empty when timestamp is absent."""
+        user_id = uuid4()
+        samples = garmin_247._build_blood_pressure_samples(user_id, {"systolic": 112, "diastolic": 73})
         assert samples == []
 
     def test_build_hrv_samples(self, garmin_247: Garmin247Data) -> None:


### PR DESCRIPTION
## Description

Garmin's `bloodPressures` webhook readings were silently dropped. `_build_blood_pressure_samples` read the timestamp from `measurementTimestampGMT`/`startTimeInSeconds`, but the webhook actually sends `measurementTimeInSeconds`, so the timestamp resolved to `0` and the function returned early before reading `systolic`/`diastolic`. Now reads the correct field (legacy fields kept as fallback).

Fixes #1192 - please check out the details there. 

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

## Testing Instructions

**Steps to test:**

Use the data generator in the Garmin panel and verify whether the data is being saved to the database using the query below:

```sql
SELECT
    dps.recorded_at,
    dps.zone_offset,
    std.code        AS series_type,
    dps.value,
    std.unit,
    ds.provider,
    ds.device_model,
    dps.external_id,
    dps.id          AS data_point_id
FROM data_point_series dps
JOIN data_source ds            ON ds.id = dps.data_source_id
JOIN series_type_definition std ON std.id = dps.series_type_definition_id
WHERE ds.user_id = :user_id
  AND std.code IN ('blood_pressure_systolic', 'blood_pressure_diastolic')
ORDER BY dps.recorded_at DESC;
```


**Expected behavior:**
A `bloodPressures` item with `measurementTimeInSeconds` produces systolic + diastolic data points instead of being dropped.