### PR TITLE
docs: sync .env.example with config.py + CodeRabbit drift check

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,6 +26,13 @@ reviews:
         the PR to state whether a data migration or backfill is needed for
         historical records, or explicitly note that only new data is affected.
 
+    - path: "backend/app/config.py"
+      instructions: |
+        If settings fields are added, removed, or renamed, or their defaults
+        change, verify that backend/config/.env.example is updated to match.
+        New optional settings may be added commented-out with their default
+        value. Flag any drift between the two files.
+
     - path: "backend/app/schemas/**"
       instructions: |
         If data models or enums change (e.g. new provider, new data type),

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -4,12 +4,18 @@
 ENVIRONMENT="local"
 API_PORT=8000
 CORS_ORIGINS=["http://localhost:3000"]
+# CORS_ALLOW_ALL=false  # Allow any origin instead of the CORS_ORIGINS list
+# API_NAME="Open Wearables API"  # FastAPI title
+# PAGING_LIMIT=100  # Default page size for list endpoints
 
 # EMAIL SETTINGS (Resend)
 RESEND_API_KEY=your-resend-api-key
 EMAIL_FROM_ADDRESS="onboarding@resend.dev"
 EMAIL_FROM_NAME="Open Wearables"
 FRONTEND_URL=http://localhost:3000
+# INVITATION_EXPIRE_DAYS=7  # Developer invitation link lifetime
+# EMAIL_MAX_RETRIES=5  # Retries for failed email sends
+# USER_INVITATION_CODE_EXPIRE_DAYS=7  # SDK user invitation code lifetime
 
 #--- DB ---#
 DB_HOST=db
@@ -32,15 +38,25 @@ SENTRY_DSN=""
 SENTRY_ENV=production
 SENTRY_SAMPLES_RATE=0.5
 SENTRY_SERVER_NAME=
+# GIT_SHA=  # Optional: appended to the Sentry release identifier
 
 #--- AUTH ---#
 # python3 -c "import secrets; print(secrets.token_urlsafe(64))"
 SECRET_KEY=secret-key-str
+# ALGORITHM=HS256  # JWT signing algorithm
+# ACCESS_TOKEN_EXPIRE_MINUTES=60  # Lifetime of issued access tokens
+# MIN_PASSWORD_LENGTH=8
 
 #--- ADMIN SEED ---#
 # Auto-created on first startup if no developer account exists
 ADMIN_EMAIL=admin@admin.com
 ADMIN_PASSWORD=your-secure-password
+
+#--- RAW PAYLOAD STORAGE ---#
+# Store raw provider payloads for debugging/replay: disabled | log | s3
+# (s3 mode uses the RAW_PAYLOAD_S3_* settings below; bucket defaults to AWS_BUCKET_NAME)
+# RAW_PAYLOAD_STORAGE=disabled
+# RAW_PAYLOAD_MAX_SIZE_BYTES=10485760  # Max stored payload size (10 MB)
 
 #--- REPLAY RAW PAYLOADS ---#
 # set -a && source config/.env && set +a
@@ -60,6 +76,7 @@ AWS_SNS_TOPIC_ARN=arn:aws:sns:eu-north-1:123456789012:owear
 
 #--- SYNC SETTINGS ---#
 SYNC_INTERVAL_SECONDS=3600  # How often to run automatic sync (default: 1 hour)
+# SLEEP_SYNC_INTERVAL_SECONDS=3600  # How often to run the sleep sync task (default: 1 hour)
 # Re-fetch a trailing window on each live pull sync so late provider revisions
 # (e.g. Oura finalising a day's step count after we moved past it) are picked up.
 # Disabled by default. Compact duration: "2d", "20h", "90m", "1d12h". Capped per
@@ -67,6 +84,7 @@ SYNC_INTERVAL_SECONDS=3600  # How often to run automatic sync (default: 1 hour)
 # PULL_SYNC_LOOKBACK=2d
 SLEEP_SCORE_INTERVAL_SECONDS=600  # How often to run the fill-missing-sleep-scores task (default: 10 min)
 RESILIENCE_SCORE_INTERVAL_SECONDS=600  # How often to run the fill-missing-resilience-scores task (default: 10 min)
+# SCORE_BACKFILL_DAYS=30  # How far back the missing-score tasks look
 # Automatically dispatch a historical sync after a successful OAuth callback.
 # Set to false once your integration calls POST /sync/{provider}/users/{user_id}/sync/historical explicitly.
 # Will default to false in a future release.
@@ -78,9 +96,18 @@ INGEST_WORKOUT_SAMPLES=false
 # Independent of INGEST_WORKOUT_SAMPLES and RAW_PAYLOAD_STORAGE.
 STORE_FIT_FILES=false
 
+#--- SLEEP SESSION TRACKING ---#
+# REDIS_SLEEP_TTL_SECONDS=86400  # TTL for in-progress sleep session state in Redis (24 h)
+# SLEEP_END_GAP_MINUTES=120  # Gap between sleep phases that closes a sleep session (2 h)
+
 #--- OUTGOING WEBHOOKS (Svix) ---#
 # Self-hosted Svix server URL (default matches docker-compose.yml)
 SVIX_SERVER_URL=http://svix-server:8071
+# Signing secret the Svix server uses to verify JWTs. Must match SVIX_JWT_SECRET
+# in docker-compose. Defaults to SECRET_KEY if unset.
+# SVIX_JWT_SECRET=
+# Bearer token for the Svix API. Auto-generated from SVIX_JWT_SECRET if unset.
+# SVIX_AUTH_TOKEN=
 
 #--- Providers ---#
 
@@ -91,14 +118,18 @@ API_BASE_URL=http://localhost:8000
 SUUNTO_CLIENT_ID=public-client-id
 SUUNTO_CLIENT_SECRET=private-secret-id
 SUUNTO_SUBSCRIPTION_KEY=private-subscription-id
+# SUUNTO_DEFAULT_SCOPE=
+# SUUNTO_WEBHOOK_SECRET=your-secret  # Optional: defaults to SECRET_KEY; configure the same value in the Suunto developer portal
 
 #--- Polar ---#
 POLAR_CLIENT_ID=public-client-id
 POLAR_CLIENT_SECRET=private-secret-id
+# POLAR_DEFAULT_SCOPE=accesslink.read_all
 
 #--- Garmin ---#
 GARMIN_CLIENT_ID=your-garmin-client-id
 GARMIN_CLIENT_SECRET=your-garmin-client-secret
+# GARMIN_DEFAULT_SCOPE=  # Scope is managed at app creation in the Garmin Developer Portal
 
 #--- Whoop ---#
 WHOOP_CLIENT_ID=public-client-id
@@ -116,6 +147,8 @@ STRAVA_CLIENT_ID=your-strava-client-id
 STRAVA_CLIENT_SECRET=your-strava-client-secret
 STRAVA_DEFAULT_SCOPE=activity:read_all,profile:read_all
 STRAVA_WEBHOOK_VERIFY_TOKEN=your-strava-webhook-verify-token
+# STRAVA_WEBHOOK_SIGNATURE_TOLERANCE_SECONDS=300  # Max allowed webhook signature timestamp skew
+# STRAVA_EVENTS_PER_PAGE=200  # Strava API max is 200 activities per page
 
 #--- Fitbit ---#
 FITBIT_CLIENT_ID=your-fitbit-client-id


### PR DESCRIPTION
# Sync `backend/config/.env.example` with `config.py`

Fixes #1222.

## What changed

Added every user-tunable `Settings` field from `backend/app/config.py` that was missing from `backend/config/.env.example`, as commented-out entries with their default values (per the suggestion in the issue), grouped into the file's existing sections:

- **App:** `CORS_ALLOW_ALL`, `API_NAME`, `PAGING_LIMIT`
- **Sentry:** `GIT_SHA`
- **Auth:** `ALGORITHM`, `ACCESS_TOKEN_EXPIRE_MINUTES`, `MIN_PASSWORD_LENGTH`
- **Email:** `INVITATION_EXPIRE_DAYS`, `EMAIL_MAX_RETRIES`, `USER_INVITATION_CODE_EXPIRE_DAYS`
- **Raw payload storage** (new sub-section above the replay one): `RAW_PAYLOAD_STORAGE`, `RAW_PAYLOAD_MAX_SIZE_BYTES` — the main `disabled | log | s3` switch called out in the issue was missing while its `RAW_PAYLOAD_S3_*` companions were present
- **Sync:** `SLEEP_SYNC_INTERVAL_SECONDS`, `SCORE_BACKFILL_DAYS`
- **Sleep session tracking** (new sub-section): `REDIS_SLEEP_TTL_SECONDS`, `SLEEP_END_GAP_MINUTES`
- **Svix:** `SVIX_JWT_SECRET`, `SVIX_AUTH_TOKEN`
- **Providers:** `SUUNTO_DEFAULT_SCOPE`, `SUUNTO_WEBHOOK_SECRET`, `POLAR_DEFAULT_SCOPE`, `GARMIN_DEFAULT_SCOPE`, `STRAVA_WEBHOOK_SIGNATURE_TOLERANCE_SECONDS`, `STRAVA_EVENTS_PER_PAGE`

Comments were written from the actual usage sites (e.g. the Strava tolerance is the webhook signature timestamp skew check in `webhook_handler.py`), not just the field names.

Also added a `.coderabbit.yaml` path instruction for `backend/app/config.py` so CodeRabbit flags future drift between the two files, as suggested in the issue.

## Deliberately left out

- `XML_CHUNK_SIZE` — the issue itself suggests niche knobs like this can stay config-only
- `API_V1` / `API_LATEST` — route-path constants, not deployment config
- `*_REDIRECT_URI` provider vars — deprecated in favor of `API_BASE_URL`
- `TOKEN_LIFETIME` — defined in `Settings` but not referenced anywhere in `app/`; possibly dead (happy to remove it from `config.py` instead if that's preferred)
- `MASTER_KEY` / `fernet_decryptor` — read directly from `os.environ`, but no current `Settings` field uses `EncryptedField`, so documenting it seemed premature

## Verification

- AST-based cross-check: parsed the `Settings` class fields and the `.env.example` keys — every non-excluded field now appears in the example (case-insensitive), and every example key maps to a `Settings` field (`OPEN_WEARABLES_API_KEY` is the replay-script exception already documented in the file). 104 fields / 92 example keys, zero drift.
- Boot check: `cp config/.env.example config/.env` and instantiated `Settings()` (pydantic-settings) — loads cleanly; `raw_payload_storage="disabled"`, `store_fit_files=False`, derived Svix/webhook secrets all resolve.

Context: we run open-wearables in our production docker-compose alongside our FHIR guardrail stack (healthclaw.io), which is how we hit the example/config drift in practice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the sample environment configuration with more commented options and guidance for common settings.
  * Added new optional configuration entries for app behavior, authentication, storage, sync timing, sleep session tracking, webhooks, and provider integrations.
  * Improved review guidance so configuration changes should be kept in sync with the environment example file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->