### PR TITLE
fix(webhooks): fire event record webhook directly instead of via after_commit

### DIFF
--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -124,15 +124,15 @@ class EventRecordService(
         detail_type: str = "workout",
     ) -> EventRecordDetail:
         result = self.event_record_detail_repo.create(db_session, detail, detail_type=detail_type)
+        # event_record_detail_repo.create commits internally, so data is already persisted.
+        # Fire the webhook directly with fresh fetches rather than via after_commit — using
+        # after_commit defers the call to the *next* session commit, at which point SQLAlchemy
+        # has expired the captured ORM objects, causing lazy-load failures inside after_commit.
         record = db_session.get(EventRecord, detail.record_id)
         if record is not None and record.data_source_id is not None:
             data_source = db_session.get(DataSource, record.data_source_id)
             if data_source is not None:
-                _record, _data_source, _detail = record, data_source, detail
-
-                @sa_event.listens_for(db_session, "after_commit", once=True)
-                def _dispatch_webhook(session: DbSession) -> None:  # noqa: ARG001
-                    self._emit_event_record_webhook(_record, _data_source, _detail)
+                self._emit_event_record_webhook(record, data_source, detail)
 
         return result  # ty:ignore[invalid-return-type]
 

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -615,6 +615,14 @@ class EventRecordService(
         if not dispatches:
             return
 
+        # Detach so expire_on_commit doesn't expire these; reading expired attributes
+        # inside after_commit (committed session) would raise. Only loaded scalars are
+        # read, and these objects are local (callers get only IDs), so detaching is safe.
+        for record in records:
+            db_session.expunge(record)
+        for data_source in data_sources:
+            db_session.expunge(data_source)
+
         @sa_event.listens_for(db_session, "after_commit", once=True)
         def _dispatch_bulk_webhooks(session: DbSession) -> None:  # noqa: ARG001
             for record, data_source, detail in dispatches:


### PR DESCRIPTION
Closes #1207

## Problem

`EventRecordService.create_detail` registered an `after_commit` listener with `once=True` to dispatch the outgoing webhook after the detail record was persisted. This listener fired during the *next* session commit — not the one from `create_detail` itself.

By that point, `expire_on_commit=True` (SQLAlchemy default) had expired all tracked ORM objects captured in the closure (`_record`, `_data_source`, `_detail`). Any attribute access inside `_dispatch_webhook` triggered a lazy load. However, during `after_commit` dispatch, `session._transaction` is still non-None (in `COMMITTED` state — `close()` hasn't been called yet), so `_autobegin_t()` returns the committed transaction instead of starting a new one. SQL execution then raises:

```
sqlalchemy.exc.InvalidRequestError: This session is in 'committed' state;
no further SQL can be emitted within this transaction.
```

This caused every Whoop sync to fail immediately on the first workout write.

## Fix

`event_record_detail_repo.create()` commits internally, so the data is already persisted before `create_detail` returns. Remove the deferred `after_commit` listener and call `_emit_event_record_webhook` directly, using the `record` and `data_source` objects already fetched in the same method (which are valid and unexpired at that point).

## Testing

- Triggered a full 6-month historical backfill (29 workouts, 144 sleep sessions, 568 recovery samples) — no errors.
- Confirmed webhook dispatch fires correctly post-fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved event record webhook dispatch to send notifications more promptly after new details are created, rather than waiting for a later commit.
  * Enhanced webhook emission reliability by ensuring event and data source data remains available at dispatch time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->