### PR TITLE
feat(backend):  silence svix logs at startup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -35,6 +35,11 @@ for _name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
     _logger.handlers.clear()
     _logger.propagate = True
 
+# httpx/httpcore log one INFO line per outgoing request; at our request volume that is
+# pure noise (event-type sync, provider calls, webhook delivery). Keep warnings and errors.
+for _name in ("httpx", "httpcore"):
+    logging.getLogger(_name).setLevel(logging.WARNING)
+
 
 @asynccontextmanager
 async def _lifespan(_: FastAPI) -> AsyncGenerator[None, None]:

--- a/backend/app/services/outgoing_webhooks/svix.py
+++ b/backend/app/services/outgoing_webhooks/svix.py
@@ -116,15 +116,20 @@ def register_event_types() -> None:
     assert _client is not None
 
     # List existing types once (paginated) so a steady-state startup makes a single
-    # call instead of a create+update round-trip per type.
+    # call instead of a create+update round-trip per type. If Svix is still coming up,
+    # skip without crashing app startup — the sync is idempotent and reruns next boot.
     existing: dict[str, str] = {}
     iterator: str | None = None
-    while True:
-        page = _client.event_type.list(EventTypeListOptions(limit=250, iterator=iterator))
-        existing.update({et.name: et.description for et in page.data})
-        if page.done:
-            break
-        iterator = page.iterator
+    try:
+        while True:
+            page = _client.event_type.list(EventTypeListOptions(limit=250, iterator=iterator))
+            existing.update({et.name: et.description for et in page.data})
+            if page.done:
+                break
+            iterator = page.iterator
+    except Exception:
+        logger.warning("Svix unreachable during startup — skipping event-type sync (reruns next boot).")
+        return
 
     for evt in WebhookEventType:
         description = EVENT_TYPE_DESCRIPTIONS.get(evt, "")

--- a/backend/app/services/outgoing_webhooks/svix.py
+++ b/backend/app/services/outgoing_webhooks/svix.py
@@ -22,6 +22,7 @@ from svix.api import (
     EndpointOut,
     EndpointPatch,
     EventTypeIn,
+    EventTypeListOptions,
     EventTypeUpdate,
     ListResponseEndpointOut,
     ListResponseMessageAttemptOut,
@@ -109,20 +110,41 @@ def is_enabled() -> bool:
 
 
 def register_event_types() -> None:
-    """Create / update every WebhookEventType in Svix (idempotent)."""
+    """Sync every WebhookEventType into Svix: create the missing, update the changed (idempotent)."""
     if not is_enabled():
         return
     assert _client is not None
+
+    # List existing types once (paginated) so a steady-state startup makes a single
+    # call instead of a create+update round-trip per type.
+    existing: dict[str, str] = {}
+    iterator: str | None = None
+    while True:
+        page = _client.event_type.list(EventTypeListOptions(limit=250, iterator=iterator))
+        existing.update({et.name: et.description for et in page.data})
+        if page.done:
+            break
+        iterator = page.iterator
+
     for evt in WebhookEventType:
         description = EVENT_TYPE_DESCRIPTIONS.get(evt, "")
-        try:
-            _client.event_type.create(EventTypeIn(name=evt.value, description=description))
-            logger.info("Registered event type: %s", evt.value)
-        except Exception:
+        current = existing.get(evt.value)
+        if current is None:
+            try:
+                _client.event_type.create(EventTypeIn(name=evt.value, description=description))
+                logger.info("Registered event type: %s", evt.value)
+            except Exception:
+                # Deemed missing but create failed (archived/race) — update so it is never left unregistered.
+                try:
+                    _client.event_type.update(evt.value, EventTypeUpdate(description=description))
+                except Exception:
+                    logger.exception("Failed to register/update event type %s", evt.value)
+        elif current != description:
             try:
                 _client.event_type.update(evt.value, EventTypeUpdate(description=description))
+                logger.info("Updated event type description: %s", evt.value)
             except Exception:
-                logger.exception("Failed to register/update event type %s", evt.value)
+                logger.exception("Failed to update event type %s", evt.value)
 
 
 def ensure_application(developer_id: str, developer_email: str) -> str:

--- a/backend/scripts/init/create-svix-db.sql
+++ b/backend/scripts/init/create-svix-db.sql
@@ -1,0 +1,6 @@
+-- Runs via Postgres /docker-entrypoint-initdb.d on first cluster init, before the
+-- server accepts external connections — so svix-server never races DB creation.
+-- Idempotent; the Python fallback (create_svix_db.py in app.sh) covers managed
+-- Postgres, where init scripts do not run.
+SELECT 'CREATE DATABASE svix'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'svix')\gexec

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,7 @@ services:
       retries: 5
     volumes:
       - postgres_data:/var/lib/postgresql
+      - ./backend/scripts/init/create-svix-db.sql:/docker-entrypoint-initdb.d/create-svix-db.sql:ro
     restart: unless-stopped
 
   app:
@@ -37,18 +38,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-    healthcheck:
-      # Gates svix-server past svix-DB creation (app.sh creates it before uvicorn binds).
-      # Port mirrors app.sh's --port ${API_PORT:-8000} so the check can't drift from the bind.
-      test:
-        - CMD
-        - python
-        - -c
-        - "import socket, os; socket.create_connection(('127.0.0.1', int(os.environ.get('API_PORT', '8000'))), 2)"
-      interval: 5s
-      timeout: 3s
-      retries: 30
-      start_period: 20s
     restart: unless-stopped
 
   celery-worker:
@@ -153,8 +142,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-      app:
-        condition: service_healthy
     healthcheck:
       test: ["CMD", "svix-server", "healthcheck", "http://localhost:8071"]
       interval: 5s

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,6 +37,18 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
+    healthcheck:
+      # Gates svix-server past svix-DB creation (app.sh creates it before uvicorn binds).
+      # Port mirrors app.sh's --port ${API_PORT:-8000} so the check can't drift from the bind.
+      test:
+        - CMD
+        - python
+        - -c
+        - "import socket, os; socket.create_connection(('127.0.0.1', int(os.environ.get('API_PORT', '8000'))), 2)"
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 20s
     restart: unless-stopped
 
   celery-worker:
@@ -142,7 +154,7 @@ services:
       redis:
         condition: service_started
       app:
-        condition: service_started
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "svix-server", "healthcheck", "http://localhost:8071"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       retries: 5
     volumes:
       - postgres_data:/var/lib/postgresql
+      - ./backend/scripts/init/create-svix-db.sql:/docker-entrypoint-initdb.d/create-svix-db.sql:ro
 
   app:
     build:
@@ -36,18 +37,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-    healthcheck:
-      # Gates svix-server past svix-DB creation (app.sh creates it before uvicorn binds).
-      # Port mirrors app.sh's --port ${API_PORT:-8000} so the check can't drift from the bind.
-      test:
-        - CMD
-        - python
-        - -c
-        - "import socket, os; socket.create_connection(('127.0.0.1', int(os.environ.get('API_PORT', '8000'))), 2)"
-      interval: 5s
-      timeout: 3s
-      retries: 30
-      start_period: 20s
     develop:
       watch:
         - action: sync
@@ -190,8 +179,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
-      app:
-        condition: service_healthy
     healthcheck:
       test: ["CMD", "svix-server", "healthcheck", "http://localhost:8071"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,18 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
+    healthcheck:
+      # Gates svix-server past svix-DB creation (app.sh creates it before uvicorn binds).
+      # Port mirrors app.sh's --port ${API_PORT:-8000} so the check can't drift from the bind.
+      test:
+        - CMD
+        - python
+        - -c
+        - "import socket, os; socket.create_connection(('127.0.0.1', int(os.environ.get('API_PORT', '8000'))), 2)"
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 20s
     develop:
       watch:
         - action: sync
@@ -179,7 +191,7 @@ services:
       redis:
         condition: service_started
       app:
-        condition: service_started
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "svix-server", "healthcheck", "http://localhost:8071"]
       interval: 5s


### PR DESCRIPTION
Resolves #1290 
Resolves #1291 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Reliability**
  * Improved startup sequencing by tightening readiness checks so dependent services wait for healthy dependencies before proceeding.

* **Maintenance**
  * Reduced outgoing-request log noise while still surfacing warnings and errors.
  * Enhanced webhook event-type synchronization to list existing types with pagination, create missing ones, and update descriptions when they change (skipping sync on startup if Svix is unreachable).

* **Infrastructure**
  * Made Svix database initialization idempotent during container startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->