### PR TITLE
fix(integrations): accept float totalDistance in Suunto workout schema

### DIFF
--- a/backend/app/schemas/providers/suunto/workout_import.py
+++ b/backend/app/schemas/providers/suunto/workout_import.py
@@ -43,7 +43,10 @@ class WorkoutJSON(BaseModel):
     timeOffsetInMinutes: int | None = None
 
     # Metrics (all optional)
-    totalDistance: int | None = None
+    # Suunto reports distance in meters as a float (e.g. 21381.4); keep it float so
+    # fractional values don't fail Pydantic's int_from_float validation. Downstream
+    # consumers already store it as Decimal(str(...)).
+    totalDistance: float | None = None
     stepCount: int | None = None
     energyConsumption: int | None = None
 

--- a/backend/tests/providers/suunto/test_suunto_workouts.py
+++ b/backend/tests/providers/suunto/test_suunto_workouts.py
@@ -169,6 +169,30 @@ class TestSuuntoWorkouts:
         # Assert
         assert metrics["steps_count"] is None
 
+    def test_workout_accepts_fractional_total_distance(
+        self,
+        suunto_workouts: SuuntoWorkouts,
+        sample_workout_data: dict,
+    ) -> None:
+        """Suunto reports totalDistance as a float, so fractional meters must parse.
+
+        Regression test: the field was typed ``int``, so a real distance such as
+        21381.4 m raised ``int_from_float`` during ``WorkoutJSON(**w)``. Because
+        load_data parses the whole payload in one list comprehension, a single
+        fractional-distance workout aborted the entire sync with an HTTP 500.
+        """
+        # Arrange
+        workout_data = sample_workout_data.copy()
+        workout_data["totalDistance"] = 21381.4
+
+        # Act
+        workout = SuuntoWorkoutJSON(**workout_data)
+        metrics = suunto_workouts._build_metrics(workout)
+
+        # Assert
+        assert workout.totalDistance == 21381.4
+        assert metrics["distance"] == Decimal("21381.4")
+
     def test_normalize_workout_creates_event_record(
         self,
         suunto_workouts: SuuntoWorkouts,


### PR DESCRIPTION
## Description

Fixes #1252.

Suunto workout sync fails with **HTTP 500** for any user whose workouts include a fractional distance, and because the payload is parsed in a single list comprehension, one bad workout takes down the user's **entire** workout sync.

Observed traceback on a live deployment:

```
File ".../app/api/routes/v1/sync_data.py", line 182, in sync_user_data
    results["workouts"] = strategy.workouts.load_data(db, user_id, **params)
File ".../app/services/providers/suunto/workouts.py", line 241, in load_data
    workouts = [SuuntoWorkoutJSON(**w) for w in workouts_data]
pydantic_core.ValidationError: 1 validation error for WorkoutJSON
totalDistance
  Input should be a valid integer, got a number with a fractional part
  [type=int_from_float, input_value=21381.4]
```

**Root cause:** `WorkoutJSON.totalDistance` (`backend/app/schemas/providers/suunto/workout_import.py`) is typed `int | None`, but Suunto reports distance in meters as a **float**. Pydantic v2 refuses to coerce a float with a fractional part into `int`, raising `int_from_float`. Even whole distances arrive as floats (`8494.0`) — those coerce silently under lax mode, which is why this hid, but any fractional distance (`21381.4`, the common case) crashes the parse. Every sibling metric in the same model is already `float | None` (`maxSpeed`, `avgSpeed`, `totalAscent`, `totalDescent`, `maxAltitude`, `minAltitude`); only `totalDistance` was `int`.

**Fix:** one-line type change.

```diff
-    totalDistance: int | None = None
+    totalDistance: float | None = None
```

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

- [ ] N/A — backend only

## Testing Instructions

**Steps to test:**
1. `cd backend`
2. `uv run pytest tests/providers/suunto/test_suunto_workouts.py::TestSuuntoWorkouts::test_workout_accepts_fractional_total_distance`
3. The new regression test constructs a `WorkoutJSON` with `totalDistance=21381.4` and runs it through `_build_metrics`.

**Expected behavior:**

On `main` the test fails with `int_from_float`; with this change it passes and the metric is `Decimal("21381.4")`. The full Suunto workouts suite passes (14/14).

## Additional Notes

**Why it's safe**

- Matches the model's already-`float` siblings.
- Downstream is already float-safe: `_build_metrics` builds the value via `Decimal(str(raw_workout.totalDistance))` and the record stores a `Decimal`. Nothing relies on `totalDistance` being `int`.
- Whole-number floats (`8494.0`) still round-trip to the same `Decimal`; fractional ones now parse instead of crashing.
- Mirrors the already-merged Polar fix #1204 (`cardio_load`/`muscle_load`/`perceived_load` `int` → `float`) for the same `int_from_float` class of bug.

**Scope**

Deliberately focused on the one confirmed field. The model's other `int` fields (`stepCount`, `energyConsumption`) are genuine integer counts and are left as-is. While auditing I noticed `polar/exercise_import.py` and `strava/activity_import.py` also type `distance: int`, which looks like the same latent pattern — flagged here, not changed, since I have no live evidence they're currently hit. Happy to follow up separately if you'd like those addressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of workout distances reported with fractional values, preventing sync failures for affected workouts.
  * Preserved exact distance values so downstream metrics continue to reflect the correct measurement.
* **Tests**
  * Added coverage for workouts that include fractional total distance values to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->