### PR TITLE
fix: garmin respiratory rate + new data points batch insert chunk size

### DIFF
--- a/backend/app/repositories/data_point_series_repository.py
+++ b/backend/app/repositories/data_point_series_repository.py
@@ -61,9 +61,11 @@ class DataPointSeriesRepository(
 ):
     """Repository for unified device data point series."""
 
-    # PostgreSQL/psycopg limit: 65535 params per query. With 7 params per row, max ~9362 rows.
-    # Use 9000 as a safe chunk size.
-    BATCH_INSERT_CHUNK_SIZE = 9_000
+    # PostgreSQL/psycopg cap of 65535 bind params per query. Derive the row chunk
+    # from the column count in _insert_data_points so adding a column can't silently
+    # push a full chunk over the limit (8 cols -> 8191 rows).
+    _INSERT_COLUMNS_PER_ROW = 8
+    BATCH_INSERT_CHUNK_SIZE = 65_535 // _INSERT_COLUMNS_PER_ROW
 
     def __init__(self, model: type[DataPointSeries]):
         super().__init__(model)

--- a/backend/app/services/providers/garmin/data_247.py
+++ b/backend/app/services/providers/garmin/data_247.py
@@ -1205,8 +1205,7 @@ class Garmin247Data(Base247DataTemplate):
                 )
             )
 
-        # Individual respiration readings
-        respiration_values = raw_respiration.get("timeOffsetRespirationRateValues", {})
+        respiration_values = raw_respiration.get("timeOffsetEpochToBreaths", {})
         if respiration_values and isinstance(respiration_values, dict):
             for offset_str, resp_value in respiration_values.items():
                 try:

--- a/backend/tests/providers/garmin/test_garmin_247.py
+++ b/backend/tests/providers/garmin/test_garmin_247.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.repositories.data_point_series_repository import WriteCounts
 from app.repositories.user_connection_repository import UserConnectionRepository
+from app.schemas.enums.series_types import SeriesType
 from app.services.providers.garmin.data_247 import Garmin247Data
 from app.services.providers.garmin.oauth import GarminOAuth
 from tests.factories import UserConnectionFactory, UserFactory
@@ -548,8 +549,6 @@ class TestGarmin247Data:
 
     def test_build_body_comp_samples(self, garmin_247: Garmin247Data, sample_body_comp: dict[str, Any]) -> None:
         """Test _build_body_comp_samples returns samples without DB call."""
-        from app.schemas.enums.series_types import SeriesType
-
         user_id = uuid4()
         samples = garmin_247._build_body_comp_samples(user_id, sample_body_comp)
         assert len(samples) == 4  # weight, body_fat, BMI, skeletal muscle mass
@@ -567,8 +566,6 @@ class TestGarmin247Data:
         self, garmin_247: Garmin247Data, sample_blood_pressure: dict[str, Any]
     ) -> None:
         """Test _build_blood_pressure_samples reads the webhook timestamp field."""
-        from app.schemas.enums.series_types import SeriesType
-
         user_id = uuid4()
         samples = garmin_247._build_blood_pressure_samples(user_id, sample_blood_pressure)
 
@@ -610,6 +607,24 @@ class TestGarmin247Data:
         }
         samples = garmin_247._build_stress_samples(user_id, stress_data)
         assert len(samples) == 4  # 2 stress + 2 battery
+
+    def test_build_respiration_samples_webhook_field(self, garmin_247: Garmin247Data) -> None:
+        """allDayRespiration webhook payload uses timeOffsetEpochToBreaths."""
+        user_id = uuid4()
+        respiration_data = {
+            "summaryId": "x36bc70e-6a3c0608",
+            "startTimeInSeconds": 1782318600,
+            "startTimeOffsetInSeconds": 7200,
+            "timeOffsetEpochToBreaths": {"0": 11.33, "60": 15.36, "120": 16.0},
+        }
+        samples = garmin_247._build_respiration_samples(user_id, respiration_data)
+
+        assert len(samples) == 3
+        assert all(s.series_type == SeriesType.respiratory_rate for s in samples)
+        first = min(samples, key=lambda s: s.recorded_at)
+        assert first.recorded_at == datetime(2026, 6, 24, 16, 30, tzinfo=timezone.utc)
+        assert first.value == Decimal("11.33")
+        assert first.zone_offset == "+02:00"
 
     def test_build_sleep_record(self, garmin_247: Garmin247Data, sample_sleep: dict[str, Any]) -> None:
         """Test _build_sleep_record returns record + detail without DB call."""

--- a/backend/tests/repositories/test_data_point_series_repository.py
+++ b/backend/tests/repositories/test_data_point_series_repository.py
@@ -722,6 +722,30 @@ class TestDataPointSeriesRepository:
         assert (counts.inserted, counts.updated) == (0, 0)
         assert int(counts) == 0
 
+    def test_bulk_create_batch_exceeding_one_chunk(self, db: Session, series_repo: DataPointSeriesRepository) -> None:
+        """A batch larger than one chunk must stay under Postgres' 65535-param cap.
+
+        Regression: a full chunk * columns-per-row once overflowed 65535 bind
+        params (e.g. 9000 rows * 8 cols), failing the whole insert.
+        """
+        user = UserFactory()
+        base = datetime(2099, 1, 1, tzinfo=timezone.utc)
+        n = series_repo.BATCH_INSERT_CHUNK_SIZE + 500
+        samples = [
+            TimeSeriesSampleCreate(
+                id=uuid4(),
+                user_id=user.id,
+                source="garmin",
+                recorded_at=base + timedelta(seconds=15 * i),
+                value=60 + (i % 40),
+                series_type=SeriesType.heart_rate,
+            )
+            for i in range(n)
+        ]
+
+        counts = series_repo.bulk_create(db, samples)
+        assert counts.inserted == n
+
     # ------------------------------------------------------------------
     # get_daily_activity_aggregates — prefer-daily-total-else-sum logic
     # ------------------------------------------------------------------


### PR DESCRIPTION
Resolves #1225 
Also fixed a bug cased by #1232 (we achieved postgres overflow by adding 8th column to data points which had insert chunk limit to 9k rows (9k * 8 exceeded postgres insert limit of 65k fields).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved large data uploads so they’re split into safe batches automatically, reducing the chance of insert failures when saving many records.
  * Fixed respiration sample processing so values from supported Garmin data are interpreted correctly.

* **Tests**
  * Added regression coverage for large batch inserts.
  * Added coverage for Garmin respiration sample parsing from webhook data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->