### PR TITLE
chore(backend): Use Oura 30-sec sleep stage granularity over 5-min

### DIFF
--- a/backend/app/schemas/providers/oura/imports.py
+++ b/backend/app/schemas/providers/oura/imports.py
@@ -65,6 +65,7 @@ class OuraSleepJSON(BaseModel):
     rem_sleep_duration: int | None = None  # seconds
     restless_periods: int | None = None
     sleep_phase_5_min: str | None = None  # 1 - deep, 2 - light, 3 - rem, 4 - awake
+    sleep_phase_30_sec: str | None = None  # same encoding, 30-second epochs
     sleep_score_delta: float | None = None
     time_in_bed: int | None = None  # seconds
     total_sleep_duration: int | None = None  # seconds

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -562,23 +562,22 @@ class Oura247Data(Base247DataTemplate):
         }
         return self._paginate(db, user_id, "/v2/usercollection/sleep", params)
 
-    def _extract_sleep_stages(self, sleep_phase_5_min: str | None, sleep_start: str | None) -> list[SleepStage]:
-        """Convert Oura's 5-minute sleep phase string into list of SleepStage."""
-        if not (sleep_phase_5_min and sleep_start):
+    def _extract_sleep_stages(
+        self, hypnogram: str | None, epoch_seconds: int, sleep_start: str | None
+    ) -> list[SleepStage]:
+        """Convert an Oura hypnogram string (one digit per epoch) into a list of SleepStage."""
+        if not (hypnogram and sleep_start):
             return []
 
         stages: list[SleepStage] = []
 
         phase_start = datetime.fromisoformat(sleep_start.replace("Z", "+00:00"))
 
-        for stage, group in groupby(sleep_phase_5_min, lambda x: SLEEP_PHASE_MAP.get(x, SleepStageType.UNKNOWN)):
+        for stage, group in groupby(hypnogram, lambda x: SLEEP_PHASE_MAP.get(x, SleepStageType.UNKNOWN)):
             occurrences = len(list(group))
-            stages.append(
-                SleepStage(
-                    stage=stage, start_time=phase_start, end_time=phase_start + timedelta(minutes=5 * occurrences)
-                )
-            )
-            phase_start += timedelta(minutes=5 * occurrences)
+            phase_end = phase_start + timedelta(seconds=epoch_seconds * occurrences)
+            stages.append(SleepStage(stage=stage, start_time=phase_start, end_time=phase_end))
+            phase_start = phase_end
 
         return stages
 
@@ -615,7 +614,11 @@ class Oura247Data(Base247DataTemplate):
                 except (ValueError, AttributeError):
                     pass
 
-            sleep_stages = self._extract_sleep_stages(sleep.sleep_phase_5_min, start_time)
+            # Prefer the 30-second hypnogram; fall back to the coarser 5-minute one.
+            if sleep.sleep_phase_30_sec:
+                sleep_stages = self._extract_sleep_stages(sleep.sleep_phase_30_sec, 30, start_time)
+            else:
+                sleep_stages = self._extract_sleep_stages(sleep.sleep_phase_5_min, 300, start_time)
 
             internal_id = uuid4()
 

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -45,7 +45,7 @@ from app.services.providers.templates.base_247_data import Base247DataTemplate
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
 from app.services.raw_payload_storage import store_raw_payload
 from app.services.timeseries_service import timeseries_service
-from app.utils.dates import offset_to_iso, to_rfc3339, parse_iso_datetime
+from app.utils.dates import offset_to_iso, parse_iso_datetime, to_rfc3339
 from app.utils.structured_logging import LogContext, log_structured
 
 

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -45,7 +45,7 @@ from app.services.providers.templates.base_247_data import Base247DataTemplate
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
 from app.services.raw_payload_storage import store_raw_payload
 from app.services.timeseries_service import timeseries_service
-from app.utils.dates import offset_to_iso, to_rfc3339
+from app.utils.dates import offset_to_iso, to_rfc3339, parse_iso_datetime
 from app.utils.structured_logging import LogContext, log_structured
 
 
@@ -566,12 +566,12 @@ class Oura247Data(Base247DataTemplate):
         self, hypnogram: str | None, epoch_seconds: int, sleep_start: str | None
     ) -> list[SleepStage]:
         """Convert an Oura hypnogram string (one digit per epoch) into a list of SleepStage."""
-        if not (hypnogram and sleep_start):
+        parsed_start = parse_iso_datetime(sleep_start)
+        if not hypnogram or parsed_start is None:
             return []
 
+        phase_start = parsed_start.astimezone(timezone.utc)
         stages: list[SleepStage] = []
-
-        phase_start = datetime.fromisoformat(sleep_start.replace("Z", "+00:00"))
 
         for stage, group in groupby(hypnogram, lambda x: SLEEP_PHASE_MAP.get(x, SleepStageType.UNKNOWN)):
             occurrences = len(list(group))

--- a/backend/tests/providers/oura/test_oura_247.py
+++ b/backend/tests/providers/oura/test_oura_247.py
@@ -1,9 +1,11 @@
 """Tests for Oura247Data normalization."""
 
+from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
 
+from app.constants.sleep import SleepStageType
 from app.services.providers.oura.data_247 import Oura247Data
 from app.services.providers.oura.strategy import OuraStrategy
 
@@ -60,6 +62,50 @@ class TestOura247SleepNormalization:
         assert stages["light_seconds"] == 14400
         assert stages["rem_seconds"] == 7200
         assert stages["awake_seconds"] == 1800
+
+    def test_stage_timestamps_use_30_sec_hypnogram(self, data_247: Oura247Data) -> None:
+        raw = {
+            "id": "sleep-30s",
+            "bedtime_start": "2024-01-15T23:00:00+00:00",
+            "bedtime_end": "2024-01-16T07:00:00+00:00",
+            "type": "long_sleep",
+            "sleep_phase_30_sec": "1" * 4 + "3" * 2,  # 120s deep, 60s rem
+        }
+        stages = data_247.normalize_sleeps([raw], uuid4())[0]["stage_timestamps"]
+
+        assert [s.stage for s in stages] == [SleepStageType.DEEP, SleepStageType.REM]
+        assert stages[0].start_time == datetime(2024, 1, 15, 23, 0, tzinfo=timezone.utc)
+        assert stages[0].end_time == datetime(2024, 1, 15, 23, 2, tzinfo=timezone.utc)
+        assert stages[1].end_time == datetime(2024, 1, 15, 23, 3, tzinfo=timezone.utc)
+
+    def test_stage_timestamps_prefer_30_sec_over_5_min(self, data_247: Oura247Data) -> None:
+        raw = {
+            "id": "sleep-both",
+            "bedtime_start": "2024-01-15T23:00:00+00:00",
+            "bedtime_end": "2024-01-16T07:00:00+00:00",
+            "type": "long_sleep",
+            "sleep_phase_30_sec": "111",  # 90s deep — not expressible at 5-min resolution
+            "sleep_phase_5_min": "2",
+        }
+        stages = data_247.normalize_sleeps([raw], uuid4())[0]["stage_timestamps"]
+
+        assert len(stages) == 1
+        assert stages[0].stage == SleepStageType.DEEP
+        assert stages[0].end_time == datetime(2024, 1, 15, 23, 1, 30, tzinfo=timezone.utc)
+
+    def test_stage_timestamps_fall_back_to_5_min(self, data_247: Oura247Data) -> None:
+        raw = {
+            "id": "sleep-5m",
+            "bedtime_start": "2024-01-15T23:00:00+00:00",
+            "bedtime_end": "2024-01-16T07:00:00+00:00",
+            "type": "long_sleep",
+            "sleep_phase_5_min": "14",  # 5min deep, 5min awake
+        }
+        stages = data_247.normalize_sleeps([raw], uuid4())[0]["stage_timestamps"]
+
+        assert [s.stage for s in stages] == [SleepStageType.DEEP, SleepStageType.AWAKE]
+        assert stages[0].end_time == datetime(2024, 1, 15, 23, 5, tzinfo=timezone.utc)
+        assert stages[1].end_time == datetime(2024, 1, 15, 23, 10, tzinfo=timezone.utc)
 
     def test_normalize_sleep_timestamps(self, data_247: Oura247Data, sample_oura_sleep: dict) -> None:
         user_id = uuid4()


### PR DESCRIPTION
## Description

We noticed differences between sleep logged to Apple Health from Oura and extracted via Healthkit, and the response we parsed from Oura API - Oura also sends 30-sec sleep stage hypnogram alongside the 5-minute one that we use, and the 30-sec one coincides with what Apple Health shows (verified with real payloads and data), and is the more accurate measurement - so we prefer it over the 5-min one, if it is available.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [ ] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Sleep-stage data from Oura now supports the more precise 30-second hypnogram when available.
  * Sleep-stage timestamp generation was updated to produce more accurate phase start/end times based on the hypnogram granularity.
  * When 30-second hypnogram data is unavailable, the system continues to fall back to 5-minute sleep data.
* **Tests**
  * Added coverage to verify correct stage timestamps for 30-second, preferred 30-second over 5-minute, and 5-minute fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->