### PR TITLE
feat(backend): implement deregistration for polar

### DIFF
--- a/backend/app/services/providers/polar/oauth.py
+++ b/backend/app/services/providers/polar/oauth.py
@@ -1,3 +1,5 @@
+import httpx
+
 from app.config import settings
 from app.schemas.enums import ProviderName
 from app.schemas.model_crud.credentials import (
@@ -27,6 +29,15 @@ class PolarOAuth(BaseOAuthTemplate):
             default_scope=settings.polar_default_scope,
         )
 
+    def deregister_user(self, access_token: str) -> None:
+        """Deregister user from Polar API."""
+        response = httpx.delete(
+            f"{self.api_base_url}/v3/users",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=30.0,
+        )
+        response.raise_for_status()
+
     def _get_provider_user_info(self, token_response: OAuthTokenResponse, user_id: str) -> dict[str, str | None]:
         """Extracts Polar user ID from token response and registers user."""
         raw = token_response.model_extra.get("x_user_id") if token_response.model_extra else None
@@ -39,8 +50,6 @@ class PolarOAuth(BaseOAuthTemplate):
 
     def _register_user(self, access_token: str, member_id: str) -> None:
         """Registers the user with Polar API."""
-        import httpx
-
         try:
             register_url = f"{self.api_base_url}/v3/users"
             headers = {

--- a/backend/tests/providers/polar/test_polar_oauth.py
+++ b/backend/tests/providers/polar/test_polar_oauth.py
@@ -7,6 +7,7 @@ Tests the PolarOAuth class for OAuth 2.0 authentication flow with Polar API.
 from unittest.mock import MagicMock, patch
 
 import httpx
+import pytest
 from sqlalchemy.orm import Session
 
 from app.schemas.model_crud.credentials import OAuthTokenResponse
@@ -322,3 +323,68 @@ class TestPolarUserRegistration:
         # Act & Assert - should not raise exception
         oauth._register_user("test_access_token", str(user.id))
         # User might already be registered, so we handle errors gracefully
+
+
+class TestPolarDeregisterUser:
+    """Tests for Polar user deregistration API call."""
+
+    @patch("httpx.delete")
+    def test_deregister_user_success(self, mock_httpx_delete: MagicMock, db: Session) -> None:
+        """Test deregistering user from Polar API."""
+        # Arrange
+        from app.models import User
+        from app.repositories.user_connection_repository import UserConnectionRepository
+        from app.repositories.user_repository import UserRepository
+
+        user_repo = UserRepository(User)
+        connection_repo = UserConnectionRepository()
+
+        oauth = PolarOAuth(
+            user_repo=user_repo,
+            connection_repo=connection_repo,
+            provider_name="polar",
+            api_base_url="https://www.polaraccesslink.com",
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.raise_for_status.return_value = None
+        mock_httpx_delete.return_value = mock_response
+
+        # Act
+        oauth.deregister_user("test_access_token")
+
+        # Assert
+        mock_httpx_delete.assert_called_once_with(
+            "https://www.polaraccesslink.com/v3/users",
+            headers={"Authorization": "Bearer test_access_token"},
+            timeout=30.0,
+        )
+
+    @patch("httpx.delete")
+    def test_deregister_user_raises_on_http_error(self, mock_httpx_delete: MagicMock, db: Session) -> None:
+        """Test that deregister_user raises on HTTP error."""
+        # Arrange
+        from app.models import User
+        from app.repositories.user_connection_repository import UserConnectionRepository
+        from app.repositories.user_repository import UserRepository
+
+        user_repo = UserRepository(User)
+        connection_repo = UserConnectionRepository()
+
+        oauth = PolarOAuth(
+            user_repo=user_repo,
+            connection_repo=connection_repo,
+            provider_name="polar",
+            api_base_url="https://www.polaraccesslink.com",
+        )
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Unauthorized", request=MagicMock(), response=MagicMock(status_code=401)
+        )
+        mock_httpx_delete.return_value = mock_response
+
+        # Act & Assert
+        with pytest.raises(httpx.HTTPStatusError):
+            oauth.deregister_user("expired_token")


### PR DESCRIPTION
Fixes #682

Minimal fix for the linked issue.

Local tests pass.

---
This change was prepared with AI assistance under human direction and review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for disconnecting a user from Polar during account deregistration.
  * Improved error handling so failures from Polar are surfaced clearly when the disconnect request does not succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->