### PR TITLE
fix(frontend): remove redundant layers & add .output to .dockerignore

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,5 +1,11 @@
 node_modules
 dist
+dist-ssr
+.output
+.nitro
+.tanstack
+.vinxi
+.wrangler
 .git
 .gitignore
 README.md

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,28 +23,11 @@ COPY . .
 ENV NODE_ENV=production
 RUN pnpm run build
 
-# Determine build output directory and prepare it for copying
-# Nitro outputs to .output/public, Vite outputs to dist
-RUN if [ -d /app/.output/public ]; then \
-      echo "Using Nitro output: .output/public"; \
-      cp -r /app/.output/public /app/build-output; \
-    elif [ -d /app/dist ]; then \
-      echo "Using Vite output: dist"; \
-      cp -r /app/dist /app/build-output; \
-    else \
-      echo "ERROR: No build output found!"; \
-      ls -la /app/; \
-      exit 1; \
-    fi
-
 # Production stage
 FROM node:22-alpine
 
 WORKDIR /app
-# Copy built assets from builder
-COPY --from=builder /app/build-output /usr/share/nginx/html
-
-# Copy built output from builder
+# Copy the Nitro build output (server + static public assets) from the builder
 COPY --from=builder /app/.output ./.output
 
 # Expose port


### PR DESCRIPTION
part of the #1292 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production deployment reliability by running the application server directly from its generated output.
  * Updated container settings to use the configured application port and host.

* **Chores**
  * Expanded build-output exclusions to prevent generated framework directories from being included in container contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->