### PR TITLE
fix(backend): split iOS & Android coverage

### DIFF
--- a/backend/app/constants/series_types/sdk/metric_types.py
+++ b/backend/app/constants/series_types/sdk/metric_types.py
@@ -312,6 +312,15 @@ METRIC_TYPE_TO_SERIES_TYPE: dict[SDKMetricType, SeriesType] = {
 }
 
 
+APPLE_METRIC_TYPE_TO_SERIES_TYPE: dict[SDKMetricType, SeriesType] = {
+    k: v for k, v in METRIC_TYPE_TO_SERIES_TYPE.items() if k.value.startswith("HK")
+}
+
+ANDROID_METRIC_TYPE_TO_SERIES_TYPE: dict[SDKMetricType, SeriesType] = {
+    k: v for k, v in METRIC_TYPE_TO_SERIES_TYPE.items() if not k.value.startswith("HK")
+}
+
+
 def get_series_type_from_metric_type(metric_type: SDKMetricType | str) -> SeriesType | None:
     """
     Map a metric type identifier (Apple HealthKit or Samsung/Health Connect SDK)

--- a/backend/app/services/providers/apple/coverage.py
+++ b/backend/app/services/providers/apple/coverage.py
@@ -1,13 +1,12 @@
-from app.constants.series_types.sdk.metric_types import METRIC_TYPE_TO_SERIES_TYPE
+from app.constants.series_types.sdk.metric_types import APPLE_METRIC_TYPE_TO_SERIES_TYPE
 from app.constants.series_types.sdk.workout_statistics import WORKOUT_STATISTIC_TYPE_TO_SERIES_TYPE
 from app.schemas.enums import SeriesType
 from app.schemas.enums.health_score_category import HealthScoreCategory
 
-# Apple/Samsung/Google share the SDK import pipeline; emitted series are exactly
-# the values of the SDK metric + workout-statistic maps, so TIMESERIES is derived.
+# Apple HealthKit emits only HKQuantityTypeIdentifier... metrics (SDNN, not RMSSD).
 TIMESERIES: frozenset[SeriesType] = frozenset(
     {
-        *METRIC_TYPE_TO_SERIES_TYPE.values(),
+        *APPLE_METRIC_TYPE_TO_SERIES_TYPE.values(),
         *WORKOUT_STATISTIC_TYPE_TO_SERIES_TYPE.values(),
     }
 )

--- a/backend/app/services/providers/google/coverage.py
+++ b/backend/app/services/providers/google/coverage.py
@@ -1,7 +1,14 @@
-# Google Health Connect uses the same SDK import pipeline as Apple; coverage is identical.
-from app.services.providers.apple.coverage import (  # noqa: F401
-    HEALTH_SCORES,
-    SLEEP_FIELDS,
-    TIMESERIES,
-    WORKOUT_FIELDS,
+from app.constants.series_types.sdk.metric_types import ANDROID_METRIC_TYPE_TO_SERIES_TYPE
+from app.constants.series_types.sdk.workout_statistics import WORKOUT_STATISTIC_TYPE_TO_SERIES_TYPE
+from app.schemas.enums import SeriesType
+from app.services.providers.apple.coverage import HEALTH_SCORES, SLEEP_FIELDS, WORKOUT_FIELDS
+
+# Google Health Connect emits Android/HC metric types (RMSSD, not SDNN).
+TIMESERIES: frozenset[SeriesType] = frozenset(
+    {
+        *ANDROID_METRIC_TYPE_TO_SERIES_TYPE.values(),
+        *WORKOUT_STATISTIC_TYPE_TO_SERIES_TYPE.values(),
+    }
 )
+
+__all__ = ["HEALTH_SCORES", "SLEEP_FIELDS", "TIMESERIES", "WORKOUT_FIELDS"]

--- a/backend/app/services/providers/samsung/coverage.py
+++ b/backend/app/services/providers/samsung/coverage.py
@@ -1,7 +1,14 @@
-# Samsung Health uses the same SDK import pipeline as Apple; coverage is identical.
-from app.services.providers.apple.coverage import (  # noqa: F401
-    HEALTH_SCORES,
-    SLEEP_FIELDS,
-    TIMESERIES,
-    WORKOUT_FIELDS,
+from app.constants.series_types.sdk.metric_types import ANDROID_METRIC_TYPE_TO_SERIES_TYPE
+from app.constants.series_types.sdk.workout_statistics import WORKOUT_STATISTIC_TYPE_TO_SERIES_TYPE
+from app.schemas.enums import SeriesType
+from app.services.providers.apple.coverage import HEALTH_SCORES, SLEEP_FIELDS, WORKOUT_FIELDS
+
+# Samsung Health Connect emits Android/HC metric types (RMSSD, not SDNN).
+TIMESERIES: frozenset[SeriesType] = frozenset(
+    {
+        *ANDROID_METRIC_TYPE_TO_SERIES_TYPE.values(),
+        *WORKOUT_STATISTIC_TYPE_TO_SERIES_TYPE.values(),
+    }
 )
+
+__all__ = ["HEALTH_SCORES", "SLEEP_FIELDS", "TIMESERIES", "WORKOUT_FIELDS"]

--- a/backend/tests/providers/test_provider_coverage.py
+++ b/backend/tests/providers/test_provider_coverage.py
@@ -18,7 +18,10 @@ from types import ModuleType
 
 import pytest
 
-from app.constants.series_types.sdk.metric_types import METRIC_TYPE_TO_SERIES_TYPE
+from app.constants.series_types.sdk.metric_types import (
+    ANDROID_METRIC_TYPE_TO_SERIES_TYPE,
+    APPLE_METRIC_TYPE_TO_SERIES_TYPE,
+)
 from app.constants.series_types.sdk.workout_statistics import WORKOUT_STATISTIC_TYPE_TO_SERIES_TYPE
 from app.schemas.enums import SeriesType
 from app.schemas.enums.health_score_category import HealthScoreCategory
@@ -106,14 +109,19 @@ def test_set_detail_fields_are_declared(provider: str) -> None:
     assert not undeclared, f"{provider}: sets EventRecordDetail fields not declared in coverage: {sorted(undeclared)}"
 
 
+_SDK_METRIC_MAP = {
+    "apple": APPLE_METRIC_TYPE_TO_SERIES_TYPE,
+    "samsung": ANDROID_METRIC_TYPE_TO_SERIES_TYPE,
+    "google": ANDROID_METRIC_TYPE_TO_SERIES_TYPE,
+}
+
+
 @pytest.mark.parametrize("provider", sorted(SDK_PROVIDERS))
 def test_sdk_timeseries_match_maps(provider: str) -> None:
     cov = _load_coverage(provider)
-    expected = frozenset(METRIC_TYPE_TO_SERIES_TYPE.values()) | frozenset(
-        WORKOUT_STATISTIC_TYPE_TO_SERIES_TYPE.values()
-    )
+    expected = frozenset(_SDK_METRIC_MAP[provider].values()) | frozenset(WORKOUT_STATISTIC_TYPE_TO_SERIES_TYPE.values())
     assert _timeseries(cov) == expected, (
-        f"{provider}: TIMESERIES must equal the union of the SDK metric + workout-statistic maps"
+        f"{provider}: TIMESERIES must equal the union of the provider-specific SDK metric + workout-statistic maps"
     )
 
 


### PR DESCRIPTION
Resolves #1226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider coverage now uses platform-specific metric mappings, improving alignment for Apple, Google, and Samsung data sources.
  * Timeseries coverage is defined separately per provider, reducing mismatches between Apple HealthKit and Android/Health Connect metrics.
  * Provider coverage checks now validate against the correct platform-specific series types, including workout-related fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->