### PR TITLE
fix(whoop): v2 recovery webhook 404 — fetch via cycle, not /v2/recovery/{id}

### DIFF
--- a/backend/app/services/providers/whoop/data_247.py
+++ b/backend/app/services/providers/whoop/data_247.py
@@ -862,14 +862,18 @@ class Whoop247Data(Base247DataTemplate):
         user_id: UUID,
         cycle_id: str,
     ) -> dict[str, Any]:
-        """Fetch a single recovery record by cycle_id from /v2/recovery/{cycle_id}."""
-        response = self._make_api_request(db, user_id, f"/v2/recovery/{cycle_id}")
+        """Fetch the recovery for a cycle from /v2/cycle/{cycle_id}/recovery.
+
+        WHOOP API v2 has no GET /v2/recovery/{id} endpoint; recovery is fetched
+        per-cycle via the getRecoveryForCycle operation.
+        """
+        response = self._make_api_request(db, user_id, f"/v2/cycle/{cycle_id}/recovery")
         store_raw_payload(
             source="api_response",
             provider="whoop",
             payload=response,
             user_id=str(user_id),
-            trace_id=f"/v2/recovery/{cycle_id}",
+            trace_id=f"/v2/cycle/{cycle_id}/recovery",
         )
         return response if isinstance(response, dict) else {}
 
@@ -877,10 +881,27 @@ class Whoop247Data(Base247DataTemplate):
         self,
         db: DbSession,
         user_id: UUID,
-        cycle_id: str,
+        sleep_id: str,
     ) -> int:
-        """Fetch a single recovery record by cycle_id, normalize, and save to database."""
-        raw = self.get_recovery_record(db, user_id, cycle_id)
+        """Fetch the recovery for a recovery.updated webhook, normalize, and save.
+
+        In WHOOP API v2 the recovery.updated webhook carries the associated
+        SLEEP uuid (in v1 it was the cycle id). There is no single-recovery
+        by-id endpoint in v2, so resolve the sleep to its cycle and fetch
+        GET /v2/cycle/{cycle_id}/recovery.
+        """
+        raw_sleep = self.get_sleep_record(db, user_id, sleep_id)
+        cycle_id = raw_sleep.get("cycle_id") if raw_sleep else None
+        if cycle_id is None:
+            log_structured(
+                self.logger,
+                "warning",
+                f"Cannot resolve cycle for recovery webhook sleep {sleep_id}",
+                provider="whoop",
+                task="load_single_recovery",
+            )
+            return 0
+        raw = self.get_recovery_record(db, user_id, str(cycle_id))
         if not raw:
             return 0
         try:
@@ -895,7 +916,7 @@ class Whoop247Data(Base247DataTemplate):
             log_structured(
                 self.logger,
                 "warning",
-                f"Failed to save recovery record {cycle_id}: {e}",
+                f"Failed to save recovery record for sleep {sleep_id}: {e}",
                 provider="whoop",
                 task="load_single_recovery",
             )


### PR DESCRIPTION
## Problem

On a WHOOP **v2** `recovery.updated` webhook, recovery is never saved — the fetch 404s.

`webhook_handler.py` passes the webhook's `notification.id` to `load_single_recovery`, which builds:

```python
GET /v2/recovery/{cycle_id}   # data_247.py:866
```

Two things are wrong for WHOOP API v2:

1. **There is no `GET /v2/recovery/{id}` endpoint in v2.** A single recovery is fetched only via `GET /v2/cycle/{cycleId}/recovery` (`getRecoveryForCycle`); there is also the paginated collection `GET /v2/recovery`. (WHOOP v2 OpenAPI.)
2. **The `recovery.updated` / `recovery.deleted` webhook `id` is the associated *sleep* UUID, not a cycle id** in v2 (it was the integer cycle id in v1). — WHOOP webhooks docs / v1→v2 migration guide.

Observed in production: the **same** webhook UUID returns `200` on `GET /v2/activity/sleep/{id}` (it *is* a sleep id) and `404` on `GET /v2/recovery/{id}`. The hourly poll still works for past days via the valid `/v2/recovery?start=&end=` collection, but the current day's recovery is only delivered via the webhook path — so it never lands.

## Fix

For `recovery.updated`, treat the id as the sleep UUID: fetch the sleep, read its `cycle_id`, then fetch `GET /v2/cycle/{cycle_id}/recovery`. `get_recovery_record` now targets the correct v2 cycle-recovery endpoint.

## Scope / safety
- `get_recovery_record` and `load_single_recovery` are called **only** from the recovery webhook path; the collection poll (`get_recovery_data` → `/v2/recovery`) is untouched.
- `recovery.deleted` remains a no-op (unchanged).

## References
- WHOOP webhooks: *"In v2, the ID is the UUID of the sleep that the recovery is associated with."*
- WHOOP v2 OpenAPI: recovery paths are `/v2/recovery` (collection) and `/v2/cycle/{cycleId}/recovery`; no `/v2/recovery/{id}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Whoop recovery data fetching to improve data accuracy and consistency.
  * Enhanced recovery synchronization process for more reliable health metrics integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->