### PR TITLE
feat: support manual invite links when email is not configured

### DIFF
--- a/backend/app/integrations/celery/tasks/send_email_task.py
+++ b/backend/app/integrations/celery/tasks/send_email_task.py
@@ -9,7 +9,7 @@ from app.config import settings
 from app.database import SessionLocal
 from app.models import Invitation
 from app.schemas.model_crud.user_management import InvitationStatus
-from app.utils.email_client import send_invitation_email
+from app.utils.email_client import _is_email_configured, send_invitation_email
 from app.utils.sentry_helpers import log_and_capture_error
 from app.utils.structured_logging import log_structured
 
@@ -137,6 +137,21 @@ def send_invitation_email_task(
 
         if invitation.status != InvitationStatus.PENDING:
             raise ValueError(f"Invitation {invitation_id} has invalid status: {invitation.status}")
+
+        # Skip sending if email is not configured (allow manual invite links)
+        if not _is_email_configured():
+            log_structured(
+                logger,
+                "warning",
+                f"Email not configured, skipping send for invitation {invitation_id}",
+                provider="email",
+                task="send_invitation_email_task",
+            )
+            return {
+                "status": "skipped",
+                "message": "Email not configured, invitation created but not sent",
+                "invitation_id": invitation_id,
+            }
 
         # Send email only if status is PENDING
         attempt = self.request.retries + 1

--- a/backend/app/schemas/model_crud/user_management/invitation.py
+++ b/backend/app/schemas/model_crud/user_management/invitation.py
@@ -49,6 +49,7 @@ class InvitationRead(BaseModel):
 
     id: UUID
     email: str
+    token: str
     status: InvitationStatus
     expires_at: datetime
     created_at: datetime

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -649,6 +649,7 @@ export interface Developer {
 export interface Invitation {
   id: string;
   email: string;
+  token: string;
   invited_by: string;
   created_at: string;
   expires_at: string;

--- a/frontend/src/routes/_authenticated/settings/-team-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/-team-tab.tsx
@@ -8,6 +8,7 @@ import {
   Clock,
   Copy,
   Check,
+  Link,
 } from 'lucide-react';
 import { useDevelopers, useDeleteDeveloper } from '@/hooks/api/use-developers';
 import {
@@ -16,10 +17,12 @@ import {
   useRevokeInvitation,
   useResendInvitation,
 } from '@/hooks/api/use-invitations';
+import type { Invitation } from '@/lib/api/types';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/use-auth';
 import { isValidEmail } from '@/lib/utils';
 import { copyToClipboard } from '@/lib/utils/clipboard';
+import { ROUTES } from '@/lib/constants/routes';
 import { truncateId } from '@/lib/utils/format';
 import {
   Dialog,
@@ -37,6 +40,7 @@ export function TeamTab() {
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
   const [inviteEmail, setInviteEmail] = useState('');
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [copiedInviteId, setCopiedInviteId] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{
     id: string;
     email: string;
@@ -111,6 +115,18 @@ export function TeamTab() {
 
   const handleResendInvitation = (id: string) => {
     resendInvitationMutation.mutate(id);
+  };
+
+  const handleCopyInviteLink = async (invitation: Invitation) => {
+    const inviteUrl = `${window.location.origin}${ROUTES.acceptInvite}?token=${invitation.token}`;
+    const success = await copyToClipboard(
+      inviteUrl,
+      'Invite link copied to clipboard'
+    );
+    if (success) {
+      setCopiedInviteId(invitation.id);
+      setTimeout(() => setCopiedInviteId(null), 2000);
+    }
   };
 
   const formatDate = (dateString: string) => {
@@ -248,6 +264,18 @@ export function TeamTab() {
                     </td>
                     <td className="px-6 py-4">
                       <div className="flex justify-end gap-1">
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          onClick={() => handleCopyInviteLink(invitation)}
+                          title="Copy invite link"
+                        >
+                          {copiedInviteId === invitation.id ? (
+                            <Check className="h-4 w-4 text-[hsl(var(--success-muted))]" />
+                          ) : (
+                            <Link className="h-4 w-4" />
+                          )}
+                        </Button>
                         <Button
                           variant="outline"
                           size="icon"
@@ -437,7 +465,8 @@ export function TeamTab() {
               className="bg-muted border-border"
             />
             <p className="text-[10px] text-muted-foreground/70">
-              They will receive an email with instructions to join
+              They will receive an email with instructions to join (or send
+              invite link manually)
             </p>
           </div>
           <DialogFooter className="gap-3">

--- a/frontend/src/routes/_authenticated/settings/-team-tab.tsx
+++ b/frontend/src/routes/_authenticated/settings/-team-tab.tsx
@@ -118,7 +118,7 @@ export function TeamTab() {
   };
 
   const handleCopyInviteLink = async (invitation: Invitation) => {
-    const inviteUrl = `${window.location.origin}${ROUTES.acceptInvite}?token=${invitation.token}`;
+    const inviteUrl = `${window.location.origin}${ROUTES.acceptInvite}?token=${encodeURIComponent(invitation.token)}`;
     const success = await copyToClipboard(
       inviteUrl,
       'Invite link copied to clipboard'


### PR DESCRIPTION
## Description

- Expose invitation token in InvitationRead schema and frontend types
- Skip email Celery task gracefully when Resend is not configured
- Add 'Copy invite link' button to pending invitations table
- Update invite dialog copy to reflect manual link option

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

## Testing Instructions

**Steps to test:**
1. Go to `http://localhost:3000/settings`
2. Click `Team` tab
3. Click `Invite Member`
4. Enter an email
5. Click copy link button
6. Paste link into browser window
7. Complete `Accept Invitation` flow

**Expected behavior:**
An admin can still invite new members if Resend is not configured. Invite link should take the new user through the same flow as email.

## Screenshots
<img width="1206" height="840" alt="image" src="https://github.com/user-attachments/assets/f4e119fb-513d-4eba-b5cd-8f6fc424044a" />

<img width="1206" height="814" alt="image" src="https://github.com/user-attachments/assets/83c577d2-e807-426e-8aad-b254089ed185" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for copying invitation links from the team settings page.
  * Invitation details now include a token, enabling direct invite-link sharing.

* **Bug Fixes**
  * Email invitations now skip delivery gracefully when email sending is not configured, avoiding unnecessary failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->