### PR TITLE
docs: remove custom deployment note from Garmin warning

### DIFF
--- a/docs/providers/garmin-api-integration.mdx
+++ b/docs/providers/garmin-api-integration.mdx
@@ -17,8 +17,6 @@ keywords: ["garmin api", "garmin connect api", "garmin health data", "garmin api
 
 <Warning>
 **The Garmin Connect Developer Program is currently on hold.** Garmin has suspended the developer program and there is no information on when it will be resumed. This means you **cannot create a new developer account at this time**. Existing accounts continue to work normally - only new sign-ups are blocked.
-
-**Need Garmin integration anyway?** With the Open Wearables [custom deployment offer](https://openwearables.io/custom-deployment), the Garmin developer application can be managed for you, which unlocks the integration. Reach out to us on [Discord](https://discord.gg/qrcfFnNE6H) or at [hello@openwearables.io](mailto:hello@openwearables.io) to learn more.
 </Warning>
 
 ## Overview


### PR DESCRIPTION
## Description

Removes the custom deployment paragraph from the Garmin developer program warning.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Garmin integration guidance to reflect that the Garmin Connect Developer Program is currently on hold, with no announced restart date.
  * Clarified that new developer accounts can’t be created right now, while existing accounts continue to function.
  * Removed outdated guidance about using an alternate deployment path and related contact instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->