### PR TITLE
feat(backend): timestamp for HTTP middleware logs

### DIFF
--- a/backend/app/utils/structured_logging.py
+++ b/backend/app/utils/structured_logging.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+from datetime import datetime, timezone
 from logging import Logger
 from typing import Any, NamedTuple
 from uuid import UUID
@@ -79,6 +80,7 @@ def log_structured(
             attributes["trace_id"] = tid
 
     log_entry = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "level": level.lower(),
         "message": message,
         "provider": provider,


### PR DESCRIPTION
Related to. #1297

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added UTC timestamps to structured log entries using the ISO-8601 format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->