### PR TITLE
feat(backend): structured JSON access logs with timing

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,7 @@ from app.api import head_router
 from app.config import settings
 from app.integrations.celery import create_celery
 from app.integrations.sentry import init_sentry
-from app.middlewares import add_cors_middleware
+from app.middlewares import RequestTimingMiddleware, add_cors_middleware
 from app.services import raw_payload_storage
 from app.services.outgoing_webhooks import svix as svix_service
 from app.utils.exceptions import DatetimeParseError, handle_exception
@@ -55,6 +55,7 @@ raw_payload_storage.configure(
 )
 
 add_cors_middleware(api)
+api.add_middleware(RequestTimingMiddleware)  # ty:ignore[invalid-argument-type]
 
 # Mount static files for provider icons
 static_dir = Path(__file__).parent / "static"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,11 +29,13 @@ basicConfig(
 )
 
 # Remove uvicorn's default handlers to prevent duplicate logs (uvicorn.error)
-# and ensure access logs (uvicorn.access) also get timestamps via the root logger
-for _name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+for _name in ("uvicorn", "uvicorn.error"):
     _logger = logging.getLogger(_name)
     _logger.handlers.clear()
     _logger.propagate = True
+
+# Suppress uvicorn.access — RequestTimingMiddleware already logs method/path/status/duration
+logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
 
 
 @asynccontextmanager

--- a/backend/app/middlewares.py
+++ b/backend/app/middlewares.py
@@ -1,7 +1,28 @@
-from fastapi import FastAPI
+import logging
+import time
+
+from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
 from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class RequestTimingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration = time.perf_counter() - start
+        logger.info(
+            "%s %s %s (%.3fs)",
+            request.method,
+            request.url.path,
+            response.status_code,
+            duration,
+        )
+        return response
 
 
 def add_cors_middleware(app: FastAPI) -> None:
@@ -10,7 +31,7 @@ def add_cors_middleware(app: FastAPI) -> None:
         cors_origins = ["*"]
 
     app.add_middleware(
-        CORSMiddleware,
+        CORSMiddleware,  # ty:ignore[invalid-argument-type]
         allow_origins=cors_origins,
         allow_credentials=True,
         allow_methods=["*"],

--- a/backend/app/middlewares.py
+++ b/backend/app/middlewares.py
@@ -7,18 +7,26 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 
 from app.config import settings
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("app.access")
 
 
 class RequestTimingMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         start = time.perf_counter()
-        response = await call_next(request)
+        safe_path = request.url.path.replace("\r", "\\r").replace("\n", "\\n")
+        client = f"{request.client.host}:{request.client.port}" if request.client else "-"
+        try:
+            response = await call_next(request)
+        except Exception:
+            duration = time.perf_counter() - start
+            logger.exception("%s %s %s ERROR (%.3fs)", client, request.method, safe_path, duration)
+            raise
         duration = time.perf_counter() - start
         logger.info(
-            "%s %s %s (%.3fs)",
+            "%s %s %s %s (%.3fs)",
+            client,
             request.method,
-            request.url.path,
+            safe_path,
             response.status_code,
             duration,
         )

--- a/backend/app/middlewares.py
+++ b/backend/app/middlewares.py
@@ -6,6 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
 from app.config import settings
+from app.utils.structured_logging import log_structured
 
 logger = logging.getLogger("app.access")
 
@@ -19,17 +20,10 @@ class RequestTimingMiddleware(BaseHTTPMiddleware):
             response = await call_next(request)
         except Exception:
             duration = time.perf_counter() - start
-            logger.exception("%s %s %s ERROR (%.3fs)", client, request.method, safe_path, duration)
+            log_structured(logger, "error", "request failed", method=request.method, path=safe_path, client=client, duration_ms=round(duration * 1000, 2))
             raise
         duration = time.perf_counter() - start
-        logger.info(
-            "%s %s %s %s (%.3fs)",
-            client,
-            request.method,
-            safe_path,
-            response.status_code,
-            duration,
-        )
+        log_structured(logger, "info", "request", method=request.method, path=safe_path, status=response.status_code, client=client, duration_ms=round(duration * 1000, 2))
         return response
 
 

--- a/backend/app/utils/structured_logging.py
+++ b/backend/app/utils/structured_logging.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+from datetime import datetime, timezone
 from logging import Logger
 from typing import Any, NamedTuple
 from uuid import UUID
@@ -82,6 +83,7 @@ def log_structured(
         "level": level.lower(),
         "message": message,
         "provider": provider,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         **attributes,
     }
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,3 +1,25 @@
+# Open Wearables — self-hosted production stack
+#
+# Runs the prebuilt images published to Docker Hub by the "Publish Docker
+# images" GitHub workflow (.github/workflows/publish-images.yml). Unlike the
+# dev docker-compose.yml, nothing is built from source here.
+#
+# Image tags default to :latest. Pin a specific build (e.g. for a repeatable
+# deploy or a rollback) by exporting BACKEND_IMAGE / FRONTEND_IMAGE — any tag
+# the workflow pushes works, including the per-commit sha-<short> tags:
+#   BACKEND_IMAGE=themomentum/open-wearables-backend:sha-1a2b3c4 \
+#   FRONTEND_IMAGE=themomentum/open-wearables-frontend:sha-1a2b3c4 \
+#     docker compose -f docker-compose.prod.yml up -d
+#
+# PostgreSQL and Redis are bundled here so the stack runs out of the box. To
+# point at managed services instead (RDS, ElastiCache, ...), drop the db/redis
+# services via a docker-compose.override.yml and set DB_HOST/REDIS_HOST in
+# ./backend/config/.env.
+
+name: open-wearables
+
+x-backend-image: &backend-image ${BACKEND_IMAGE:-themomentum/open-wearables-backend:latest}
+
 services:
   db:
     image: postgres:18
@@ -18,12 +40,8 @@ services:
     restart: unless-stopped
 
   app:
-    build:
-        context: ./backend
-        dockerfile: Dockerfile
+    image: *backend-image
     container_name: backend__open-wearables
-    image: open-wearables-platform:latest
-    pull_policy: never
     command: scripts/start/app.sh
     env_file:
       - ./backend/config/.env
@@ -40,9 +58,8 @@ services:
     restart: unless-stopped
 
   celery-worker:
+    image: *backend-image
     container_name: celery-worker__open-wearables
-    image: open-wearables-platform:latest
-    pull_policy: never
     command: scripts/start/worker.sh
     env_file:
       - ./backend/config/.env
@@ -56,9 +73,8 @@ services:
     restart: unless-stopped
 
   celery-beat:
+    image: *backend-image
     container_name: celery-beat__open-wearables
-    image: open-wearables-platform:latest
-    pull_policy: never
     command: scripts/start/beat.sh
     env_file:
       - ./backend/config/.env
@@ -72,9 +88,8 @@ services:
     restart: unless-stopped
 
   flower:
+    image: *backend-image
     container_name: flower__open-wearables
-    image: open-wearables-platform:latest
-    pull_policy: never
     command: scripts/start/flower.sh
     env_file:
       - ./backend/config/.env
@@ -135,14 +150,13 @@ services:
     restart: unless-stopped
 
   frontend:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
-      args:
-        VITE_API_URL: ${VITE_API_URL:?Set VITE_API_URL in your environment}
+    image: ${FRONTEND_IMAGE:-themomentum/open-wearables-frontend:latest}
     container_name: frontend__open-wearables
-    image: open-wearables-frontend:latest
-    pull_policy: never
+    # VITE_API_URL is read at runtime by the Nitro SSR server (and injected into
+    # the browser) — nothing is baked into the image at build time. Set it in
+    # ./frontend/.env (see ./frontend/.env.example).
+    env_file:
+      - ./frontend/.env
     ports:
       - "${FRONTEND_PORT:-3000}:3000"
     depends_on:


### PR DESCRIPTION
## Description

Adds `RequestTimingMiddleware` that logs each request as structured JSON with queryable fields (`method`, `path`, `status`, `client`, `duration_ms`). Also adds `timestamp` to all `log_structured` output so Grafana/Loki uses event time rather than ingestion time. `uvicorn.access` is suppressed to avoid duplicate per-request entries.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

- [ ] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. Run the backend locally
2. Make any API request
3. Check logs — should see one JSON entry per request:

```json
{"level": "info", "message": "request", "timestamp": "2026-06-26T00:22:17Z", "method": "GET", "path": "/api/v1/auth/me", "status": 200, "client": "1.2.3.4:52364", "duration_ms": 93.12}
```

**Expected behavior:** single structured log per request, no duplicate `uvicorn.access` lines. In Grafana/Loki, filter by `duration_ms > 500` or `status = 500` directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added request timing tracking for API calls, including method, path, status code, and elapsed time, to improve observability.

- **Chores**
  - Enabled the new timing middleware during application startup.
  - Updated production logging so access logs are handled separately.
  - Updated production container setup to use prebuilt images (configurable backend/frontend tags) and moved frontend API configuration to runtime environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->