### PR TITLE
refactor(backend): update get method to accept string as object_id

### DIFF
--- a/backend/app/repositories/repositories.py
+++ b/backend/app/repositories/repositories.py
@@ -32,7 +32,7 @@ class CrudRepository[
     def exists_any(self, db_session: DbSession) -> bool:
         return db_session.query(exists().where(getattr(self.model, "id").isnot(None))).scalar()
 
-    def get(self, db_session: DbSession, object_id: UUID | int) -> ModelType | None:
+    def get(self, db_session: DbSession, object_id: UUID | int | str) -> ModelType | None:
         return db_session.query(self.model).filter(getattr(self.model, "id") == object_id).one_or_none()
 
     def get_all(

--- a/backend/app/services/services.py
+++ b/backend/app/services/services.py
@@ -54,7 +54,7 @@ class AppService[
         else:
             id_to_fetch = object_id
 
-        if not (fetched := self.crud.get(db_session, id_to_fetch)) and raise_404:  # ty:ignore[invalid-argument-type]
+        if not (fetched := self.crud.get(db_session, id_to_fetch)) and raise_404:
             raise ResourceNotFoundError(self.name, id_to_fetch)  # ty:ignore[invalid-argument-type]
 
         if fetched and print_log:


### PR DESCRIPTION
## Description
Widens the `object_id` type hint on `CrudRepository.get()` from `UUID | int` to `UUID | int | str`, since some models (e.g. `ApiKey`) use string primary keys rather than UUID/int.

<!-- Provide a brief summary of your changes. What problem does this solve? -->

## Checklist

### General

- [ ] My code follows the project's code style
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [ ] `pnpm run lint` passes
- [ ] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds

## Testing Instructions

<!-- Describe how reviewers can test your changes -->

**Steps to test:**
1.
2.
3.

**Expected behavior:**



## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->



## Additional Notes

<!-- Any additional context or information reviewers should know -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Broadened record lookup support so IDs can now be provided as a string, integer, or UUID when fetching items by identifier.
* **Chores**
  * Removed an inline type-check suppression comment from the application’s item retrieval path (no behavioral change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->