### PR TITLE
fix: update sleep summary endpoint

### DIFF
--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -775,7 +775,85 @@ class EventRecordRepository(
                     "avg_spo2": float(row.avg_spo2) if row.avg_spo2 is not None else None,
                 }
             )
+
+        # Attach per-session breakdown (individual sleep/nap records) for each summary,
+        # keyed by the same (date, provider, source, device_model) grouping identity.
+        sessions_by_key = self._get_sleep_sessions(db_session, user_id, start_date, end_date)
+        for summary in summaries:
+            key = (
+                summary["sleep_date"],
+                summary["provider"],
+                summary["source"],
+                summary["device_model"],
+            )
+            summary["sessions"] = sessions_by_key.get(key, [])
+
         return summaries
+
+    def _get_sleep_sessions(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> dict[tuple, list[dict]]:
+        """Get individual sleep/nap sessions keyed by (sleep_date, provider, source, device_model).
+
+        Mirrors the date filter and grouping identity of ``get_sleep_summaries`` but returns one
+        entry per underlying EventRecord instead of collapsing them. Per-session duration prefers
+        net sleep time (SleepDetails.sleep_total_duration_minutes) and falls back to wall-clock
+        duration, matching the aggregate duration logic. Sessions are sorted by start time.
+        """
+        local_sleep_date = cast(
+            EventRecord.end_datetime + cast(func.coalesce(EventRecord.zone_offset, "+00:00"), Interval),
+            Date,
+        )
+        is_nap_expr = func.coalesce(SleepDetails.is_nap, False)
+        duration_seconds = case(
+            (is_nap_expr, EventRecord.duration_seconds),
+            else_=func.coalesce(
+                SleepDetails.sleep_total_duration_minutes * 60,
+                EventRecord.duration_seconds,
+                0,
+            ),
+        )
+
+        rows = (
+            db_session.query(
+                local_sleep_date.label("sleep_date"),
+                EventRecord.start_datetime.label("start_time"),
+                EventRecord.end_datetime.label("end_time"),
+                duration_seconds.label("duration_seconds"),
+                func.coalesce(SleepDetails.is_nap, False).label("is_nap"),
+                DataSource.provider,
+                DataSource.source,
+                DataSource.device_model,
+            )
+            .join(DataSource, EventRecord.data_source_id == DataSource.id)
+            .outerjoin(SleepDetails, SleepDetails.record_id == EventRecord.id)
+            .filter(
+                DataSource.user_id == user_id,
+                EventRecord.category == "sleep",
+                EventRecord.end_datetime >= start_date - timedelta(days=1),
+                local_sleep_date >= cast(start_date, Date),
+                local_sleep_date < cast(end_date, Date),
+            )
+            .order_by(asc(local_sleep_date), asc(EventRecord.start_datetime))
+            .all()
+        )
+
+        sessions_by_key: dict[tuple, list[dict]] = {}
+        for row in rows:
+            key = (row.sleep_date, row.provider, row.source, row.device_model)
+            sessions_by_key.setdefault(key, []).append(
+                {
+                    "start_time": row.start_time,
+                    "end_time": row.end_time,
+                    "duration_minutes": int(row.duration_seconds) // 60 if row.duration_seconds is not None else None,
+                    "is_nap": bool(row.is_nap),
+                }
+            )
+        return sessions_by_key
 
     def get_daily_workout_aggregates(
         self,

--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -823,6 +823,7 @@ class EventRecordRepository(
                 local_sleep_date.label("sleep_date"),
                 EventRecord.start_datetime.label("start_time"),
                 EventRecord.end_datetime.label("end_time"),
+                EventRecord.zone_offset.label("zone_offset"),
                 duration_seconds.label("duration_seconds"),
                 func.coalesce(SleepDetails.is_nap, False).label("is_nap"),
                 DataSource.provider,
@@ -849,6 +850,7 @@ class EventRecordRepository(
                 {
                     "start_time": row.start_time,
                     "end_time": row.end_time,
+                    "zone_offset": row.zone_offset,
                     "duration_minutes": int(row.duration_seconds) // 60 if row.duration_seconds is not None else None,
                     "is_nap": bool(row.is_nap),
                 }

--- a/backend/app/schemas/responses/activity/__init__.py
+++ b/backend/app/schemas/responses/activity/__init__.py
@@ -26,6 +26,7 @@ from .summaries import (
     HeartRateStats,
     IntensityMinutes,
     RecoverySummary,
+    SleepSessionSummary,
     SleepStagesSummary,
     SleepSummary,
 )
@@ -57,5 +58,6 @@ __all__ = [
     "IntensityMinutes",
     "RecoverySummary",
     "SleepSummary",
+    "SleepSessionSummary",
     "SleepStagesSummary",
 ]

--- a/backend/app/schemas/responses/activity/summaries.py
+++ b/backend/app/schemas/responses/activity/summaries.py
@@ -55,6 +55,7 @@ class SleepSessionSummary(BaseModel):
 
     start_time: datetime
     end_time: datetime
+    zone_offset: str | None = Field(None, description="UTC offset of the session, e.g. '+02:00'")
     duration_minutes: int | None = Field(None, description="Session duration", example=420)
     is_nap: bool = Field(False, description="True if this session is a nap rather than main sleep")
 
@@ -64,6 +65,7 @@ class SleepSummary(BaseModel):
     source: SourceMetadata
     start_time: datetime | None = Field(None, description="Start of the longest main-sleep session")
     end_time: datetime | None = Field(None, description="End of the longest main-sleep session")
+    zone_offset: str | None = Field(None, description="UTC offset of the longest main-sleep session, e.g. '+02:00'")
     duration_minutes: int | None = Field(None, description="Total sleep duration excluding naps", example=450)
     total_duration_minutes: int | None = Field(
         None, description="Total of all sleep + nap durations for the day", example=480

--- a/backend/app/schemas/responses/activity/summaries.py
+++ b/backend/app/schemas/responses/activity/summaries.py
@@ -47,18 +47,36 @@ class SleepStagesSummary(BaseModel):
     rem_minutes: int | None = None
 
 
+class SleepSessionSummary(BaseModel):
+    """Lightweight per-session breakdown of a single sleep or nap within a day.
+
+    For full per-session detail (stages, intervals, source) use the sleep-sessions endpoint.
+    """
+
+    start_time: datetime
+    end_time: datetime
+    duration_minutes: int | None = Field(None, description="Session duration", example=420)
+    is_nap: bool = Field(False, description="True if this session is a nap rather than main sleep")
+
+
 class SleepSummary(BaseModel):
     date: date
     source: SourceMetadata
-    start_time: datetime | None = None
-    end_time: datetime | None = None
+    start_time: datetime | None = Field(None, description="Start of the longest main-sleep session")
+    end_time: datetime | None = Field(None, description="End of the longest main-sleep session")
     duration_minutes: int | None = Field(None, description="Total sleep duration excluding naps", example=450)
+    total_duration_minutes: int | None = Field(
+        None, description="Total of all sleep + nap durations for the day", example=480
+    )
     time_in_bed_minutes: int | None = Field(None, description="Total time in bed excluding naps", example=480)
     efficiency_percent: float | None = Field(None, ge=0, le=100, example=89.5)
     stages: SleepStagesSummary | None = None
     interruptions_count: int | None = None
     nap_count: int | None = Field(None, description="Number of naps taken", example=1)
     nap_duration_minutes: int | None = Field(None, description="Total nap duration", example=30)
+    sessions: list[SleepSessionSummary] | None = Field(
+        None, description="Per-session breakdown of all sleep and nap sessions for the day"
+    )
     avg_heart_rate_bpm: int | None = None
     avg_hrv_sdnn_ms: float | None = Field(None, description="Average HRV (SDNN) during sleep")
     avg_hrv_rmssd_ms: float | None = Field(None, description="Average HRV (RMSSD) during sleep")

--- a/backend/app/services/summaries_service.py
+++ b/backend/app/services/summaries_service.py
@@ -335,13 +335,6 @@ class SummariesService:
             end_time = longest_main.end_time if longest_main else result["max_end_time"]
             zone_offset = longest_main.zone_offset if longest_main else None
 
-            hr_avg = result.get("avg_hr")
-            avg_hr: int | None = int(round(hr_avg)) if hr_avg is not None else None
-            avg_hrv_sdnn: float | None = result.get("avg_hrv_sdnn")
-            avg_hrv_rmssd: float | None = result.get("avg_hrv_rmssd")
-            avg_respiratory_rate: float | None = result.get("avg_resp")
-            avg_spo2_percent: float | None = result.get("avg_spo2")
-
             summary = SleepSummary(
                 date=result["sleep_date"],
                 source=SourceMetadata(provider=result["source"] or "unknown", device=result.get("device_model")),

--- a/backend/app/services/summaries_service.py
+++ b/backend/app/services/summaries_service.py
@@ -36,6 +36,7 @@ from app.schemas.responses.activity import (
     HeartRateStats,
     IntensityMinutes,
     RecoverySummary,
+    SleepSessionSummary,
     SleepStagesSummary,
     SleepSummary,
 )
@@ -310,12 +311,36 @@ class SummariesService:
             avg_respiratory_rate: float | None = result.get("avg_resp")
             avg_spo2_percent: float | None = result.get("avg_spo2")
 
+            raw_sessions = result.get("sessions") or []
+            sessions = [
+                SleepSessionSummary(
+                    start_time=s["start_time"],
+                    end_time=s["end_time"],
+                    duration_minutes=s.get("duration_minutes"),
+                    is_nap=s["is_nap"],
+                )
+                for s in raw_sessions
+            ]
+
+            main_minutes = result.get("total_duration_minutes")
+            nap_minutes = result.get("nap_duration_minutes")
+            total_duration_minutes = None
+            if main_minutes is not None or nap_minutes is not None:
+                total_duration_minutes = (main_minutes or 0) + (nap_minutes or 0)
+
+            main_sessions = [s for s in sessions if not s.is_nap]
+            longest_main = max(main_sessions, key=lambda s: s.duration_minutes or 0, default=None)
+            start_time = longest_main.start_time if longest_main else result["min_start_time"]
+            end_time = longest_main.end_time if longest_main else result["max_end_time"]
+
             summary = SleepSummary(
                 date=result["sleep_date"],
                 source=SourceMetadata(provider=result["source"] or "unknown", device=result.get("device_model")),
-                start_time=result["min_start_time"],
-                end_time=result["max_end_time"],
+                start_time=start_time,
+                end_time=end_time,
                 duration_minutes=result["total_duration_minutes"],
+                total_duration_minutes=total_duration_minutes,
+                sessions=sessions or None,
                 time_in_bed_minutes=result.get("time_in_bed_minutes"),
                 efficiency_percent=result.get("efficiency_percent"),
                 stages=stages,

--- a/backend/app/services/summaries_service.py
+++ b/backend/app/services/summaries_service.py
@@ -335,35 +335,12 @@ class SummariesService:
             end_time = longest_main.end_time if longest_main else result["max_end_time"]
             zone_offset = longest_main.zone_offset if longest_main else None
 
-            avg_hr: int | None = None
-            avg_hrv_sdnn: float | None = None
-            avg_hrv_rmssd: float | None = None
-            avg_respiratory_rate: float | None = None
-            avg_spo2_percent: float | None = None
-
-            if start_time and end_time:
-                try:
-                    physio_averages = self.data_point_repo.get_averages_for_time_range(
-                        db_session,
-                        user_id,
-                        start_time,
-                        end_time,
-                        SLEEP_PHYSIO_SERIES_TYPES,
-                    )
-                    hr_avg = physio_averages.get(SeriesType.heart_rate)
-                    avg_hr = int(round(hr_avg)) if hr_avg is not None else None
-                    avg_hrv_sdnn = physio_averages.get(SeriesType.heart_rate_variability_sdnn)
-                    avg_hrv_rmssd = physio_averages.get(SeriesType.heart_rate_variability_rmssd)
-                    avg_respiratory_rate = physio_averages.get(SeriesType.respiratory_rate)
-                    avg_spo2_percent = physio_averages.get(SeriesType.oxygen_saturation)
-                except Exception as e:
-                    log_structured(
-                        self.logger,
-                        "warning",
-                        f"Failed to fetch physiological metrics for sleep: {e}",
-                        sleep_start=start_time,
-                        sleep_end=end_time,
-                    )
+            hr_avg = result.get("avg_hr")
+            avg_hr: int | None = int(round(hr_avg)) if hr_avg is not None else None
+            avg_hrv_sdnn: float | None = result.get("avg_hrv_sdnn")
+            avg_hrv_rmssd: float | None = result.get("avg_hrv_rmssd")
+            avg_respiratory_rate: float | None = result.get("avg_resp")
+            avg_spo2_percent: float | None = result.get("avg_spo2")
 
             summary = SleepSummary(
                 date=result["sleep_date"],

--- a/backend/app/services/summaries_service.py
+++ b/backend/app/services/summaries_service.py
@@ -316,6 +316,7 @@ class SummariesService:
                 SleepSessionSummary(
                     start_time=s["start_time"],
                     end_time=s["end_time"],
+                    zone_offset=s.get("zone_offset"),
                     duration_minutes=s.get("duration_minutes"),
                     is_nap=s["is_nap"],
                 )
@@ -332,6 +333,7 @@ class SummariesService:
             longest_main = max(main_sessions, key=lambda s: s.duration_minutes or 0, default=None)
             start_time = longest_main.start_time if longest_main else result["min_start_time"]
             end_time = longest_main.end_time if longest_main else result["max_end_time"]
+            zone_offset = longest_main.zone_offset if longest_main else None
 
             avg_hr: int | None = None
             avg_hrv_sdnn: float | None = None
@@ -368,6 +370,7 @@ class SummariesService:
                 source=SourceMetadata(provider=result["source"] or "unknown", device=result.get("device_model")),
                 start_time=start_time,
                 end_time=end_time,
+                zone_offset=zone_offset,
                 duration_minutes=result["total_duration_minutes"],
                 total_duration_minutes=total_duration_minutes,
                 sessions=sessions or None,

--- a/backend/app/services/summaries_service.py
+++ b/backend/app/services/summaries_service.py
@@ -333,6 +333,36 @@ class SummariesService:
             start_time = longest_main.start_time if longest_main else result["min_start_time"]
             end_time = longest_main.end_time if longest_main else result["max_end_time"]
 
+            avg_hr: int | None = None
+            avg_hrv_sdnn: float | None = None
+            avg_hrv_rmssd: float | None = None
+            avg_respiratory_rate: float | None = None
+            avg_spo2_percent: float | None = None
+
+            if start_time and end_time:
+                try:
+                    physio_averages = self.data_point_repo.get_averages_for_time_range(
+                        db_session,
+                        user_id,
+                        start_time,
+                        end_time,
+                        SLEEP_PHYSIO_SERIES_TYPES,
+                    )
+                    hr_avg = physio_averages.get(SeriesType.heart_rate)
+                    avg_hr = int(round(hr_avg)) if hr_avg is not None else None
+                    avg_hrv_sdnn = physio_averages.get(SeriesType.heart_rate_variability_sdnn)
+                    avg_hrv_rmssd = physio_averages.get(SeriesType.heart_rate_variability_rmssd)
+                    avg_respiratory_rate = physio_averages.get(SeriesType.respiratory_rate)
+                    avg_spo2_percent = physio_averages.get(SeriesType.oxygen_saturation)
+                except Exception as e:
+                    log_structured(
+                        self.logger,
+                        "warning",
+                        f"Failed to fetch physiological metrics for sleep: {e}",
+                        sleep_start=start_time,
+                        sleep_end=end_time,
+                    )
+
             summary = SleepSummary(
                 date=result["sleep_date"],
                 source=SourceMetadata(provider=result["source"] or "unknown", device=result.get("device_model")),

--- a/backend/tests/api/v1/test_summaries.py
+++ b/backend/tests/api/v1/test_summaries.py
@@ -277,6 +277,61 @@ class TestSleepSummaryEndpoint:
         assert main_sleep_data["nap_count"] == 1
         assert main_sleep_data["nap_duration_minutes"] == 30
 
+        # total_duration spans main sleep (480) + nap (30)
+        assert main_sleep_data["total_duration_minutes"] == 510
+
+        # Per-session breakdown lists both sessions, sorted by start time
+        sessions = main_sleep_data["sessions"]
+        assert len(sessions) == 2
+        assert sessions[0]["is_nap"] is False
+        assert sessions[0]["duration_minutes"] == 480
+        assert sessions[1]["is_nap"] is True
+        assert sessions[1]["duration_minutes"] == 30
+
+    def test_get_sleep_summary_start_end_anchor_longest_session(self, client: TestClient, db: Session) -> None:
+        """Split-sleep night: start/end anchor on the longest main-sleep session."""
+        user = UserFactory()
+        mapping = DataSourceFactory(user=user)
+
+        # Short fragment: 2am - 3am (1 hour)
+        short_record = EventRecordFactory(
+            mapping=mapping,
+            category="sleep",
+            start_datetime=datetime(2025, 12, 26, 2, 0, 0, tzinfo=timezone.utc),
+            end_datetime=datetime(2025, 12, 26, 3, 0, 0, tzinfo=timezone.utc),
+            duration_seconds=3600,
+        )
+        SleepDetailsFactory(event_record=short_record, sleep_total_duration_minutes=60, is_nap=False)
+
+        # Long fragment: 3:30am - 9:30am (6 hours) — the longest session
+        long_record = EventRecordFactory(
+            mapping=mapping,
+            category="sleep",
+            start_datetime=datetime(2025, 12, 26, 3, 30, 0, tzinfo=timezone.utc),
+            end_datetime=datetime(2025, 12, 26, 9, 30, 0, tzinfo=timezone.utc),
+            duration_seconds=21600,
+        )
+        SleepDetailsFactory(event_record=long_record, sleep_total_duration_minutes=360, is_nap=False)
+
+        api_key = ApiKeyFactory()
+        response = client.get(
+            f"/api/v1/users/{user.id}/summaries/sleep",
+            headers=api_key_headers(api_key.id),
+            params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["data"]) == 1
+        sleep_data = data["data"][0]
+
+        # start/end come from the longest session (3:30 - 9:30), not the min/max span
+        assert sleep_data["start_time"] == "2025-12-26T03:30:00Z"
+        assert sleep_data["end_time"] == "2025-12-26T09:30:00Z"
+        # total still sums both fragments (1h + 6h = 420 min)
+        assert sleep_data["total_duration_minutes"] == 420
+        assert len(sleep_data["sessions"]) == 2
+
     def test_get_sleep_summary_no_naps(self, client: TestClient, db: Session) -> None:
         """Test sleep summary returns null for nap fields when no naps exist."""
         user = UserFactory()

--- a/backend/tests/api/v1/test_summaries.py
+++ b/backend/tests/api/v1/test_summaries.py
@@ -310,6 +310,7 @@ class TestSleepSummaryEndpoint:
             start_datetime=datetime(2025, 12, 26, 3, 30, 0, tzinfo=timezone.utc),
             end_datetime=datetime(2025, 12, 26, 9, 30, 0, tzinfo=timezone.utc),
             duration_seconds=21600,
+            zone_offset="+02:00",
         )
         SleepDetailsFactory(event_record=long_record, sleep_total_duration_minutes=360, is_nap=False)
 
@@ -331,6 +332,12 @@ class TestSleepSummaryEndpoint:
         # total still sums both fragments (1h + 6h = 420 min)
         assert sleep_data["total_duration_minutes"] == 420
         assert len(sleep_data["sessions"]) == 2
+
+        # zone_offset is surfaced from the longest session; sessions are self-describing.
+        # The short fragment has no offset (None); the long one carries +02:00.
+        assert sleep_data["zone_offset"] == "+02:00"
+        assert sleep_data["sessions"][0]["zone_offset"] is None
+        assert sleep_data["sessions"][1]["zone_offset"] == "+02:00"
 
     def test_get_sleep_summary_no_naps(self, client: TestClient, db: Session) -> None:
         """Test sleep summary returns null for nap fields when no naps exist."""


### PR DESCRIPTION
## Description

- `min_sleep_start` and `max_sleep_end` only as fallback - now start/end is returned as edges of longest sleep session for that day
- physiological averages only for main sleep session
- include zone offset
- add session list (with is_nap field to differentiate)
- add info for docs openapi config for clarity

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sleep summaries now include a session breakdown for each day, showing individual sleep and nap periods.
  * Summary responses now surface total sleep duration and time zone offset details.

* **Bug Fixes**
  * Sleep summary start and end times now anchor to the longest sleep segment when multiple segments exist.
  * Daily totals now more accurately combine main sleep and nap durations.
  * Sleep metrics are now populated more consistently from available summary data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->