### PR TITLE
docs: update Strava integration docs to reflect API terms changes

### DIFF
--- a/docs/providers/strava-api-integration.mdx
+++ b/docs/providers/strava-api-integration.mdx
@@ -1,22 +1,15 @@
 ---
 title: "Strava API Integration"
-description: "Connect Strava via OAuth 2.0 for personal activity sync. Single-user only, no analytics. Webhooks for real-time events plus polling for historical data."
+description: "Connect Strava via OAuth 2.0 for activity sync. Webhooks for real-time events plus polling for historical data."
 keywords: ["strava api integration", "strava oauth", "strava activity data", "strava api"]
 "og:title": "Strava API Integration | Open Wearables"
-"og:description": "Connect Strava via OAuth 2.0. Syncs personal activities. Single-user only, webhooks plus polling for historical data."
+"og:description": "Connect Strava via OAuth 2.0. Syncs activities. Webhooks plus polling for historical data."
 "og:url": "https://docs.openwearables.io/providers/strava-api-integration"
 "og:type": "article"
 "twitter:title": "Strava API Integration | Open Wearables"
-"twitter:description": "Connect Strava via OAuth 2.0. Syncs personal activities. Single-user only, webhooks plus polling for historical data."
+"twitter:description": "Connect Strava via OAuth 2.0. Syncs activities. Webhooks plus polling for historical data."
 "twitter:card": "summary_large_image"
 ---
-
-<Warning>
-**Before you start:** The Strava integration is intended solely for the Open Wearables single-user usage scenario (i.e., personal use, not as an aggregator of multiple users’ data). Keep in mind:
-- **No analytics** are calculated from Strava data — it is only aggregated and displayed as-is.
-- **Only one athlete** (single user) can be connected to the integration at a time.
-- This integration should be used as a **data tracker**, not as a data source for business analytics or reporting.
-</Warning>
 
 <Note>
 **Need help with your Strava integration?** Pop into our [Discord](https://discord.gg/qrcfFnNE6H) if you have questions or want to discover how Open Wearables can solve your problems.
@@ -25,6 +18,12 @@ keywords: ["strava api integration", "strava oauth", "strava activity data", "st
 ## Overview
 
 Strava provides access to activity/workout data through their API. The integration supports real-time webhook notifications for new activities as well as historical activity data via polling.
+
+Each Open Wearables user can connect their own Strava account. Strava's Standard Tier allows up to **10 connected athletes** — upgradeable directly from your [API Settings Dashboard](https://www.strava.com/settings/api) without formal review. For more than 10 athletes, apply for Extended Access Tier.
+
+<Warning>
+**Strava subscription required (as of June 2026).** A Strava subscription is now required to access the API as a Standard Tier developer. If you registered before June 1, 2026 you have until June 30, 2026 to subscribe. Extended Access Tier developers are not affected.
+</Warning>
 
 ### Supported data types
 
@@ -44,6 +43,15 @@ Strava is an activity-focused platform — it does not provide continuous health
 | **Webhooks (push)** | Strava sends real-time notifications when activities are created or updated |
 | **Polling (pull)** | Historical activity data can be fetched via the API |
 
+## Developer tiers
+
+| Tier | Athletes | Rate limits | Subscription required |
+|------|----------|-------------|----------------------|
+| Standard | Up to 10 (self-upgrade) | 200 req/15 min, 2,000 req/day | Yes |
+| Extended Access | Higher limits | 400 req/15 min, 4,000 req/day | No |
+
+Self-upgrade to Standard Tier (up to 10 athletes) directly from your [API Settings Dashboard](https://www.strava.com/settings/api). For Extended Access, submit your app for review through the same dashboard.
+
 ## What you need by the end
 
 - **App credentials**: Client ID + Client Secret
@@ -53,7 +61,7 @@ Strava is an activity-focused platform — it does not provide continuous health
 
 ## Prerequisites
 
-- A Strava account
+- A Strava account with an active subscription (required for API access)
 
 ## Application walkthrough
 

--- a/docs/providers/strava-api-integration.mdx
+++ b/docs/providers/strava-api-integration.mdx
@@ -40,7 +40,7 @@ Strava is an activity-focused platform — it does not provide continuous health
 
 | Method | Description |
 |--------|-------------|
-| **Webhooks (push)** | Strava sends real-time notifications when activities are created or updated |
+| **Webhooks (push)** | Strava sends real-time notifications for activity create/update/delete events, plus athlete deauthorization events |
 | **Polling (pull)** | Historical activity data can be fetched via the API |
 
 ## Developer tiers
@@ -61,7 +61,7 @@ Self-upgrade to Standard Tier (up to 10 athletes) directly from your [API Settin
 
 ## Prerequisites
 
-- A Strava account with an active subscription (required for API access)
+- A Strava account (active subscription required for Standard Tier API access; Extended Access Tier is exempt)
 
 ## Application walkthrough
 


### PR DESCRIPTION
## Description

Strava updated their API terms - new developer tiers, subscription requirement for Standard Tier, and athlete limits. Updated the Strava integration docs to reflect all of this.

More info: https://www.strava.com/legal/api_policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Strava integration guide to reflect OAuth 2.0 activity sync using webhooks plus polling.
  * Clarified that each person connects their own Strava account.
  * Added a “Developer tiers” section comparing Standard vs Extended access, including rate limits and subscription requirements.
  * Refined prerequisites to require a Strava account with an active subscription for Standard Tier API access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->