### PR TITLE
fix: include icon_url on user connections

### DIFF
--- a/backend/app/api/routes/v1/connections.py
+++ b/backend/app/api/routes/v1/connections.py
@@ -26,6 +26,7 @@ def _with_capabilities(
     with contextlib.suppress(ValueError):
         strategy = factory.get_provider(enriched.provider)
         caps = strategy.capabilities
+        enriched.icon_url = strategy.icon_url
         enriched.max_historical_days = caps.max_historical_days
         enriched.rest_pull = caps.rest_pull
         enriched.webhook_stream = caps.webhook_stream

--- a/backend/app/schemas/model_crud/user_management/user_connection.py
+++ b/backend/app/schemas/model_crud/user_management/user_connection.py
@@ -64,6 +64,13 @@ class UserConnectionWithCapabilities(UserConnectionRead):
     Extra fields are populated by the endpoint, not from the ORM model.
     """
 
+    icon_url: str | None = Field(
+        None,
+        description=(
+            "Relative URL to provider icon (e.g., '/static/provider-icons/garmin.svg')."
+            " Resolve against the API base URL."
+        ),
+    )
     max_historical_days: int | None = None
     rest_pull: bool = False
     webhook_stream: bool = False

--- a/backend/tests/api/v1/test_connections.py
+++ b/backend/tests/api/v1/test_connections.py
@@ -171,12 +171,14 @@ class TestConnectionsEndpoints:
         assert "status" in connection_data
         assert "created_at" in connection_data
         assert "updated_at" in connection_data
+        assert "icon_url" in connection_data
 
         # Verify values
         assert connection_data["id"] == str(connection.id)
         assert connection_data["user_id"] == str(user.id)
         assert connection_data["provider"] == "garmin"
         assert connection_data["status"] == ConnectionStatus.ACTIVE.value
+        assert connection_data["icon_url"] == "/static/provider-icons/garmin.svg"
 
     def test_get_connections_missing_api_key(self, client: TestClient, db: Session) -> None:
         """Test that request without API key is rejected."""

--- a/docs/dev-guides/integration-guide.mdx
+++ b/docs/dev-guides/integration-guide.mdx
@@ -524,10 +524,13 @@ curl "http://localhost:8000/api/v1/users/176be8de-8452-4eb7-a7ea-147fec925d9d/co
     "provider_user_id": "12345678",
     "created_at": "2025-01-15T10:30:00Z",
     "updated_at": "2025-01-15T10:30:00Z",
-    "last_synced_at": null
+    "last_synced_at": null,
+    "icon_url": "/static/provider-icons/garmin.svg"
   }
 ]
 ```
+
+`icon_url` is a **relative path**. Resolve it against your API base URL the same way as provider settings: `{OPEN_WEARABLES_API_URL}{icon_url}`.
 
 ---
 

--- a/frontend/src/components/user/connection-card.tsx
+++ b/frontend/src/components/user/connection-card.tsx
@@ -14,13 +14,13 @@ import {
   Timer,
   TriangleAlert,
   Unlink,
-  Watch,
   XCircle,
   Zap,
 } from 'lucide-react';
 import { Link } from '@tanstack/react-router';
 import { formatDistanceToNow } from 'date-fns';
 import { UserConnection } from '@/lib/api/types';
+import { API_CONFIG } from '@/lib/api/config';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -45,6 +45,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import { providerLabel } from '@/components/common/source-badge';
 import { cn } from '@/lib/utils';
 import {
   STAGE_LABELS,
@@ -253,6 +254,12 @@ export function ConnectionCard({
 }: ConnectionCardProps) {
   const [showDisconnectDialog, setShowDisconnectDialog] = useState(false);
   const [showLastSyncs, setShowLastSyncs] = useState(false);
+  const [imageError, setImageError] = useState(false);
+
+  const iconUrl = connection.icon_url
+    ? new URL(connection.icon_url, API_CONFIG.baseUrl).toString()
+    : null;
+  const displayName = providerLabel(connection.provider);
 
   const { mutate: disconnectProvider, isPending: isDisconnecting } =
     useDisconnectProvider(connection.provider, connection.user_id);
@@ -346,13 +353,23 @@ export function ConnectionCard({
       <CardHeader className="pb-4">
         <div className="flex items-start justify-between">
           <div className="flex items-center gap-3">
-            {/* Provider Icon - placeholder for now TODO: Implement provider icon */}
-            <div className="h-14 w-14 rounded-full bg-white flex items-center justify-center">
-              <Watch className="h-6 w-6 text-muted-foreground" />
+            <div className="h-14 w-14 rounded-full bg-white flex items-center justify-center overflow-hidden p-2">
+              {iconUrl && !imageError ? (
+                <img
+                  src={iconUrl}
+                  alt={`${displayName} logo`}
+                  className="h-full w-full object-contain"
+                  onError={() => setImageError(true)}
+                />
+              ) : (
+                <span className="text-lg font-medium text-black">
+                  {displayName.charAt(0).toUpperCase()}
+                </span>
+              )}
             </div>
             <div>
               <h3 className="font-semibold text-card-foreground text-lg">
-                {connection.provider}
+                {displayName}
               </h3>
               <p className="text-sm text-muted-foreground mt-0.5">
                 Last live sync:{' '}
@@ -474,12 +491,10 @@ export function ConnectionCard({
             >
               <AlertDialogContent>
                 <AlertDialogHeader>
-                  <AlertDialogTitle>
-                    Disconnect {connection.provider}?
-                  </AlertDialogTitle>
+                  <AlertDialogTitle>Disconnect {displayName}?</AlertDialogTitle>
                   <AlertDialogDescription>
                     This will revoke the connection. The user will need to
-                    reconnect to {connection.provider} to resume data syncing.
+                    reconnect to {displayName} to resume data syncing.
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -275,6 +275,7 @@ export interface UserConnection {
   last_synced_at?: string;
   created_at: string;
   updated_at: string;
+  icon_url?: string | null;
   max_historical_days?: number | null;
   rest_pull?: boolean;
   webhook_stream?: boolean;


### PR DESCRIPTION
## Description

Closes: #1278 
Adds `icon_url` to `GET /api/v1/users/{user_id}/connections` and uses it on the user connection card so provider logos render the same way as in Settings → Providers, instead of the Watch placeholder.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

## Testing Instructions

<!-- Describe how reviewers can test your changes -->

**Steps to test:**
1. Restart/reload the backend so it picks up the schema + enrichment change (`docker compose up --watch` or `docker compose restart app`).
2. Open a user profile that has at least one active provider connection.
3. Inspect the Network response for `GET /api/v1/users/{user_id}/connections` and confirm each connection includes `icon_url` (e.g. `/static/provider-icons/garmin.svg`).
4. Confirm the connection card shows the provider logo (and a letter fallback if the image fails to load).

**Expected behavior:**

Connection cards show the correct provider icon and display name. The connections API returns `icon_url` as a relative path, resolved against the API base URL on the frontend (same pattern as `ProviderItem`).

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->



## Additional Notes

<!-- Any additional context or information reviewers should know -->

- `icon_url` is enriched at response time from `strategy.icon_url` in `_with_capabilities` — not stored on the connection row; no migration needed.
- Do not include unrelated `frontend/src/routeTree.gen.ts` regenerations in this PR.
- Backend tests: assertion added in `test_get_connections_response_structure`. Local pytest may need a healthy `uv`/Docker test env.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider connections now display recognizable provider icons and names.
  * Added a fallback initial when a provider icon cannot be loaded.
  * Connection responses now include an optional provider icon URL.

* **Documentation**
  * Updated integration guidance with the new `icon_url` field and URL resolution details.

* **Bug Fixes**
  * Disconnect confirmation messages now use the provider’s display name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->