### PR TITLE
docs: remove Garmin API integration page from nav menu

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -49,7 +49,6 @@
             "pages": [
               "providers/supported",
               "providers/coverage",
-              "providers/garmin-api-integration",
               "providers/garmin-data-pipeline"
             ]
           },


### PR DESCRIPTION
## Description

Removed Garmin API integration from the docs nav under Providers, for consistency with the other providers linked from the [supported providers table](https://openwearables.io/docs/providers/supported). 

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

## Testing Instructions

**Steps to test:**
1. Open the docs sidebar, check the Providers group

**Expected behavior:**
"Garmin API integration" no longer shows up in the nav; "Garmin Data Pipeline" is still there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Providers navigation to point to the Garmin data pipeline page instead of the previous Garmin API integration page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->