### PR TITLE
feat(ultrahuman): add night_rhr (resting heart rate) parsing and tests

### DIFF
--- a/backend/app/services/providers/ultrahuman/data_247.py
+++ b/backend/app/services/providers/ultrahuman/data_247.py
@@ -281,6 +281,69 @@ class Ultrahuman247Data(Base247DataTemplate):
         }
 
     # -------------------------------------------------------------------------
+    # Resting Heart Rate (night_rhr)
+    # -------------------------------------------------------------------------
+
+    def normalize_night_rhr(
+        self,
+        raw_rhr: dict[str, Any],
+        user_id: UUID,
+    ) -> list[dict[str, Any]]:
+        """Normalize Ultrahuman night_rhr object into individual bpm sample dicts.
+
+        Prefers the fine-grained ``values[]`` time-series entries.  Falls back to
+        a single daily record using ``avg`` + ``day_start_timestamp`` when no
+        individual samples are present (e.g. older firmware responses).
+
+        Args:
+            raw_rhr: The ``object`` dict from the ``night_rhr`` metric item.
+            user_id: Owner's UUID.
+
+        Returns:
+            List of sample dicts, each with keys:
+            ``id``, ``user_id``, ``provider``, ``recorded_at`` (ISO-8601 str),
+            ``value`` (int bpm), ``unit`` ("bpm").
+        """
+        samples: list[dict[str, Any]] = []
+
+        values = raw_rhr.get("values", [])
+        if values:
+            for entry in values:
+                ts = entry.get("timestamp")
+                value = entry.get("value")
+                if ts is None or value is None:
+                    continue
+                recorded_at = datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+                samples.append(
+                    {
+                        "id": uuid4(),
+                        "user_id": user_id,
+                        "provider": self.provider_name,
+                        "recorded_at": recorded_at,
+                        "value": int(value),
+                        "unit": "bpm",
+                    }
+                )
+        else:
+            # Fallback: use the daily average as a single data point
+            avg = raw_rhr.get("avg")
+            day_ts = raw_rhr.get("day_start_timestamp")
+            if avg is not None and day_ts is not None:
+                recorded_at = datetime.fromtimestamp(day_ts, tz=timezone.utc).isoformat()
+                samples.append(
+                    {
+                        "id": uuid4(),
+                        "user_id": user_id,
+                        "provider": self.provider_name,
+                        "recorded_at": recorded_at,
+                        "value": int(avg),
+                        "unit": "bpm",
+                    }
+                )
+
+        return samples
+
+    # -------------------------------------------------------------------------
     # Activity Samples (HR, HRV, Temperature, Steps)
     # -------------------------------------------------------------------------
 
@@ -547,6 +610,37 @@ class Ultrahuman247Data(Base247DataTemplate):
                                 ),
                             )
                             results["activity_samples"] += 1
+
+                    # Resting heart rate — nightly time-series samples (night_rhr)
+                    if "night_rhr" in items_by_type:
+                        rhr_samples = self.normalize_night_rhr(items_by_type["night_rhr"], user_id)
+                        for sample in rhr_samples:
+                            recorded_at_str = sample["recorded_at"]
+                            try:
+                                recorded_at = datetime.fromisoformat(
+                                    recorded_at_str.replace("Z", "+00:00")
+                                )
+                                self.data_point_repo.create(
+                                    db,
+                                    TimeSeriesSampleCreate(
+                                        id=uuid4(),
+                                        user_id=user_id,
+                                        provider=self.provider_name,
+                                        recorded_at=recorded_at,
+                                        value=Decimal(str(sample["value"])),
+                                        series_type=SeriesType.resting_heart_rate,
+                                        is_daily_total=daily_total_flag(
+                                            SeriesType.resting_heart_rate, is_daily=False
+                                        ),
+                                    ),
+                                )
+                                results["activity_samples"] += 1
+                            except Exception as e:
+                                self.logger.warning(
+                                    f"Failed to save night_rhr sample for user {user_id} "
+                                    f"at {recorded_at_str}: {e}"
+                                )
+
                 except Exception as e:
                     day_error = f"Activity samples processing failed: {e}"
 
@@ -652,7 +746,7 @@ class Ultrahuman247Data(Base247DataTemplate):
 
             for item in metrics_list:
                 item_type = item.get("type")
-                if item_type in ("hr", "hrv", "temp", "steps") and "object" in item:
+                if item_type in ("hr", "hrv", "temp", "steps", "night_rhr") and "object" in item:
                     item["object"]["ultrahuman_date"] = date_str
                     samples.append({"type": item_type, "object": item["object"]})
 

--- a/backend/tests/providers/ultrahuman/test_ultrahuman_night_rhr.py
+++ b/backend/tests/providers/ultrahuman/test_ultrahuman_night_rhr.py
@@ -1,0 +1,156 @@
+"""
+Integration tests for Ultrahuman night_rhr (resting heart rate) parsing.
+
+Covers the normalize_night_rhr helper introduced in data_247.py to resolve
+https://github.com/the-momentum/open-wearables/issues/664.
+"""
+
+from uuid import UUID
+
+import pytest
+
+from app.models import User
+from app.repositories.user_connection_repository import UserConnectionRepository
+from app.repositories.user_repository import UserRepository
+from app.services.providers.ultrahuman.data_247 import Ultrahuman247Data
+from app.services.providers.ultrahuman.oauth import UltrahumanOAuth
+from tests.factories import UserFactory
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_data_247() -> Ultrahuman247Data:
+    """Construct an Ultrahuman247Data instance for unit-level tests."""
+    user_repo = UserRepository(User)
+    connection_repo = UserConnectionRepository()
+    oauth = UltrahumanOAuth(
+        user_repo=user_repo,
+        connection_repo=connection_repo,
+        provider_name="ultrahuman",
+        api_base_url="https://partner.ultrahuman.com",
+    )
+    return Ultrahuman247Data(
+        provider_name="ultrahuman",
+        api_base_url="https://partner.ultrahuman.com",
+        oauth=oauth,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixture data — matches the payload documented in issue #664 and
+# pre-seeded in tests/providers/conftest.py:417
+# ---------------------------------------------------------------------------
+
+NIGHT_RHR_FIXTURE = {
+    "type": "night_rhr",
+    "object": {
+        "day_start_timestamp": 1705276800,  # 2024-01-15 00:00:00 UTC
+        "title": "Resting HR",
+        "values": [
+            {"value": 52, "timestamp": 1705290000},  # 2024-01-15 03:40:00 UTC
+            {"value": 50, "timestamp": 1705293600},  # 2024-01-15 04:40:00 UTC
+            {"value": 51, "timestamp": 1705297200},  # 2024-01-15 05:40:00 UTC
+        ],
+        "subtitle": "Sleep Time Average",
+        "avg": 51,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestNightRhrNormalization:
+    """Unit tests for Ultrahuman247Data.normalize_night_rhr."""
+
+    def test_values_array_produces_one_sample_per_entry(self, db) -> None:
+        """Each entry in values[] should produce exactly one bpm sample."""
+        data_247 = _make_data_247()
+        user = UserFactory()
+        raw_rhr = NIGHT_RHR_FIXTURE["object"]
+
+        samples = data_247.normalize_night_rhr(raw_rhr, user.id)
+
+        assert len(samples) == 3, "Expected one sample per values[] entry"
+
+        for sample in samples:
+            assert sample["unit"] == "bpm"
+            assert sample["provider"] == "ultrahuman"
+            assert sample["user_id"] == user.id
+            assert isinstance(sample["value"], int)
+            assert sample["recorded_at"] is not None
+            # UUID shape check
+            assert isinstance(sample["id"], UUID)
+
+        # Values should round-trip correctly
+        assert [s["value"] for s in samples] == [52, 50, 51]
+
+    def test_avg_fallback_used_when_no_values_array(self, db) -> None:
+        """When values[] is absent, avg + day_start_timestamp produces one sample."""
+        data_247 = _make_data_247()
+        user = UserFactory()
+        raw_rhr = {
+            "day_start_timestamp": 1705276800,
+            "title": "Resting HR",
+            "subtitle": "Sleep Time Average",
+            "avg": 54,
+            # no "values" key
+        }
+
+        samples = data_247.normalize_night_rhr(raw_rhr, user.id)
+
+        assert len(samples) == 1, "Expected exactly one fallback sample from avg"
+        assert samples[0]["value"] == 54
+        assert samples[0]["unit"] == "bpm"
+        assert samples[0]["provider"] == "ultrahuman"
+        # Timestamp must decode to the day_start
+        assert "2024-01-15" in samples[0]["recorded_at"]
+
+    def test_empty_payload_returns_no_samples(self, db) -> None:
+        """An empty dict (night_rhr absent from API) must not raise and returns []."""
+        data_247 = _make_data_247()
+        user = UserFactory()
+
+        samples = data_247.normalize_night_rhr({}, user.id)
+
+        assert samples == [], "Expected empty list for missing night_rhr data"
+
+    def test_partial_values_entry_without_timestamp_skipped(self, db) -> None:
+        """A values entry missing 'timestamp' is silently skipped."""
+        data_247 = _make_data_247()
+        user = UserFactory()
+        raw_rhr = {
+            "values": [
+                {"value": 55, "timestamp": 1705290000},
+                {"value": 53},  # missing timestamp — should be skipped
+            ],
+            "avg": 54,
+            "day_start_timestamp": 1705276800,
+        }
+
+        samples = data_247.normalize_night_rhr(raw_rhr, user.id)
+
+        # Only the valid entry should survive
+        assert len(samples) == 1
+        assert samples[0]["value"] == 55
+
+    def test_partial_values_entry_without_value_skipped(self, db) -> None:
+        """A values entry missing 'value' is silently skipped."""
+        data_247 = _make_data_247()
+        user = UserFactory()
+        raw_rhr = {
+            "values": [
+                {"timestamp": 1705290000},  # missing value — should be skipped
+                {"value": 48, "timestamp": 1705293600},
+            ],
+        }
+
+        samples = data_247.normalize_night_rhr(raw_rhr, user.id)
+
+        assert len(samples) == 1
+        assert samples[0]["value"] == 48


### PR DESCRIPTION
## Summary

Closes #664

Adds `night_rhr` (Resting HR — Sleep Time Average) processing to the Ultrahuman provider. The `night_rhr` metric was returned by the API but silently ignored: `data_247.py` had no handler for it, and the `sleep_stages` / `DataPointSeries` path for resting heart rate was never reached for this metric type.

## Changes

### `backend/app/services/providers/ultrahuman/data_247.py`

**New helper — `normalize_night_rhr(raw_rhr, user_id)`**
- Iterates `values[]` (timestamped bpm entries) and converts each to a typed sample dict.
- Falls back to a single daily record using `avg` + `day_start_timestamp` for older firmware responses that omit `values[]`.
- Skips entries with missing `timestamp` or `value` without raising.

**`load_and_save_all`** — new `night_rhr` block (mirrors `vo2_max` / `active_minutes` pattern):
```python
if "night_rhr" in items_by_type:
    rhr_samples = self.normalize_night_rhr(items_by_type["night_rhr"], user_id)
    for sample in rhr_samples:
        # persist as SeriesType.resting_heart_rate via DataPointSeriesRepository
        ...
        results["activity_samples"] += 1
```

**`get_activity_samples`** — adds `"night_rhr"` to the type filter so the raw metric is also surfaced through the abstract interface.

### `backend/tests/providers/ultrahuman/test_ultrahuman_night_rhr.py` *(new file)*

5 focused tests:

| Test | What it checks |
|---|---|
| `test_values_array_produces_one_sample_per_entry` | 3 fixture entries → 3 bpm samples, correct values, unit, provider |
| `test_avg_fallback_used_when_no_values_array` | `avg=54` + `day_start_timestamp` → 1 sample, correct date |
| `test_empty_payload_returns_no_samples` | `{}` → `[]`, no exception |
| `test_partial_values_entry_without_timestamp_skipped` | Entry missing `timestamp` is silently dropped |
| `test_partial_values_entry_without_value_skipped` | Entry missing `value` is silently dropped |

Fixture data matches the payload documented in the issue and pre-seeded in `tests/providers/conftest.py:417`.

## Design decisions

- **`values[]` preferred over `avg`** — finer-grained time series is more useful for trend analysis; `avg` used only as a fallback for backwards compatibility with older API responses.
- **`SeriesType.resting_heart_rate`** — as specified in the issue (id=2, unit=bpm).
- **No schema migrations** — `DataPointSeries` already supports `resting_heart_rate` via the existing series type enum.
- **No new dependencies.**

## Testing

```bash
cd backend
python -m pytest tests/providers/ultrahuman/test_ultrahuman_night_rhr.py -v
python -m pytest tests/providers/ultrahuman/ -v
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for syncing Ultrahuman nightly resting heart-rate data.
  * Fine-grained heart-rate samples are now recorded when available, with daily averages used as a fallback.
  * Resting heart-rate data is available alongside other health metrics.

* **Bug Fixes**
  * Improved handling of incomplete or empty heart-rate readings so invalid samples are skipped safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->