### PR TITLE
feat(backend): outgoing webhooks enable flag + manual disconnect event

### DIFF
--- a/backend/app/api/routes/v1/__init__.py
+++ b/backend/app/api/routes/v1/__init__.py
@@ -4,6 +4,7 @@ from .api_keys import router as api_keys_router
 from .applications import router as applications_router
 from .archival import router as archival_router
 from .auth import router as auth_router
+from .config import router as config_router
 from .connections import router as connections_router
 from .dashboard import router as dashboard_router
 from .data_sources import router as data_sources_router
@@ -63,6 +64,7 @@ v1_router.include_router(invitations_router, prefix="/invitations", tags=["Inter
 v1_router.include_router(api_keys_router, prefix="/developer", tags=["Internal: API Keys"])
 v1_router.include_router(applications_router, tags=["Internal: Applications"])
 v1_router.include_router(dashboard_router, prefix="/dashboard", tags=["Internal: Dashboard"])
+v1_router.include_router(config_router, tags=["Internal: Config"])
 v1_router.include_router(archival_router, tags=["Internal: Data Lifecycle"])
 v1_router.include_router(seed_data_router, tags=["Internal: Seed Data"])
 v1_router.include_router(priorities_router, tags=["Internal: Priorities"])

--- a/backend/app/api/routes/v1/config.py
+++ b/backend/app/api/routes/v1/config.py
@@ -14,6 +14,6 @@ class ConfigResponse(BaseModel):
     outgoing_webhooks_enabled: bool
 
 
-@router.get("/config")
-def get_config(_developer: DeveloperDep) -> ConfigResponse:
+@router.get("/config", response_model=ConfigResponse)
+def get_config(_developer: DeveloperDep):
     return ConfigResponse(outgoing_webhooks_enabled=settings.outgoing_webhooks_enabled)

--- a/backend/app/api/routes/v1/config.py
+++ b/backend/app/api/routes/v1/config.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from app.config import settings
+from app.services import DeveloperDep
+
+router = APIRouter()
+
+
+class ConfigResponse(BaseModel):
+    """Instance feature flags for the admin panel. Additive-only: append new flags,
+    never remove or repurpose, so the frontend stays backward compatible."""
+
+    outgoing_webhooks_enabled: bool
+
+
+@router.get("/config")
+def get_config(_developer: DeveloperDep) -> ConfigResponse:
+    return ConfigResponse(outgoing_webhooks_enabled=settings.outgoing_webhooks_enabled)

--- a/backend/app/api/routes/v1/outgoing_webhooks.py
+++ b/backend/app/api/routes/v1/outgoing_webhooks.py
@@ -49,7 +49,7 @@ def _svix_app_id(developer: DeveloperDep) -> str:
     if not svix_service.is_enabled():
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Outgoing webhooks are not configured (set SVIX_JWT_SECRET or SVIX_AUTH_TOKEN).",
+            detail="Outgoing webhooks are not enabled (set OUTGOING_WEBHOOKS_ENABLED=true in the backend environment).",
         )
     return svix_service.ensure_application(str(developer.id), developer.email)
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -202,6 +202,9 @@ class Settings(BaseSettings):
     raw_payload_s3_endpoint_url: str | None = None  # for S3-compatible storage (e.g. Railway Object Storage)
 
     # SVIX WEBHOOK SETTINGS
+    # Master switch for outgoing webhooks. Off by default so deployments without Svix
+    # (no svix-server container) never build a client, emit, or register event types.
+    outgoing_webhooks_enabled: bool = False
     svix_server_url: str = "http://svix-server:8071"
     # Signing secret used by the Svix server to verify JWTs.  Must match SVIX_JWT_SECRET in docker-compose.
     svix_jwt_secret: SecretStr | None = None

--- a/backend/app/services/outgoing_webhooks/svix.py
+++ b/backend/app/services/outgoing_webhooks/svix.py
@@ -111,10 +111,16 @@ def is_enabled() -> bool:
     return _client is not None
 
 
-def register_event_types() -> None:
-    """Sync every WebhookEventType into Svix: create the missing, update the changed (idempotent)."""
+def register_event_types() -> bool:
+    """Sync every WebhookEventType into Svix: create the missing, update the changed (idempotent).
+
+    Returns:
+        True if the sync completed with no failures (or nothing needed to run). False if
+        Svix was unreachable or any individual event type failed — callers must not report
+        success in that case, since the sync simply retries next boot.
+    """
     if not is_enabled():
-        return
+        return True
     assert _client is not None
 
     # List existing types once (paginated) so a steady-state startup makes a single
@@ -131,8 +137,9 @@ def register_event_types() -> None:
             iterator = page.iterator
     except Exception:
         logger.warning("Svix unreachable during startup — skipping event-type sync (reruns next boot).")
-        return
+        return False
 
+    all_ok = True
     for evt in WebhookEventType:
         description = EVENT_TYPE_DESCRIPTIONS.get(evt, "")
         current = existing.get(evt.value)
@@ -146,12 +153,16 @@ def register_event_types() -> None:
                     _client.event_type.update(evt.value, EventTypeUpdate(description=description))
                 except Exception:
                     logger.exception("Failed to register/update event type %s", evt.value)
+                    all_ok = False
         elif current != description:
             try:
                 _client.event_type.update(evt.value, EventTypeUpdate(description=description))
                 logger.info("Updated event type description: %s", evt.value)
             except Exception:
                 logger.exception("Failed to update event type %s", evt.value)
+                all_ok = False
+
+    return all_ok
 
 
 def ensure_application(developer_id: str, developer_email: str) -> str:

--- a/backend/app/services/outgoing_webhooks/svix.py
+++ b/backend/app/services/outgoing_webhooks/svix.py
@@ -95,7 +95,9 @@ def _resolve_auth_token() -> str | None:
 
 
 def _build_client() -> Svix | None:
-    """Create the Svix client. Returns None when no credentials are configured."""
+    """Create the Svix client. Returns None when webhooks are disabled or no credentials are configured."""
+    if not settings.outgoing_webhooks_enabled:
+        return None
     token = _resolve_auth_token()
     if token is None:
         return None

--- a/backend/app/services/user_connection_service.py
+++ b/backend/app/services/user_connection_service.py
@@ -7,6 +7,7 @@ from app.models import UserConnection
 from app.repositories.user_connection_repository import UserConnectionRepository
 from app.schemas.model_crud.user_management import UserConnectionCreate, UserConnectionUpdate
 from app.schemas.responses.upload import ConnectionsCoverage, ProviderConnectionCount
+from app.services.outgoing_webhooks.events import on_connection_revoked
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
 from app.services.services import AppService
 from app.utils.exceptions import ResourceNotFoundError, handle_exceptions
@@ -69,6 +70,15 @@ class UserConnectionService(
         updated = self.crud.disconnect(db_session, user_id, provider)
         if updated:
             self.logger.info("Revoked connection for user %s from provider %s", user_id, provider)
+            connection = self.crud.get_by_user_and_provider(db_session, user_id, provider)
+            if connection:
+                on_connection_revoked(
+                    user_id=user_id,
+                    provider=provider,
+                    connection_id=connection.id,
+                    reason="user_disconnected",
+                    revoked_at=connection.updated_at.isoformat(),
+                )
             return
 
         # Nothing updated - check if connection exists (already revoked) or not found

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -101,6 +101,9 @@ STORE_FIT_FILES=false
 # SLEEP_END_GAP_MINUTES=120  # Gap between sleep phases that closes a sleep session (2 h)
 
 #--- OUTGOING WEBHOOKS (Svix) ---#
+# Master switch for the app's outgoing webhooks (Svix client + emission). Off by default.
+# svix-server runs regardless; set true to emit. App tolerates svix-server being absent.
+OUTGOING_WEBHOOKS_ENABLED=false
 # Self-hosted Svix server URL (default matches docker-compose.yml)
 SVIX_SERVER_URL=http://svix-server:8071
 # Signing secret the Svix server uses to verify JWTs. Must match SVIX_JWT_SECRET

--- a/backend/scripts/init/create_svix_db.py
+++ b/backend/scripts/init/create_svix_db.py
@@ -5,13 +5,20 @@ Runs before migrations so that svix-server can connect on first deploy.
 Uses autocommit because CREATE DATABASE cannot run inside a transaction.
 """
 
+import logging
+
 import psycopg
 import psycopg.errors
 
 from app.config import settings
 
+logger = logging.getLogger(__name__)
+
 
 def create_svix_db() -> None:
+    if not settings.outgoing_webhooks_enabled:
+        logger.info("Outgoing webhooks disabled — skipping svix database creation.")
+        return
     dsn = (
         f"host={settings.db_host} "
         f"port={settings.db_port} "
@@ -22,10 +29,11 @@ def create_svix_db() -> None:
     with psycopg.connect(dsn, autocommit=True) as conn:
         try:
             conn.execute("CREATE DATABASE svix")
-            print("✓ Created 'svix' database.")
+            logger.info("Created 'svix' database.")
         except psycopg.errors.DuplicateDatabase:
-            print("Svix database already exists, skipping.")
+            logger.info("Svix database already exists, skipping.")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="[%(asctime)s - %(name)s] (%(levelname)s) %(message)s")
     create_svix_db()

--- a/backend/scripts/init/create_svix_db.py
+++ b/backend/scripts/init/create_svix_db.py
@@ -26,12 +26,17 @@ def create_svix_db() -> None:
         f"user={settings.db_user} "
         f"password={settings.db_password.get_secret_value()}"
     )
-    with psycopg.connect(dsn, autocommit=True) as conn:
-        try:
-            conn.execute("CREATE DATABASE svix")
-            logger.info("Created 'svix' database.")
-        except psycopg.errors.DuplicateDatabase:
-            logger.info("Svix database already exists, skipping.")
+    try:
+        with psycopg.connect(dsn, autocommit=True) as conn:
+            try:
+                conn.execute("CREATE DATABASE svix")
+                logger.info("Created 'svix' database.")
+            except psycopg.errors.DuplicateDatabase:
+                logger.info("Svix database already exists, skipping.")
+    except Exception:
+        # Best-effort: never block app boot (e.g. managed Postgres without CREATEDB).
+        # A real connectivity problem still surfaces at the next alembic step.
+        logger.warning("Could not ensure 'svix' database - continuing without it.", exc_info=True)
 
 
 if __name__ == "__main__":

--- a/backend/scripts/init/seed_webhook_event_types.py
+++ b/backend/scripts/init/seed_webhook_event_types.py
@@ -1,13 +1,21 @@
 #!/usr/bin/env python3
 """Register all webhook event types with the Svix server (idempotent)."""
 
+import logging
+
 from app.services.outgoing_webhooks import svix as svix_service
+
+logger = logging.getLogger(__name__)
 
 
 def seed_webhook_event_types() -> None:
+    if not svix_service.is_enabled():
+        logger.info("Outgoing webhooks disabled — skipping webhook event type registration.")
+        return
     svix_service.register_event_types()
-    print("✓ Webhook event types registered with Svix.")
+    logger.info("Webhook event types registered with Svix.")
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="[%(asctime)s - %(name)s] (%(levelname)s) %(message)s")
     seed_webhook_event_types()

--- a/backend/scripts/init/seed_webhook_event_types.py
+++ b/backend/scripts/init/seed_webhook_event_types.py
@@ -12,8 +12,10 @@ def seed_webhook_event_types() -> None:
     if not svix_service.is_enabled():
         logger.info("Outgoing webhooks disabled — skipping webhook event type registration.")
         return
-    svix_service.register_event_types()
-    logger.info("Webhook event types registered with Svix.")
+    if svix_service.register_event_types():
+        logger.info("Webhook event types registered with Svix.")
+    else:
+        logger.warning("Webhook event type registration did not complete — will retry on next startup.")
 
 
 if __name__ == "__main__":

--- a/backend/tests/api/v1/test_outgoing_webhooks.py
+++ b/backend/tests/api/v1/test_outgoing_webhooks.py
@@ -56,6 +56,12 @@ class TestWebhookEventTypes:
 
 
 class TestWebhookEmit:
+    @pytest.fixture(autouse=True)
+    def _webhooks_enabled(self) -> Any:
+        # Dispatch only fires when webhooks are enabled; these tests assert it does.
+        with patch("app.services.outgoing_webhooks.svix.is_enabled", return_value=True):
+            yield
+
     @patch("app.integrations.celery.tasks.emit_webhook_event_task.emit_webhook_event")
     def test_on_workout_created_dispatches(self, mock_task: MagicMock) -> None:
         uid = uuid4()
@@ -273,6 +279,20 @@ class TestWebhookEmit:
             mock_task.delay.side_effect = ConnectionError("Redis not available")
             # Should NOT raise
             _dispatch("workout.created", {"type": "workout.created", "data": {}})
+
+    def test_dispatch_skipped_when_webhooks_disabled(self) -> None:
+        """With OUTGOING_WEBHOOKS_ENABLED off, nothing is enqueued."""
+        with (
+            patch("app.services.outgoing_webhooks.svix.is_enabled", return_value=False),
+            patch("app.integrations.celery.tasks.emit_webhook_event_task.emit_webhook_event") as mock_task,
+        ):
+            on_connection_created(
+                user_id=uuid4(),
+                provider="garmin",
+                connection_id=uuid4(),
+                connected_at="2026-01-01T12:00:00+00:00",
+            )
+            mock_task.delay.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/api/v1/test_outgoing_webhooks.py
+++ b/backend/tests/api/v1/test_outgoing_webhooks.py
@@ -10,6 +10,7 @@ Covers:
 from __future__ import annotations
 
 import re
+from collections.abc import Generator
 from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -57,7 +58,7 @@ class TestWebhookEventTypes:
 
 class TestWebhookEmit:
     @pytest.fixture(autouse=True)
-    def _webhooks_enabled(self) -> Any:
+    def _webhooks_enabled(self) -> Generator[None, None, None]:
         # Dispatch only fires when webhooks are enabled; these tests assert it does.
         with patch("app.services.outgoing_webhooks.svix.is_enabled", return_value=True):
             yield

--- a/docs/api-reference/guides/webhooks.mdx
+++ b/docs/api-reference/guides/webhooks.mdx
@@ -202,7 +202,7 @@ Fired once when a complete session is saved or merged.
 | Event | Description |
 |-------|-------------|
 | `connection.created` | A user successfully connected a wearable provider. |
-| `connection.revoked` | A connection became invalid (refresh token expired/revoked, or the user deregistered on the provider side). The user must re-authorize to resume syncing. |
+| `connection.revoked` | A connection became invalid or was disconnected (refresh token expired/revoked, the user deregistered on the provider side, or the user manually disconnected). The user must re-authorize to resume syncing. |
 | `workout.created` | A new workout session was saved. |
 | `sleep.created` | A new (or merged) sleep session was saved. |
 | `menstrual_cycle.created` | A new menstrual cycle record was saved. |
@@ -254,7 +254,7 @@ Every payload envelope has `type` (the event name as a string) and `data`.
 
 ### `connection.revoked`
 
-`reason` is a short cause, e.g. `refresh_failed` or `deregistration`.
+`reason` is a short cause, e.g. `refresh_failed`, `deregistration`, or `user_disconnected`.
 
 ```json
 {

--- a/docs/api-reference/guides/webhooks.mdx
+++ b/docs/api-reference/guides/webhooks.mdx
@@ -18,6 +18,10 @@ Outgoing webhooks let Open Wearables push events to your backend in real time, s
 
 Webhooks are delivered via [Svix](https://svix.com/), which handles retries, signature signing, and delivery history.
 
+<Note>
+  **Self-hosting:** outgoing webhooks are **disabled by default**. To emit events, set `OUTGOING_WEBHOOKS_ENABLED=true` in the backend `.env` and restart — no command-line flags needed, plain `docker compose up`. The `svix-server` container runs either way, and the app runs fine when it is absent (e.g. a deployment without webhooks). On managed Postgres (AWS RDS / Railway), the app's database user must be allowed to create databases, or create a `svix` database up front — Svix keeps its schema there.
+</Note>
+
 <CardGroup cols={2}>
   <Card title="Things you can do" icon="bolt">
     Trigger downstream processing when a workout is synced, update your UI in real time when sleep data arrives, scope an endpoint to a single user's events, or verify payloads are genuinely from Open Wearables.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -49,6 +49,11 @@ Get Open Wearables running locally and start integrating wearable device data.
     - `VITE_API_URL` - Backend API URL (default: `http://localhost:8000`)
     
     <Tip>Default credentials are provided in the `.env.example` files for local development.</Tip>
+
+    <Tip>
+      Outgoing webhooks are disabled by default. Set `OUTGOING_WEBHOOKS_ENABLED=true` to enable
+      real-time event delivery — see the [webhooks guide](/api-reference/guides/webhooks).
+    </Tip>
   </Accordion>
 </AccordionGroup>
 

--- a/frontend/src/hooks/api/use-config.ts
+++ b/frontend/src/hooks/api/use-config.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { configService } from '@/lib/api';
+import { queryKeys } from '@/lib/query/keys';
+
+export function useConfig() {
+  return useQuery({
+    queryKey: queryKeys.config.all,
+    queryFn: () => configService.get(),
+    staleTime: 24 * 60 * 60 * 1000, // 24h — instance config changes only on redeploy
+  });
+}

--- a/frontend/src/hooks/api/use-webhooks.ts
+++ b/frontend/src/hooks/api/use-webhooks.ts
@@ -18,11 +18,12 @@ export function useWebhookEventTypes() {
   });
 }
 
-export function useWebhookEndpoints() {
+export function useWebhookEndpoints(enabled = true) {
   return useQuery({
     queryKey: queryKeys.webhooks.list(),
     queryFn: () => webhooksService.list(),
     retry: false,
+    enabled,
   });
 }
 

--- a/frontend/src/lib/api/config.ts
+++ b/frontend/src/lib/api/config.ts
@@ -121,6 +121,7 @@ export const API_ENDPOINTS = {
 
   // Meta endpoints
   coverage: '/api/v1/meta/coverage',
+  config: '/api/v1/config',
 
   // Sync status / SSE endpoints
   // ApiKeyDep accepts both API keys and developer JWT tokens, so a single

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -15,6 +15,8 @@ export type {
   MenstrualCycleField,
   HealthScore,
 } from './services/meta.service';
+export { configService } from './services/config.service';
+export type { AppConfig } from './services/config.service';
 export { usersService } from './services/users.service';
 export { dashboardService } from './services/dashboard.service';
 export { webhooksService } from './services/webhooks.service';

--- a/frontend/src/lib/api/services/config.service.ts
+++ b/frontend/src/lib/api/services/config.service.ts
@@ -1,0 +1,12 @@
+import { apiClient } from '../client';
+import { API_ENDPOINTS } from '../config';
+
+export interface AppConfig {
+  outgoing_webhooks_enabled: boolean;
+}
+
+export const configService = {
+  async get(): Promise<AppConfig> {
+    return apiClient.get<AppConfig>(API_ENDPOINTS.config);
+  },
+};

--- a/frontend/src/lib/query/keys.ts
+++ b/frontend/src/lib/query/keys.ts
@@ -183,6 +183,9 @@ export const queryKeys = {
     all: ['meta'] as const,
     coverage: () => [...queryKeys.meta.all, 'coverage'] as const,
   },
+  config: {
+    all: ['config'] as const,
+  },
 
   syncStatus: {
     all: ['syncStatus'] as const,

--- a/frontend/src/routes/_authenticated/webhooks/index.tsx
+++ b/frontend/src/routes/_authenticated/webhooks/index.tsx
@@ -68,7 +68,7 @@ function WebhooksPage() {
               href="https://openwearables.io/docs/api-reference/guides/webhooks"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-primary hover:underline"
+              className="text-primary underline underline-offset-2"
             >
               webhooks guide
             </a>{' '}

--- a/frontend/src/routes/_authenticated/webhooks/index.tsx
+++ b/frontend/src/routes/_authenticated/webhooks/index.tsx
@@ -8,7 +8,7 @@ import { WebhooksTable } from '@/components/webhooks/webhooks-table';
 import { WebhookCreateDialog } from '@/components/webhooks/webhook-create-dialog';
 import { WebhookDeleteDialog } from '@/components/webhooks/webhook-delete-dialog';
 import { useWebhookEndpoints } from '@/hooks/api/use-webhooks';
-import { ApiError } from '@/lib/errors/api-error';
+import { useConfig } from '@/hooks/api/use-config';
 
 export const Route = createFileRoute('/_authenticated/webhooks/')({
   component: WebhooksPage,
@@ -18,15 +18,14 @@ function WebhooksPage() {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
-  const endpoints = useWebhookEndpoints();
+  const config = useConfig();
+  const webhooksEnabled = config.data?.outgoing_webhooks_enabled === true;
+  const endpoints = useWebhookEndpoints(webhooksEnabled);
 
   const deleteUrl = useMemo(
     () => endpoints.data?.find((e) => e.id === deleteId)?.url,
     [endpoints.data, deleteId]
   );
-
-  const isSvixDisabled =
-    endpoints.error instanceof ApiError && endpoints.error.statusCode === 503;
 
   return (
     <div className="p-6 md:p-8 space-y-6">
@@ -36,7 +35,7 @@ function WebhooksPage() {
         action={
           <Button
             onClick={() => setIsCreateOpen(true)}
-            disabled={isSvixDisabled}
+            disabled={!webhooksEnabled}
           >
             <Plus className="h-4 w-4" />
             Add webhook
@@ -44,15 +43,20 @@ function WebhooksPage() {
         }
       />
 
-      {isSvixDisabled ? (
+      {config.isLoading ? (
+        <div className="rounded-2xl border border-border/60 bg-gradient-to-br from-card/80 to-card/40 p-6 backdrop-blur-xl animate-pulse space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-12 bg-muted/50 rounded-md" />
+          ))}
+        </div>
+      ) : !webhooksEnabled ? (
         <div className="rounded-2xl border border-[hsl(var(--warning-muted)/0.4)] bg-[hsl(var(--warning-muted)/0.08)] p-6">
           <p className="text-sm font-medium text-[hsl(var(--warning-muted))]">
             Webhooks are not enabled on this instance.
           </p>
           <p className="text-xs text-muted-foreground mt-1">
-            Configure <code>SVIX_AUTH_TOKEN</code> or{' '}
-            <code>SVIX_JWT_SECRET</code> in the backend environment to enable
-            outgoing webhook delivery.
+            Set <code>OUTGOING_WEBHOOKS_ENABLED=true</code> in the backend
+            environment to enable outgoing webhook delivery.
           </p>
         </div>
       ) : endpoints.isLoading ? (

--- a/frontend/src/routes/_authenticated/webhooks/index.tsx
+++ b/frontend/src/routes/_authenticated/webhooks/index.tsx
@@ -49,6 +49,13 @@ function WebhooksPage() {
             <div key={i} className="h-12 bg-muted/50 rounded-md" />
           ))}
         </div>
+      ) : config.isError ? (
+        <div className="rounded-2xl border border-border/60 bg-gradient-to-br from-card/80 to-card/40 p-8 text-center backdrop-blur-xl">
+          <p className="text-muted-foreground mb-4">
+            Failed to load instance configuration. Please try again.
+          </p>
+          <Button onClick={() => config.refetch()}>Retry</Button>
+        </div>
       ) : !webhooksEnabled ? (
         <div className="rounded-2xl border border-[hsl(var(--warning-muted)/0.4)] bg-[hsl(var(--warning-muted)/0.08)] p-6">
           <p className="text-sm font-medium text-[hsl(var(--warning-muted))]">
@@ -56,7 +63,16 @@ function WebhooksPage() {
           </p>
           <p className="text-xs text-muted-foreground mt-1">
             Set <code>OUTGOING_WEBHOOKS_ENABLED=true</code> in the backend
-            environment to enable outgoing webhook delivery.
+            environment to enable outgoing webhook delivery. See the{' '}
+            <a
+              href="https://openwearables.io/docs/api-reference/guides/webhooks"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary hover:underline"
+            >
+              webhooks guide
+            </a>{' '}
+            for self-hosting setup.
           </p>
         </div>
       ) : endpoints.isLoading ? (


### PR DESCRIPTION
Resolves #1111 
Resolves #1295 

<img width="1244" height="226" alt="image" src="https://github.com/user-attachments/assets/c59b3674-629f-49d0-b3da-a4f0c7099979" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added an `OUTGOING_WEBHOOKS_ENABLED` master toggle for Svix outgoing webhooks.
  * Added a configuration endpoint (`GET /api/v1/config`) and frontend support to display/drive webhooks settings.
* **Bug Fixes**
  * When webhooks are disabled, the app now skips Svix client creation, event-type registration, Svix DB setup, and webhook task enqueueing.
  * Connection revocation now emits a `user_disconnected` webhook event with the proper timestamp.
* **Documentation**
  * Updated the webhooks self-hosting guide with the toggle and absent Svix-server behavior.
* **Tests**
  * Added coverage ensuring webhook tasks are not queued when disabled.
* **Chores**
  * Improved init script logging and made setup behavior safely conditional/idempotent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->