### PR TITLE
refactor: Show source provider in health score responses and UI

### DIFF
--- a/backend/app/api/routes/v1/health_scores.py
+++ b/backend/app/api/routes/v1/health_scores.py
@@ -38,7 +38,11 @@ def list_health_scores(
     )
     scores, total_count = health_score_service.get_scores_with_filters(db, user_id, params)
 
-    data = [HealthScoreResponse.model_validate(s) for s in scores]
+    data = []
+    for health_score, source_provider in scores:
+        response = HealthScoreResponse.model_validate(health_score)
+        response.source_provider = source_provider if health_score.provider == ProviderName.INTERNAL else health_score.provider
+        data.append(response)
     has_more = (offset + len(data)) < total_count
 
     return PaginatedResponse(

--- a/backend/app/api/routes/v1/health_scores.py
+++ b/backend/app/api/routes/v1/health_scores.py
@@ -41,7 +41,9 @@ def list_health_scores(
     data = []
     for health_score, source_provider in scores:
         response = HealthScoreResponse.model_validate(health_score)
-        response.source_provider = source_provider if health_score.provider == ProviderName.INTERNAL else health_score.provider
+        response.source_provider = (
+            source_provider if health_score.provider == ProviderName.INTERNAL else health_score.provider
+        )
         data.append(response)
     has_more = (offset + len(data)) < total_count
 

--- a/backend/app/repositories/health_score_repository.py
+++ b/backend/app/repositories/health_score_repository.py
@@ -6,7 +6,7 @@ from sqlalchemy import and_, asc, desc, tuple_
 from sqlalchemy.dialects.postgresql import insert
 
 from app.database import DbSession
-from app.models import HealthScore, EventRecord, DataSource
+from app.models import DataSource, EventRecord, HealthScore
 from app.repositories.repositories import CrudRepository
 from app.schemas.enums import HealthScoreCategory, ProviderName
 from app.schemas.model_crud.activities import HealthScoreCreate, HealthScoreQueryParams, HealthScoreUpdate
@@ -27,10 +27,7 @@ class HealthScoreRepository(CrudRepository[HealthScore, HealthScoreCreate, Healt
         db_session: DbSession,
         user_id: UUID,
         params: HealthScoreQueryParams,
-    ) -> tuple[
-            list[tuple[HealthScore, ProviderName | None]],
-            int
-        ]:
+    ) -> tuple[list[tuple[HealthScore, ProviderName | None]], int]:
         filters = [HealthScore.user_id == user_id]
 
         if params.category:
@@ -52,7 +49,10 @@ class HealthScoreRepository(CrudRepository[HealthScore, HealthScoreCreate, Healt
         )
 
         total_count = query.count()
-        results = query.order_by(desc(HealthScore.recorded_at)).offset(params.offset).limit(params.limit).all()
+        results = cast(
+            list[tuple[HealthScore, ProviderName | None]],
+            query.order_by(desc(HealthScore.recorded_at)).offset(params.offset).limit(params.limit).all(),
+        )
         return results, total_count
 
     def bulk_create(self, db_session: DbSession, creators: list[HealthScoreCreate]) -> None:

--- a/backend/app/repositories/health_score_repository.py
+++ b/backend/app/repositories/health_score_repository.py
@@ -6,9 +6,9 @@ from sqlalchemy import and_, asc, desc, tuple_
 from sqlalchemy.dialects.postgresql import insert
 
 from app.database import DbSession
-from app.models import HealthScore
+from app.models import HealthScore, EventRecord, DataSource
 from app.repositories.repositories import CrudRepository
-from app.schemas.enums import HealthScoreCategory
+from app.schemas.enums import HealthScoreCategory, ProviderName
 from app.schemas.model_crud.activities import HealthScoreCreate, HealthScoreQueryParams, HealthScoreUpdate
 from app.utils.pagination import decode_cursor
 
@@ -27,7 +27,10 @@ class HealthScoreRepository(CrudRepository[HealthScore, HealthScoreCreate, Healt
         db_session: DbSession,
         user_id: UUID,
         params: HealthScoreQueryParams,
-    ) -> tuple[list[HealthScore], int]:
+    ) -> tuple[
+            list[tuple[HealthScore, ProviderName | None]],
+            int
+        ]:
         filters = [HealthScore.user_id == user_id]
 
         if params.category:
@@ -41,7 +44,12 @@ class HealthScoreRepository(CrudRepository[HealthScore, HealthScoreCreate, Healt
         if params.end_datetime:
             filters.append(HealthScore.recorded_at < params.end_datetime)
 
-        query = db_session.query(HealthScore).filter(and_(*filters))
+        query = (
+            db_session.query(HealthScore, DataSource.provider)
+            .outerjoin(EventRecord, HealthScore.sleep_record_id == EventRecord.id)
+            .outerjoin(DataSource, EventRecord.data_source_id == DataSource.id)
+            .filter(and_(*filters))
+        )
 
         total_count = query.count()
         results = query.order_by(desc(HealthScore.recorded_at)).offset(params.offset).limit(params.limit).all()

--- a/backend/app/schemas/model_crud/activities/health_score.py
+++ b/backend/app/schemas/model_crud/activities/health_score.py
@@ -64,3 +64,4 @@ class HealthScoreResponse(HealthScoreBase):
     id: UUID
     data_source_id: UUID | None
     provider: ProviderName | None
+    source_provider: ProviderName | None = None

--- a/backend/app/services/health_score_service.py
+++ b/backend/app/services/health_score_service.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from app.database import DbSession
 from app.models import HealthScore
 from app.repositories import HealthScoreRepository
-from app.schemas.enums import HealthScoreCategory
+from app.schemas.enums import HealthScoreCategory, ProviderName
 from app.schemas.model_crud.activities import HealthScoreCreate, HealthScoreQueryParams, HealthScoreUpdate
 from app.services.services import AppService
 from app.utils.exceptions import handle_exceptions
@@ -53,7 +53,7 @@ class HealthScoreService(
         db_session: DbSession,
         user_id: UUID,
         params: HealthScoreQueryParams,
-    ) -> tuple[list[HealthScore], int]:
+    ) -> tuple[list[tuple[HealthScore, ProviderName | None]], int]:
         return self.crud.get_with_filters(db_session, user_id, params)
 
 

--- a/backend/tests/api/v1/test_health_scores.py
+++ b/backend/tests/api/v1/test_health_scores.py
@@ -86,6 +86,35 @@ class TestHealthScoresEndpoint:
         assert len(data) == 1
         assert data[0]["id"] == str(garmin_score.id)
 
+    def test_list_health_scores_includes_source_provider_for_internal_scores(
+        self,
+        client: TestClient,
+        db: Session,
+    ) -> None:
+        user = UserFactory()
+        source_data_source = DataSourceFactory(user=user, provider=ProviderName.GARMIN)
+        sleep_record = HealthScoreFactory(data_source=source_data_source, provider=ProviderName.GARMIN)
+        internal_score = HealthScoreFactory(
+            data_source=DataSourceFactory(user=user, provider=ProviderName.INTERNAL),
+            provider=ProviderName.INTERNAL,
+            sleep_record_id=sleep_record.id,
+            category=HealthScoreCategory.SLEEP,
+        )
+        api_key = ApiKeyFactory()
+
+        response = client.get(
+            f"/api/v1/users/{user.id}/health-scores",
+            headers=api_key_headers(api_key.id),
+            params={"provider": "internal"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert len(data) == 1
+        assert data[0]["id"] == str(internal_score.id)
+        assert data[0]["provider"] == ProviderName.INTERNAL
+        assert data[0]["source_provider"] == ProviderName.GARMIN
+
     def test_list_health_scores_filter_by_date_range(self, client: TestClient, db: Session) -> None:
         user = UserFactory()
         data_source = DataSourceFactory(user=user)

--- a/frontend/src/components/common/source-badge.tsx
+++ b/frontend/src/components/common/source-badge.tsx
@@ -2,6 +2,7 @@ import { cn } from '@/lib/utils';
 
 interface SourceBadgeProps {
   provider: string;
+  sourceProvider?: string | null;
   className?: string;
 }
 
@@ -44,10 +45,16 @@ export function providerLabel(provider: string): string {
   return PROVIDER_STYLES[provider]?.label ?? provider;
 }
 
-export function SourceBadge({ provider, className = '' }: SourceBadgeProps) {
+export function SourceBadge({ provider, sourceProvider, className = '' }: SourceBadgeProps) {
   const style = PROVIDER_STYLES[provider] ?? DEFAULT_STYLE;
-  const label = PROVIDER_STYLES[provider]?.label ?? provider;
+  const providerLabel = PROVIDER_STYLES[provider]?.label ?? provider;
+  let label = providerLabel;
+  if (provider === 'internal' && sourceProvider) {
+    const sourceLabel =
+      PROVIDER_STYLES[sourceProvider]?.label ?? sourceProvider;
 
+    label = `${providerLabel} · ${sourceLabel}`;
+  }
   return (
     <span
       className={cn(

--- a/frontend/src/components/common/source-badge.tsx
+++ b/frontend/src/components/common/source-badge.tsx
@@ -45,7 +45,11 @@ export function providerLabel(provider: string): string {
   return PROVIDER_STYLES[provider]?.label ?? provider;
 }
 
-export function SourceBadge({ provider, sourceProvider, className = '' }: SourceBadgeProps) {
+export function SourceBadge({
+  provider,
+  sourceProvider,
+  className = '',
+}: SourceBadgeProps) {
   const style = PROVIDER_STYLES[provider] ?? DEFAULT_STYLE;
   const providerLabel = PROVIDER_STYLES[provider]?.label ?? provider;
   let label = providerLabel;

--- a/frontend/src/components/user/scores-section.tsx
+++ b/frontend/src/components/user/scores-section.tsx
@@ -299,7 +299,10 @@ function ScoreDayCard({
                           key={score.id}
                           className="inline-flex items-center gap-2 px-2.5 py-1 rounded-md bg-muted/50 border border-border/30"
                         >
-                          <SourceBadge provider={score.provider || 'unknown'} />
+                          <SourceBadge 
+                          provider={score.provider || 'unknown'}
+                          sourceProvider={score.source_provider ?? undefined}
+                          />
                           <span className="text-sm font-semibold text-foreground">
                             {resilienceScore !== null
                               ? Number(resilienceScore).toFixed(0)
@@ -340,7 +343,10 @@ function ScoreDayCard({
               .map((score) => (
                 <div key={score.id}>
                   <div className="flex items-center gap-2 mb-2">
-                    <SourceBadge provider={score.provider || 'unknown'} />
+                    <SourceBadge
+                      provider={score.provider || 'unknown'}
+                      sourceProvider={score.source_provider ?? undefined}
+                    />
                     <span className="text-xs text-muted-foreground">
                       {CATEGORY_CONFIG[score.category]?.label || score.category}
                     </span>

--- a/frontend/src/components/user/scores-section.tsx
+++ b/frontend/src/components/user/scores-section.tsx
@@ -299,9 +299,9 @@ function ScoreDayCard({
                           key={score.id}
                           className="inline-flex items-center gap-2 px-2.5 py-1 rounded-md bg-muted/50 border border-border/30"
                         >
-                          <SourceBadge 
-                          provider={score.provider || 'unknown'}
-                          sourceProvider={score.source_provider ?? undefined}
+                          <SourceBadge
+                            provider={score.provider || 'unknown'}
+                            sourceProvider={score.source_provider ?? undefined}
                           />
                           <span className="text-sm font-semibold text-foreground">
                             {resilienceScore !== null

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -679,6 +679,7 @@ export interface HealthScoreResponse {
   id: string;
   data_source_id: string | null;
   provider: string | null;
+  source_provider: string | null;
   category: string;
   value: number | null;
   qualifier: string | null;


### PR DESCRIPTION
## Description
Closes #983
This change makes internal OW sleep scores show their underlying source provider in the UI. The backend now exposes `source_provider` on health score responses so the frontend can render labels like `OW · Garmin` or `OW · Whoop`.

On the backend, I added a new source_provider field to the health score API response. For internally generated ("OW") sleep scores, this field is populated with the provider associated with the linked sleep record, such as Garmin or Whoop.
On the frontend, I updated the dashboard badge component to display labels such as OW · Garmin or OW · Whoop while leaving non-internal providers unchanged.
I also added backend tests to verify that the correct source provider is returned for internal sleep scores.


## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` or no docs update needed

### Backend Changes

- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

## Testing Instructions

1. Open the dashboard and confirm internal OW sleep badges now display the source provider, for example `OW · Garmin` or `OW · Whoop`.
2. Verify that non-internal sleep scores still render correctly and keep the same styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Health score badges now show the originating data source for internally generated scores.
  - Health score responses include source-provider information when available.
- **Bug Fixes**
  - Corrected health score provider details so displayed source information matches the linked data source.
- **Tests**
  - Added coverage verifying source-provider details for internal health scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->