### PR TITLE
fix: accept float values for Polar training load fields (Fixes #1198)

### DIFF
--- a/backend/app/schemas/providers/polar/exercise_import.py
+++ b/backend/app/schemas/providers/polar/exercise_import.py
@@ -29,9 +29,9 @@ class RoutePointJSON(BaseModel):
 
 class TrainingLoadProJSON(BaseModel):
     date: str | None = None
-    cardio_load: int | None = Field(None, alias="cardio-load")
-    muscle_load: int | None = Field(None, alias="muscle-load")
-    perceived_load: int | None = Field(None, alias="perceived-load")
+    cardio_load: float | None = Field(None, alias="cardio-load")
+    muscle_load: float | None = Field(None, alias="muscle-load")
+    perceived_load: float | None = Field(None, alias="perceived-load")
     cardio_load_interpretation: str | None = Field(None, alias="cardio-load-interpretation")
     muscle_load_interpretation: str | None = Field(None, alias="muscle-load-interpretation")
     perceived_load_interpretation: str | None = Field(None, alias="perceived-load-interpretation")


### PR DESCRIPTION
Fixes #1198

## Problem

Polar AccessLink API returns `training-load-pro-sample` fields (`cardio-load`, `muscle-load`, `perceived-load`) as floats (e.g., `3.85565`). However, `TrainingLoadProJSON` in `exercise_import.py` declared these fields as `int | None`, causing Pydantic v2's strict `int_from_float` validation to reject every Polar workout sync with:

```
1 validation error for ExerciseJSON
training_load_pro.cardio-load
  Input should be a valid integer, got a number with a fractional part
  [type=int_from_float, input_value=3.85565, input_type=float]
```

This blocked all Polar workout storage — users only saw steps, not training sessions.

## Fix

Changed `cardio_load`, `muscle_load`, and `perceived_load` in `TrainingLoadProJSON` from `int | None` to `float | None`.

**Verification:**
- Float values from Polar API (e.g., 3.85565) are now accepted ✅
- `None` values still work ✅  
- Integer values remain backward compatible (5 → 5.0) ✅
- The old `int` schema confirmed to reject floats with `ValidationError` ✅

```python
# Before (fails):
TrainingLoadProJSON(**{'cardio-load': 3.85565})  # ValidationError

# After (works):
TrainingLoadProJSON(**{'cardio-load': 3.85565})  # cardio_load=3.85565
```

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced precision for training load measurements by enabling support for decimal values instead of whole numbers for cardio, muscle, and perceived load metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->