### PR TITLE
feat(backend): Implement deregistration for providers with Cloud API

### DIFF
--- a/backend/app/services/providers/fitbit/oauth.py
+++ b/backend/app/services/providers/fitbit/oauth.py
@@ -1,4 +1,5 @@
 import httpx
+
 from app.config import settings
 from app.schemas.auth import AuthenticationMethod
 from app.schemas.enums import ProviderName
@@ -48,6 +49,6 @@ class FitbitOAuth(BaseOAuthTemplate):
             f"{self.api_base_url}/oauth2/revoke",
             data={"token": access_token},
             headers=self._get_basic_auth_headers(),
-            timeout=30.0
+            timeout=30.0,
         )
         response.raise_for_status()

--- a/backend/app/services/providers/fitbit/oauth.py
+++ b/backend/app/services/providers/fitbit/oauth.py
@@ -1,3 +1,4 @@
+import httpx
 from app.config import settings
 from app.schemas.auth import AuthenticationMethod
 from app.schemas.enums import ProviderName
@@ -40,3 +41,13 @@ class FitbitOAuth(BaseOAuthTemplate):
             "user_id": provider_user_id,
             "username": None,
         }
+
+    def deregister_user(self, access_token: str, provider_user_id: str | None = None) -> None:
+        """Call Fitbit's user deregistration endpoint to remove the app association."""
+        response = httpx.post(
+            f"{self.api_base_url}/oauth2/revoke",
+            data={"token": access_token},
+            headers=self._get_basic_auth_headers(),
+            timeout=30.0
+        )
+        response.raise_for_status()

--- a/backend/app/services/providers/garmin/oauth.py
+++ b/backend/app/services/providers/garmin/oauth.py
@@ -39,7 +39,7 @@ class GarminOAuth(BaseOAuthTemplate):
     use_pkce = True
     auth_method = AuthenticationMethod.BODY
 
-    def deregister_user(self, access_token: str) -> None:
+    def deregister_user(self, access_token: str, provider_user_id: str | None = None) -> None:
         """Call Garmin's user deregistration endpoint to remove the app association."""
         response = httpx.delete(
             f"{self.api_base_url}/partner-gateway/rest/user/registration",

--- a/backend/app/services/providers/oura/oauth.py
+++ b/backend/app/services/providers/oura/oauth.py
@@ -74,3 +74,12 @@ class OuraOAuth(BaseOAuthTemplate):
                 error=str(e),
             )
             return {"user_id": None, "username": None}
+    
+    def deregister_user(self, access_token: str, provider_user_id: str | None = None) -> None:
+        """Revoke Oura OAuth access for this user."""
+        response = httpx.post(
+            f"{self.api_base_url}/oauth/revoke",
+            params={"access_token": access_token},
+            timeout=30.0,
+        )
+        response.raise_for_status()

--- a/backend/app/services/providers/oura/oauth.py
+++ b/backend/app/services/providers/oura/oauth.py
@@ -74,7 +74,7 @@ class OuraOAuth(BaseOAuthTemplate):
                 error=str(e),
             )
             return {"user_id": None, "username": None}
-    
+
     def deregister_user(self, access_token: str, provider_user_id: str | None = None) -> None:
         """Revoke Oura OAuth access for this user."""
         response = httpx.post(

--- a/backend/app/services/providers/polar/oauth.py
+++ b/backend/app/services/providers/polar/oauth.py
@@ -1,4 +1,5 @@
 import httpx
+
 from app.config import settings
 from app.schemas.enums import ProviderName
 from app.schemas.model_crud.credentials import (
@@ -54,10 +55,10 @@ class PolarOAuth(BaseOAuthTemplate):
         except Exception:
             # Don't fail the entire flow - user might already be registered
             pass
-    
+
     def deregister_user(self, access_token: str, provider_user_id: str | None = None) -> None:
         """Call Polar's user deregistration endpoint to remove the app association."""
-        
+
         if not provider_user_id:
             raise ValueError("Polar deregistration requires provider_user_id")
 

--- a/backend/app/services/providers/polar/oauth.py
+++ b/backend/app/services/providers/polar/oauth.py
@@ -57,6 +57,7 @@ class PolarOAuth(BaseOAuthTemplate):
     
     def deregister_user(self, access_token: str, provider_user_id: str | None = None) -> None:
         """Call Polar's user deregistration endpoint to remove the app association."""
+        
         if not provider_user_id:
             raise ValueError("Polar deregistration requires provider_user_id")
 

--- a/backend/app/services/providers/polar/oauth.py
+++ b/backend/app/services/providers/polar/oauth.py
@@ -1,3 +1,4 @@
+import httpx
 from app.config import settings
 from app.schemas.enums import ProviderName
 from app.schemas.model_crud.credentials import (
@@ -39,7 +40,6 @@ class PolarOAuth(BaseOAuthTemplate):
 
     def _register_user(self, access_token: str, member_id: str) -> None:
         """Registers the user with Polar API."""
-        import httpx
 
         try:
             register_url = f"{self.api_base_url}/v3/users"
@@ -54,3 +54,15 @@ class PolarOAuth(BaseOAuthTemplate):
         except Exception:
             # Don't fail the entire flow - user might already be registered
             pass
+    
+    def deregister_user(self, access_token: str, provider_user_id: str | None = None) -> None:
+        """Call Polar's user deregistration endpoint to remove the app association."""
+        if not provider_user_id:
+            raise ValueError("Polar deregistration requires provider_user_id")
+
+        deregister_url = f"{self.api_base_url}/v3/users/{provider_user_id}"
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+        }
+        response = httpx.delete(deregister_url, headers=headers, timeout=10.0)
+        response.raise_for_status()

--- a/backend/app/services/providers/strava/oauth.py
+++ b/backend/app/services/providers/strava/oauth.py
@@ -41,8 +41,9 @@ class StravaOAuth(BaseOAuthTemplate):
     def deregister_user(self, access_token: str, provider_user_id: str | None = None) -> None:
         """Revoke access and remove the app from the athlete's connected apps."""
         response = httpx.post(
-            f"{self.api_base_url}/oauth/deauthorize",
-            params={"access_token": access_token},
+            f"{self.api_base_url}/oauth/revoke",
+            data={"token": access_token, "token_type_hint": "access_token"},
+            headers=self._get_basic_auth_headers(),
             timeout=30.0,
         )
         response.raise_for_status()

--- a/backend/app/services/providers/strava/oauth.py
+++ b/backend/app/services/providers/strava/oauth.py
@@ -38,7 +38,7 @@ class StravaOAuth(BaseOAuthTemplate):
     use_pkce: bool = False  # Strava doesn't require PKCE
     auth_method: AuthenticationMethod = AuthenticationMethod.BODY  # Strava expects credentials in body
 
-    def deregister_user(self, access_token: str) -> None:
+    def deregister_user(self, access_token: str, provider_user_id: str | None = None) -> None:
         """Revoke access and remove the app from the athlete's connected apps."""
         response = httpx.post(
             f"{self.api_base_url}/oauth/deauthorize",

--- a/backend/app/services/providers/templates/base_oauth.py
+++ b/backend/app/services/providers/templates/base_oauth.py
@@ -354,7 +354,7 @@ class BaseOAuthTemplate(ABC):
             "Content-Type": "application/x-www-form-urlencoded",
         }
 
-    def deregister_user(self, access_token: str) -> None:
+    def deregister_user(self, access_token: str, provider_user_id: str | None = None) -> None:
         """Notify provider that user is disconnecting. Override in subclasses that support deregistration."""
         log_structured(
             logger,

--- a/backend/app/services/providers/ultrahuman/oauth.py
+++ b/backend/app/services/providers/ultrahuman/oauth.py
@@ -84,3 +84,17 @@ class UltrahumanOAuth(BaseOAuthTemplate):
         except Exception as e:
             self.logger.error(f"Unexpected error fetching Ultrahuman user profile for user {user_id}: {e}")
             return {"user_id": None, "username": None}
+
+    def deregister_user(self, access_token: str, provider_user_id: str | None = None) -> None:
+        """Revoke Ultrahuman OAuth access for this user."""
+
+        response = httpx.post(
+            "https://partner.ultrahuman.com/api/partners/oauth/revoke",
+            data={
+                "token": access_token,
+                "client_id": self.credentials.client_id,
+                "client_secret": self.credentials.client_secret,
+            },
+            timeout=30.0,
+        )
+        response.raise_for_status()

--- a/backend/app/services/providers/whoop/oauth.py
+++ b/backend/app/services/providers/whoop/oauth.py
@@ -77,7 +77,7 @@ class WhoopOAuth(BaseOAuthTemplate):
                 user_id=user_id,
             )
             return {"user_id": None, "username": None}
-    
+
     def deregister_user(self, access_token: str, provider_user_id: str | None = None) -> None:
         """Revoke WHOOP OAuth access for this user."""
 

--- a/backend/app/services/providers/whoop/oauth.py
+++ b/backend/app/services/providers/whoop/oauth.py
@@ -77,3 +77,13 @@ class WhoopOAuth(BaseOAuthTemplate):
                 user_id=user_id,
             )
             return {"user_id": None, "username": None}
+    
+    def deregister_user(self, access_token: str, provider_user_id: str | None = None) -> None:
+        """Revoke WHOOP OAuth access for this user."""
+
+        response = httpx.delete(
+            f"{self.api_base_url}/v2/user/access",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=30.0,
+        )
+        response.raise_for_status()

--- a/backend/app/services/user_connection_service.py
+++ b/backend/app/services/user_connection_service.py
@@ -107,7 +107,10 @@ class UserConnectionService(
             return
 
         try:
-            oauth.deregister_user(connection.access_token)
+            oauth.deregister_user(
+                connection.access_token,
+                provider_user_id=connection.provider_user_id,
+            )
             log_structured(
                 self.logger,
                 "info",

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -73,7 +73,7 @@ class UserService(AppService[UserRepository, User, UserCreateInternal, UserUpdat
             try:
                 strategy = provider_factory.get_provider(connection.provider)
                 if oauth := strategy.oauth:
-                    oauth.deregister_user(connection.access_token)
+                    oauth.deregister_user(connection.access_token, provider_user_id=connection.provider_user_id)
             except Exception as e:
                 log_structured(
                     self.logger,

--- a/backend/tests/providers/polar/test_polar_oauth.py
+++ b/backend/tests/providers/polar/test_polar_oauth.py
@@ -7,6 +7,7 @@ Tests the PolarOAuth class for OAuth 2.0 authentication flow with Polar API.
 from unittest.mock import MagicMock, patch
 
 import httpx
+import pytest
 from sqlalchemy.orm import Session
 
 from app.schemas.model_crud.credentials import OAuthTokenResponse
@@ -322,3 +323,56 @@ class TestPolarUserRegistration:
         # Act & Assert - should not raise exception
         oauth._register_user("test_access_token", str(user.id))
         # User might already be registered, so we handle errors gracefully
+
+
+class TestPolarUserDeregistration:
+    """Tests for Polar user deregistration API call."""
+
+    def _make_oauth(self) -> PolarOAuth:
+        from app.models import User
+        from app.repositories.user_connection_repository import UserConnectionRepository
+        from app.repositories.user_repository import UserRepository
+
+        return PolarOAuth(
+            user_repo=UserRepository(User),
+            connection_repo=UserConnectionRepository(),
+            provider_name="polar",
+            api_base_url="https://www.polaraccesslink.com",
+        )
+
+    @patch("httpx.delete")
+    def test_deregister_user_success(self, mock_httpx_delete: MagicMock) -> None:
+        """Test calling Polar deregistration endpoint."""
+        oauth = self._make_oauth()
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.raise_for_status.return_value = None
+        mock_httpx_delete.return_value = mock_response
+
+        oauth.deregister_user("test_access_token", provider_user_id="12345")
+
+        mock_httpx_delete.assert_called_once_with(
+            "https://www.polaraccesslink.com/v3/users/12345",
+            headers={"Authorization": "Bearer test_access_token"},
+            timeout=10.0,
+        )
+
+    @patch("httpx.delete")
+    def test_deregister_user_raises_on_http_error(self, mock_httpx_delete: MagicMock) -> None:
+        """Test that deregister_user raises on HTTP error (caller handles it)."""
+        oauth = self._make_oauth()
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Unauthorized", request=MagicMock(), response=MagicMock(status_code=401)
+        )
+        mock_httpx_delete.return_value = mock_response
+
+        with pytest.raises(httpx.HTTPStatusError):
+            oauth.deregister_user("expired_token", provider_user_id="12345")
+
+    def test_deregister_user_raises_without_provider_user_id(self) -> None:
+        """Test that deregister_user requires provider_user_id."""
+        oauth = self._make_oauth()
+
+        with pytest.raises(ValueError, match="provider_user_id"):
+            oauth.deregister_user("test_access_token")

--- a/contributing/pull-requests.md
+++ b/contributing/pull-requests.md
@@ -13,7 +13,6 @@ This guide covers how to submit pull requests to Open Wearables.
 Use this format: `<issue-number>-<brief-description>`
 
 Examples:
-
 - `123-fix-user-authentication`
 - `456-add-garmin-provider`
 - `789-update-dashboard-layout`
@@ -30,25 +29,19 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 [optional footer]
 ```
 
-
-
 ### Types
 
-
-| Type       | Description                             |
-| ---------- | --------------------------------------- |
-| `feat`     | New feature                             |
-| `fix`      | Bug fix                                 |
-| `docs`     | Documentation changes                   |
-| `chore`    | Maintenance tasks                       |
+| Type | Description |
+|------|-------------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation changes |
+| `chore` | Maintenance tasks |
 | `refactor` | Code refactoring (no functional change) |
-| `test`     | Adding or updating tests                |
-| `style`    | Formatting changes                      |
-| `perf`     | Performance improvements                |
-| `ci`       | CI/CD changes                           |
-
-
-
+| `test` | Adding or updating tests |
+| `style` | Formatting changes |
+| `perf` | Performance improvements |
+| `ci` | CI/CD changes |
 
 ### Examples
 
@@ -71,8 +64,6 @@ pagination in the workouts list endpoint.
 Closes #123
 ```
 
-
-
 ## PR Title Convention
 
 **PR titles must follow the same [Conventional Commits](https://www.conventionalcommits.org/) format as commit messages.**
@@ -83,8 +74,6 @@ The CI workflow automatically validates PR titles to ensure they follow this con
 <type>(<optional scope>): <description>
 ```
 
-
-
 ### Examples
 
 - `feat: add user profile endpoint`
@@ -93,49 +82,39 @@ The CI workflow automatically validates PR titles to ensure they follow this con
 - `ci: add PR title validation to workflow`
 - `refactor(backend): simplify authentication logic`
 
-
-
 ## Creating a Pull Request
 
 1. **Create a branch** from `main`:
-  ```bash
+   ```bash
    git checkout -b 123-your-feature-description
-  ```
+   ```
+
 2. **Make your changes** and commit following the conventions above
+
 3. **Push your branch**:
-  ```bash
+   ```bash
    git push -u origin 123-your-feature-description
-  ```
+   ```
+
 4. **Open a PR** on GitHub and fill out the template
-
-
 
 ## PR Checklist
 
 The PR template includes these requirements:
 
 ### General
-
 - [ ] Code follows the project's code style
 - [ ] Self-review completed
 - [ ] Tests added (if applicable)
 - [ ] All tests pass locally
 
-
-
 ### Backend Changes
-
 - [ ] `uv run pre-commit run --all-files` passes (runs ruff, ty, and formatting checks)
 
-
-
 ### Frontend Changes
-
 - [ ] `pnpm run lint` passes
 - [ ] `pnpm run format:check` passes
 - [ ] `pnpm run build` succeeds
-
-
 
 ## Linking Issues
 
@@ -145,16 +124,12 @@ Link related issues in your PR description:
 - `Closes #456` - Same as Fixes
 - `Relates to #789` - References without closing
 
-
-
 ## Code Review Process
 
 1. **Request review**: PRs require at least one approval
 2. **Address feedback**: Respond to comments and make requested changes
 3. **CI must pass**: All automated checks must be green
 4. **Merge**: Once approved, the PR can be merged
-
-
 
 ## Tips for a Good PR
 
@@ -163,4 +138,3 @@ Link related issues in your PR description:
 - Include screenshots for UI changes
 - Update documentation if needed
 - Add tests for new functionality
-

--- a/contributing/pull-requests.md
+++ b/contributing/pull-requests.md
@@ -13,6 +13,7 @@ This guide covers how to submit pull requests to Open Wearables.
 Use this format: `<issue-number>-<brief-description>`
 
 Examples:
+
 - `123-fix-user-authentication`
 - `456-add-garmin-provider`
 - `789-update-dashboard-layout`
@@ -29,19 +30,25 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 [optional footer]
 ```
 
+
+
 ### Types
 
-| Type | Description |
-|------|-------------|
-| `feat` | New feature |
-| `fix` | Bug fix |
-| `docs` | Documentation changes |
-| `chore` | Maintenance tasks |
+
+| Type       | Description                             |
+| ---------- | --------------------------------------- |
+| `feat`     | New feature                             |
+| `fix`      | Bug fix                                 |
+| `docs`     | Documentation changes                   |
+| `chore`    | Maintenance tasks                       |
 | `refactor` | Code refactoring (no functional change) |
-| `test` | Adding or updating tests |
-| `style` | Formatting changes |
-| `perf` | Performance improvements |
-| `ci` | CI/CD changes |
+| `test`     | Adding or updating tests                |
+| `style`    | Formatting changes                      |
+| `perf`     | Performance improvements                |
+| `ci`       | CI/CD changes                           |
+
+
+
 
 ### Examples
 
@@ -64,6 +71,8 @@ pagination in the workouts list endpoint.
 Closes #123
 ```
 
+
+
 ## PR Title Convention
 
 **PR titles must follow the same [Conventional Commits](https://www.conventionalcommits.org/) format as commit messages.**
@@ -74,6 +83,8 @@ The CI workflow automatically validates PR titles to ensure they follow this con
 <type>(<optional scope>): <description>
 ```
 
+
+
 ### Examples
 
 - `feat: add user profile endpoint`
@@ -82,39 +93,49 @@ The CI workflow automatically validates PR titles to ensure they follow this con
 - `ci: add PR title validation to workflow`
 - `refactor(backend): simplify authentication logic`
 
+
+
 ## Creating a Pull Request
 
 1. **Create a branch** from `main`:
-   ```bash
+  ```bash
    git checkout -b 123-your-feature-description
-   ```
-
+  ```
 2. **Make your changes** and commit following the conventions above
-
 3. **Push your branch**:
-   ```bash
+  ```bash
    git push -u origin 123-your-feature-description
-   ```
-
+  ```
 4. **Open a PR** on GitHub and fill out the template
+
+
 
 ## PR Checklist
 
 The PR template includes these requirements:
 
 ### General
+
 - [ ] Code follows the project's code style
 - [ ] Self-review completed
 - [ ] Tests added (if applicable)
 - [ ] All tests pass locally
 
+
+
 ### Backend Changes
+
 - [ ] `uv run pre-commit run --all-files` passes (runs ruff, ty, and formatting checks)
 
+
+
 ### Frontend Changes
+
 - [ ] `pnpm run lint` passes
 - [ ] `pnpm run format:check` passes
 - [ ] `pnpm run build` succeeds
+
+
 
 ## Linking Issues
 
@@ -124,12 +145,16 @@ Link related issues in your PR description:
 - `Closes #456` - Same as Fixes
 - `Relates to #789` - References without closing
 
+
+
 ## Code Review Process
 
 1. **Request review**: PRs require at least one approval
 2. **Address feedback**: Respond to comments and make requested changes
 3. **CI must pass**: All automated checks must be green
 4. **Merge**: Once approved, the PR can be merged
+
+
 
 ## Tips for a Good PR
 
@@ -138,3 +163,4 @@ Link related issues in your PR description:
 - Include screenshots for UI changes
 - Update documentation if needed
 - Add tests for new functionality
+


### PR DESCRIPTION
## Description

<!-- Provide a brief summary of your changes. What problem does this solve? -->


Adds provider-side OAuth deregistration for Fitbit, Oura, Polar, Ultrahuman, and Whoop when a user disconnects or is deleted.

Previously only Garmin (and Strava) implemented `deregister_user`; other providers fell through to the base no-op. This wires real revoke/deregister API calls for the providers that support them, extends `deregister_user` with an optional `provider_user_id` (required by Polar’s `DELETE /v3/users/{user-id}`), and passes that id from the disconnect and user-delete call sites. Polar deregistration is covered with unit tests. Suunto remains on the base no-op pending a confirmed deauthorize API.

Closes #682

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [ ] `pnpm run lint` passes
- [ ] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds

## Testing Instructions

<!-- Describe how reviewers can test your changes -->

**Steps to test:**
1. From `backend/`, run: `uv run pytest tests/providers/polar/test_polar_oauth.py::TestPolarUserDeregistration -v`
2. (Optional) Connect a provider that implements deregistration (e.g. Fitbit/Whoop/Oura), then disconnect it from the user’s **Connected Providers** card (... -> Disconnect).
3. Confirm backend logs show a successful deregister, or a captured error if the provider call fails (local disconnect should still complete).

**Expected behavior:**
- Polar unit tests pass (success path, HTTP error propagation, missing `provider_user_id` raises `ValueError`).
- On disconnect/user delete, providers with `deregister_user` overrides call their revoke/deregister APIs with the access token (and Polar with `provider_user_id`).
- Deregistration failures are best-effort and do not block local disconnect/delete.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added OAuth token revocation and account deregistration methods for multiple fitness providers.
  - Deregistration now supports (and, for some providers, requires) the provider user identifier.
- **Bug Fixes**
  - Improved disconnect reliability by propagating HTTP failures from deregistration requests.
- **Tests**
  - Added Polar deregistration tests for success, HTTP error handling, and missing identifier validation.
- **Documentation**
  - Reformatted contribution guidance for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->