### PR TITLE
fix(backend): webhooks syncs being saved into sync logs

### DIFF
--- a/backend/app/integrations/celery/tasks/webhook_push_task.py
+++ b/backend/app/integrations/celery/tasks/webhook_push_task.py
@@ -9,11 +9,14 @@ Queue and retry policy are configured per-provider at the call site (send_task w
 
 from logging import getLogger
 from typing import Any
+from uuid import UUID
 
 from celery import Task, shared_task
 from fastapi import HTTPException
 
 from app.database import SessionLocal
+from app.schemas.sync_status import SyncStatus
+from app.services import sync_status_service
 from app.services.providers.factory import ProviderFactory
 from app.utils.structured_logging import log_structured
 
@@ -22,6 +25,82 @@ logger = getLogger(__name__)
 # Upstream 4xx where retrying can't recover the object. 401 (token refresh) and
 # 429 (rate limit) are excluded — those still benefit from a retry.
 _NONRETRIABLE_UPSTREAM_STATUSES = frozenset({400, 403, 404, 410, 422})
+
+# Providers whose webhook deliveries are surfaced in the sync log via this task.
+# Garmin self-reports sync status from its own handler/backfill, so it is excluded
+# here to avoid duplicate run entries.
+_SYNC_LOG_PROVIDERS = frozenset({"oura", "strava", "polar", "whoop", "suunto"})
+
+# process_payload "status" values that mean data was actually persisted.
+_SAVED_STATUSES = frozenset({"processed", "saved", "accepted", "deleted", "success"})
+
+
+def _extract_item_count(result: dict[str, Any]) -> int | None:
+    """Best-effort count of records persisted, across provider result shapes."""
+    for key in ("records_saved", "saved_count", "items_processed", "processed_count", "record_count"):
+        value = result.get(key)
+        if isinstance(value, int):
+            return value
+    saved = result.get("saved")
+    if isinstance(saved, int):
+        return saved
+    if isinstance(saved, dict):
+        return sum(v for v in saved.values() if isinstance(v, int))
+    return None
+
+
+def _emit_webhook_sync_status(provider_name: str, result: Any) -> None:
+    """Record a webhook delivery in the sync log (best-effort, never raises).
+
+    Saves and errors become full run entries; ignored / duplicate / no-op
+    deliveries are recorded as SKIPPED so the UI can filter them out.
+    Deliveries that never resolved to a user (invalid payload, user_not_found)
+    are skipped entirely — there is no user to attribute the run to.
+    """
+    try:
+        if provider_name not in _SYNC_LOG_PROVIDERS or not isinstance(result, dict):
+            return
+
+        raw_user_id = result.get("user_id")
+        if not raw_user_id:
+            return
+        try:
+            user_id = UUID(str(raw_user_id))
+        except (ValueError, TypeError):
+            return
+
+        status_str = str(result.get("status") or "").lower()
+        count = _extract_item_count(result)
+        descriptor = result.get("data_type") or result.get("event_type") or ""
+
+        if status_str == "error":
+            sync_status_service.webhook_delivered(
+                user_id,
+                provider_name,
+                status=SyncStatus.FAILED,
+                error=str(result.get("error") or "unknown"),
+                message=f"webhook {descriptor}".strip(),
+            )
+        elif status_str in _SAVED_STATUSES and (count or 0) > 0:
+            sync_status_service.webhook_delivered(
+                user_id,
+                provider_name,
+                status=SyncStatus.SUCCESS,
+                items_processed=count,
+                message=f"webhook {descriptor}".strip(),
+            )
+        else:
+            # processed-but-no-data, ignored, duplicate, unknown_event_type, …
+            reason = result.get("reason") or (descriptor if status_str in _SAVED_STATUSES else status_str)
+            sync_status_service.webhook_delivered(
+                user_id,
+                provider_name,
+                status=SyncStatus.SKIPPED,
+                items_processed=count,
+                message=f"skipped: {reason}".strip(),
+            )
+    except Exception as exc:  # pragma: no cover - sync log must never break processing
+        logger.debug("Failed to emit webhook sync status: %s", exc, exc_info=True)
 
 
 @shared_task(
@@ -46,7 +125,9 @@ def process_webhook_push(
         if strategy.webhooks is None:
             raise ValueError(f"Provider '{provider_name}' has no webhook handler")
         with SessionLocal() as db:
-            return strategy.webhooks.process_payload(db, payload, request_trace_id)
+            result = strategy.webhooks.process_payload(db, payload, request_trace_id)
+        _emit_webhook_sync_status(provider_name, result)
+        return result
     except ValueError as exc:
         # Configuration error (unknown provider, missing handler) — retrying won't help.
         log_structured(

--- a/backend/app/schemas/sync_status.py
+++ b/backend/app/schemas/sync_status.py
@@ -50,6 +50,7 @@ class SyncStatus(StrEnum):
     PARTIAL = "partial"
     FAILED = "failed"
     CANCELLED = "cancelled"
+    SKIPPED = "skipped"  # Delivered but no data saved (ignored/duplicate/no-op webhook)
 
 
 class SyncStatusEvent(BaseModel):

--- a/backend/app/services/providers/oura/webhook_handler.py
+++ b/backend/app/services/providers/oura/webhook_handler.py
@@ -246,7 +246,11 @@ class OuraWebhookHandler(BaseWebhookHandler):
                 data_type=notification.data_type,
                 user_id=str(user_id),
             )
-            return {"status": "ignored", "reason": f"unhandled_data_type: {notification.data_type}"}
+            return {
+                "status": "ignored",
+                "reason": f"unhandled_data_type: {notification.data_type}",
+                "user_id": str(user_id),
+            }
 
         log_structured(
             logger,
@@ -266,6 +270,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
             "data_type": notification.data_type,
             "event_type": notification.event_type,
             "records_saved": count,
+            "user_id": str(user_id),
         }
 
     # ------------------------------------------------------------------

--- a/backend/app/services/providers/polar/webhook_handler.py
+++ b/backend/app/services/providers/polar/webhook_handler.py
@@ -246,4 +246,4 @@ class PolarWebhookHandler(BaseWebhookHandler):
                     "user_id": str(user_id),
                 },
             )
-            return {"status": "error", "error": str(exc)}
+            return {"status": "error", "error": str(exc), "user_id": str(user_id)}

--- a/backend/app/services/providers/strava/webhook_handler.py
+++ b/backend/app/services/providers/strava/webhook_handler.py
@@ -275,7 +275,7 @@ class StravaWebhookHandler(BaseWebhookHandler):
             return self._handle_activity_delete(db, user_id, object_id, trace_id)
 
         if aspect_type not in ("create", "update"):
-            return {"status": "ignored", "reason": f"aspect_type:{aspect_type}"}
+            return {"status": "ignored", "reason": f"aspect_type:{aspect_type}", "user_id": str(user_id)}
 
         log_structured(
             logger,
@@ -302,7 +302,12 @@ class StravaWebhookHandler(BaseWebhookHandler):
                     activity_id=object_id,
                     user_id=str(user_id),
                 )
-                return {"status": "warning", "reason": "no_activity_data", "activity_id": object_id}
+                return {
+                    "status": "warning",
+                    "reason": "no_activity_data",
+                    "activity_id": object_id,
+                    "user_id": str(user_id),
+                }
 
             activity = StravaActivityJSON(**activity_data)
             created_ids = self.workouts.process_push_activity(db=db, activity=activity, user_id=user_id)
@@ -322,6 +327,7 @@ class StravaWebhookHandler(BaseWebhookHandler):
                 "status": "processed",
                 "activity_id": object_id,
                 "records_saved": len(created_ids),
+                "user_id": str(user_id),
             }
 
         except IntegrityError:
@@ -336,7 +342,12 @@ class StravaWebhookHandler(BaseWebhookHandler):
                 activity_id=object_id,
                 user_id=str(user_id),
             )
-            return {"status": "ignored", "reason": "duplicate_activity", "activity_id": object_id}
+            return {
+                "status": "ignored",
+                "reason": "duplicate_activity",
+                "activity_id": object_id,
+                "user_id": str(user_id),
+            }
 
         except ValidationError as exc:
             log_and_capture_error(
@@ -352,7 +363,7 @@ class StravaWebhookHandler(BaseWebhookHandler):
                     "error": str(exc),
                 },
             )
-            return {"status": "error", "error": f"validation_error: {exc}"}
+            return {"status": "error", "error": f"validation_error: {exc}", "user_id": str(user_id)}
 
         except Exception as exc:
             log_and_capture_error(

--- a/backend/app/services/providers/whoop/webhook_handler.py
+++ b/backend/app/services/providers/whoop/webhook_handler.py
@@ -205,20 +205,23 @@ class WhoopWebhookHandler(BaseWebhookHandler):
         self.connection_repo.update_last_synced_at(db, connection)
 
         if notification.type.is_delete_type:
-            return self._handle_deleted(db, notification.type, user_id, resource_id)
-        if notification.type.is_update_type:
-            return self._handle_updated(db, notification.type, user_id, resource_id)
+            result = self._handle_deleted(db, notification.type, user_id, resource_id)
+        elif notification.type.is_update_type:
+            result = self._handle_updated(db, notification.type, user_id, resource_id)
+        else:
+            log_structured(
+                logger,
+                "info",
+                "Unhandled Whoop webhook event type",
+                provider="whoop",
+                trace_id=trace_id,
+                event_type=notification.type,
+                user_id=str(user_id),
+            )
+            result = {"status": "ignored", "reason": f"unhandled_event_type: {notification.type}"}
 
-        log_structured(
-            logger,
-            "info",
-            "Unhandled Whoop webhook event type",
-            provider="whoop",
-            trace_id=trace_id,
-            event_type=notification.type,
-            user_id=str(user_id),
-        )
-        return {"status": "ignored", "reason": f"unhandled_event_type: {notification.type}"}
+        result.setdefault("user_id", str(user_id))
+        return result
 
     # ------------------------------------------------------------------
     # Per-event-type handlers

--- a/backend/app/services/sync_status_service.py
+++ b/backend/app/services/sync_status_service.py
@@ -501,3 +501,41 @@ def cancelled(
         metadata=metadata,
         ended_at=datetime.now(timezone.utc),
     )
+
+
+def webhook_delivered(
+    user_id: str | UUID,
+    provider: str,
+    *,
+    status: SyncStatus,
+    items_processed: int | None = None,
+    message: str | None = None,
+    error: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> SyncStatusEvent:
+    """Record a single webhook delivery as a self-contained sync run.
+
+    Webhook processing is a one-shot operation (no separate started/progress
+    events), so this emits a single terminal event carrying both
+    ``started_at`` and ``ended_at`` set to now. ``source`` is always
+    :data:`SyncSource.WEBHOOK`.
+
+    ``status`` should be SUCCESS/PARTIAL when data was saved, FAILED on error,
+    or SKIPPED for delivered-but-no-op events (ignored / duplicate).
+    """
+    now = datetime.now(timezone.utc)
+    stage = SyncStage.FAILED if status == SyncStatus.FAILED else SyncStage.COMPLETED
+    return emit_event(
+        user_id=user_id,
+        provider=provider,
+        source=SyncSource.WEBHOOK,
+        stage=stage,
+        status=status,
+        run_id=new_run_id("wh"),
+        message=message,
+        items_processed=items_processed,
+        error=error,
+        metadata=metadata,
+        started_at=now,
+        ended_at=now,
+    )

--- a/frontend/src/lib/utils/sync-format.ts
+++ b/frontend/src/lib/utils/sync-format.ts
@@ -30,6 +30,7 @@ export const RUN_STATUS_CLASSES: Record<string, string> = {
     'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
   failed: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300',
   cancelled: 'bg-zinc-200 text-zinc-700 dark:bg-zinc-800/60 dark:text-zinc-300',
+  skipped: 'bg-zinc-100 text-zinc-500 dark:bg-zinc-800/40 dark:text-zinc-400',
   in_progress:
     'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
 };


### PR DESCRIPTION

<img width="1151" height="407" alt="image" src="https://github.com/user-attachments/assets/02a2c91d-b67d-4e72-bd67-3f6017706e3c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhooks are now tracked in sync status and history, enabling users to monitor webhook deliveries and processing outcomes.
  * Added "skipped" status to distinguish webhook deliveries where no data was saved (duplicates, ignored data types, or no-op events) from successful syncs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->