### PR TITLE
fix(backend): add event emission after reconnection

### DIFF
--- a/backend/app/services/outgoing_webhooks/events.py
+++ b/backend/app/services/outgoing_webhooks/events.py
@@ -307,7 +307,7 @@ def on_connection_revoked(
                 "revoked_at": revoked_at,
             },
         },
-        idempotency_key=f"connection.revoked.{user_id}.{provider}.{revoked_at}",
+        idempotency_key=_safe_key(f"connection.revoked.{user_id}.{provider}.{revoked_at}"),
         channels=[f"user.{user_id}"],
     )
 

--- a/backend/app/services/outgoing_webhooks/events.py
+++ b/backend/app/services/outgoing_webhooks/events.py
@@ -277,7 +277,7 @@ def on_connection_created(
                 "connected_at": connected_at,
             },
         },
-        idempotency_key=f"connection.created.{user_id}.{provider}",
+        idempotency_key=_safe_key(f"connection.created.{user_id}.{provider}.{connected_at}"),
         channels=[f"user.{user_id}"],
     )
 

--- a/backend/app/services/providers/templates/base_oauth.py
+++ b/backend/app/services/providers/templates/base_oauth.py
@@ -391,6 +391,7 @@ class BaseOAuthTemplate(ABC):
         )
 
         if existing_connection:
+            was_inactive = existing_connection.status != ConnectionStatus.ACTIVE
             # Update tokens, user info, and scope
             self.connection_repo.update_connection_info(
                 db,
@@ -402,6 +403,13 @@ class BaseOAuthTemplate(ABC):
                 provider_username=provider_username,
                 scope=scope,
             )
+            if was_inactive:
+                on_connection_created(
+                    user_id=user_id,
+                    provider=self.provider_name,
+                    connection_id=existing_connection.id,
+                    connected_at=datetime.now(timezone.utc).isoformat(),
+                )
         else:
             connection_create = UserConnectionCreate(
                 user_id=user_id,

--- a/backend/tests/api/v1/test_outgoing_webhooks.py
+++ b/backend/tests/api/v1/test_outgoing_webhooks.py
@@ -9,6 +9,7 @@ Covers:
 
 from __future__ import annotations
 
+import re
 from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -23,12 +24,16 @@ from app.services.outgoing_webhooks.events import (
     SVIX_MAX_SAMPLES_PER_EVENT,
     _dispatch,
     on_connection_created,
+    on_connection_revoked,
     on_sleep_created,
     on_timeseries_batch_saved,
     on_workout_created,
 )
 from app.utils.security import create_access_token
 from tests.factories import DeveloperFactory
+
+# Svix eventId charset: colons/plus signs from ISO 8601 timestamps must not survive.
+_SVIX_ID_SAFE_RE = re.compile(r"^[a-zA-Z0-9\-_.]+$")
 
 # ---------------------------------------------------------------------------
 # WebhookEventType enum
@@ -234,6 +239,30 @@ class TestWebhookEmit:
         assert args[0][0] == "connection.created"
         assert args[0][1]["data"]["provider"] == "garmin"
         assert args[0][1]["data"]["connection_id"] == str(cid)
+        # connected_at's colons/offset must not leak into the Svix event_id
+        assert _SVIX_ID_SAFE_RE.match(args.kwargs["idempotency_key"])
+
+    @patch("app.integrations.celery.tasks.emit_webhook_event_task.emit_webhook_event")
+    def test_on_connection_revoked_dispatches(self, mock_task: MagicMock) -> None:
+        uid = uuid4()
+        cid = uuid4()
+        on_connection_revoked(
+            user_id=uid,
+            provider="garmin",
+            connection_id=cid,
+            reason="refresh_failed",
+            revoked_at="2026-01-01T12:00:00.123456+00:00",
+        )
+        mock_task.delay.assert_called_once()
+        args = mock_task.delay.call_args
+        assert args[0][0] == "connection.revoked"
+        assert args[0][1]["data"]["provider"] == "garmin"
+        assert args[0][1]["data"]["reason"] == "refresh_failed"
+        # revoked_at is an isoformat() timestamp - colons/offset must be sanitized
+        idempotency_key = args.kwargs["idempotency_key"]
+        assert _SVIX_ID_SAFE_RE.match(idempotency_key)
+        assert ":" not in idempotency_key
+        assert "+" not in idempotency_key
 
     def test_dispatch_swallows_broker_error(self) -> None:
         """_dispatch silently drops the event when Celery is unreachable."""


### PR DESCRIPTION
fix #1223 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reconnecting an existing inactive account now correctly triggers a connection-created notification, so webhook-driven workflows stay in sync.
  * Outgoing webhook idempotency for connection creation/revocation is generated more robustly, improving duplicate suppression.
* **Tests**
  * Added coverage to ensure webhook idempotency keys for connection revoke events are properly sanitized and match expected safe formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->