### PR TITLE
fix(backend): resolve $defs refs in SDK sync OpenAPI schema

### DIFF
--- a/backend/app/api/routes/v1/sdk_sync.py
+++ b/backend/app/api/routes/v1/sdk_sync.py
@@ -1,7 +1,6 @@
 import json
 import uuid
 from logging import getLogger
-from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
 
@@ -9,39 +8,12 @@ from app.integrations.celery.tasks.process_sdk_upload_task import process_sdk_up
 from app.schemas.providers.mobile_sdk import SyncRequest
 from app.schemas.responses.upload import UploadDataResponse
 from app.services.raw_payload_storage import store_raw_payload
+from app.utils.api_utils import inline_schema_defs
 from app.utils.auth import SDKAuthDep
 from app.utils.structured_logging import log_structured
 
 router = APIRouter()
 logger = getLogger(__name__)
-
-
-def _inline_defs(schema: dict[str, Any]) -> dict[str, Any]:
-    """Inline local ``#/$defs/`` references produced by ``model_json_schema()``.
-
-    ``openapi_extra`` is embedded verbatim into the OpenAPI document, where local
-    ``$defs`` refs don't resolve (validators look them up at the document root).
-    """
-    defs: dict[str, Any] = schema.get("$defs", {})
-
-    def resolve(node: Any, seen: tuple[str, ...]) -> Any:
-        if isinstance(node, dict):
-            ref = node.get("$ref")
-            if isinstance(ref, str) and ref.startswith("#/$defs/"):
-                name = ref.removeprefix("#/$defs/")
-                if name in seen:
-                    raise ValueError(f"Circular $defs reference: {name}")
-                if name not in defs:
-                    raise ValueError(f"Unknown $defs reference: {name}")
-                target = resolve(defs[name], (*seen, name))
-                siblings = {key: resolve(value, seen) for key, value in node.items() if key != "$ref"}
-                return {**target, **siblings}
-            return {key: resolve(value, seen) for key, value in node.items() if key != "$defs"}
-        if isinstance(node, list):
-            return [resolve(item, seen) for item in node]
-        return node
-
-    return resolve(schema, ())
 
 
 @router.post(
@@ -51,7 +23,7 @@ def _inline_defs(schema: dict[str, Any]) -> dict[str, Any]:
     openapi_extra={
         "requestBody": {
             "required": True,
-            "content": {"application/json": {"schema": _inline_defs(SyncRequest.model_json_schema())}},
+            "content": {"application/json": {"schema": inline_schema_defs(SyncRequest.model_json_schema())}},
         }
     },
 )

--- a/backend/app/api/routes/v1/sdk_sync.py
+++ b/backend/app/api/routes/v1/sdk_sync.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 from logging import getLogger
+from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
 
@@ -15,6 +16,34 @@ router = APIRouter()
 logger = getLogger(__name__)
 
 
+def _inline_defs(schema: dict[str, Any]) -> dict[str, Any]:
+    """Inline local ``#/$defs/`` references produced by ``model_json_schema()``.
+
+    ``openapi_extra`` is embedded verbatim into the OpenAPI document, where local
+    ``$defs`` refs don't resolve (validators look them up at the document root).
+    """
+    defs: dict[str, Any] = schema.get("$defs", {})
+
+    def resolve(node: Any, seen: tuple[str, ...]) -> Any:
+        if isinstance(node, dict):
+            ref = node.get("$ref")
+            if isinstance(ref, str) and ref.startswith("#/$defs/"):
+                name = ref.removeprefix("#/$defs/")
+                if name in seen:
+                    raise ValueError(f"Circular $defs reference: {name}")
+                if name not in defs:
+                    raise ValueError(f"Unknown $defs reference: {name}")
+                target = resolve(defs[name], (*seen, name))
+                siblings = {key: resolve(value, seen) for key, value in node.items() if key != "$ref"}
+                return {**target, **siblings}
+            return {key: resolve(value, seen) for key, value in node.items() if key != "$defs"}
+        if isinstance(node, list):
+            return [resolve(item, seen) for item in node]
+        return node
+
+    return resolve(schema, ())
+
+
 @router.post(
     "/sdk/users/{user_id}/sync",
     status_code=status.HTTP_202_ACCEPTED,
@@ -22,7 +51,7 @@ logger = getLogger(__name__)
     openapi_extra={
         "requestBody": {
             "required": True,
-            "content": {"application/json": {"schema": SyncRequest.model_json_schema()}},
+            "content": {"application/json": {"schema": _inline_defs(SyncRequest.model_json_schema())}},
         }
     },
 )

--- a/backend/app/utils/api_utils.py
+++ b/backend/app/utils/api_utils.py
@@ -1,10 +1,40 @@
 from collections.abc import Callable
 from functools import wraps
+from typing import Any
 
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 
 from app.utils.hateoas import get_hateoas_item, get_hateoas_list
+
+
+def inline_schema_defs(schema: dict[str, Any]) -> dict[str, Any]:
+    """Inline local ``#/$defs/`` references produced by ``model_json_schema()``.
+
+    ``openapi_extra`` is embedded verbatim into the OpenAPI document, where local
+    ``$defs`` refs don't resolve (validators look them up at the document root).
+    Pydantic has no built-in inlining (pydantic/pydantic#12023).
+    """
+    defs: dict[str, Any] = schema.get("$defs", {})
+
+    def resolve(node: Any, seen: tuple[str, ...]) -> Any:
+        if isinstance(node, dict):
+            ref = node.get("$ref")
+            if isinstance(ref, str) and ref.startswith("#/$defs/"):
+                name = ref.removeprefix("#/$defs/")
+                if name in seen:
+                    raise ValueError(f"Circular $defs reference: {name}")
+                if name not in defs:
+                    raise ValueError(f"Unknown $defs reference: {name}")
+                target = resolve(defs[name], (*seen, name))
+                siblings = {key: resolve(value, seen) for key, value in node.items() if key != "$ref"}
+                return {**target, **siblings}
+            return {key: resolve(value, seen) for key, value in node.items() if key != "$defs"}
+        if isinstance(node, list):
+            return [resolve(item, seen) for item in node]
+        return node
+
+    return resolve(schema, ())
 
 
 def format_response(extra_rels: list[dict] = [], status_code: int = 200) -> Callable:


### PR DESCRIPTION
## Description

`mint dev` started failing docs validation with a wall of `Can't resolve reference: #/$defs/...` errors, and Swagger UI silently stopped rendering the request body for `POST /api/v1/sdk/users/{user_id}/sync`.

Root cause: #1323 changed the endpoint body to a raw `dict` (validation moved to the celery worker) and kept the docs schema by injecting `SyncRequest.model_json_schema()` verbatim via `openapi_extra`. Pydantic emits local `#/$defs/...` refs there, but `openapi_extra` is embedded into the OpenAPI document as-is - validators resolve refs against the document root, where no `$defs` exists. Mintlify errors out, Swagger UI drops the section.

Fix: a small `_inline_defs()` helper that expands the `$defs` refs in place before embedding. Hand-rolled because Pydantic has no built-in ref inlining and FastAPI doesn't post-process `openapi_extra`; considered `jsonref` (new dependency) and registering the defs into `components.schemas` via an `api.openapi()` override (global machinery for one endpoint) - kept it local and dependency-free instead.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes (`ty check` fails on 9 pre-existing diagnostics in unrelated files; 0 in this change - all other hooks pass)

## Testing Instructions

**Steps to test:**
1. Dump the spec: `docker compose run --rm --no-deps --entrypoint "" app uv run python -c "import json; from app.main import api; print(json.dumps(api.openapi()))" > openapi.json`
2. `grep -c '#/$defs/' openapi.json`
3. `mint validate openapi.json` (or open `/docs` and expand the SDK sync endpoint)

**Expected behavior:**
- 0 occurrences of `#/$defs/`
- Mintlify: "OpenAPI definition is valid"
- Swagger UI renders the full request body schema again (provider/sdkVersion/syncTimestamp/data with records/sleep/workouts)

## Additional Notes

Related discussions - built-in `$defs` inlining has been requested in Pydantic for years but still isn't implemented:

- [pydantic#889](https://github.com/samuelcolvin/pydantic/issues/889) - "Is it possible to have a schema with no $ref references?" (2019, v1 era)
- [pydantic discussion #2417](https://github.com/pydantic/pydantic/discussions/2417) - follow-up asking for built-in flattening (2021, still unanswered)
- [pydantic#12023](https://github.com/pydantic/pydantic/issues/12023) - open feature request proposing `ref_mode` (`never`/`always`/`if-necessary`); no PR yet - if `ref_mode="never"` ever lands, `_inline_defs()` can be replaced with a single argument to `model_json_schema()`
- [pydantic#12232](https://github.com/pydantic/pydantic/issues/12232) - same problem hit by OpenAI structured outputs users (no `$ref` support), closed as duplicate of #12023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the SDK synchronization API documentation by ensuring the request JSON schema is fully self-contained and resolves correctly.
  * Enhanced compatibility with tools that consume the generated OpenAPI specification by inlining previously local schema definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
