### PR TITLE
fix: Mark connection as revoked on failed token refresh + connection.revoked outgoing webhook

### DIFF
--- a/backend/app/constants/webhooks/test_payloads.py
+++ b/backend/app/constants/webhooks/test_payloads.py
@@ -57,6 +57,16 @@ EXAMPLE_PAYLOADS: dict[str, dict] = {
             "connected_at": "2024-01-01T08:00:00+00:00",
         },
     },
+    WebhookEventType.CONNECTION_REVOKED: {
+        "type": WebhookEventType.CONNECTION_REVOKED,
+        "data": {
+            "user_id": _USER_ID,
+            "provider": "garmin",
+            "connection_id": _CONNECTION_ID,
+            "reason": "refresh_failed",
+            "revoked_at": "2024-01-01T08:00:00+00:00",
+        },
+    },
     # ------------------------------------------------------------------
     # Session events
     # ------------------------------------------------------------------

--- a/backend/app/schemas/webhooks/event_types.py
+++ b/backend/app/schemas/webhooks/event_types.py
@@ -24,6 +24,7 @@ class WebhookEventType(StrEnum):
     # Provider connection events
     # -------------------------------------------------------------------------
     CONNECTION_CREATED = "connection.created"
+    CONNECTION_REVOKED = "connection.revoked"
 
     # -------------------------------------------------------------------------
     # Sync lifecycle events (terminal transitions only -- per run)
@@ -190,6 +191,10 @@ class WebhookEventType(StrEnum):
 EVENT_TYPE_DESCRIPTIONS: dict[WebhookEventType, str] = {
     # Session events
     WebhookEventType.CONNECTION_CREATED: "A user successfully connected a wearable provider.",
+    WebhookEventType.CONNECTION_REVOKED: (
+        "A provider connection became invalid (refresh token expired/revoked, or the user "
+        "deregistered on the provider side). The user must re-authorize to resume syncing."
+    ),
     WebhookEventType.SYNC_STARTED: "A sync run started for a user (live, historical, backfill, SDK or XML).",
     WebhookEventType.SYNC_COMPLETED: "A sync run completed successfully (terminal state).",
     WebhookEventType.SYNC_FAILED: "A sync run failed (terminal state, includes error message).",

--- a/backend/app/services/outgoing_webhooks/events.py
+++ b/backend/app/services/outgoing_webhooks/events.py
@@ -282,6 +282,36 @@ def on_connection_created(
     )
 
 
+def on_connection_revoked(
+    *,
+    user_id: UUID,
+    provider: str,
+    connection_id: UUID,
+    reason: str,
+    revoked_at: str,
+) -> None:
+    """Emit when a connection becomes invalid and the user must re-authorize.
+
+    ``reason`` is a short cause, e.g. ``"refresh_failed"`` or
+    ``"deregistration"``.
+    """
+    _dispatch(
+        WebhookEventType.CONNECTION_REVOKED,
+        {
+            "type": WebhookEventType.CONNECTION_REVOKED,
+            "data": {
+                "user_id": str(user_id),
+                "provider": provider,
+                "connection_id": str(connection_id),
+                "reason": reason,
+                "revoked_at": revoked_at,
+            },
+        },
+        idempotency_key=f"connection.revoked.{user_id}.{provider}.{revoked_at}",
+        channels=[f"user.{user_id}"],
+    )
+
+
 def on_sync_started(
     *,
     user_id: UUID,

--- a/backend/app/services/providers/garmin/handlers/lifecycle.py
+++ b/backend/app/services/providers/garmin/handlers/lifecycle.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from app.database import DbSession
 from app.repositories import UserConnectionRepository
+from app.services.outgoing_webhooks.events import on_connection_revoked
 from app.utils.structured_logging import log_structured
 
 logger = logging.getLogger(__name__)
@@ -105,6 +106,13 @@ def process_deregistrations(
             continue
 
         connection_repo.mark_as_revoked(db, connection)
+        on_connection_revoked(
+            user_id=connection.user_id,
+            provider="garmin",
+            connection_id=connection.id,
+            reason="deregistration",
+            revoked_at=connection.updated_at.isoformat(),
+        )
 
         log_structured(
             logger,

--- a/backend/app/services/providers/templates/base_oauth.py
+++ b/backend/app/services/providers/templates/base_oauth.py
@@ -11,13 +11,13 @@ from uuid import UUID
 import httpx
 from fastapi import HTTPException
 from redis import Redis
-from starlette.status import HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
+from starlette.status import HTTP_400_BAD_REQUEST, HTTP_401_UNAUTHORIZED, HTTP_500_INTERNAL_SERVER_ERROR
 
 from app.database import DbSession
 from app.integrations.redis_client import get_redis_client
 from app.repositories.user_connection_repository import UserConnectionRepository
 from app.repositories.user_repository import UserRepository
-from app.schemas.auth import AuthenticationMethod
+from app.schemas.auth import AuthenticationMethod, ConnectionStatus
 from app.schemas.model_crud.credentials import (
     OAuthState,
     OAuthTokenResponse,
@@ -25,7 +25,7 @@ from app.schemas.model_crud.credentials import (
     ProviderEndpoints,
 )
 from app.schemas.model_crud.user_management import UserConnectionCreate
-from app.services.outgoing_webhooks.events import on_connection_created
+from app.services.outgoing_webhooks.events import on_connection_created, on_connection_revoked
 from app.utils.structured_logging import log_structured
 
 logger = logging.getLogger(__name__)
@@ -178,17 +178,38 @@ class BaseOAuthTemplate(ABC):
                 user_id=str(user_id),
                 status_code=e.response.status_code,
             )
+            # 400/401 = refresh token is dead so revoke + notify
+            if e.response.status_code in (HTTP_400_BAD_REQUEST, HTTP_401_UNAUTHORIZED):
+                self._revoke_connection(db, user_id, reason="refresh_failed")
+                raise HTTPException(
+                    status_code=HTTP_401_UNAUTHORIZED,
+                    detail=f"Refresh token rejected for {self.provider_name}; reconnection required",
+                )
             raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=f"Failed to refresh token: {e.response.text}")
         except Exception as e:
             log_structured(
                 logger,
-                "error",
+                "warning",
                 f"OAuth token refresh failed: {e}",
                 provider=self.provider_name,
                 task="refresh_access_token",
                 user_id=str(user_id),
             )
             raise HTTPException(status_code=HTTP_500_INTERNAL_SERVER_ERROR, detail=f"Token refresh failed: {str(e)}")
+
+    def _revoke_connection(self, db: DbSession, user_id: UUID, *, reason: str) -> None:
+        """Mark the connection revoked and emit a connection.revoked webhook."""
+        connection = self.connection_repo.get_by_user_and_provider(db, user_id, self.provider_name)
+        if not connection or connection.status == ConnectionStatus.REVOKED:
+            return
+        self.connection_repo.mark_as_revoked(db, connection)
+        on_connection_revoked(
+            user_id=user_id,
+            provider=self.provider_name,
+            connection_id=connection.id,
+            reason=reason,
+            revoked_at=connection.updated_at.isoformat(),
+        )
 
     def _build_auth_url(self, state: str) -> tuple[str, dict[str, Any] | None]:
         """Builds the authorization URL.

--- a/backend/app/utils/sentry_helpers.py
+++ b/backend/app/utils/sentry_helpers.py
@@ -3,6 +3,7 @@
 from logging import Logger
 
 import sentry_sdk
+from fastapi import HTTPException
 
 
 def log_and_capture_error(
@@ -38,6 +39,12 @@ def log_and_capture_error(
             )
             # Continue processing other items
     """
+    # HTTPExceptions are explicit handled error responses returned by endpoints,
+    # they shouldnt be logged to sentry, just logger
+    if isinstance(exception, HTTPException):
+        logger.warning(message, exc_info=True)
+        return
+
     # Log with standard logger
     log_func = getattr(logger, level, logger.error)
     log_func(message, exc_info=True)

--- a/backend/app/utils/sentry_helpers.py
+++ b/backend/app/utils/sentry_helpers.py
@@ -39,9 +39,10 @@ def log_and_capture_error(
             )
             # Continue processing other items
     """
-    # HTTPExceptions are explicit handled error responses returned by endpoints,
-    # they shouldnt be logged to sentry, just logger
-    if isinstance(exception, HTTPException):
+    # 4xx HTTPExceptions are explicit, handled client errors (e.g. a provider
+    # rejecting a token refresh) — log them but keep them out of Sentry. 5xx and
+    # everything else stay alertable.
+    if isinstance(exception, HTTPException) and 400 <= exception.status_code < 500:
         logger.warning(message, exc_info=True)
         return
 

--- a/docs/api-reference/guides/webhooks.mdx
+++ b/docs/api-reference/guides/webhooks.mdx
@@ -198,6 +198,7 @@ Fired once when a complete session is saved or merged.
 | Event | Description |
 |-------|-------------|
 | `connection.created` | A user successfully connected a wearable provider. |
+| `connection.revoked` | A connection became invalid (refresh token expired/revoked, or the user deregistered on the provider side). The user must re-authorize to resume syncing. |
 | `workout.created` | A new workout session was saved. |
 | `sleep.created` | A new (or merged) sleep session was saved. |
 | `menstrual_cycle.created` | A new menstrual cycle record was saved. |
@@ -243,6 +244,23 @@ Every payload envelope has `type` (the event name as a string) and `data`.
     "provider": "garmin",
     "connection_id": "7f3d9c2a-1b4e-4f8a-9d6c-8e5f2a0b3c7e",
     "connected_at": "2025-12-19T10:30:00+00:00"
+  }
+}
+```
+
+### `connection.revoked`
+
+`reason` is a short cause, e.g. `refresh_failed` or `deregistration`.
+
+```json
+{
+  "type": "connection.revoked",
+  "data": {
+    "user_id": "550e8400-e29b-41d4-a716-446655440000",
+    "provider": "garmin",
+    "connection_id": "7f3d9c2a-1b4e-4f8a-9d6c-8e5f2a0b3c7e",
+    "reason": "refresh_failed",
+    "revoked_at": "2025-12-19T10:30:00+00:00"
   }
 }
 ```


### PR DESCRIPTION
## Description

When we try to refresh token and get `400` / `401` response, the connection is still active and each periodic sync tries to refresh an inactive access token, causing constant errors. This way, the connection will be considered revoked during syncs, showing up on frontend.

Also adding `connection.revoked` outgoing webhook type to notify of that

 
## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `connection.revoked` webhook event when a provider connection becomes invalid and requires re-authorization.
  * Webhook payload now includes connection identifiers plus `reason` and `revoked_at`, emitted on provider deregistration and certain refresh-token failures (HTTP 400/401).
* **Documentation**
  * Updated webhook API docs with the new `connection.revoked` event, payload schema, and an example.
* **Bug Fixes**
  * Improved error reporting by treating expected 4xx HTTP errors as client-side issues and avoiding unnecessary Sentry capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->