### PR TITLE
fix: propagate saved item counts in UploadDataResponse

### DIFF
--- a/backend/app/schemas/responses/upload/upload_response.py
+++ b/backend/app/schemas/responses/upload/upload_response.py
@@ -11,3 +11,6 @@ class UploadDataResponse(BaseModel):
     status_code: int = Field(..., description="HTTP status code (typically 202 for async operations)")
     response: str = Field(..., description="Human-readable response message")
     user_id: str | None = Field(None, description="User ID associated with the import operation")
+    records_saved: int = Field(0, description="Number of records saved")
+    workouts_saved: int = Field(0, description="Number of workouts saved")
+    sleep_saved: int = Field(0, description="Number of sleep records saved")

--- a/backend/app/services/apple/healthkit/import_service.py
+++ b/backend/app/services/apple/healthkit/import_service.py
@@ -396,8 +396,14 @@ class ImportService:
                 response=f"Import failed: {str(e)}",
                 user_id=user_id,
             )
-
-        return UploadDataResponse(status_code=200, response="Import successful", user_id=user_id)
+        return UploadDataResponse(
+            status_code=200,
+            response="Import successful",
+            user_id=user_id,
+            records_saved=saved_counts["records_saved"],
+            workouts_saved=saved_counts["workouts_saved"],
+            sleep_saved=saved_counts["sleep_saved"],
+        )
 
     def _parse_multipart_content(self, content: str) -> dict | None:
         """Parse multipart form data to extract JSON."""


### PR DESCRIPTION
## Summary

This PR propagates the processed item counts from the SDK import service into `UploadDataResponse`.

Previously, `records_saved`, `workouts_saved`, and `sleep_saved` were calculated during import but were not included in the response. As a result, `process_sdk_upload_task` defaulted these values to `0`, causing `items_processed` to always be reported as zero.

## Changes

- Added `records_saved`, `workouts_saved`, and `sleep_saved` fields to `UploadDataResponse`
- Included the saved counts in the successful response returned by `ImportService`

## Testing

- Ran `ruff check` successfully.
- Attempted to run the test suite using `uv run pytest`. The project requires Docker/Testcontainers, which were not available in my local environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload responses now report how many records, workouts, and sleep entries were saved.
  * Successful imports provide detailed saved-item counts alongside the success status.

* **Bug Fixes**
  * Improved import response consistency by explicitly returning a successful status and message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->