### PR TITLE
perf(integrations): skip Strava stream fetch when workout samples already exist

### DIFF
--- a/backend/app/repositories/data_point_series_repository.py
+++ b/backend/app/repositories/data_point_series_repository.py
@@ -336,6 +336,27 @@ class DataPointSeriesRepository(
         limit = params.limit or 50
         return query.limit(limit + 1).all(), total_count  # ty:ignore[invalid-return-type]
 
+    def has_samples_in_range(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        source: str,
+        start_datetime: datetime,
+        end_datetime: datetime,
+    ) -> bool:
+        """Whether any sample from `source` exists for the user in [start, end)."""
+        query = (
+            db_session.query(self.model.id)
+            .join(DataSource, self.model.data_source_id == DataSource.id)
+            .filter(
+                DataSource.user_id == user_id,
+                DataSource.source == source,
+                self.model.recorded_at >= start_datetime,
+                self.model.recorded_at < end_datetime,
+            )
+        )
+        return bool(db_session.query(query.exists()).scalar())
+
     def get_total_count(self, db_session: DbSession) -> int:
         """Get total count of all data points."""
         return db_session.query(func.count(self.model.id)).scalar() or 0

--- a/backend/app/services/providers/strava/workouts.py
+++ b/backend/app/services/providers/strava/workouts.py
@@ -309,6 +309,19 @@ class StravaWorkouts(BaseWorkoutsTemplate):
         """Fetch + persist per-sample streams on workout arrival, flag-gated and failure-isolated."""
         if not settings.ingest_workout_samples:
             return 0
+        # Workouts are re-upserted whenever a sync window re-covers them (webhook
+        # arrival followed by the periodic pull is the common case). Streams are
+        # immutable once the activity is uploaded, so if samples already exist in
+        # the workout window skip the extra API call instead of re-fetching and
+        # re-upserting identical rows.
+        if record.end_datetime is not None and timeseries_service.has_samples_in_range(
+            db,
+            user_id,
+            "strava",
+            record.start_datetime,
+            record.end_datetime,
+        ):
+            return 0
         try:
             samples = self._build_workout_samples(
                 db,

--- a/backend/app/services/timeseries_service.py
+++ b/backend/app/services/timeseries_service.py
@@ -70,6 +70,17 @@ class TimeSeriesService(
 
         return counts
 
+    def has_samples_in_range(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        source: str,
+        start_datetime: datetime,
+        end_datetime: datetime,
+    ) -> bool:
+        """Whether any sample from `source` already exists for the user in [start, end)."""
+        return self.crud.has_samples_in_range(db_session, user_id, source, start_datetime, end_datetime)
+
     @staticmethod
     def _emit_timeseries_webhooks(
         samples: list[TimeSeriesSampleCreate] | list[HeartRateSampleCreate] | list[StepSampleCreate],

--- a/backend/tests/providers/strava/test_strava_workout_samples.py
+++ b/backend/tests/providers/strava/test_strava_workout_samples.py
@@ -265,6 +265,7 @@ class TestIngestionWiring:
             patch.object(strava_workouts, "_make_api_request", return_value=_STRAVA_STREAMS_3S),
             patch("app.services.providers.strava.workouts.timeseries_service") as mock_ts,
         ):
+            mock_ts.has_samples_in_range.return_value = False
             count = strava_workouts._ingest_workout_streams(db, _SAMPLE_ACTIVITY, user_id, record_mock)
 
         mock_ts.bulk_create_samples.assert_called_once()
@@ -273,6 +274,66 @@ class TestIngestionWiring:
         assert len(saved_samples) == 6
         assert count == 6
         assert all(s.device_model == _DEVICE_MODEL for s in saved_samples)
+
+    def test_existing_samples_skip_fetch(
+        self,
+        strava_workouts: StravaWorkouts,
+        db: Session,
+    ) -> None:
+        """Samples already in the workout window: no API call, no save, 0 returned."""
+        user_id = uuid4()
+        record_mock = MagicMock()
+        record_mock.start_datetime = _START_DT
+        record_mock.end_datetime = _START_DT + timedelta(seconds=3600)
+        record_mock.zone_offset = _ZONE_OFFSET
+
+        with (
+            patch(
+                "app.services.providers.strava.workouts.settings",
+                ingest_workout_samples=True,
+            ),
+            patch.object(strava_workouts, "_make_api_request") as mock_api,
+            patch("app.services.providers.strava.workouts.timeseries_service") as mock_ts,
+        ):
+            mock_ts.has_samples_in_range.return_value = True
+            count = strava_workouts._ingest_workout_streams(db, _SAMPLE_ACTIVITY, user_id, record_mock)
+
+        mock_api.assert_not_called()
+        mock_ts.bulk_create_samples.assert_not_called()
+        assert count == 0
+        mock_ts.has_samples_in_range.assert_called_once_with(
+            db,
+            user_id,
+            "strava",
+            record_mock.start_datetime,
+            record_mock.end_datetime,
+        )
+
+    def test_no_end_datetime_skips_probe_and_fetches(
+        self,
+        strava_workouts: StravaWorkouts,
+        db: Session,
+    ) -> None:
+        """Record without end_datetime: existence probe bypassed, streams fetched as before."""
+        user_id = uuid4()
+        record_mock = MagicMock()
+        record_mock.start_datetime = _START_DT
+        record_mock.end_datetime = None
+        record_mock.zone_offset = _ZONE_OFFSET
+
+        with (
+            patch(
+                "app.services.providers.strava.workouts.settings",
+                ingest_workout_samples=True,
+            ),
+            patch.object(strava_workouts, "_make_api_request", return_value=_STRAVA_STREAMS_3S),
+            patch("app.services.providers.strava.workouts.timeseries_service") as mock_ts,
+        ):
+            count = strava_workouts._ingest_workout_streams(db, _SAMPLE_ACTIVITY, user_id, record_mock)
+
+        mock_ts.has_samples_in_range.assert_not_called()
+        mock_ts.bulk_create_samples.assert_called_once()
+        assert count == 6
 
     def test_save_raises_swallowed_returns_zero(
         self,
@@ -293,6 +354,7 @@ class TestIngestionWiring:
             patch.object(strava_workouts, "_make_api_request", return_value=_STRAVA_STREAMS_3S),
             patch("app.services.providers.strava.workouts.timeseries_service") as mock_ts,
         ):
+            mock_ts.has_samples_in_range.return_value = False
             mock_ts.bulk_create_samples.side_effect = RuntimeError("db write failure")
             count = strava_workouts._ingest_workout_streams(db, _SAMPLE_ACTIVITY, user_id, record_mock)
 
@@ -321,6 +383,7 @@ class TestIngestionWiring:
             ),
             patch("app.services.providers.strava.workouts.timeseries_service") as mock_ts,
         ):
+            mock_ts.has_samples_in_range.return_value = False
             count = strava_workouts._ingest_workout_streams(db, _SAMPLE_ACTIVITY, user_id, record_mock)
 
         mock_ts.bulk_create_samples.assert_not_called()
@@ -346,6 +409,7 @@ class TestIngestionWiring:
             patch.object(strava_workouts, "_make_api_request", return_value=streams_no_time),
             patch("app.services.providers.strava.workouts.timeseries_service") as mock_ts,
         ):
+            mock_ts.has_samples_in_range.return_value = False
             count = strava_workouts._ingest_workout_streams(db, _SAMPLE_ACTIVITY, user_id, record_mock)
 
         mock_ts.bulk_create_samples.assert_not_called()


### PR DESCRIPTION
## Problem

`_ingest_workout_streams` fetches `/api/v3/activities/{id}/streams` for every workout that passes through `load_data` or `process_push_activity`, with no check whether the samples are already in the DB. Workouts get re-upserted whenever a sync window re-covers them, the common case being a webhook arrival followed by the periodic pull over the same days. Each re-cover then re-fetches the full stream payload and re-upserts identical rows.

Cost per re-covered workout: one extra Strava API call (against the 100/15min and 1000/day budget) plus the memory of materializing the full per-second sample list. On our deployment one pull sync re-covering 24 recent activities re-fetched all 24 streams it already had.

## Fix

Streams are immutable once the activity is uploaded, so a cheap existence probe is enough: before hitting the API, check whether any `strava` sample exists for the user within `[record.start_datetime, record.end_datetime)` and return early if so.

- `DataPointSeriesRepository.has_samples_in_range` — single EXISTS query over `data_point_series` joined to `data_source`
- `TimeSeriesService.has_samples_in_range` — thin passthrough
- `StravaWorkouts._ingest_workout_streams` — early return when the probe hits

Records without `end_datetime` keep the old always-fetch behaviour. Workouts whose stream fetch failed previously have no samples in the window, so they are still retried on the next sync.

## Tests

`tests/providers/strava/test_strava_workout_samples.py`: two new wiring tests (probe hit skips fetch and save; missing `end_datetime` bypasses the probe), existing wiring tests updated to stub the probe as False. 16/16 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwvKzR4F85gS6NBZAngfge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate time-series samples during Strava workout reprocessing.
  * Skips unnecessary data retrieval and saving when samples already exist for the workout period.
  * Preserves normal ingestion when no end time is available or when samples are missing.

* **Tests**
  * Added coverage for existing samples, missing end times, fetch failures, save failures, and empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->