### PR TITLE
fix(backend): persist body composition muscle mass from Garmin webhooks

### DIFF
--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -822,6 +822,22 @@ class Garmin247Data(Base247DataTemplate):
                 )
             )
 
+        # Skeletal muscle mass (convert grams to kg)
+        muscle_mass_grams = raw_body_comp.get("muscleMassInGrams")
+        if muscle_mass_grams:
+            samples.append(
+                TimeSeriesSampleCreate(
+                    id=uuid4(),
+                    user_id=user_id,
+                    source=self.provider_name,
+                    recorded_at=recorded_at,
+                    zone_offset=zone_offset,
+                    value=Decimal(str(muscle_mass_grams)) / 1000,  # Convert to kg
+                    series_type=SeriesType.skeletal_muscle_mass,
+                    external_id=summary_id,
+                )
+            )
+
         return samples
 
     def save_body_composition(

--- a/backend/tests/providers/garmin/test_garmin_247.py
+++ b/backend/tests/providers/garmin/test_garmin_247.py
@@ -364,10 +364,10 @@ class TestGarmin247Data:
 
         count = garmin_247.save_body_composition(db, user.id, sample_body_comp)
 
-        # Should create 3 data points: weight, body_fat, BMI
+        # Should create 4 data points: weight, body_fat, BMI, skeletal muscle mass
         mock_bulk_create.assert_called_once()
-        assert len(mock_bulk_create.call_args[0][1]) == 3
-        assert count == 3
+        assert len(mock_bulk_create.call_args[0][1]) == 4
+        assert count == 4
 
     def test_save_body_composition_missing_timestamp(self, garmin_247: Garmin247Data, db: Session) -> None:
         """Test saving body composition with missing timestamp."""
@@ -533,9 +533,14 @@ class TestGarmin247Data:
 
     def test_build_body_comp_samples(self, garmin_247: Garmin247Data, sample_body_comp: dict[str, Any]) -> None:
         """Test _build_body_comp_samples returns samples without DB call."""
+        from app.schemas.enums.series_types import SeriesType
+
         user_id = uuid4()
         samples = garmin_247._build_body_comp_samples(user_id, sample_body_comp)
-        assert len(samples) == 3  # weight, body_fat, BMI
+        assert len(samples) == 4  # weight, body_fat, BMI, skeletal muscle mass
+
+        muscle = next(s for s in samples if s.series_type == SeriesType.skeletal_muscle_mass)
+        assert muscle.value == Decimal("35")  # 35000 g -> 35 kg
 
     def test_build_body_comp_samples_missing_timestamp(self, garmin_247: Garmin247Data) -> None:
         """Test _build_body_comp_samples returns empty for missing timestamp."""


### PR DESCRIPTION
## Description

Garmin's `bodyComps` webhook sends `muscleMassInGrams`, but `_build_body_comp_samples` never mapped it - the `skeletal_muscle_mass` series type already exists, it just wasn't wired up. Now persisted (grams converted to kg, same as weight).

Example payload we receive:

```json
[
  {
    "summaryId": "...",
    "muscleMassInGrams": 37106,
    "boneMassInGrams": 37211,
    "bodyWaterInPercent": 77.53936,
    "bodyFatInPercent": 15.4246235,
    "bodyMassIndex": 52.723537,
    "weightInGrams": 73166,
    "measurementTimeInSeconds": 1781625600,
    "measurementTimeOffsetInSeconds": -18000
  }
]
```

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally

## Testing Instructions

Use the data generator in the Garmin panel and verify whether the data is being saved to the database using the query below:

```sql
SELECT
    dps.recorded_at,
    std.code AS series_type,
    dps.value,
    std.unit,
    ds.provider,
    ds.user_id,
    dps.external_id,
    dps.created_at
FROM data_point_series dps
JOIN series_type_definition std ON std.id = dps.series_type_definition_id
JOIN data_source ds             ON ds.id = dps.data_source_id
WHERE std.code = 'skeletal_muscle_mass'
  AND ds.provider = 'garmin'
ORDER BY dps.created_at DESC
LIMIT 20;
```

**Expected:** rows with `series_type = skeletal_muscle_mass` and the muscle mass value in kg (e.g. `37106 g -> 37.106 kg`).