### PR TITLE
docs: remove custom deployment note from Garmin warning

### DIFF
--- a/docs/providers/garmin-api-integration.mdx
+++ b/docs/providers/garmin-api-integration.mdx
@@ -60,7 +60,7 @@ Once you get access to the Developer Portal, you’ll find the full docs, includ
     - [Garmin Connect Developer Program Access Request Form](https://www.garmin.com/en-US/forms/GarminConnectDeveloperAccess/)
 
     <Warning>
-    **The developer program is currently suspended by Garmin**, with no announced resumption date - you cannot create a new developer account right now. Existing accounts still work. If you can't get access this way, the Open Wearables [custom deployment offer](https://openwearables.io/custom-deployment) can manage the Garmin developer application on your behalf and unlock the integration - reach out at [hello@openwearables.io](mailto:hello@openwearables.io).
+    **The developer program is currently suspended by Garmin**, with no announced resumption date - you cannot create a new developer account right now. Existing accounts still work.
     </Warning>
 
     <Note>


### PR DESCRIPTION
## Description

Trimmed the Garmin developer program suspension warning - dropped the custom deployment offer/contact bit, keeping just the fact that the program is suspended and existing accounts still work.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

## Testing Instructions

**Steps to test:**
1. View the Garmin API integration doc page

**Expected behavior:**
Warning box no longer mentions the custom deployment offer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Garmin integration guidance to keep the developer-program suspension notice current.
  * Removed the extra note about an alternative deployment option from the warning section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->