### PR TITLE
fix: support Sensor Bio OAuth callback and HTTP/2

### DIFF
--- a/backend/app/api/routes/v1/oauth.py
+++ b/backend/app/api/routes/v1/oauth.py
@@ -129,7 +129,7 @@ def oauth_callback(
     )
 
 
-@router.get("/callback/{provider}", tags=["System: OAuth"])
+@router.get("/callback/{provider}", tags=["System: OAuth"], status_code=status.HTTP_303_SEE_OTHER)
 def oauth_callback_compat(
     provider: ProviderName,
     db: DbSession,
@@ -137,7 +137,7 @@ def oauth_callback_compat(
     state: Annotated[str | None, Query(description="State parameter for CSRF protection")] = None,
     error: Annotated[str | None, Query()] = None,
     error_description: Annotated[str | None, Query()] = None,
-):
+) -> RedirectResponse:
     """Handle the callback path used by already-registered provider redirect URIs."""
     return oauth_callback(
         provider=provider,

--- a/backend/app/api/routes/v1/oauth.py
+++ b/backend/app/api/routes/v1/oauth.py
@@ -129,6 +129,26 @@ def oauth_callback(
     )
 
 
+@router.get("/callback/{provider}", tags=["System: OAuth"])
+def oauth_callback_compat(
+    provider: ProviderName,
+    db: DbSession,
+    code: Annotated[str | None, Query(description="Authorization code from provider")] = None,
+    state: Annotated[str | None, Query(description="State parameter for CSRF protection")] = None,
+    error: Annotated[str | None, Query()] = None,
+    error_description: Annotated[str | None, Query()] = None,
+):
+    """Handle the callback path used by already-registered provider redirect URIs."""
+    return oauth_callback(
+        provider=provider,
+        db=db,
+        code=code,
+        state=state,
+        error=error,
+        error_description=error_description,
+    )
+
+
 @router.get("/success", tags=["System: OAuth"])
 def oauth_success(
     provider: Annotated[str, Query()],

--- a/backend/app/services/providers/sensorbio/oauth.py
+++ b/backend/app/services/providers/sensorbio/oauth.py
@@ -7,6 +7,7 @@ from app.config import settings
 from app.schemas.auth import AuthenticationMethod
 from app.schemas.model_crud.credentials import OAuthTokenResponse, ProviderCredentials, ProviderEndpoints
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
+from app.utils.exceptions import handle_exceptions
 from app.utils.structured_logging import log_structured
 
 logger = logging.getLogger(__name__)
@@ -37,6 +38,7 @@ class SensorBioOAuth(BaseOAuthTemplate):
             default_scope=settings.sensorbio_default_scope,
         )
 
+    @handle_exceptions
     def _get_provider_user_info(self, token_response: OAuthTokenResponse, user_id: str) -> dict[str, Any]:
         """Fetches Sensor Bio user profile via /v1/user."""
         try:

--- a/backend/app/services/providers/sensorbio/oauth.py
+++ b/backend/app/services/providers/sensorbio/oauth.py
@@ -17,6 +17,7 @@ class SensorBioOAuth(BaseOAuthTemplate):
 
     use_pkce = False
     auth_method = AuthenticationMethod.BODY
+    use_http2 = True
 
     @property
     def endpoints(self) -> ProviderEndpoints:
@@ -39,11 +40,11 @@ class SensorBioOAuth(BaseOAuthTemplate):
     def _get_provider_user_info(self, token_response: OAuthTokenResponse, user_id: str) -> dict[str, Any]:
         """Fetches Sensor Bio user profile via /v1/user."""
         try:
-            response = httpx.get(
-                f"{self.api_base_url}/v1/user",
-                headers={"Authorization": f"Bearer {token_response.access_token}"},
-                timeout=30.0,
-            )
+            with self._http_client() as client:
+                response = client.get(
+                    f"{self.api_base_url}/v1/user",
+                    headers={"Authorization": f"Bearer {token_response.access_token}"},
+                )
             response.raise_for_status()
             payload = response.json()
             data = payload.get("data", payload) if isinstance(payload, dict) else {}

--- a/backend/app/services/providers/templates/base_oauth.py
+++ b/backend/app/services/providers/templates/base_oauth.py
@@ -66,6 +66,11 @@ class BaseOAuthTemplate(ABC):
 
     use_pkce: bool = False
     auth_method: AuthenticationMethod = AuthenticationMethod.BASIC_AUTH
+    use_http2: bool = False
+
+    def _http_client(self) -> httpx.Client:
+        """Build an HTTP client configured for this provider's OAuth endpoints."""
+        return httpx.Client(http2=self.use_http2, timeout=30.0)
 
     def get_authorization_url(self, user_id: UUID, redirect_uri: str | None = None) -> tuple[str, str]:
         """Generates the provider's authorization URL.
@@ -138,12 +143,12 @@ class BaseOAuthTemplate(ABC):
         data, headers = self._prepare_refresh_request(refresh_token)
 
         try:
-            response = httpx.post(
-                self.endpoints.token_url,
-                data=data,
-                headers=headers,
-                timeout=30.0,
-            )
+            with self._http_client() as client:
+                response = client.post(
+                    self.endpoints.token_url,
+                    data=data,
+                    headers=headers,
+                )
             response.raise_for_status()
             token_response = OAuthTokenResponse.model_validate(response.json())
 
@@ -276,12 +281,12 @@ class BaseOAuthTemplate(ABC):
         data, headers = self._prepare_token_request(code, code_verifier)
 
         try:
-            response = httpx.post(
-                self.endpoints.token_url,
-                data=data,
-                headers=headers,
-                timeout=30.0,
-            )
+            with self._http_client() as client:
+                response = client.post(
+                    self.endpoints.token_url,
+                    data=data,
+                    headers=headers,
+                )
             response.raise_for_status()
             return OAuthTokenResponse.model_validate(response.json())
         except httpx.HTTPStatusError as e:

--- a/backend/app/services/providers/templates/base_oauth.py
+++ b/backend/app/services/providers/templates/base_oauth.py
@@ -26,6 +26,7 @@ from app.schemas.model_crud.credentials import (
 )
 from app.schemas.model_crud.user_management import UserConnectionCreate
 from app.services.outgoing_webhooks.events import on_connection_created, on_connection_revoked
+from app.utils.exceptions import handle_exceptions
 from app.utils.structured_logging import log_structured
 
 logger = logging.getLogger(__name__)
@@ -138,6 +139,7 @@ class BaseOAuthTemplate(ABC):
 
         return oauth_state
 
+    @handle_exceptions
     def refresh_access_token(self, db: DbSession, user_id: UUID, refresh_token: str) -> OAuthTokenResponse:
         """Refreshes the access token using the refresh token."""
         data, headers = self._prepare_refresh_request(refresh_token)
@@ -276,6 +278,7 @@ class BaseOAuthTemplate(ABC):
         # code_verifier will be None for non-PKCE providers
         return oauth_state, code_verifier
 
+    @handle_exceptions
     def _exchange_token(self, code: str, code_verifier: str | None) -> OAuthTokenResponse:
         """Exchanges authorization code for tokens."""
         data, headers = self._prepare_token_request(code, code_verifier)

--- a/backend/tests/api/v1/test_oauth.py
+++ b/backend/tests/api/v1/test_oauth.py
@@ -7,12 +7,13 @@ Tests the /api/v1/oauth endpoints including:
 - PUT /api/v1/oauth/providers/{provider} - test update provider status
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.schemas.model_crud.credentials import OAuthState
 from tests.factories import DeveloperFactory
 from tests.utils import developer_auth_headers
 
@@ -126,6 +127,37 @@ class TestOAuthAuthorizeEndpoint:
 
         # Assert - Should fail because apple doesn't have OAuth
         assert response.status_code in [400, 401, 422]
+
+
+class TestOAuthCallbackEndpoint:
+    """Test suite for OAuth callback endpoints."""
+
+    @patch("app.api.routes.v1.oauth.user_connection_service.stamp_last_synced_at")
+    @patch("app.api.routes.v1.oauth.get_oauth_strategy")
+    def test_compat_callback_routes_to_oauth_handler(
+        self,
+        mock_get_oauth_strategy: MagicMock,
+        mock_stamp_last_synced_at: MagicMock,
+        client: TestClient,
+        db: Session,
+    ) -> None:
+        """The registered redirect URI path should dispatch to the OAuth callback handler."""
+        user_id = uuid4()
+        strategy = MagicMock()
+        strategy.oauth.handle_callback.return_value = OAuthState(user_id=user_id, provider="sensorbio")
+        strategy.capabilities.webhook_callback = False
+        strategy.capabilities.rest_pull = False
+        mock_get_oauth_strategy.return_value = strategy
+
+        response = client.get(
+            "/api/v1/oauth/callback/sensorbio",
+            params={"code": "synthetic-code", "state": "synthetic-state"},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 303
+        strategy.oauth.handle_callback.assert_called_once_with(db, "synthetic-code", "synthetic-state")
+        mock_stamp_last_synced_at.assert_called_once_with(db, user_id, "sensorbio")
 
 
 class TestOAuthProvidersEndpoint:

--- a/backend/tests/api/v1/test_oauth.py
+++ b/backend/tests/api/v1/test_oauth.py
@@ -156,6 +156,11 @@ class TestOAuthCallbackEndpoint:
         )
 
         assert response.status_code == 303
+        # The compat route must redirect to the same success page as the canonical
+        # oauth_callback success path (redirect_uri is None here, so the internal
+        # /api/v1/oauth/success page is used). Asserting Location guards against a
+        # wrong or missing redirect destination that a status-only check would miss.
+        assert response.headers["location"] == f"/api/v1/oauth/success?provider=sensorbio&user_id={user_id}"
         strategy.oauth.handle_callback.assert_called_once_with(db, "synthetic-code", "synthetic-state")
         mock_stamp_last_synced_at.assert_called_once_with(db, user_id, "sensorbio")
 

--- a/backend/tests/integrations/test_polar_import.py
+++ b/backend/tests/integrations/test_polar_import.py
@@ -75,7 +75,7 @@ class TestPolarOAuthFlow:
 
     @patch("app.integrations.celery.tasks.sync_vendor_data.delay")
     @patch("app.services.providers.templates.base_oauth.get_redis_client")
-    @patch("httpx.post")
+    @patch("app.services.providers.templates.base_oauth.httpx.Client")
     def test_polar_oauth_callback_success(
         self,
         mock_post: MagicMock,
@@ -113,7 +113,7 @@ class TestPolarOAuthFlow:
             "token_type": "Bearer",
             "x_user_id": 12345,
         }
-        mock_post.return_value = mock_token_response
+        mock_post.return_value.__enter__.return_value.post.return_value = mock_token_response
 
         # Mock Celery task
         mock_celery_task.return_value = MagicMock()

--- a/backend/tests/integrations/test_suunto_import.py
+++ b/backend/tests/integrations/test_suunto_import.py
@@ -88,7 +88,7 @@ class TestSuuntoImport:
             ],
         }
 
-    @patch("httpx.post")
+    @patch("app.services.providers.templates.base_oauth.httpx.Client")
     def test_oauth_token_exchange_with_jwt(
         self,
         mock_post: MagicMock,
@@ -116,7 +116,7 @@ class TestSuuntoImport:
         }
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
+        mock_post.return_value.__enter__.return_value.post.return_value = mock_response
 
         # Mock Redis state
         assert suunto_strategy.oauth is not None
@@ -251,7 +251,7 @@ class TestSuuntoImport:
         assert "samples" in result
         mock_request.assert_called_once()
 
-    @patch("httpx.post")
+    @patch("app.services.providers.templates.base_oauth.httpx.Client")
     def test_token_refresh_flow(
         self,
         mock_post: MagicMock,
@@ -277,7 +277,7 @@ class TestSuuntoImport:
         }
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
+        mock_post.return_value.__enter__.return_value.post.return_value = mock_response
         assert suunto_strategy.oauth is not None
 
         # Act

--- a/backend/tests/providers/garmin/test_garmin_oauth.py
+++ b/backend/tests/providers/garmin/test_garmin_oauth.py
@@ -231,7 +231,7 @@ class TestGarminOAuth:
         assert user_info["user_id"] == "garmin_user_abc"
         assert user_info["scope"] is None
 
-    @patch("httpx.post")
+    @patch("app.services.providers.templates.base_oauth.httpx.Client")
     @patch("app.integrations.redis_client.get_redis_client")
     def test_exchange_token_with_pkce(
         self,
@@ -249,7 +249,7 @@ class TestGarminOAuth:
             "token_type": "Bearer",
         }
         mock_response.raise_for_status.return_value = None
-        mock_httpx_post.return_value = mock_response
+        mock_httpx_post.return_value.__enter__.return_value.post.return_value = mock_response
 
         code = "auth_code_123"
         code_verifier = "test_verifier_abc123"
@@ -262,10 +262,10 @@ class TestGarminOAuth:
         assert token_response.refresh_token == "new_refresh_token"
 
         # Verify PKCE verifier was included in request
-        call_args = mock_httpx_post.call_args
+        call_args = mock_httpx_post.return_value.__enter__.return_value.post.call_args
         assert call_args[1]["data"]["code_verifier"] == code_verifier
 
-    @patch("httpx.post")
+    @patch("app.services.providers.templates.base_oauth.httpx.Client")
     def test_refresh_access_token(
         self,
         mock_httpx_post: MagicMock,
@@ -290,7 +290,7 @@ class TestGarminOAuth:
             "token_type": "Bearer",
         }
         mock_response.raise_for_status.return_value = None
-        mock_httpx_post.return_value = mock_response
+        mock_httpx_post.return_value.__enter__.return_value.post.return_value = mock_response
 
         # Act
         token_response = garmin_oauth.refresh_access_token(db, user.id, "old_refresh_token")

--- a/backend/tests/providers/sensorbio/test_sensorbio_oauth.py
+++ b/backend/tests/providers/sensorbio/test_sensorbio_oauth.py
@@ -4,7 +4,7 @@ import pytest
 
 from app.schemas.enums import ProviderName
 from app.services.providers.sensorbio.oauth import SensorBioOAuth
-from app.services.providers.templates.base_oauth import AuthenticationMethod
+from app.services.providers.templates.base_oauth import AuthenticationMethod, BaseOAuthTemplate
 
 
 @pytest.fixture
@@ -29,3 +29,21 @@ def test_uses_body_auth(sensorbio_oauth: SensorBioOAuth) -> None:
 
 def test_uses_no_pkce(sensorbio_oauth: SensorBioOAuth) -> None:
     assert sensorbio_oauth.use_pkce is False
+
+
+def test_sensorbio_enables_http2_for_oauth_client(
+    sensorbio_oauth: SensorBioOAuth,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    constructed_clients: list[dict[str, object]] = []
+
+    def capture_client(**kwargs: object) -> MagicMock:
+        constructed_clients.append(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr("app.services.providers.templates.base_oauth.httpx.Client", capture_client)
+
+    assert BaseOAuthTemplate.use_http2 is False
+    sensorbio_oauth._http_client()
+
+    assert constructed_clients == [{"http2": True, "timeout": 30.0}]

--- a/backend/tests/providers/suunto/test_suunto_oauth.py
+++ b/backend/tests/providers/suunto/test_suunto_oauth.py
@@ -142,7 +142,7 @@ class TestSuuntoOAuth:
         assert user_info["user_id"] is None
         assert user_info["username"] is None
 
-    @patch("httpx.post")
+    @patch("app.services.providers.templates.base_oauth.httpx.Client")
     def test_exchange_token_success(self, mock_post: MagicMock, suunto_oauth: SuuntoOAuth, db: Session) -> None:
         """Should exchange authorization code for tokens."""
         # Arrange
@@ -155,7 +155,7 @@ class TestSuuntoOAuth:
         }
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
+        mock_post.return_value.__enter__.return_value.post.return_value = mock_response
 
         # Act
         token_response = suunto_oauth._exchange_token("test_code", None)
@@ -164,9 +164,9 @@ class TestSuuntoOAuth:
         assert token_response.access_token == "test_access_token"
         assert token_response.refresh_token == "test_refresh_token"
         assert token_response.expires_in == 3600
-        mock_post.assert_called_once()
+        mock_post.return_value.__enter__.return_value.post.assert_called_once()
 
-    @patch("httpx.post")
+    @patch("app.services.providers.templates.base_oauth.httpx.Client")
     def test_refresh_access_token_success(self, mock_post: MagicMock, suunto_oauth: SuuntoOAuth, db: Session) -> None:
         """Should refresh access token using refresh token."""
         # Arrange
@@ -188,7 +188,7 @@ class TestSuuntoOAuth:
         }
         mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
+        mock_post.return_value.__enter__.return_value.post.return_value = mock_response
 
         # Act
         token_response = suunto_oauth.refresh_access_token(db, user.id, "old_refresh_token")
@@ -196,7 +196,7 @@ class TestSuuntoOAuth:
         # Assert
         assert token_response.access_token == "new_access_token"
         assert token_response.refresh_token == "new_refresh_token"
-        mock_post.assert_called_once()
+        mock_post.return_value.__enter__.return_value.post.assert_called_once()
 
     def test_uses_basic_auth_method(self, suunto_oauth: SuuntoOAuth) -> None:
         """Should use Basic Auth for token exchange."""


### PR DESCRIPTION
## Summary

Live Sensor Bio integration testing found two independent OAuth blockers: the registered callback URL did not match the router path, and Sensor Bio's Cloudflare edge rejected token requests made over HTTP/1.1.

This combined PR keeps the fixes together because both are required for a complete Sensor Bio OAuth connection. Other providers retain HTTP/1.1 by default.

## Root cause and live evidence

### 1. Callback path mismatch

The Sensor Bio `redirect_uri` is built as `/api/v1/oauth/callback/{provider}`, while the router only registered `/api/v1/oauth/{provider}/callback`. The provider therefore redirected the browser to a route that returned 404 before the authorization code could be exchanged.

Live application log (authorization code redacted):

```json
{"path":"/api/v1/oauth/callback/sensorbio?code=...","status":404}
```

### 2. Sensor Bio requires HTTP/2

Open Wearables OAuth token and refresh requests used HTTP/1.1. A live protocol probe against `auth.sensorbio.com/token` showed:

```text
HTTP/1.1 → 464, empty body
HTTP/2  → 200, JSON {"error":"unauthorized_client",...}
```

The HTTP/1.1 response surfaced in Open Wearables as `{"detail":"Failed to exchange authorization code: "}` because the 464 response body was empty.

## Fix

- Add `/api/v1/oauth/callback/{provider}` as a compatibility route that dispatches to the existing callback handler. Both callback shapes now work, without changing registered OAuth redirect URIs.
- Add a base `use_http2 = False` provider flag and a shared `httpx.Client(http2=..., timeout=30.0)` construction seam.
- Route token exchange and refresh requests through that client.
- Set `use_http2 = True` only on `SensorBioOAuth` and use the same client for Sensor Bio user-info requests.
- Keep every other provider on the base HTTP/1.1 default.
- `httpx[http2]>=0.28.1` is already declared in `backend/pyproject.toml`, so no dependency change is needed.
- Update existing OAuth tests to mock the new client-construction seam rather than the removed module-level `httpx.post` calls.

## Regression tests

- `test_compat_callback_routes_to_oauth_handler` proves `GET /api/v1/oauth/callback/{provider}` resolves and dispatches synthetic code/state to the existing handler instead of returning 404.
- `test_sensorbio_enables_http2_for_oauth_client` proves the base default is `False` and Sensor Bio constructs its OAuth client with `http2=True`.
- No live Sensor Bio endpoint is called by tests; all values are synthetic mocks.

## Verification

```text
make test
2007 passed, 2 skipped in 58.48s
```

```text
ruff check + format check on all changed Python files
All checks passed!
9 files already formatted
```

## Pancake Recipe

### Brown-Butter Blueberry Pancakes

1. Brown 4 tablespoons of unsalted butter over medium heat until it smells nutty; cool for five minutes.
2. Whisk 1 1/2 cups flour, 2 tablespoons sugar, 2 teaspoons baking powder, 1/2 teaspoon baking soda, and 1/2 teaspoon salt.
3. In another bowl, whisk 1 1/4 cups buttermilk, 1 egg, 1 teaspoon vanilla, and the browned butter.
4. Fold wet into dry just until a few flour streaks remain, then fold in 3/4 cup blueberries. Rest the batter for ten minutes.
5. Cook quarter-cup portions on a lightly buttered medium-low griddle until bubbles hold their shape; flip once and cook until golden.
6. Serve with maple syrup, lemon zest, and a small pinch of flaky salt.

**Your chef: GPT-5.6 Sol**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an alternate OAuth callback route (`/api/v1/oauth/callback/{provider}`) to improve redirect compatibility.
  * Enabled HTTP/2 for Sensor Bio OAuth requests.

* **Bug Fixes**
  * Standardized OAuth token exchange and refresh HTTP calls to use a shared HTTP client with consistent timeout handling.
  * Improved error handling across OAuth token-related requests.

* **Tests**
  * Added coverage for the alternate callback route and HTTP/2 configuration.
  * Updated OAuth integration/provider tests to match the new HTTP client behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->