### PR TITLE
feat(backend): lookback in pull sync

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from datetime import timedelta
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -16,6 +17,7 @@ from app.utils.config_utils import (
     EncryptedField,
     EnvironmentType,
     FernetDecryptorField,
+    parse_duration,
 )
 
 
@@ -86,6 +88,11 @@ class Settings(BaseSettings):
     # SYNC SETTINGS
     sync_interval_seconds: int = 3600  # Default: 1 hour (3600 seconds)
     sleep_sync_interval_seconds: int = 3600  # Default: 1 hour (3600 seconds)
+    # Re-fetch a trailing window on each *live* pull sync so late provider revisions
+    # (e.g. Oura finalising a day's step count after we already moved past it) are
+    # picked up. Disabled by default. Set via a compact duration string: "2d", "20h",
+    # "90m", "1d12h". Capped per provider by max_historical_days.
+    pull_sync_lookback: timedelta | None = None
     # Grace-period flag: auto-dispatch historical sync after OAuth connect (default: true).
     # Pre-0.4.2 behaviour. Set to false once your integration calls /sync/historical explicitly.
     # Will default to false in a future release.
@@ -238,6 +245,15 @@ class Settings(BaseSettings):
 
         # This should never be reached given the type annotation, but ensures type safety
         raise ValueError(f"Unexpected type for cors_origins: {type(v)}")
+
+    @field_validator("pull_sync_lookback", mode="before")
+    @classmethod
+    def _parse_pull_sync_lookback(cls, v: Any) -> timedelta | None:
+        if v is None or isinstance(v, timedelta):
+            return v
+        if isinstance(v, str) and not v.strip():
+            return None
+        return parse_duration(str(v))  # "2d" / "20h" / "1d12h" → timedelta (fail fast at startup)
 
     def oauth_redirect_uri(self, provider: ProviderName) -> str:
         """Build OAuth redirect URI for a provider.

--- a/backend/app/integrations/celery/tasks/sync_vendor_data_task.py
+++ b/backend/app/integrations/celery/tasks/sync_vendor_data_task.py
@@ -1,11 +1,12 @@
 from contextlib import suppress
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from logging import getLogger
 from typing import Any, cast
 from uuid import UUID, uuid4
 
 from celery import shared_task
 
+from app.config import settings
 from app.database import SessionLocal
 from app.repositories.provider_settings_repository import ProviderSettingsRepository
 from app.repositories.user_connection_repository import UserConnectionRepository
@@ -15,6 +16,7 @@ from app.schemas.sync_status import SyncSource, SyncStage, SyncStatus
 from app.services.providers.factory import ProviderFactory
 from app.services.sync_coordination import release_primary, release_stale_primary, try_become_primary
 from app.services.sync_status_service import completed, failed, new_run_id, progress, started
+from app.utils.config_utils import format_duration
 from app.utils.context import trace_id_var
 from app.utils.sentry_helpers import log_and_capture_error
 from app.utils.structured_logging import log_structured
@@ -251,9 +253,9 @@ def sync_vendor_data(
                     strategy = factory.get_provider(provider_name)
                     provider_result = ProviderSyncResult(success=True, params={})
 
-                    # Running totals for the sync-log: total rows written plus the
-                    # new-vs-updated split (timeseries upserts report it via WriteCounts).
-                    items_written = 0
+                    # New-vs-updated split for the sync-log (timeseries upserts report it
+                    # via WriteCounts). items_processed is derived from these so the headline
+                    # count always equals "X new, Y updated".
                     pull_inserted = 0
                     pull_updated = 0
 
@@ -265,6 +267,14 @@ def sync_vendor_data(
                         if last is not None:
                             if last.tzinfo is None:
                                 last = last.replace(tzinfo=timezone.utc)
+                            # Optional trailing lookback so late provider revisions get
+                            # re-fetched (live pull only; capped by max_historical_days).
+                            lookback = settings.pull_sync_lookback
+                            if lookback is not None and not is_historical:
+                                last -= lookback
+                                max_days = strategy.capabilities.max_historical_days
+                                if max_days is not None:
+                                    last = max(last, datetime.now(timezone.utc) - timedelta(days=max_days))
                             effective_start = last.isoformat()
                         else:
                             # First ever sync — start from now, historical must be explicit
@@ -285,8 +295,6 @@ def sync_vendor_data(
                         try:
                             success = strategy.workouts.load_data(db, user_uuid, **params)
                             provider_result.params["workouts"] = {"success": success, **params}
-                            if isinstance(success, int) and not isinstance(success, bool):
-                                items_written += success
                         except Exception as e:
                             log_structured(
                                 logger,
@@ -345,8 +353,6 @@ def sync_vendor_data(
                                 )
                                 provider_result.params["data_247"] = {"success": True, "saved": True, **results_247}
                                 for _count in results_247.values():
-                                    if isinstance(_count, int) and not isinstance(_count, bool):
-                                        items_written += int(_count)
                                     pull_inserted += getattr(_count, "inserted", 0)
                                     pull_updated += getattr(_count, "updated", 0)
                             else:
@@ -431,6 +437,8 @@ def sync_vendor_data(
                         provider=provider_name,
                         task="sync_vendor_data",
                         user_id=user_id,
+                        effective_start=effective_start,
+                        lookback=format_duration(settings.pull_sync_lookback) if settings.pull_sync_lookback else None,
                     )
 
                     sub_results = list(provider_result.params.values())
@@ -482,7 +490,7 @@ def sync_vendor_data(
                             run_id=run_id,
                             status=final_status,
                             message=completed_message,
-                            items_processed=items_written,
+                            items_processed=pull_inserted + pull_updated,
                             primary_user_id=primary_uuid,
                             metadata=completed_metadata,
                         )

--- a/backend/app/integrations/celery/tasks/sync_vendor_data_task.py
+++ b/backend/app/integrations/celery/tasks/sync_vendor_data_task.py
@@ -258,6 +258,7 @@ def sync_vendor_data(
                     # count always equals "X new, Y updated".
                     pull_inserted = 0
                     pull_updated = 0
+                    applied_lookback: timedelta | None = None  # set when the lookback actually widened the window
 
                     # Resolve effective start: explicit arg > last_synced_at > now
                     # This ensures live syncs never re-pull history.
@@ -275,6 +276,7 @@ def sync_vendor_data(
                                 max_days = strategy.capabilities.max_historical_days
                                 if max_days is not None:
                                     last = max(last, datetime.now(timezone.utc) - timedelta(days=max_days))
+                                applied_lookback = lookback
                             effective_start = last.isoformat()
                         else:
                             # First ever sync — start from now, historical must be explicit
@@ -482,6 +484,10 @@ def sync_vendor_data(
                             completed_metadata["inserted"] = pull_inserted
                             completed_metadata["updated"] = pull_updated
                             completed_message += f" · {pull_inserted} new, {pull_updated} updated"
+                        if applied_lookback is not None:
+                            lookback_label = format_duration(applied_lookback)
+                            completed_metadata["lookback"] = lookback_label
+                            completed_message += f" · lookback {lookback_label}"
                         _emit_sync_status(
                             completed,
                             user_uuid,

--- a/backend/app/utils/config_utils.py
+++ b/backend/app/utils/config_utils.py
@@ -1,4 +1,6 @@
 import os
+import re
+from datetime import timedelta
 from enum import Enum
 from functools import wraps
 from typing import Any, Callable, Generator, Protocol
@@ -7,6 +9,34 @@ from cryptography.fernet import Fernet
 from pydantic import ValidationInfo
 
 CallableGenerator = Generator[Callable[..., Any], None, None]
+
+_DURATION_RE = re.compile(r"(\d+)([dhm])")
+_DURATION_UNIT_SECONDS = {"d": 86400, "h": 3600, "m": 60}
+
+
+def parse_duration(value: str) -> timedelta:
+    """Parse a compact duration string into a timedelta.
+
+    Units: ``d`` (days), ``h`` (hours), ``m`` (minutes). One or more segments,
+    e.g. ``"2d"``, ``"20h"``, ``"90m"``, ``"1d12h"``. Raises ``ValueError`` on an
+    invalid or empty format.
+    """
+    cleaned = value.strip().lower()
+    matches = _DURATION_RE.findall(cleaned)
+    if not matches or _DURATION_RE.sub("", cleaned).strip():
+        raise ValueError(f"Invalid duration {value!r}; expected e.g. '2d', '20h', '90m', '1d12h'")
+    total_seconds = sum(int(amount) * _DURATION_UNIT_SECONDS[unit] for amount, unit in matches)
+    return timedelta(seconds=total_seconds)
+
+
+def format_duration(value: timedelta) -> str:
+    """Render a timedelta as a compact string, omitting zero parts (e.g. '2d', '1d12h', '1h30m')."""
+    total_seconds = int(value.total_seconds())
+    days, remainder = divmod(total_seconds, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes = remainder // 60
+    parts = [f"{n}{unit}" for n, unit in ((days, "d"), (hours, "h"), (minutes, "m")) if n]
+    return "".join(parts) or "0m"
 
 
 class EnvironmentType(str, Enum):

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -60,6 +60,11 @@ AWS_SNS_TOPIC_ARN=arn:aws:sns:eu-north-1:123456789012:owear
 
 #--- SYNC SETTINGS ---#
 SYNC_INTERVAL_SECONDS=3600  # How often to run automatic sync (default: 1 hour)
+# Re-fetch a trailing window on each live pull sync so late provider revisions
+# (e.g. Oura finalising a day's step count after we moved past it) are picked up.
+# Disabled by default. Compact duration: "2d", "20h", "90m", "1d12h". Capped per
+# provider by its max_historical_days.
+# PULL_SYNC_LOOKBACK=2d
 SLEEP_SCORE_INTERVAL_SECONDS=600  # How often to run the fill-missing-sleep-scores task (default: 10 min)
 RESILIENCE_SCORE_INTERVAL_SECONDS=600  # How often to run the fill-missing-resilience-scores task (default: 10 min)
 # Automatically dispatch a historical sync after a successful OAuth callback.

--- a/backend/tests/utils_tests/test_config_utils.py
+++ b/backend/tests/utils_tests/test_config_utils.py
@@ -1,0 +1,42 @@
+"""Tests for app.utils.config_utils helpers."""
+
+from datetime import timedelta
+
+import pytest
+
+from app.utils.config_utils import format_duration, parse_duration
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2d", timedelta(days=2)),
+        ("20h", timedelta(hours=20)),
+        ("90m", timedelta(minutes=90)),
+        ("1d12h", timedelta(days=1, hours=12)),
+        ("1d12h30m", timedelta(days=1, hours=12, minutes=30)),
+        (" 2D ", timedelta(days=2)),  # trimmed + case-insensitive
+    ],
+)
+def test_parse_duration_valid(value: str, expected: timedelta) -> None:
+    assert parse_duration(value) == expected
+
+
+@pytest.mark.parametrize("value", ["", "abc", "2", "d", "2x", "2days", "-2d", "1.5h"])
+def test_parse_duration_invalid_raises(value: str) -> None:
+    with pytest.raises(ValueError, match="Invalid duration"):
+        parse_duration(value)
+
+
+@pytest.mark.parametrize(
+    ("td", "expected"),
+    [
+        (timedelta(days=2), "2d"),
+        (timedelta(hours=20), "20h"),
+        (timedelta(days=1, hours=12), "1d12h"),
+        (timedelta(minutes=90), "1h30m"),
+        (timedelta(0), "0m"),
+    ],
+)
+def test_format_duration(td: timedelta, expected: str) -> None:
+    assert format_duration(td) == expected

--- a/docs/dev-guides/integration-guide.mdx
+++ b/docs/dev-guides/integration-guide.mdx
@@ -435,6 +435,10 @@ Returned when an invalid mode string or an explicit `null` is sent for `live_syn
   Passing `"live_sync_mode": null` in the JSON body is invalid and returns 400. To leave the current mode unchanged, omit the field entirely from the request body.
 </Note>
 
+<Note>
+  **Pull mode and late revisions.** In `pull` mode each periodic sync starts from the connection's last synced time and moves forward, so a day a provider revises *after* we passed it (e.g. Oura finalising a step count once the ring finishes uploading) is not re-fetched. Set the server-side `PULL_SYNC_LOOKBACK` env var (compact duration — `2d`, `20h`, `90m`, `1d12h`; disabled by default, capped per provider by its `max_historical_days`) to re-fetch a trailing window on every live pull. Re-fetched days are upserted, so unchanged values stay as they are. `webhook` mode is unaffected — providers push the exact object that changed.
+</Note>
+
 ### Get Authorization URL
 
 <Warning>


### PR DESCRIPTION
<img width="1105" height="113" alt="image" src="https://github.com/user-attachments/assets/cb86c8b8-0997-484d-a0c1-1e87f733416d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `PULL_SYNC_LOOKBACK` setting to re-fetch recent data windows during syncs, enabling capture of late provider revisions.

* **Documentation**
  * Updated configuration examples and integration guide with details on sync behavior and the new lookback feature.

* **Tests**
  * Added comprehensive test coverage for duration parsing and formatting utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->