### PR TITLE
Add secure Team42 Strava OAuth handoffs

### DIFF
--- a/backend/app/api/routes/v1/__init__.py
+++ b/backend/app/api/routes/v1/__init__.py
@@ -15,6 +15,7 @@ from .import_xml import router as import_xml_router
 from .invitations import router as invitations_router
 from .meta import router as meta_router
 from .oauth import router as oauth_router
+from .oauth_handoffs import router as oauth_handoffs_router
 from .oura_webhooks import router as oura_webhooks_router
 from .outgoing_webhooks import router as outgoing_webhooks_router
 from .priorities import router as priorities_router
@@ -44,6 +45,7 @@ v1_router.include_router(timeseries_router, tags=["External: Timeseries"])
 v1_router.include_router(events_router, tags=["External: Events"])
 v1_router.include_router(health_scores_router, tags=["External: Health Scores"])
 v1_router.include_router(oauth_router, prefix="/oauth")
+v1_router.include_router(oauth_handoffs_router, prefix="/oauth", tags=["External: OAuth Handoff"])
 v1_router.include_router(sync_data_router, prefix="/providers", tags=["External: Data Sync"])
 v1_router.include_router(sync_status_router, tags=["External: Sync Status"])
 v1_router.include_router(vendor_workouts_router, prefix="/providers", tags=["System: Vendor Workouts"])

--- a/backend/app/api/routes/v1/oauth.py
+++ b/backend/app/api/routes/v1/oauth.py
@@ -15,6 +15,7 @@ from app.schemas.model_crud.data_priority import (
     ProviderSettingUpdate,
 )
 from app.services import DeveloperDep, user_connection_service
+from app.services.oauth_handoff_service import oauth_handoff_service
 from app.services.provider_settings_service import ProviderSettingsService
 from app.services.providers.base_strategy import BaseProviderStrategy
 from app.services.providers.factory import ProviderFactory
@@ -68,12 +69,18 @@ def oauth_callback(
     state: Annotated[str | None, Query(description="State parameter for CSRF protection")] = None,
     error: Annotated[str | None, Query()] = None,
     error_description: Annotated[str | None, Query()] = None,
+    scope: Annotated[str | None, Query(description="Scopes granted by the provider")] = None,
 ):
     """
     OAuth callback endpoint.
 
     Provider redirects here after user authorizes. Exchanges code for tokens.
     """
+    if provider == ProviderName.STRAVA:
+        handoff_response = oauth_handoff_service.handle_callback(code, state, error, error_description, scope)
+        if handoff_response is not None:
+            return handoff_response
+
     if error:
         return RedirectResponse(
             url=f"/api/v1/oauth/error?message={error}:+{error_description or 'Unknown+error'}",

--- a/backend/app/api/routes/v1/oauth_handoffs.py
+++ b/backend/app/api/routes/v1/oauth_handoffs.py
@@ -1,0 +1,49 @@
+from fastapi import APIRouter
+
+from app.database import DbSession
+from app.schemas.model_crud.credentials import (
+    OAuthHandoffBootstrapRequest,
+    OAuthHandoffBootstrapResponse,
+    OAuthHandoffClaimRequest,
+    OAuthHandoffClaimResponse,
+    OAuthHandoffInspectRequest,
+    OAuthHandoffInspectResponse,
+)
+from app.services import ApiKeyDep
+from app.services.oauth_handoff_service import oauth_handoff_service
+
+router = APIRouter()
+
+
+@router.post(
+    "/bootstrap/strava",
+    summary="Start a Strava identity handoff",
+)
+def bootstrap_strava(
+    payload: OAuthHandoffBootstrapRequest,
+    _api_key: ApiKeyDep,
+) -> OAuthHandoffBootstrapResponse:
+    return oauth_handoff_service.bootstrap(payload)
+
+
+@router.post(
+    "/handoffs/inspect",
+    summary="Consume and inspect a Strava identity handoff",
+)
+def inspect_handoff(
+    payload: OAuthHandoffInspectRequest,
+    _api_key: ApiKeyDep,
+) -> OAuthHandoffInspectResponse:
+    return oauth_handoff_service.inspect(payload)
+
+
+@router.post(
+    "/handoffs/claim",
+    summary="Claim a registration handoff for an Open Wearables user",
+)
+def claim_handoff(
+    payload: OAuthHandoffClaimRequest,
+    db: DbSession,
+    _api_key: ApiKeyDep,
+) -> OAuthHandoffClaimResponse:
+    return oauth_handoff_service.claim(payload, db)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -167,6 +167,16 @@ class Settings(BaseSettings):
     # Strava API max is 200 activities per page
     strava_events_per_page: int = 200
 
+    # TEAM42 STRAVA AUTHENTICATION HANDOFF
+    # This integration is intentionally separate from the normal provider
+    # connection flow and remains disabled until both applications are ready.
+    team42_oauth_handoff_enabled: bool = False
+    team42_oauth_handoff_key: SecretStr | None = None
+    team42_oauth_handoff_return_uris: str = ""
+    team42_oauth_handoff_allowed_scopes: str = "read,activity:read_all"
+    team42_oauth_handoff_state_ttl_seconds: int = Field(600, ge=60, le=900)
+    team42_oauth_handoff_code_ttl_seconds: int = Field(600, ge=60, le=900)
+
     # ULTRAHUMAN OAUTH SETTINGS
     ultrahuman_client_id: str | None = None
     ultrahuman_client_secret: SecretStr | None = None

--- a/backend/app/repositories/user_connection_repository.py
+++ b/backend/app/repositories/user_connection_repository.py
@@ -150,6 +150,30 @@ class UserConnectionRepository(CrudRepository[UserConnection, UserConnectionCrea
         """
         return self._active_by_provider_external_id(db_session, provider, provider_user_id).all()
 
+    def get_all_by_provider_user_id_any_status(
+        self,
+        db_session: DbSession,
+        provider: str,
+        provider_user_id: str,
+    ) -> list[UserConnection]:
+        """Get every connection with a provider subject, including revoked rows.
+
+        Authentication handoffs use this stricter lookup because a disconnected
+        connection still establishes historical ownership of the provider
+        account and must not be reassigned silently.
+        """
+        return (
+            db_session.query(self.model)
+            .filter(
+                and_(
+                    self.model.provider == provider,
+                    self.model.provider_user_id == provider_user_id,
+                ),
+            )
+            .order_by(self.model.created_at.asc(), self.model.id.asc())
+            .all()
+        )
+
     def get_by_provider_user_id(
         self,
         db_session: DbSession,

--- a/backend/app/schemas/model_crud/credentials/__init__.py
+++ b/backend/app/schemas/model_crud/credentials/__init__.py
@@ -17,6 +17,15 @@ from .oauth import (
     ProviderCredentials,
     ProviderEndpoints,
 )
+from .oauth_handoff import (
+    OAuthHandoffBootstrapRequest,
+    OAuthHandoffBootstrapResponse,
+    OAuthHandoffClaimRequest,
+    OAuthHandoffClaimResponse,
+    OAuthHandoffInspectRequest,
+    OAuthHandoffInspectResponse,
+    OAuthHandoffPurpose,
+)
 from .user_invitation_code import (
     InvitationCodeRedeemResponse,
     UserInvitationCodeCreate,
@@ -41,6 +50,13 @@ __all__ = [
     "ProviderEndpoints",
     "ProviderCredentials",
     "AuthorizationURLResponse",
+    "OAuthHandoffPurpose",
+    "OAuthHandoffBootstrapRequest",
+    "OAuthHandoffBootstrapResponse",
+    "OAuthHandoffInspectRequest",
+    "OAuthHandoffInspectResponse",
+    "OAuthHandoffClaimRequest",
+    "OAuthHandoffClaimResponse",
     # UserInvitationCode
     "UserInvitationCodeCreate",
     "UserInvitationCodeRead",

--- a/backend/app/schemas/model_crud/credentials/oauth_handoff.py
+++ b/backend/app/schemas/model_crud/credentials/oauth_handoff.py
@@ -1,0 +1,49 @@
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class OAuthHandoffPurpose(StrEnum):
+    """The website action that initiated a Strava identity handoff."""
+
+    LOGIN = "login"
+    REGISTER = "register"
+    LINK_IDENTITY = "link_identity"
+
+
+class OAuthHandoffBootstrapRequest(BaseModel):
+    state: str = Field(min_length=20, max_length=256)
+    return_uri: str = Field(min_length=12, max_length=512)
+    purpose: OAuthHandoffPurpose
+    scopes: list[str] = Field(default_factory=list, max_length=8)
+
+
+class OAuthHandoffBootstrapResponse(BaseModel):
+    authorization_url: str
+
+
+class OAuthHandoffInspectRequest(BaseModel):
+    handoff_code: str = Field(min_length=32, max_length=256)
+
+
+class OAuthHandoffInspectResponse(BaseModel):
+    provider_subject: str
+    scope: str
+    first_name: str = ""
+    last_name: str = ""
+    provider_username: str | None = None
+    purpose: OAuthHandoffPurpose
+    activity_sync_authorized: bool
+    claim_code: str | None = None
+
+
+class OAuthHandoffClaimRequest(BaseModel):
+    handoff_code: str = Field(min_length=32, max_length=256)
+    user_id: UUID
+
+
+class OAuthHandoffClaimResponse(BaseModel):
+    claimed: bool
+    provider_subject: str
+    scope: str

--- a/backend/app/services/oauth_handoff_service.py
+++ b/backend/app/services/oauth_handoff_service.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import secrets
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlencode
+
+from cryptography.fernet import Fernet, InvalidToken
+from fastapi import HTTPException, status
+from fastapi.responses import RedirectResponse
+from redis import Redis
+
+from app.config import settings
+from app.database import DbSession
+from app.integrations.redis_client import get_redis_client
+from app.schemas.enums import ProviderName
+from app.schemas.model_crud.credentials import (
+    OAuthHandoffBootstrapRequest,
+    OAuthHandoffBootstrapResponse,
+    OAuthHandoffClaimRequest,
+    OAuthHandoffClaimResponse,
+    OAuthHandoffInspectRequest,
+    OAuthHandoffInspectResponse,
+    OAuthHandoffPurpose,
+    OAuthState,
+    OAuthTokenResponse,
+)
+from app.services.providers.base_strategy import BaseProviderStrategy
+from app.services.providers.factory import ProviderFactory
+from app.services.user_connection_service import user_connection_service
+from app.utils.structured_logging import log_structured
+
+logger = logging.getLogger(__name__)
+
+
+class OAuthHandoffService:
+    """Encrypted, single-use Strava identity handoffs for Team42."""
+
+    _state_prefix = "team42_oauth_handoff_state:"
+    _inspect_prefix = "team42_oauth_handoff_inspect:"
+    _claim_prefix = "team42_oauth_handoff_claim:"
+    _subject_lock_prefix = "team42_oauth_handoff_subject_lock:"
+    _user_lock_prefix = "team42_oauth_handoff_user_lock:"
+    _envelope_version = 1
+
+    def __init__(self) -> None:
+        self.factory = ProviderFactory()
+
+    @property
+    def redis(self) -> Redis:
+        return get_redis_client()
+
+    def bootstrap(self, payload: OAuthHandoffBootstrapRequest) -> OAuthHandoffBootstrapResponse:
+        self._require_enabled()
+        self._validate_return_uri(payload.return_uri)
+
+        scopes = self._normalize_scopes(payload.scopes, payload.purpose)
+        internal_state = secrets.token_urlsafe(32)
+        strategy = self._strategy()
+        assert strategy.oauth
+        authorization_url, pkce_data = strategy.oauth._build_auth_url(internal_state, ",".join(scopes))
+
+        envelope: dict[str, Any] = {
+            "version": self._envelope_version,
+            "kind": "state",
+            "client_state": payload.state,
+            "return_uri": payload.return_uri,
+            "purpose": payload.purpose.value,
+            "requested_scopes": scopes,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        if pkce_data:
+            envelope.update(pkce_data)
+
+        self._store_encrypted(
+            f"{self._state_prefix}{internal_state}",
+            envelope,
+            settings.team42_oauth_handoff_state_ttl_seconds,
+        )
+        log_structured(
+            logger,
+            "info",
+            "Team42 OAuth handoff bootstrapped",
+            provider=ProviderName.STRAVA.value,
+            task="oauth_handoff_bootstrap",
+            purpose=payload.purpose.value,
+        )
+        return OAuthHandoffBootstrapResponse(authorization_url=authorization_url)
+
+    def handle_callback(
+        self,
+        code: str | None,
+        state: str | None,
+        error: str | None,
+        error_description: str | None,
+        granted_scope: str | None,
+    ) -> RedirectResponse | None:
+        """Handle Team42 state or return None for the normal OAuth flow."""
+        if not state:
+            return None
+
+        encrypted = self.redis.getdel(f"{self._state_prefix}{state}")
+        if not encrypted:
+            return None
+
+        state_data = self._decrypt(encrypted, expected_kind="state")
+        return_uri = str(state_data["return_uri"])
+        client_state = str(state_data["client_state"])
+        self._validate_return_uri(return_uri)
+
+        if not settings.team42_oauth_handoff_enabled:
+            return self._error_redirect(return_uri, client_state, "temporarily_unavailable")
+
+        if error or not code:
+            return self._error_redirect(
+                return_uri,
+                client_state,
+                error or "access_denied",
+                error_description or "Authorization was not completed",
+            )
+
+        strategy = self._strategy()
+        assert strategy.oauth
+        try:
+            token = strategy.oauth._exchange_token(code, state_data.get("code_verifier"))
+            user_info = strategy.oauth._get_provider_user_info(token, "team42-handoff")
+        except HTTPException:
+            log_structured(
+                logger,
+                "warning",
+                "Team42 OAuth handoff token exchange failed",
+                provider=ProviderName.STRAVA.value,
+                task="oauth_handoff_callback",
+                purpose=str(state_data["purpose"]),
+            )
+            return self._error_redirect(return_uri, client_state, "oauth_exchange_failed")
+
+        subject = str(user_info.get("user_id") or "")
+        if not subject:
+            return self._error_redirect(return_uri, client_state, "identity_unavailable")
+
+        granted_scopes = self._scope_set(user_info.get("scope") or token.scope or granted_scope or "")
+        inspect_code = secrets.token_urlsafe(48)
+        inspect_envelope = {
+            "version": self._envelope_version,
+            "kind": "inspect",
+            "provider_subject": subject,
+            "provider_username": user_info.get("username"),
+            "first_name": user_info.get("first_name") or "",
+            "last_name": user_info.get("last_name") or "",
+            "scopes": sorted(granted_scopes),
+            "purpose": str(state_data["purpose"]),
+            "token": token.model_dump(mode="json"),
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._store_encrypted(
+            f"{self._inspect_prefix}{inspect_code}",
+            inspect_envelope,
+            settings.team42_oauth_handoff_code_ttl_seconds,
+        )
+
+        log_structured(
+            logger,
+            "info",
+            "Team42 OAuth handoff callback completed",
+            provider=ProviderName.STRAVA.value,
+            task="oauth_handoff_callback",
+            purpose=str(state_data["purpose"]),
+            subject_hash=self._subject_hash(subject),
+        )
+        fragment = urlencode({"state": client_state, "handoff": inspect_code})
+        return RedirectResponse(f"{return_uri}#{fragment}", status_code=status.HTTP_303_SEE_OTHER)
+
+    def inspect(self, payload: OAuthHandoffInspectRequest) -> OAuthHandoffInspectResponse:
+        self._require_enabled()
+        data = self._consume_encrypted(f"{self._inspect_prefix}{payload.handoff_code}", expected_kind="inspect")
+        purpose = OAuthHandoffPurpose(str(data["purpose"]))
+        scopes = self._scope_set(data.get("scopes", []))
+        activity_sync_authorized = purpose == OAuthHandoffPurpose.REGISTER and "activity:read_all" in scopes
+
+        claim_code = None
+        if activity_sync_authorized:
+            claim_code = secrets.token_urlsafe(48)
+            claim_envelope = dict(data)
+            claim_envelope["kind"] = "claim"
+            claim_envelope["created_at"] = datetime.now(timezone.utc).isoformat()
+            self._store_encrypted(
+                f"{self._claim_prefix}{claim_code}",
+                claim_envelope,
+                settings.team42_oauth_handoff_code_ttl_seconds,
+            )
+
+        subject = str(data["provider_subject"])
+        log_structured(
+            logger,
+            "info",
+            "Team42 OAuth handoff inspected",
+            provider=ProviderName.STRAVA.value,
+            task="oauth_handoff_inspect",
+            purpose=purpose.value,
+            subject_hash=self._subject_hash(subject),
+            claimable=bool(claim_code),
+        )
+        return OAuthHandoffInspectResponse(
+            provider_subject=subject,
+            provider_username=data.get("provider_username"),
+            scope=",".join(sorted(scopes)),
+            first_name=str(data.get("first_name") or ""),
+            last_name=str(data.get("last_name") or ""),
+            purpose=purpose,
+            activity_sync_authorized=activity_sync_authorized,
+            claim_code=claim_code,
+        )
+
+    def claim(self, payload: OAuthHandoffClaimRequest, db: DbSession) -> OAuthHandoffClaimResponse:
+        self._require_enabled()
+        data = self._consume_encrypted(f"{self._claim_prefix}{payload.handoff_code}", expected_kind="claim")
+        purpose = OAuthHandoffPurpose(str(data["purpose"]))
+        scopes = self._scope_set(data.get("scopes", []))
+        if purpose != OAuthHandoffPurpose.REGISTER or "activity:read_all" not in scopes:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Handoff cannot create a data connection")
+
+        subject = str(data["provider_subject"])
+        subject_lock_key = f"{self._subject_lock_prefix}{self._subject_hash(subject)}"
+        if not self.redis.set(subject_lock_key, "1", nx=True, ex=60):
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Strava identity is already being claimed")
+
+        user_lock_key = f"{self._user_lock_prefix}{payload.user_id}"
+        if not self.redis.set(user_lock_key, "1", nx=True, ex=60):
+            self.redis.delete(subject_lock_key)
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Open Wearables user is already receiving a provider connection",
+            )
+
+        try:
+            strategy = self._strategy()
+            assert strategy.oauth
+            if not strategy.oauth.user_repo.get(db, payload.user_id):
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Open Wearables user was not found")
+
+            target_connection = strategy.oauth.connection_repo.get_by_user_and_provider(
+                db,
+                payload.user_id,
+                ProviderName.STRAVA.value,
+            )
+            if (
+                target_connection
+                and target_connection.provider_user_id
+                and target_connection.provider_user_id != subject
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Open Wearables user is connected to a different Strava identity",
+                )
+
+            subject_connections = strategy.oauth.connection_repo.get_all_by_provider_user_id_any_status(
+                db,
+                ProviderName.STRAVA.value,
+                subject,
+            )
+            if any(connection.user_id != payload.user_id for connection in subject_connections):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Strava identity belongs to another Open Wearables user",
+                )
+
+            token = OAuthTokenResponse.model_validate(data["token"])
+            user_info = {
+                "user_id": subject,
+                "username": data.get("provider_username"),
+                "scope": ",".join(sorted(scopes)),
+            }
+            oauth_state = OAuthState(user_id=payload.user_id, provider=ProviderName.STRAVA.value)
+            strategy.oauth._save_connection(db, payload.user_id, token, user_info, oauth_state)
+            user_connection_service.stamp_last_synced_at(db, payload.user_id, ProviderName.STRAVA.value)
+
+            log_structured(
+                logger,
+                "info",
+                "Team42 OAuth handoff claimed",
+                provider=ProviderName.STRAVA.value,
+                task="oauth_handoff_claim",
+                user_id=str(payload.user_id),
+                subject_hash=self._subject_hash(subject),
+            )
+            return OAuthHandoffClaimResponse(
+                claimed=True,
+                provider_subject=subject,
+                scope=",".join(sorted(scopes)),
+            )
+        finally:
+            self.redis.delete(user_lock_key, subject_lock_key)
+
+    def _strategy(self) -> BaseProviderStrategy:
+        strategy = self.factory.get_provider(ProviderName.STRAVA.value)
+        if not strategy.oauth:
+            raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Strava OAuth is unavailable")
+        return strategy
+
+    def _require_enabled(self) -> None:
+        if not settings.team42_oauth_handoff_enabled:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+        self._fernet()
+
+    def _fernet(self) -> Fernet:
+        configured = settings.team42_oauth_handoff_key
+        if configured is None or not configured.get_secret_value():
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="OAuth handoff encryption is not configured",
+            )
+        try:
+            return Fernet(configured.get_secret_value().encode())
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="OAuth handoff encryption is invalid",
+            ) from exc
+
+    def _allowed_return_uris(self) -> set[str]:
+        return {uri.strip() for uri in settings.team42_oauth_handoff_return_uris.split(",") if uri.strip()}
+
+    def _validate_return_uri(self, return_uri: str) -> None:
+        if return_uri not in self._allowed_return_uris():
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unregistered return URI")
+
+    def _normalize_scopes(self, requested: list[str], purpose: OAuthHandoffPurpose) -> list[str]:
+        default_scopes = ["read", "activity:read_all"] if purpose == OAuthHandoffPurpose.REGISTER else ["read"]
+        scopes = self._scope_set(requested or default_scopes)
+        allowed = self._scope_set(settings.team42_oauth_handoff_allowed_scopes)
+        if not scopes or "read" not in scopes or not scopes.issubset(allowed):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported Strava OAuth scopes")
+        if purpose != OAuthHandoffPurpose.REGISTER and any(scope.startswith("activity:") for scope in scopes):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Login and identity linking cannot request activity scopes",
+            )
+        return sorted(scopes)
+
+    @staticmethod
+    def _scope_set(value: Any) -> set[str]:
+        if isinstance(value, str):
+            parts = value.replace(" ", ",").split(",")
+        elif isinstance(value, list):
+            parts = value
+        else:
+            parts = []
+        return {str(part).strip() for part in parts if str(part).strip()}
+
+    def _store_encrypted(self, key: str, value: dict[str, Any], ttl: int) -> None:
+        encoded = json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+        self.redis.setex(key, ttl, self._fernet().encrypt(encoded).decode())
+
+    def _consume_encrypted(self, key: str, expected_kind: str) -> dict[str, Any]:
+        encrypted = self.redis.getdel(key)
+        if not encrypted:
+            raise HTTPException(status_code=status.HTTP_410_GONE, detail="Handoff is invalid or expired")
+        return self._decrypt(encrypted, expected_kind)
+
+    def _decrypt(self, encrypted: Any, expected_kind: str) -> dict[str, Any]:
+        encoded = encrypted.decode() if isinstance(encrypted, bytes) else str(encrypted)
+        try:
+            data = json.loads(self._fernet().decrypt(encoded.encode()))
+        except (InvalidToken, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise HTTPException(status_code=status.HTTP_410_GONE, detail="Handoff is invalid or expired") from exc
+        if data.get("version") != self._envelope_version or data.get("kind") != expected_kind:
+            raise HTTPException(status_code=status.HTTP_410_GONE, detail="Handoff is invalid or expired")
+        return data
+
+    @staticmethod
+    def _subject_hash(subject: str) -> str:
+        return hashlib.sha256(subject.encode()).hexdigest()
+
+    @staticmethod
+    def _error_redirect(
+        return_uri: str,
+        client_state: str,
+        error: str,
+        description: str | None = None,
+    ) -> RedirectResponse:
+        fragment_data = {"state": client_state, "error": error}
+        if description:
+            fragment_data["error_description"] = description
+        return RedirectResponse(
+            f"{return_uri}#{urlencode(fragment_data)}",
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+
+
+oauth_handoff_service = OAuthHandoffService()

--- a/backend/app/services/providers/strava/oauth.py
+++ b/backend/app/services/providers/strava/oauth.py
@@ -61,6 +61,16 @@ class StravaOAuth(BaseOAuthTemplate):
             provider_user_id = athlete_data.get("id")
             provider_user_id = str(provider_user_id) if provider_user_id is not None else None
             username = athlete_data.get("username")
-            return {"user_id": provider_user_id, "username": username}
+            return {
+                "user_id": provider_user_id,
+                "username": username,
+                "first_name": athlete_data.get("firstname"),
+                "last_name": athlete_data.get("lastname"),
+            }
         except Exception:
-            return {"user_id": None, "username": None}
+            return {
+                "user_id": None,
+                "username": None,
+                "first_name": None,
+                "last_name": None,
+            }

--- a/backend/app/services/providers/templates/base_oauth.py
+++ b/backend/app/services/providers/templates/base_oauth.py
@@ -211,7 +211,7 @@ class BaseOAuthTemplate(ABC):
             revoked_at=connection.updated_at.isoformat(),
         )
 
-    def _build_auth_url(self, state: str) -> tuple[str, dict[str, Any] | None]:
+    def _build_auth_url(self, state: str, scope_override: str | None = None) -> tuple[str, dict[str, Any] | None]:
         """Builds the authorization URL.
 
         Returns:
@@ -234,10 +234,11 @@ class BaseOAuthTemplate(ABC):
             f"{extra_params}"
         )
 
-        if self.credentials.default_scope:
+        requested_scope = self.credentials.default_scope if scope_override is None else scope_override
+        if requested_scope:
             from urllib.parse import quote
 
-            encoded_scope = quote(self.credentials.default_scope)
+            encoded_scope = quote(requested_scope)
             auth_url += f"&scope={encoded_scope}"
 
         # pkce_data will be None for non-PKCE providers

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -150,6 +150,14 @@ STRAVA_WEBHOOK_VERIFY_TOKEN=your-strava-webhook-verify-token
 # STRAVA_WEBHOOK_SIGNATURE_TOLERANCE_SECONDS=300  # Max allowed webhook signature timestamp skew
 # STRAVA_EVENTS_PER_PAGE=200  # Strava API max is 200 activities per page
 
+# Team42 Strava authentication handoff (disabled by default)
+TEAM42_OAUTH_HANDOFF_ENABLED=false
+# TEAM42_OAUTH_HANDOFF_KEY=generate-a-fernet-key
+# TEAM42_OAUTH_HANDOFF_RETURN_URIS=https://science.team42.run/auth/strava/callback
+# TEAM42_OAUTH_HANDOFF_ALLOWED_SCOPES=read,activity:read_all
+# TEAM42_OAUTH_HANDOFF_STATE_TTL_SECONDS=600
+# TEAM42_OAUTH_HANDOFF_CODE_TTL_SECONDS=600
+
 #--- Fitbit ---#
 FITBIT_CLIENT_ID=your-fitbit-client-id
 FITBIT_CLIENT_SECRET=your-fitbit-client-secret

--- a/backend/tests/api/v1/test_oauth_handoffs.py
+++ b/backend/tests/api/v1/test_oauth_handoffs.py
@@ -1,0 +1,430 @@
+from collections.abc import Generator
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from cryptography.fernet import Fernet
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.integrations.redis_client import get_redis_client
+from app.models import UserConnection
+from app.schemas.auth import ConnectionStatus
+from app.schemas.model_crud.credentials import OAuthTokenResponse
+from tests.factories import ApiKeyFactory, UserConnectionFactory, UserFactory
+from tests.utils import api_key_headers
+
+RETURN_URI = "https://science.team42.run/auth/strava/callback"
+CLIENT_STATE = "client-state-with-enough-entropy"
+
+
+@pytest.fixture
+def enabled_handoffs() -> Generator[None, None, None]:
+    key = Fernet.generate_key().decode()
+    with (
+        patch.object(settings, "team42_oauth_handoff_enabled", True),
+        patch.object(settings, "team42_oauth_handoff_key", SecretStr(key)),
+        patch.object(settings, "team42_oauth_handoff_return_uris", RETURN_URI),
+        patch.object(settings, "team42_oauth_handoff_allowed_scopes", "read,activity:read_all"),
+        patch.object(settings, "team42_oauth_handoff_state_ttl_seconds", 600),
+        patch.object(settings, "team42_oauth_handoff_code_ttl_seconds", 600),
+    ):
+        yield
+
+
+def _bootstrap(
+    client: TestClient,
+    *,
+    purpose: str,
+    scopes: list[str],
+    return_uri: str = RETURN_URI,
+) -> tuple[str, str]:
+    api_key = ApiKeyFactory()
+    response = client.post(
+        "/api/v1/oauth/bootstrap/strava",
+        headers=api_key_headers(api_key.id),
+        json={
+            "state": CLIENT_STATE,
+            "return_uri": return_uri,
+            "purpose": purpose,
+            "scopes": scopes,
+        },
+    )
+    assert response.status_code == 200
+    authorization_url = response.json()["authorization_url"]
+    internal_state = parse_qs(urlparse(authorization_url).query)["state"][0]
+    return api_key.id, internal_state
+
+
+def _complete_callback(
+    client: TestClient,
+    internal_state: str,
+    *,
+    scope: str = "read,activity:read_all",
+    callback_scope: str | None = None,
+    subject: str = "424242",
+) -> str:
+    token = OAuthTokenResponse(
+        access_token="secret-access-token",
+        refresh_token="secret-refresh-token",
+        token_type="Bearer",
+        expires_in=21600,
+        scope=scope,
+    )
+    profile = {
+        "user_id": subject,
+        "username": "runner",
+        "first_name": "Ada",
+        "last_name": "Lovelace",
+    }
+    with (
+        patch(
+            "app.services.providers.strava.oauth.StravaOAuth._exchange_token",
+            return_value=token,
+        ),
+        patch(
+            "app.services.providers.strava.oauth.StravaOAuth._get_provider_user_info",
+            return_value=profile,
+        ),
+    ):
+        params = {"code": "provider-code", "state": internal_state}
+        if callback_scope is not None:
+            params["scope"] = callback_scope
+        response = client.get("/api/v1/oauth/strava/callback", params=params, follow_redirects=False)
+
+    assert response.status_code == 303
+    location = response.headers["location"]
+    assert location.startswith(f"{RETURN_URI}#")
+    fragment = parse_qs(urlparse(location).fragment)
+    assert fragment["state"] == [CLIENT_STATE]
+    return fragment["handoff"][0]
+
+
+def _inspect(client: TestClient, api_key: str, handoff_code: str) -> dict:
+    response = client.post(
+        "/api/v1/oauth/handoffs/inspect",
+        headers=api_key_headers(api_key),
+        json={"handoff_code": handoff_code},
+    )
+    assert response.status_code == 200
+    return response.json()
+
+
+class TestOAuthHandoffBootstrap:
+    def test_disabled_by_default(self, client: TestClient) -> None:
+        api_key = ApiKeyFactory()
+        response = client.post(
+            "/api/v1/oauth/bootstrap/strava",
+            headers=api_key_headers(api_key.id),
+            json={
+                "state": CLIENT_STATE,
+                "return_uri": RETURN_URI,
+                "purpose": "login",
+                "scopes": ["read"],
+            },
+        )
+        assert response.status_code == 404
+
+    def test_requires_api_key(self, client: TestClient, enabled_handoffs: None) -> None:
+        response = client.post(
+            "/api/v1/oauth/bootstrap/strava",
+            json={
+                "state": CLIENT_STATE,
+                "return_uri": RETURN_URI,
+                "purpose": "login",
+                "scopes": ["read"],
+            },
+        )
+        assert response.status_code == 401
+
+    def test_rejects_unregistered_return_uri(self, client: TestClient, enabled_handoffs: None) -> None:
+        api_key = ApiKeyFactory()
+        response = client.post(
+            "/api/v1/oauth/bootstrap/strava",
+            headers=api_key_headers(api_key.id),
+            json={
+                "state": CLIENT_STATE,
+                "return_uri": "https://evil.example/callback",
+                "purpose": "login",
+                "scopes": ["read"],
+            },
+        )
+        assert response.status_code == 400
+
+    def test_login_cannot_request_activity_scopes(self, client: TestClient, enabled_handoffs: None) -> None:
+        api_key = ApiKeyFactory()
+        response = client.post(
+            "/api/v1/oauth/bootstrap/strava",
+            headers=api_key_headers(api_key.id),
+            json={
+                "state": CLIENT_STATE,
+                "return_uri": RETURN_URI,
+                "purpose": "login",
+                "scopes": ["read", "activity:read_all"],
+            },
+        )
+        assert response.status_code == 400
+
+    def test_state_payload_is_encrypted(self, client: TestClient, enabled_handoffs: None) -> None:
+        _, internal_state = _bootstrap(client, purpose="login", scopes=["read"])
+        raw = get_redis_client().get(f"team42_oauth_handoff_state:{internal_state}")
+        assert raw
+        assert CLIENT_STATE not in str(raw)
+        assert RETURN_URI not in str(raw)
+
+
+class TestOAuthHandoffCallbackAndInspect:
+    def test_denial_redirect_consumes_state(self, client: TestClient, enabled_handoffs: None) -> None:
+        _, internal_state = _bootstrap(client, purpose="login", scopes=["read"])
+        response = client.get(
+            "/api/v1/oauth/strava/callback",
+            params={"state": internal_state, "error": "access_denied"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 303
+        fragment = parse_qs(urlparse(response.headers["location"]).fragment)
+        assert fragment["state"] == [CLIENT_STATE]
+        assert fragment["error"] == ["access_denied"]
+
+        replay = client.get(
+            "/api/v1/oauth/strava/callback",
+            params={"state": internal_state, "error": "access_denied"},
+            follow_redirects=False,
+        )
+        assert replay.status_code == 303
+        assert replay.headers["location"].startswith("/api/v1/oauth/error")
+
+    def test_login_inspection_is_identity_only_and_single_use(
+        self,
+        client: TestClient,
+        enabled_handoffs: None,
+    ) -> None:
+        api_key, internal_state = _bootstrap(client, purpose="login", scopes=["read"])
+        handoff_code = _complete_callback(client, internal_state, scope="read")
+        inspected = _inspect(client, api_key, handoff_code)
+
+        assert inspected == {
+            "provider_subject": "424242",
+            "scope": "read",
+            "first_name": "Ada",
+            "last_name": "Lovelace",
+            "provider_username": "runner",
+            "purpose": "login",
+            "activity_sync_authorized": False,
+            "claim_code": None,
+        }
+        assert "secret-access-token" not in str(inspected)
+        assert not get_redis_client().keys("team42_oauth_handoff_claim:*")
+
+        replay = client.post(
+            "/api/v1/oauth/handoffs/inspect",
+            headers=api_key_headers(api_key),
+            json={"handoff_code": handoff_code},
+        )
+        assert replay.status_code == 410
+
+    def test_registration_inspection_rotates_to_claim_code(
+        self,
+        client: TestClient,
+        enabled_handoffs: None,
+    ) -> None:
+        api_key, internal_state = _bootstrap(
+            client,
+            purpose="register",
+            scopes=["read", "activity:read_all"],
+        )
+        handoff_code = _complete_callback(client, internal_state)
+        inspected = _inspect(client, api_key, handoff_code)
+
+        assert inspected["purpose"] == "register"
+        assert inspected["activity_sync_authorized"] is True
+        assert inspected["claim_code"]
+        assert "secret-access-token" not in str(inspected)
+
+    def test_callback_scope_is_used_when_token_response_omits_scope(
+        self,
+        client: TestClient,
+        enabled_handoffs: None,
+    ) -> None:
+        api_key, internal_state = _bootstrap(
+            client,
+            purpose="register",
+            scopes=["read", "activity:read_all"],
+        )
+        handoff_code = _complete_callback(
+            client,
+            internal_state,
+            scope="",
+            callback_scope="read,activity:read_all",
+        )
+        inspected = _inspect(client, api_key, handoff_code)
+
+        assert inspected["scope"] == "activity:read_all,read"
+        assert inspected["activity_sync_authorized"] is True
+        assert inspected["claim_code"]
+
+
+class TestOAuthHandoffClaim:
+    def test_claim_connects_target_without_starting_historical_sync(
+        self,
+        client: TestClient,
+        db: Session,
+        enabled_handoffs: None,
+    ) -> None:
+        api_key, internal_state = _bootstrap(
+            client,
+            purpose="register",
+            scopes=["read", "activity:read_all"],
+        )
+        inspected = _inspect(client, api_key, _complete_callback(client, internal_state))
+        user = UserFactory()
+
+        response = client.post(
+            "/api/v1/oauth/handoffs/claim",
+            headers=api_key_headers(api_key),
+            json={"handoff_code": inspected["claim_code"], "user_id": str(user.id)},
+        )
+        assert response.status_code == 200
+        assert response.json()["claimed"] is True
+
+        connection = (
+            db.query(UserConnection)
+            .filter(UserConnection.user_id == user.id, UserConnection.provider == "strava")
+            .one()
+        )
+        assert connection.provider_user_id == "424242"
+        assert connection.access_token == "secret-access-token"
+        assert connection.refresh_token == "secret-refresh-token"
+        assert connection.status == ConnectionStatus.ACTIVE
+        assert connection.last_synced_at is not None
+
+        replay = client.post(
+            "/api/v1/oauth/handoffs/claim",
+            headers=api_key_headers(api_key),
+            json={"handoff_code": inspected["claim_code"], "user_id": str(user.id)},
+        )
+        assert replay.status_code == 410
+
+    def test_claim_rejects_subject_owned_by_revoked_other_user(
+        self,
+        client: TestClient,
+        enabled_handoffs: None,
+    ) -> None:
+        other_user = UserFactory()
+        UserConnectionFactory(
+            user=other_user,
+            provider="strava",
+            provider_user_id="424242",
+            status=ConnectionStatus.REVOKED,
+            access_token=None,
+            refresh_token=None,
+        )
+        target_user = UserFactory()
+        api_key, internal_state = _bootstrap(
+            client,
+            purpose="register",
+            scopes=["read", "activity:read_all"],
+        )
+        inspected = _inspect(client, api_key, _complete_callback(client, internal_state))
+
+        response = client.post(
+            "/api/v1/oauth/handoffs/claim",
+            headers=api_key_headers(api_key),
+            json={"handoff_code": inspected["claim_code"], "user_id": str(target_user.id)},
+        )
+        assert response.status_code == 409
+
+    def test_claim_reactivates_same_subject_for_same_user(
+        self,
+        client: TestClient,
+        db: Session,
+        enabled_handoffs: None,
+    ) -> None:
+        target_user = UserFactory()
+        existing = UserConnectionFactory(
+            user=target_user,
+            provider="strava",
+            provider_user_id="424242",
+            status=ConnectionStatus.REVOKED,
+            access_token=None,
+            refresh_token=None,
+        )
+        api_key, internal_state = _bootstrap(
+            client,
+            purpose="register",
+            scopes=["read", "activity:read_all"],
+        )
+        inspected = _inspect(client, api_key, _complete_callback(client, internal_state))
+
+        response = client.post(
+            "/api/v1/oauth/handoffs/claim",
+            headers=api_key_headers(api_key),
+            json={"handoff_code": inspected["claim_code"], "user_id": str(target_user.id)},
+        )
+
+        assert response.status_code == 200
+        db.refresh(existing)
+        assert existing.status == ConnectionStatus.ACTIVE
+        assert existing.provider_user_id == "424242"
+        assert existing.access_token == "secret-access-token"
+        assert existing.refresh_token == "secret-refresh-token"
+        assert (
+            db.query(UserConnection)
+            .filter(UserConnection.user_id == target_user.id, UserConnection.provider == "strava")
+            .count()
+            == 1
+        )
+
+    def test_claim_rejects_replacing_targets_existing_subject(
+        self,
+        client: TestClient,
+        enabled_handoffs: None,
+    ) -> None:
+        target_user = UserFactory()
+        UserConnectionFactory(
+            user=target_user,
+            provider="strava",
+            provider_user_id="different-subject",
+            status=ConnectionStatus.REVOKED,
+            access_token=None,
+            refresh_token=None,
+        )
+        api_key, internal_state = _bootstrap(
+            client,
+            purpose="register",
+            scopes=["read", "activity:read_all"],
+        )
+        inspected = _inspect(client, api_key, _complete_callback(client, internal_state))
+
+        response = client.post(
+            "/api/v1/oauth/handoffs/claim",
+            headers=api_key_headers(api_key),
+            json={"handoff_code": inspected["claim_code"], "user_id": str(target_user.id)},
+        )
+        assert response.status_code == 409
+
+    def test_claim_serializes_connections_for_the_target_user(
+        self,
+        client: TestClient,
+        enabled_handoffs: None,
+    ) -> None:
+        target_user = UserFactory()
+        api_key, internal_state = _bootstrap(
+            client,
+            purpose="register",
+            scopes=["read", "activity:read_all"],
+        )
+        inspected = _inspect(client, api_key, _complete_callback(client, internal_state))
+        lock_key = f"team42_oauth_handoff_user_lock:{target_user.id}"
+        get_redis_client().set(lock_key, "1", ex=60)
+
+        response = client.post(
+            "/api/v1/oauth/handoffs/claim",
+            headers=api_key_headers(api_key),
+            json={"handoff_code": inspected["claim_code"], "user_id": str(target_user.id)},
+        )
+
+        assert response.status_code == 409
+        assert not get_redis_client().keys("team42_oauth_handoff_subject_lock:*")

--- a/docs/api-reference/guides/oauth-identity-handoffs.mdx
+++ b/docs/api-reference/guides/oauth-identity-handoffs.mdx
@@ -1,0 +1,89 @@
+---
+title: "OAuth Identity Handoffs"
+description: "Use short-lived, encrypted OAuth handoffs without exposing provider tokens to an integrating application."
+---
+
+OAuth identity handoffs let an API-key-authenticated application use Strava as
+an account identity provider while Open Wearables remains the only owner of the
+Strava access and refresh tokens.
+
+<Warning>
+The Team42 handoff integration is disabled by default. It is intentionally
+separate from the normal provider connection endpoint and should only be
+enabled after the website and Open Wearables configuration have been deployed
+and tested together.
+</Warning>
+
+## Security model
+
+The protocol rotates each secret exactly once:
+
+1. The bootstrap endpoint stores an encrypted, short-lived callback state.
+2. The Strava callback consumes that state and redirects with an opaque
+   inspection code in the URL fragment.
+3. Inspection consumes its code and returns token-free identity information.
+4. A registration that received `activity:read_all` also receives a new
+   one-time claim code.
+5. Claim consumes that code and binds the tokens to a specific Open Wearables
+   user. It does not start historical synchronization.
+
+Login and identity-linking handoffs can never be claimed. Consequently, signing
+in cannot reactivate or replace a disconnected data connection.
+
+## Configuration
+
+```bash
+TEAM42_OAUTH_HANDOFF_ENABLED=false
+TEAM42_OAUTH_HANDOFF_KEY=your-fernet-key
+TEAM42_OAUTH_HANDOFF_RETURN_URIS=https://science.team42.run/auth/strava/callback
+TEAM42_OAUTH_HANDOFF_ALLOWED_SCOPES=read,activity:read_all
+TEAM42_OAUTH_HANDOFF_STATE_TTL_SECONDS=600
+TEAM42_OAUTH_HANDOFF_CODE_TTL_SECONDS=600
+```
+
+Generate the encryption key outside the repository and store it in the
+deployment secret manager:
+
+```bash
+python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'
+```
+
+Return URIs are compared exactly. Multiple URIs may be configured as a
+comma-separated list. Production return URIs should use HTTPS.
+
+## Flow
+
+Start with `POST /api/v1/oauth/bootstrap/strava`. Provide:
+
+- A website-generated OAuth `state`.
+- An exact registered `return_uri`.
+- A purpose: `login`, `register`, or `link_identity`.
+- `read` for login or linking.
+- `read` and `activity:read_all` when registration also offers activity sync.
+
+After Strava authorization, the browser returns to the registered URI with a
+URL fragment containing the original state and an opaque handoff code. Post the
+code from the browser to the integrating application's server, then call
+`POST /api/v1/oauth/handoffs/inspect`.
+
+Inspection returns the Strava subject and profile fields but never returns
+tokens. Registration responses indicate whether activity synchronization was
+authorized and may include a short-lived `claim_code`.
+
+To connect the registration to data syncing, create or locate the intended
+Open Wearables user and pass its UUID with the claim code to
+`POST /api/v1/oauth/handoffs/claim`.
+
+After the account is verified, explicitly call the provider historical-sync
+endpoint. Claim itself deliberately has no backfill side effect.
+
+## Collision behavior
+
+Claim fails safely when:
+
+- The Strava subject appears on another Open Wearables user, even if revoked.
+- The target Open Wearables user already has a different Strava subject.
+- The handoff is expired, malformed, replayed, or already being claimed.
+
+The caller must start a fresh Strava authorization after a consumed handoff
+fails. Tokens are never returned for recovery.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -167,6 +167,7 @@
               "api-reference/guides/sync-status-stream",
               "api-reference/guides/apple-xml-import",
               "api-reference/guides/provider-setup",
+              "api-reference/guides/oauth-identity-handoffs",
               "api-reference/guides/error-handling"
             ]
           },
@@ -198,7 +199,10 @@
             "group": "Providers",
             "pages": [
               "GET /api/v1/oauth/providers",
-              "GET /api/v1/oauth/{provider}/authorize"
+              "GET /api/v1/oauth/{provider}/authorize",
+              "POST /api/v1/oauth/bootstrap/strava",
+              "POST /api/v1/oauth/handoffs/inspect",
+              "POST /api/v1/oauth/handoffs/claim"
             ]
           },
           {

--- a/docs/providers/strava-api-integration.mdx
+++ b/docs/providers/strava-api-integration.mdx
@@ -175,6 +175,15 @@ curl -X DELETE "https://www.strava.com/api/v3/push_subscriptions/SUBSCRIPTION_ID
 
 The default scope `activity:read_all,profile:read_all` is recommended for full activity data access.
 
+## Optional identity handoff
+
+Open Wearables can act as the token-owning side of a short-lived Strava
+identity handoff for Team42. This feature is disabled by default and does not
+change the standard provider connection flow.
+
+See [OAuth Identity Handoffs](/api-reference/guides/oauth-identity-handoffs)
+for the security model, configuration, and endpoint sequence.
+
 ## Next Steps
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## What changed

- add API-key-authenticated Strava OAuth handoff bootstrap, inspect, and claim endpoints
- keep OAuth state, inspection codes, and claim codes encrypted, short-lived, purpose-bound, and single-use in Redis
- allow login and identity-linking handoffs to request identity scope only
- allow an explicitly consented registration handoff to claim a Strava data connection without starting historical synchronization
- reject provider-subject ownership collisions across active and revoked connections
- preserve the existing standard provider OAuth and activity synchronization flows
- add disabled-by-default configuration, API documentation, provider documentation, and focused tests

## Why

Team42 needs to use Strava as an account identity provider while Open Wearables remains the sole owner of Strava access and refresh tokens. Authentication must remain independent from activity synchronization so signing in or linking an identity cannot silently reconnect a disconnected data connection.

## User and developer impact

- the feature remains unavailable unless `TEAM42_OAUTH_HANDOFF_ENABLED=true`
- return URIs and requested scopes are explicitly allowlisted
- login and identity linking cannot produce a claimable token handoff
- registration claims do not trigger historical activity import; the integrating application must request that separately after verification
- existing Open Wearables OAuth consumers continue through the original flow

## Validation

- `ruff check .`
- `ruff format . --check`
- `ty check .`
- `pytest tests/api/v1/test_oauth_handoffs.py tests/api/v1/test_oauth.py` — 35 passed

The broader local regression run completed with 1,914 passed and four pre-existing timezone-dependent failures unrelated to these changes.
