### PR TITLE
feat: capture Strava route polyline and activity name on workouts

### DIFF
--- a/backend/app/models/event_record.py
+++ b/backend/app/models/event_record.py
@@ -1,5 +1,5 @@
-from uuid import UUID
 from datetime import datetime
+from uuid import UUID
 
 from sqlalchemy import Index
 from sqlalchemy.orm import Mapped, relationship
@@ -12,6 +12,7 @@ from app.mappings import (
     str_32,
     str_64,
     str_100,
+    str_255,
 )
 
 
@@ -28,6 +29,8 @@ class EventRecord(BaseDbModel):
 
     category: Mapped[str_32]
     type: Mapped[str_32 | None]
+    # Provider-supplied display title, e.g. a Strava activity name
+    name: Mapped[str_255 | None]
     source_name: Mapped[str_64]
 
     duration_seconds: Mapped[int | None]

--- a/backend/app/models/workout_details.py
+++ b/backend/app/models/workout_details.py
@@ -1,5 +1,5 @@
-from sqlalchemy import Index
-from sqlalchemy.orm import Mapped
+from sqlalchemy import Index, Text
+from sqlalchemy.orm import Mapped, mapped_column
 
 from app.mappings import FKEventRecordDetail, json_binary, numeric_5_2, numeric_10_3
 
@@ -54,3 +54,7 @@ class WorkoutDetails(EventRecordDetail):
     segments: Mapped[json_binary | None]
     hr_zones: Mapped[json_binary | None]
     power_zones: Mapped[json_binary | None]
+
+    # GPS route encoded with the Google Encoded Polyline Algorithm (precision 5),
+    # e.g. Strava's map.summary_polyline. Null for indoor/manual workouts.
+    route_polyline: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/schemas/model_crud/activities/event_record.py
+++ b/backend/app/schemas/model_crud/activities/event_record.py
@@ -26,6 +26,7 @@ class EventRecordMetrics(TypedDict, total=False):
     average_watts: Decimal | None
     elev_high: Decimal | None
     elev_low: Decimal | None
+    route_polyline: str | None
     sleep_total_duration_minutes: int | None
     sleep_time_in_bed_minutes: int | None
     sleep_efficiency_score: Decimal | None
@@ -40,6 +41,7 @@ class EventRecordBase(BaseModel):
 
     category: str = Field("workout", description="High-level category such as workout or sleep")
     type: str | None = Field(None, description="Provider-specific subtype, e.g. running")
+    name: str | None = Field(None, description="Provider-supplied display title, e.g. a Strava activity name")
 
     source_name: str = Field(description="Source/app name")
     device_model: str | None = Field(

--- a/backend/app/schemas/model_crud/activities/event_record_detail.py
+++ b/backend/app/schemas/model_crud/activities/event_record_detail.py
@@ -31,6 +31,9 @@ class EventRecordDetailBase(BaseModel):
     elev_high: Decimal | None = None
     elev_low: Decimal | None = None
 
+    # Encoded GPS route (Google Encoded Polyline Algorithm, precision 5)
+    route_polyline: str | None = None
+
     # Sleep-specific fields
     sleep_total_duration_minutes: int | None = None
     sleep_time_in_bed_minutes: int | None = None

--- a/backend/app/schemas/providers/strava/activity_import.py
+++ b/backend/app/schemas/providers/strava/activity_import.py
@@ -13,6 +13,17 @@ class StravaGearJSON(BaseModel):
     distance: int
 
 
+class StravaMapJSON(BaseModel):
+    """Strava activity map data (encoded polylines)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str | None = None
+    summary_polyline: str | None = None  # Google Encoded Polyline (precision 5)
+    polyline: str | None = None  # Full-resolution polyline (DetailedActivity only)
+    resource_state: int | None = None
+
+
 class ActivityJSON(BaseModel):
     """Strava activity data from API responses or webhook fetches.
 
@@ -57,6 +68,9 @@ class ActivityJSON(BaseModel):
 
     # Athlete info
     athlete: dict | None = None  # {"id": 12345}
+
+    # Route
+    map: StravaMapJSON | None = None
 
     # Metadata
     gear: StravaGearJSON | None = None

--- a/backend/app/schemas/responses/activity/events.py
+++ b/backend/app/schemas/responses/activity/events.py
@@ -20,12 +20,18 @@ class Workout(BaseModel):
     zone_offset: str | None = None
     duration_seconds: int | None = None
     source: SourceMetadata
+    external_id: str | None = Field(
+        None, description="The workout's id on the source provider (e.g. Strava activity id)"
+    )
     calories_kcal: float | None = None
     distance_meters: float | None = None
     avg_heart_rate_bpm: int | None = None
     max_heart_rate_bpm: int | None = None
     avg_pace_sec_per_km: int | float | None = None
     elevation_gain_meters: float | None = None
+    route_polyline: str | None = Field(
+        None, description="GPS route encoded with the Google Encoded Polyline Algorithm (precision 5)"
+    )
 
 
 class WorkoutDetailed(Workout):

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -711,12 +711,13 @@ class EventRecordService(
             workout = Workout(
                 id=record.id,
                 type=record.type or "unknown",
-                name=None,  # Not in EventRecord currently
+                name=record.name,
                 start_time=record.start_datetime,
                 end_time=record.end_datetime,
                 zone_offset=record.zone_offset,
                 duration_seconds=record.duration_seconds,
                 source=self._map_source(data_source),
+                external_id=record.external_id,
                 calories_kcal=float(details.energy_burned) if details and details.energy_burned else None,
                 distance_meters=float(details.distance) if details and details.distance else None,
                 avg_heart_rate_bpm=computed_hr.get(record.id),
@@ -725,6 +726,7 @@ class EventRecordService(
                 elevation_gain_meters=float(details.total_elevation_gain)
                 if details and details.total_elevation_gain
                 else None,
+                route_polyline=details.route_polyline if details else None,
             )
             data.append(workout)
 
@@ -775,12 +777,13 @@ class EventRecordService(
         return WorkoutDetailed(
             id=record.id,
             type=record.type or "unknown",
-            name=None,
+            name=record.name,
             start_time=record.start_datetime,
             end_time=record.end_datetime,
             zone_offset=record.zone_offset,
             duration_seconds=record.duration_seconds,
             source=self._map_source(data_source),
+            external_id=record.external_id,
             calories_kcal=float(details.energy_burned) if details and details.energy_burned else None,
             distance_meters=float(details.distance) if details and details.distance else None,
             avg_heart_rate_bpm=self._resolve_avg_hr(db_session, [record]).get(record.id),
@@ -789,6 +792,7 @@ class EventRecordService(
             elevation_gain_meters=float(details.total_elevation_gain)
             if details and details.total_elevation_gain
             else None,
+            route_polyline=details.route_polyline if details else None,
             heart_rate_samples=[],  # TODO: Fetch from DataPointSeries if needed
         )
 

--- a/backend/app/services/providers/strava/workouts.py
+++ b/backend/app/services/providers/strava/workouts.py
@@ -180,6 +180,13 @@ class StravaWorkouts(BaseWorkoutsTemplate):
         if raw_workout.moving_time is not None:
             metrics["moving_time_seconds"] = raw_workout.moving_time
 
+        # GPS route — prefer the full-resolution polyline (DetailedActivity),
+        # fall back to summary_polyline (present on list/webhook payloads).
+        if raw_workout.map is not None:
+            polyline = raw_workout.map.polyline or raw_workout.map.summary_polyline
+            if polyline:
+                metrics["route_polyline"] = polyline
+
         return metrics
 
     def _normalize_workout(
@@ -210,6 +217,7 @@ class StravaWorkouts(BaseWorkoutsTemplate):
         record = EventRecordCreate(
             category="workout",
             type=workout_type.value,
+            name=raw_workout.name[:255] if raw_workout.name else None,
             source_name=source_name,
             device_model=device_model,
             duration_seconds=duration_seconds,

--- a/backend/migrations/versions/2026_06_10_1930-7e3a9c41f2b8_workout_route_polyline_and_event_name.py
+++ b/backend/migrations/versions/2026_06_10_1930-7e3a9c41f2b8_workout_route_polyline_and_event_name.py
@@ -1,0 +1,33 @@
+"""workout_route_polyline_and_event_name
+
+Revision ID: 7e3a9c41f2b8
+Revises: 5aaff4551af6
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7e3a9c41f2b8"
+down_revision: Union[str, None] = "5aaff4551af6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # GPS route encoded with the Google Encoded Polyline Algorithm (precision 5).
+    # Strava already sends map.summary_polyline on every activity payload we
+    # fetch; until now it was dropped during parsing.
+    op.add_column("workout_details", sa.Column("route_polyline", sa.Text(), nullable=True))
+
+    # Provider-supplied display title (e.g. Strava activity name). The public
+    # Workout response always exposed a name field but it was never populated.
+    op.add_column("event_record", sa.Column("name", sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("event_record", "name")
+    op.drop_column("workout_details", "route_polyline")

--- a/backend/tests/providers/strava/test_strava_workouts.py
+++ b/backend/tests/providers/strava/test_strava_workouts.py
@@ -1,0 +1,88 @@
+"""Tests for Strava workout normalization."""
+
+from decimal import Decimal
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from app.models import EventRecord
+from app.repositories.event_record_repository import EventRecordRepository
+from app.repositories.user_connection_repository import UserConnectionRepository
+from app.schemas.enums import WorkoutType
+from app.schemas.providers.strava import ActivityJSON as StravaActivityJSON
+from app.services.providers.strava.oauth import StravaOAuth
+from app.services.providers.strava.workouts import StravaWorkouts
+
+
+class TestStravaWorkouts:
+    """Test suite for StravaWorkouts."""
+
+    @pytest.fixture
+    def strava_workouts(self) -> StravaWorkouts:
+        workout_repo = EventRecordRepository(EventRecord)
+        connection_repo = UserConnectionRepository()
+        oauth = StravaOAuth(
+            user_repo=MagicMock(),
+            connection_repo=connection_repo,
+            provider_name="strava",
+            api_base_url="https://www.strava.com",
+        )
+        return StravaWorkouts(
+            workout_repo=workout_repo,
+            connection_repo=connection_repo,
+            provider_name="strava",
+            api_base_url="https://www.strava.com",
+            oauth=oauth,
+        )
+
+    def test_normalize_workout_keeps_activity_name_and_route(
+        self,
+        strava_workouts: StravaWorkouts,
+    ) -> None:
+        user_id = uuid4()
+        activity = StravaActivityJSON(
+            id=987654321,
+            name="Morning River Loop",
+            type="Run",
+            sport_type="Run",
+            start_date="2026-06-10T12:00:00Z",
+            elapsed_time=3600,
+            distance=10_000.0,
+            calories=640.0,
+            map={
+                "id": "a987654321",
+                "summary_polyline": "_p~iF~ps|U_ulLnnqC_mqNvxq`@",
+            },
+        )
+
+        record, detail = strava_workouts._normalize_workout(activity, user_id)
+
+        assert record.name == "Morning River Loop"
+        assert record.type == WorkoutType.RUNNING.value
+        assert record.external_id == "987654321"
+        assert detail.distance == Decimal("10000")
+        assert detail.energy_burned == Decimal("640")
+        assert detail.route_polyline == "_p~iF~ps|U_ulLnnqC_mqNvxq`@"
+
+    def test_build_metrics_prefers_full_polyline_when_present(
+        self,
+        strava_workouts: StravaWorkouts,
+    ) -> None:
+        activity = StravaActivityJSON(
+            id=987654322,
+            name="Detailed Route",
+            type="Ride",
+            sport_type="Ride",
+            start_date="2026-06-10T12:00:00Z",
+            elapsed_time=1800,
+            map={
+                "id": "a987654322",
+                "summary_polyline": "summary",
+                "polyline": "full-resolution",
+            },
+        )
+
+        metrics = strava_workouts._build_metrics(activity)
+
+        assert metrics["route_polyline"] == "full-resolution"

--- a/frontend/src/components/user/workout-route-map.tsx
+++ b/frontend/src/components/user/workout-route-map.tsx
@@ -1,0 +1,130 @@
+import { useMemo } from 'react';
+
+/**
+ * Renders a GPS route (Google Encoded Polyline, precision 5 — e.g. Strava's
+ * map.summary_polyline) as a standalone SVG trace. No map tiles or external
+ * services: the route is projected onto a plane (with cosine longitude
+ * correction so shapes aren't distorted) and fitted to the container.
+ */
+
+interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+/** Decodes a Google Encoded Polyline string into lat/lng points. */
+function decodePolyline(encoded: string, precision = 5): LatLng[] {
+  const factor = 10 ** precision;
+  const points: LatLng[] = [];
+  let index = 0;
+  let lat = 0;
+  let lng = 0;
+
+  while (index < encoded.length) {
+    for (const axis of ['lat', 'lng'] as const) {
+      let shift = 0;
+      let result = 0;
+      let byte: number;
+      do {
+        byte = encoded.charCodeAt(index++) - 63;
+        result |= (byte & 0x1f) << shift;
+        shift += 5;
+      } while (byte >= 0x20);
+      const delta = result & 1 ? ~(result >> 1) : result >> 1;
+      if (axis === 'lat') lat += delta;
+      else lng += delta;
+    }
+    points.push({ lat: lat / factor, lng: lng / factor });
+  }
+
+  return points;
+}
+
+const VIEW_W = 400;
+const VIEW_H = 180;
+const PADDING = 14;
+
+export function WorkoutRouteMap({
+  polyline,
+  className,
+}: {
+  polyline: string;
+  className?: string;
+}) {
+  const { path, start, end, pointCount } = useMemo(() => {
+    const points = decodePolyline(polyline);
+    if (points.length < 2) {
+      return { path: null, start: null, end: null, pointCount: points.length };
+    }
+
+    // Equirectangular projection with cosine latitude correction so east-west
+    // distances aren't stretched at higher latitudes.
+    const midLat = points.reduce((sum, p) => sum + p.lat, 0) / points.length;
+    const cosLat = Math.cos((midLat * Math.PI) / 180);
+    const projected = points.map((p) => ({
+      x: p.lng * cosLat,
+      y: -p.lat, // SVG y grows downward
+    }));
+
+    const xs = projected.map((p) => p.x);
+    const ys = projected.map((p) => p.y);
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const minY = Math.min(...ys);
+    const maxY = Math.max(...ys);
+
+    const spanX = maxX - minX || 1e-9;
+    const spanY = maxY - minY || 1e-9;
+    const scale = Math.min(
+      (VIEW_W - PADDING * 2) / spanX,
+      (VIEW_H - PADDING * 2) / spanY
+    );
+
+    // Center the fitted route inside the viewBox
+    const offsetX = (VIEW_W - spanX * scale) / 2;
+    const offsetY = (VIEW_H - spanY * scale) / 2;
+
+    const toSvg = (p: { x: number; y: number }) => ({
+      x: offsetX + (p.x - minX) * scale,
+      y: offsetY + (p.y - minY) * scale,
+    });
+
+    const svgPoints = projected.map(toSvg);
+    const d = svgPoints
+      .map(
+        (p, i) => `${i === 0 ? 'M' : 'L'}${p.x.toFixed(1)},${p.y.toFixed(1)}`
+      )
+      .join(' ');
+
+    return {
+      path: d,
+      start: svgPoints[0],
+      end: svgPoints[svgPoints.length - 1],
+      pointCount: points.length,
+    };
+  }, [polyline]);
+
+  if (!path) return null;
+
+  return (
+    <div className={className}>
+      <svg
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+        className="w-full h-[180px] rounded-lg border border-border/60 bg-card/40"
+        role="img"
+        aria-label={`GPS route with ${pointCount} points`}
+      >
+        <path
+          d={path}
+          fill="none"
+          stroke="var(--color-indigo-400, #818cf8)"
+          strokeWidth={2.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        {start && <circle cx={start.x} cy={start.y} r={4} fill="#34d399" />}
+        {end && <circle cx={end.x} cy={end.y} r={4} fill="#818cf8" />}
+      </svg>
+    </div>
+  );
+}

--- a/frontend/src/components/user/workout-section.tsx
+++ b/frontend/src/components/user/workout-section.tsx
@@ -42,6 +42,7 @@ import {
 } from '@/lib/utils/workout';
 import type { EventRecordResponse } from '@/lib/api/types';
 import { EventDeleteDialog } from '@/components/common/event-delete-dialog';
+import { WorkoutRouteMap } from '@/components/user/workout-route-map';
 
 interface WorkoutSectionProps {
   userId: string;
@@ -105,8 +106,14 @@ function WorkoutRow({
         <div className="flex-1 min-w-0 flex items-center">
           {/* Type & Date */}
           <div className="w-32 flex-shrink-0">
-            <p className="text-sm font-medium text-foreground">{style.label}</p>
+            <p
+              className="text-sm font-medium text-foreground truncate"
+              title={workout.name || style.label}
+            >
+              {workout.name || style.label}
+            </p>
             <p className="text-xs text-muted-foreground">
+              {workout.name ? `${style.label} · ` : ''}
               {workoutDate ? format(new Date(workoutDate), 'MMM d, yyyy') : '-'}
             </p>
             {workout.source?.provider && (
@@ -169,6 +176,16 @@ function WorkoutRow({
       {/* Expanded details */}
       {isExpanded && (
         <div className="px-4 pb-4 pt-2 border-t border-border/60 space-y-4">
+          {/* GPS Route */}
+          {workout.route_polyline && (
+            <div>
+              <h4 className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wider">
+                Route
+              </h4>
+              <WorkoutRouteMap polyline={workout.route_polyline} />
+            </div>
+          )}
+
           {/* Heart Rate During Workout Chart */}
           <div>
             <h4 className="text-xs font-medium text-muted-foreground mb-3 uppercase tracking-wider">

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -601,6 +601,10 @@ export interface EventRecordResponse {
   // Elevation and pace
   elevation_gain_meters?: number | null;
   avg_pace_sec_per_km?: number | null;
+  // GPS route encoded with the Google Encoded Polyline Algorithm (precision 5)
+  route_polyline?: string | null;
+  // The workout's id on the source provider (e.g. Strava activity id)
+  external_id?: string | null;
 
   // Legacy fields (keeping for compatibility if needed, but marked optional)
   user_id?: string;


### PR DESCRIPTION
## Description

Adds route and title support for Strava workouts.

This stores provider-supplied workout names on `event_record`, stores encoded GPS route polylines on `workout_details`, parses Strava `map.polyline` / `map.summary_polyline`, exposes the new fields through workout list/detail responses, and renders available routes in the dashboard with a local SVG trace that does not depend on map tiles or external services.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing targeted tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

Documentation note: response schema changes are reflected through the generated OpenAPI schema. No separate static docs page currently documents the workout response fields.

### Backend Changes

You have to be in `backend` directory to make it work:

- [ ] `uv run pre-commit run --all-files` passes

Pre-commit note: blocked in this Windows environment as described at the top of this file. Direct backend checks passed:

- [x] `uv run --group code-quality ruff check .`
- [x] `uv run --group code-quality ruff format --check .`
- [x] `uv run --group code-quality ty check .`
- [x] `uv run pytest tests/providers/strava/test_strava_workouts.py`

### Frontend Changes

- [x] `pnpm run lint` passes
- [ ] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

Frontend format note: `pnpm run format:check` fails on 157 pre-existing frontend files, including many unrelated files. Touched frontend files were formatted with Prettier.

## Testing Instructions

**Steps to test:**
1. Run the migration and sync or import a Strava activity with map data.
2. Call `GET /api/v1/users/{user_id}/events/workouts`.
3. Open the user workout list in the frontend and expand a workout that has `route_polyline`.

**Expected behavior:**

The workout response includes `name`, `external_id`, and `route_polyline`. The dashboard shows the Strava activity name in the workout row and renders a route trace when a polyline is available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workout route visualization with interactive maps displaying GPS routes when available
  * Workouts now display provider-supplied names (e.g., from Strava) instead of generic labels
  * Added support for tracking external workout identifiers from third-party providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->