### PR TITLE
fix(frontend): emit root stylesheet from client build

### DIFF
--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -12,7 +12,7 @@ import { queryClient } from '@/lib/query/client';
 import { runtimeConfigScript } from '@/lib/api/runtime-config';
 import { Toaster } from '@/components/ui/sonner';
 
-import appCss from '../styles.css?url';
+import '../styles.css';
 
 export const Route = createRootRoute({
   head: () => ({
@@ -47,10 +47,6 @@ export const Route = createRootRoute({
       {
         rel: 'stylesheet',
         href: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap',
-      },
-      {
-        rel: 'stylesheet',
-        href: appCss,
       },
       // Fallback for browsers that don't support media queries
       {


### PR DESCRIPTION
## Summary

- import the root stylesheet as CSS instead of a `?url` asset
- let Vite/TanStack Start inject the client-build stylesheet link into SSR HTML
- avoid Linux production builds referencing an SSR-only stylesheet that is absent from `.output/public`

Fixes #1292.

## Root cause

The existing `styles.css?url` import is resolved independently in the client and SSR environments:

- client output: `.output/public/assets/styles-DSq6jfP6.css`
- SSR intermediate output: `node_modules/.nitro/vite/services/ssr/assets/styles-DYfE_Pvq.css`

On Linux (`node:22-alpine`), the generated server route bundle references the SSR hash, but the production image copies only `.output`; the root HTML therefore requests `/assets/styles-DYfE_Pvq.css`, which returns 404. A native macOS build happened to reference the client hash, which explains why the issue was not reproducible there.

Using a side-effect CSS import makes the generated Linux server HTML link the emitted client stylesheet instead.

## Verification

- `pnpm run lint`
- `pnpm run format:check`
- clean `node:22-alpine` Docker build using the repository `frontend/Dockerfile`
- ran the resulting image and requested every asset referenced by `GET /`
- root stylesheet: `/assets/index-DSq6jfP6.css` → HTTP 200
- all 12 root-referenced assets → HTTP 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated global styling integration to ensure application styles are applied directly.
  * Removed the redundant stylesheet link from the page head.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->