### PR TITLE
fix(backend): return 409 when email already exists

### DIFF
--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -19,6 +19,9 @@ class UserRepository(CrudRepository[User, UserCreateInternal, UserUpdateInternal
     def __init__(self, model: type[User]):
         super().__init__(model)
 
+    def get_by_email(self, db_session: DbSession, email: str) -> User | None:
+        return db_session.query(self.model).filter(self.model.email == email).one_or_none()
+
     def get_total_count(self, db_session: DbSession) -> int:
         """Get total count of users."""
         return db_session.query(func.count(self.model.id)).scalar() or 0

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -19,7 +19,9 @@ class UserRepository(CrudRepository[User, UserCreateInternal, UserUpdateInternal
     def __init__(self, model: type[User]):
         super().__init__(model)
 
-    def get_by_email(self, db_session: DbSession, email: str) -> User | None:
+    def get_by_email(self, db_session: DbSession, email: str | None) -> User | None:
+        if email is None:
+            return None
         return db_session.query(self.model).filter(self.model.email == email).one_or_none()
 
     def get_total_count(self, db_session: DbSession) -> int:

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -21,7 +21,7 @@ from app.services.providers.garmin.backfill_state import force_release_backfill_
 from app.services.services import AppService
 from app.services.sync_coordination import release_stale_primary
 from app.services.user_connection_service import user_connection_service
-from app.utils.exceptions import handle_exceptions
+from app.utils.exceptions import ResourceAlreadyExistsError, handle_exceptions
 from app.utils.structured_logging import log_structured
 
 
@@ -38,8 +38,11 @@ class UserService(AppService[UserRepository, User, UserCreateInternal, UserUpdat
         """Get count of users created within a date range."""
         return self.crud.get_count_in_range(db_session, start_date, end_date)
 
+    @handle_exceptions
     def create(self, db_session: DbSession, creator: UserCreate) -> User:
         """Create a user with server-generated id and created_at."""
+        if db_session.query(User).filter(User.email == creator.email).first():
+            raise ResourceAlreadyExistsError("User with this email already exists.")
         creation_data = creator.model_dump()
         internal_creator = UserCreateInternal(**creation_data)
         return super().create(db_session, internal_creator)

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -41,7 +41,7 @@ class UserService(AppService[UserRepository, User, UserCreateInternal, UserUpdat
     @handle_exceptions
     def create(self, db_session: DbSession, creator: UserCreate) -> User:
         """Create a user with server-generated id and created_at."""
-        if db_session.query(User).filter(User.email == creator.email).first():
+        if self.crud.get_by_email(db_session, creator.email):
             raise ResourceAlreadyExistsError("User with this email already exists.")
         creation_data = creator.model_dump()
         internal_creator = UserCreateInternal(**creation_data)

--- a/backend/app/utils/exceptions.py
+++ b/backend/app/utils/exceptions.py
@@ -27,6 +27,12 @@ class ResourceNotFoundError(Exception):
             self.detail = f"{entity_name.capitalize()} not found."
 
 
+class ResourceAlreadyExistsError(Exception):
+    def __init__(self, detail: str):
+        self.detail = detail
+        super().__init__(detail)
+
+
 class InvalidCursorError(Exception):
     def __init__(self, cursor: str):
         self.detail = f"Invalid cursor format: '{cursor}'. Expected 'timestamp|id'."
@@ -54,6 +60,11 @@ def _(exc: SQLAIntegrityError | PsycopgIntegrityError, entity: str) -> HTTPExcep
 @handle_exception.register
 def _(exc: ResourceNotFoundError, _: str) -> HTTPException:
     return HTTPException(status_code=404, detail=exc.detail)
+
+
+@handle_exception.register
+def _(exc: ResourceAlreadyExistsError, _: str) -> HTTPException:
+    return HTTPException(status_code=409, detail=exc.detail)
 
 
 @handle_exception.register

--- a/backend/tests/services/test_user_service.py
+++ b/backend/tests/services/test_user_service.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from app.schemas.model_crud.user_management import UserCreate, UserUpdate
@@ -86,6 +87,15 @@ class TestUserServiceCreate:
         db_user = user_service.get(db, user.id)
         assert db_user is not None
         assert db_user.email == "persist@example.com"
+
+    def test_create_user_duplicate_email_returns_409(self, db: Session) -> None:
+        """Should raise 409 when registering with an already-used email."""
+        UserFactory(email="taken@example.com")
+
+        with pytest.raises(HTTPException) as exc_info:
+            user_service.create(db, UserCreate(email="taken@example.com"))
+
+        assert exc_info.value.status_code == 409
 
 
 class TestUserServiceUpdate:


### PR DESCRIPTION
resolves: #89 

Added also custom error and handler for "resource already exists" errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented creating multiple accounts with the same email by detecting duplicates before user creation.
  * Duplicate email attempts now consistently return an HTTP **409 Conflict** response.
* **Tests**
  * Added a test to confirm duplicate-email user creation raises an HTTP 409 error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->