### PR TITLE
chore: disallow indexing of docs Next.js and Vercel internal paths

### DIFF
--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,3 +1,4 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /docs/_next/
+Disallow: /docs/_vercel/


### PR DESCRIPTION
## Description

The _next/static/chunks/ URLs (Next.js JS bundles from the Mintlify docs) were being crawled and indexed by Google as pages. Adding Disallow: /docs/_next/ and Disallow: /docs/_vercel/ to robots.txt should prevent crawlers from indexing these internal asset paths, keeping search results clean and relevant.

## Checklist

### General

- [x] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [ ] `pnpm run lint` passes
- [ ] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds

## Testing Instructions

<!-- Describe how reviewers can test your changes -->

**Steps to test:**
1.
2.
3.

**Expected behavior:**



## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->



## Additional Notes

<!-- Any additional context or information reviewers should know -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated search engine crawler configuration to restrict access to specific documentation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->