### PR TITLE
fix: faster ack for webhooks

### DIFF
--- a/backend/app/integrations/celery/tasks/webhook_push_task.py
+++ b/backend/app/integrations/celery/tasks/webhook_push_task.py
@@ -18,6 +18,7 @@ from app.database import SessionLocal
 from app.schemas.sync_status import SyncStatus
 from app.services import sync_status_service
 from app.services.providers.factory import ProviderFactory
+from app.services.raw_payload_storage import store_raw_payload
 from app.utils.structured_logging import log_structured
 
 logger = getLogger(__name__)
@@ -148,6 +149,10 @@ def process_webhook_push(
     handler = None
     provider_user_id: str | None = None
     try:
+        # Raw payload is persisted here (worker) rather than in the webhook
+        # endpoint's dispatch(), so the inbound ACK is never blocked on an S3
+        # PUT and stays within the provider's response-time SLA (e.g. Oura 10s).
+        store_raw_payload(source="webhook", provider=provider_name, payload=payload, trace_id=request_trace_id)
         strategy = ProviderFactory().get_provider(provider_name)
         handler = strategy.webhooks
         if handler is None:

--- a/backend/app/services/providers/garmin/webhook_handler.py
+++ b/backend/app/services/providers/garmin/webhook_handler.py
@@ -34,7 +34,6 @@ from app.services.providers.garmin.handlers.lifecycle import (
 from app.services.providers.garmin.handlers.wellness import process_wellness_items
 from app.services.providers.garmin.workouts import GarminWorkouts
 from app.services.providers.templates.base_webhook_handler import BaseWebhookHandler
-from app.services.raw_payload_storage import store_raw_payload
 from app.utils.structured_logging import log_structured
 
 logger = logging.getLogger(__name__)
@@ -139,8 +138,6 @@ class GarminWebhookHandler(BaseWebhookHandler):
             item_counts=item_counts,
             garmin_user_ids=garmin_user_ids,
         )
-
-        store_raw_payload(source="webhook", provider="garmin", payload=payload, trace_id=request_trace_id)
 
         # garmin_sync is isolated from the default queue so high-volume live-push
         # events and backfill-chain tasks don't starve each other.

--- a/backend/app/services/providers/oura/webhook_handler.py
+++ b/backend/app/services/providers/oura/webhook_handler.py
@@ -17,9 +17,9 @@ Challenge verification
   ``verification_token`` and ``challenge`` query params. The handler must
   verify the token and echo the challenge back.
 
-The endpoint must respond quickly; ``dispatch()`` stores the raw payload and
-enqueues a Celery task, returning 200 immediately. ``process_payload()`` does
-the actual API fetch and DB write, called by the task.
+The endpoint must respond quickly; ``dispatch()`` enqueues a Celery task and
+returns 200 immediately. ``process_payload()`` does the raw-payload storage,
+API fetch and DB write, called by the task.
 
 Supported data types
 ---------------------
@@ -44,7 +44,6 @@ from app.schemas.providers.oura import OuraWebhookNotification
 from app.services.providers.oura.data_247 import Oura247Data
 from app.services.providers.oura.workouts import OuraWorkouts
 from app.services.providers.templates.base_webhook_handler import BaseWebhookHandler
-from app.services.raw_payload_storage import store_raw_payload
 from app.utils.structured_logging import LogContext, log_structured
 
 logger = logging.getLogger(__name__)
@@ -127,7 +126,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
             raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
 
     def dispatch(self, db: DbSession, payload: dict[str, Any]) -> dict[str, Any]:
-        """Store the raw payload and enqueue async processing. Returns immediately."""
+        """Enqueue async processing and return immediately (raw payload is stored by the task)."""
         request_trace_id = str(uuid4())[:8]
         event_type = payload.get("event_type", "unknown")
         data_type = payload.get("data_type", "unknown")
@@ -143,8 +142,6 @@ class OuraWebhookHandler(BaseWebhookHandler):
             data_type=data_type,
             provider_user_id=provider_user_id,
         )
-
-        store_raw_payload(source="webhook", provider="oura", payload=payload, trace_id=request_trace_id)
 
         task = celery_app.send_task(_PROCESS_PUSH_TASK, args=["oura", payload, request_trace_id], queue="webhook_sync")
         log_structured(

--- a/backend/app/services/providers/polar/webhook_handler.py
+++ b/backend/app/services/providers/polar/webhook_handler.py
@@ -46,7 +46,6 @@ from app.repositories.provider_settings_repository import ProviderSettingsReposi
 from app.schemas.enums import ProviderName
 from app.schemas.providers.polar import PolarWebhookEvent, PolarWebhookEventType
 from app.services.providers.templates.base_webhook_handler import BaseWebhookHandler
-from app.services.raw_payload_storage import store_raw_payload
 from app.utils.sentry_helpers import log_and_capture_error
 from app.utils.structured_logging import log_structured
 
@@ -128,8 +127,6 @@ class PolarWebhookHandler(BaseWebhookHandler):
             polar_user_id=payload.user_id,
             entity_id=payload.entity_id,
         )
-
-        store_raw_payload(source="webhook", provider="polar", payload=raw, trace_id=trace_id)
 
         task = celery_app.send_task(_PROCESS_PUSH_TASK, args=["polar", raw, trace_id], queue="webhook_sync")
         log_structured(

--- a/backend/app/services/providers/strava/webhook_handler.py
+++ b/backend/app/services/providers/strava/webhook_handler.py
@@ -49,7 +49,6 @@ from app.schemas.providers.strava import StravaWebhookEvent
 from app.services.event_record_service import event_record_service
 from app.services.providers.strava.workouts import StravaWorkouts
 from app.services.providers.templates.base_webhook_handler import BaseWebhookHandler
-from app.services.raw_payload_storage import store_raw_payload
 from app.utils.sentry_helpers import log_and_capture_error
 from app.utils.structured_logging import log_structured
 
@@ -125,8 +124,6 @@ class StravaWebhookHandler(BaseWebhookHandler):
             object_id=payload.object_id,
             owner_id=payload.owner_id,
         )
-
-        store_raw_payload(source="webhook", provider="strava", payload=raw, trace_id=trace_id)
 
         task = celery_app.send_task(_PROCESS_PUSH_TASK, args=["strava", raw, trace_id], queue="webhook_sync")
         log_structured(

--- a/backend/app/services/providers/suunto/webhook_handler.py
+++ b/backend/app/services/providers/suunto/webhook_handler.py
@@ -29,7 +29,6 @@ from app.repositories import UserConnectionRepository
 from app.services.providers.suunto.data_247 import Suunto247Data
 from app.services.providers.suunto.workouts import SuuntoWorkouts
 from app.services.providers.templates.base_webhook_handler import BaseWebhookHandler
-from app.services.raw_payload_storage import store_raw_payload
 from app.utils.structured_logging import log_structured
 
 logger = logging.getLogger(__name__)
@@ -115,8 +114,6 @@ class SuuntoWebhookHandler(BaseWebhookHandler):
             event_type=event_type,
             suunto_username=username,
         )
-
-        store_raw_payload(source="webhook", provider="suunto", payload=payload, trace_id=request_trace_id)
 
         task = celery_app.send_task(
             _PROCESS_PUSH_TASK, args=["suunto", payload, request_trace_id], queue="webhook_sync"

--- a/backend/app/services/providers/whoop/webhook_handler.py
+++ b/backend/app/services/providers/whoop/webhook_handler.py
@@ -43,7 +43,6 @@ from app.schemas.providers.whoop import WhoopWebhookNotification, WhoopWebhookNo
 from app.services.providers.templates.base_webhook_handler import BaseWebhookHandler
 from app.services.providers.whoop.data_247 import Whoop247Data
 from app.services.providers.whoop.workouts import WhoopWorkouts
-from app.services.raw_payload_storage import store_raw_payload
 from app.utils.structured_logging import log_structured
 
 logger = logging.getLogger(__name__)
@@ -144,8 +143,6 @@ class WhoopWebhookHandler(BaseWebhookHandler):
             event_type=event_type,
             whoop_user_id=whoop_user_id,
         )
-
-        store_raw_payload(source="webhook", provider="whoop", payload=payload, trace_id=request_trace_id)
 
         task = celery_app.send_task(_PROCESS_PUSH_TASK, args=["whoop", payload, request_trace_id], queue="webhook_sync")
         log_structured(


### PR DESCRIPTION
Let's try this by moving s3 saving somewhere else. We need to answer Oura within 10 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook processing is now handled more consistently in the background for supported integrations.
  * Incoming webhook data is stored as part of task processing, helping ensure payloads are captured even when request handling is interrupted.
  * Several provider endpoints now return accepted responses immediately after queueing work, improving webhook responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->