### PR TITLE
feat: Honor resolution parameter in timeseries endpoint

### DIFF
--- a/backend/app/api/routes/v1/timeseries.py
+++ b/backend/app/api/routes/v1/timeseries.py
@@ -1,10 +1,10 @@
-from typing import Annotated, Literal
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Query
 
 from app.database import DbSession
-from app.schemas.enums import SeriesType
+from app.schemas.enums import SeriesType, TimeseriesResolution
 from app.schemas.model_crud.activities import TimeSeriesQueryParams
 from app.schemas.responses.activity import TimeSeriesSample
 from app.schemas.utils import PaginatedResponse
@@ -22,15 +22,21 @@ def get_timeseries(
     db: DbSession,
     _api_key: ApiKeyDep,
     types: Annotated[list[SeriesType], Query()] = [],
-    resolution: Literal["raw", "1min", "5min", "15min", "1hour"] = "raw",
+    resolution: TimeseriesResolution = TimeseriesResolution.RAW,
     cursor: str | None = None,
     limit: Annotated[int, Query(ge=1, le=100)] = 50,
 ) -> PaginatedResponse[TimeSeriesSample]:
-    """Returns granular time series data (biometrics or activity)."""
+    """Returns granular time series data (biometrics or activity).
+
+    `resolution` controls server-side downsampling: `raw` (default) returns the
+    stored samples unchanged, other values aggregate samples into fixed
+    UTC-aligned time buckets before returning them.
+    """
     params = TimeSeriesQueryParams(
         start_datetime=parse_query_datetime(start_time),
         end_datetime=parse_query_datetime(end_time),
         limit=limit,
         cursor=cursor,
+        resolution=resolution,
     )
     return timeseries_service.get_timeseries(db, user_id, types, params)

--- a/backend/app/repositories/data_point_series_repository.py
+++ b/backend/app/repositories/data_point_series_repository.py
@@ -6,6 +6,7 @@ from psycopg.errors import UniqueViolation
 from sqlalchemy import ColumnElement, Date, Interval, String, and_, asc, case, cast, func, literal_column, text, tuple_
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError as SQLAIntegrityError
+from sqlalchemy.orm.query import RowReturningQuery
 
 from app.database import DbSession
 from app.models import DataPointSeries, DataSource, DeviceTypePriority, ProviderPriority
@@ -263,18 +264,15 @@ class DataPointSeriesRepository(
             source=creator.source,
         )
 
-    def get_samples(
+    def _build_samples_query(
         self,
         db_session: DbSession,
         params: TimeSeriesQueryParams,
         types: list[SeriesType],
         user_id: UUID,
-    ) -> tuple[list[tuple[DataPointSeries, DataSource]], int]:
-        """Get data points with filtering and keyset pagination.
-
-        Returns a tuple of (samples, total_count) where total_count is calculated
-        BEFORE applying cursor pagination, giving the total number of matching records.
-        """
+    ) -> "RowReturningQuery[tuple[DataPointSeries, DataSource]]":
+        """Base query for timeseries reads: join data sources and apply all filters
+        except cursor pagination and limit."""
         query = (
             db_session.query(self.model, DataSource)
             .join(
@@ -304,6 +302,22 @@ class DataPointSeriesRepository(
             if end_dt.time() == time.min:
                 end_dt = end_dt + timedelta(days=1)
             query = query.filter(self.model.recorded_at < end_dt)
+
+        return query
+
+    def get_samples(
+        self,
+        db_session: DbSession,
+        params: TimeSeriesQueryParams,
+        types: list[SeriesType],
+        user_id: UUID,
+    ) -> tuple[list[tuple[DataPointSeries, DataSource]], int]:
+        """Get data points with filtering and keyset pagination.
+
+        Returns a tuple of (samples, total_count) where total_count is calculated
+        BEFORE applying cursor pagination, giving the total number of matching records.
+        """
+        query = self._build_samples_query(db_session, params, types, user_id)
 
         # Calculate total count BEFORE applying cursor pagination
         # This gives us the total matching records (after all other filters)
@@ -335,6 +349,22 @@ class DataPointSeriesRepository(
         # Limit + 1 to check for next page
         limit = params.limit or 50
         return query.limit(limit + 1).all(), total_count  # ty:ignore[invalid-return-type]
+
+    def get_samples_for_range(
+        self,
+        db_session: DbSession,
+        params: TimeSeriesQueryParams,
+        types: list[SeriesType],
+        user_id: UUID,
+    ) -> list[tuple[DataPointSeries, DataSource]]:
+        """Get all data points in the requested range, without pagination.
+
+        Used by server-side downsampling, which must see every sample of a time
+        bucket before aggregating it — paginating raw rows first would split
+        buckets across pages and corrupt the aggregates.
+        """
+        query = self._build_samples_query(db_session, params, types, user_id)
+        return query.order_by(asc(self.model.recorded_at), asc(self.model.id)).all()  # ty:ignore[invalid-return-type]
 
     def get_total_count(self, db_session: DbSession) -> int:
         """Get total count of all data points."""

--- a/backend/app/schemas/enums/__init__.py
+++ b/backend/app/schemas/enums/__init__.py
@@ -29,6 +29,7 @@ from .series_types import (
 )
 from .timeseries_resolution import (
     RESOLUTION_BUCKET_SECONDS,
+    RESOLUTION_MAX_RANGE_DAYS,
     TimeseriesResolution,
 )
 from .workout_types import (
@@ -60,4 +61,5 @@ __all__ = [
     "HealthScoreCategory",
     "TimeseriesResolution",
     "RESOLUTION_BUCKET_SECONDS",
+    "RESOLUTION_MAX_RANGE_DAYS",
 ]

--- a/backend/app/schemas/enums/__init__.py
+++ b/backend/app/schemas/enums/__init__.py
@@ -2,6 +2,7 @@ from .aggregation_method import (
     AGGREGATION_METHOD_BY_TYPE,
     AggregationMethod,
     daily_total_flag,
+    get_aggregation_method,
 )
 from .data_granularity import (
     GRANULARITY_WINDOW_SECONDS,
@@ -26,6 +27,10 @@ from .series_types import (
     get_series_type_id,
     get_series_type_unit,
 )
+from .timeseries_resolution import (
+    RESOLUTION_BUCKET_SECONDS,
+    TimeseriesResolution,
+)
 from .workout_types import (
     WORKOUTS_WITH_PACE,
     WorkoutType,
@@ -39,6 +44,7 @@ __all__ = [
     "AggregationMethod",
     "AGGREGATION_METHOD_BY_TYPE",
     "daily_total_flag",
+    "get_aggregation_method",
     "DataGranularity",
     "GRANULARITY_WINDOW_SECONDS",
     "SeriesType",
@@ -52,4 +58,6 @@ __all__ = [
     "ProviderName",
     "DEFAULT_PROVIDER_PRIORITY",
     "HealthScoreCategory",
+    "TimeseriesResolution",
+    "RESOLUTION_BUCKET_SECONDS",
 ]

--- a/backend/app/schemas/enums/timeseries_resolution.py
+++ b/backend/app/schemas/enums/timeseries_resolution.py
@@ -1,0 +1,26 @@
+from enum import StrEnum
+
+
+class TimeseriesResolution(StrEnum):
+    """Downsampling resolution for time-series reads.
+
+    RAW returns the stored samples unchanged. Every other value buckets samples
+    into fixed UTC-aligned intervals (bucket start = unix epoch multiple of the
+    interval) and aggregates each bucket before returning it.
+    """
+
+    RAW = "raw"
+    ONE_MINUTE = "1min"
+    FIVE_MINUTES = "5min"
+    FIFTEEN_MINUTES = "15min"
+    ONE_HOUR = "1hour"
+
+
+# Bucket width (seconds) per aggregating resolution.
+# Raw is absent intentionally — it performs no aggregation.
+RESOLUTION_BUCKET_SECONDS: dict[TimeseriesResolution, int] = {
+    TimeseriesResolution.ONE_MINUTE: 60,
+    TimeseriesResolution.FIVE_MINUTES: 300,
+    TimeseriesResolution.FIFTEEN_MINUTES: 900,
+    TimeseriesResolution.ONE_HOUR: 3_600,
+}

--- a/backend/app/schemas/enums/timeseries_resolution.py
+++ b/backend/app/schemas/enums/timeseries_resolution.py
@@ -24,3 +24,19 @@ RESOLUTION_BUCKET_SECONDS: dict[TimeseriesResolution, int] = {
     TimeseriesResolution.FIFTEEN_MINUTES: 900,
     TimeseriesResolution.ONE_HOUR: 3_600,
 }
+
+# Maximum queryable span (days) per aggregating resolution.
+# Downsampling loads every raw row of the requested range into memory before
+# bucketing, so the span is capped relative to the bucket width: finer buckets
+# mean more rows per day, hence a shorter allowed span. Each cap allows roughly
+# 45k buckets (1min: 31d x 1440/day ~= 44.6k; 5min/15min: 93d x 288/96 per day
+# ~= 26.8k/8.9k; 1hour: 366d x 24/day ~= 8.8k), keeping memory usage bounded
+# while covering realistic dashboards (a month of minute data, a quarter of
+# 5/15-minute data, a leap year of hourly data).
+# Raw is absent intentionally — it paginates at the database level.
+RESOLUTION_MAX_RANGE_DAYS: dict[TimeseriesResolution, int] = {
+    TimeseriesResolution.ONE_MINUTE: 31,
+    TimeseriesResolution.FIVE_MINUTES: 93,
+    TimeseriesResolution.FIFTEEN_MINUTES: 93,
+    TimeseriesResolution.ONE_HOUR: 366,
+}

--- a/backend/app/schemas/model_crud/activities/data_point_series.py
+++ b/backend/app/schemas/model_crud/activities/data_point_series.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-from app.schemas.enums import SeriesType
+from app.schemas.enums import SeriesType, TimeseriesResolution
 from app.utils.dates import ZoneOffset
 
 
@@ -75,4 +75,9 @@ class TimeSeriesQueryParams(BaseModel):
     cursor: str | None = Field(
         None,
         description="Pagination cursor (use next_cursor for forward, previous_cursor for backward)",
+    )
+    resolution: TimeseriesResolution = Field(
+        TimeseriesResolution.RAW,
+        description="Downsampling resolution. 'raw' returns stored samples unchanged; "
+        "other values aggregate samples into fixed time buckets.",
     )

--- a/backend/app/schemas/utils/metadata.py
+++ b/backend/app/schemas/utils/metadata.py
@@ -1,7 +1,8 @@
 from datetime import datetime
-from typing import Literal
 
 from pydantic import BaseModel, Field
+
+from app.schemas.enums import TimeseriesResolution
 
 
 class SourceMetadata(BaseModel):
@@ -10,7 +11,7 @@ class SourceMetadata(BaseModel):
 
 
 class TimeseriesMetadata(BaseModel):
-    resolution: Literal["raw", "1min", "5min", "15min", "1hour"] | None = None
+    resolution: TimeseriesResolution | None = None
     sample_count: int | None = None
     start_time: datetime | None = None
     end_time: datetime | None = None

--- a/backend/app/services/timeseries_service.py
+++ b/backend/app/services/timeseries_service.py
@@ -1,18 +1,22 @@
 import threading
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from logging import Logger, getLogger
-from typing import Any
+from typing import Any, NamedTuple
 from uuid import UUID
 
 from sqlalchemy import event as sa_event
 
 from app.database import DbSession
-from app.models import DataPointSeries
+from app.models import DataPointSeries, DataSource
 from app.repositories import DataPointSeriesRepository
 from app.repositories.data_point_series_repository import WriteCounts
 from app.schemas.enums import (
+    RESOLUTION_BUCKET_SECONDS,
+    AggregationMethod,
     SeriesType,
+    TimeseriesResolution,
+    get_aggregation_method,
     get_series_type_from_id,
     get_series_type_unit,
 )
@@ -34,7 +38,18 @@ from app.services.outgoing_webhooks import svix as svix_service
 from app.services.outgoing_webhooks.events import on_timeseries_batch_saved
 from app.services.services import AppService
 from app.utils.exceptions import handle_exceptions
-from app.utils.pagination import encode_cursor
+from app.utils.pagination import decode_cursor, encode_cursor
+
+
+class _SampleBucket(NamedTuple):
+    """One downsampled time bucket, ready to be mapped to a response item."""
+
+    timestamp: datetime  # UTC-aligned bucket start
+    sample_id: UUID  # id of the latest raw sample in the bucket (cursor tiebreaker)
+    series_type: SeriesType
+    value: float
+    zone_offset: str | None
+    data_source: DataSource | None
 
 
 class TimeSeriesService(
@@ -143,6 +158,9 @@ class TimeSeriesService(
         types: list[SeriesType],
         params: TimeSeriesQueryParams,
     ) -> PaginatedResponse[TimeSeriesSample]:
+        if params.resolution is not TimeseriesResolution.RAW:
+            return self._get_downsampled_timeseries(db_session, user_id, types, params)
+
         samples, total_count = self.crud.get_samples(db_session, params, types, user_id)
 
         limit = params.limit or 50
@@ -218,6 +236,141 @@ class TimeSeriesService(
                 end_time=params.end_datetime,
             ),
         )
+
+    def _get_downsampled_timeseries(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        types: list[SeriesType],
+        params: TimeSeriesQueryParams,
+    ) -> PaginatedResponse[TimeSeriesSample]:
+        """Downsample raw samples into fixed time buckets before paginating.
+
+        Bucketing happens over the full requested range (no raw-level pagination),
+        so a bucket can never be split across pages. The aggregation function is
+        chosen per series type via ``get_aggregation_method`` — the same mapping
+        the daily archive rollup uses: SUM for cumulative metrics (steps,
+        distance, energy), AVG for rate/level metrics (heart rate, temperature),
+        MAX for peak metrics.
+        """
+        interval_seconds = RESOLUTION_BUCKET_SECONDS[params.resolution]
+        rows = self.crud.get_samples_for_range(db_session, params, types, user_id)
+        buckets = self._bucket_samples(rows, interval_seconds)
+
+        limit = params.limit or 50
+        is_backward = params.cursor and params.cursor.startswith("prev_")
+
+        # Total matching buckets, calculated BEFORE cursor pagination (as the
+        # raw path does for raw samples)
+        total_count = len(buckets)
+
+        # Keyset pagination over the buckets, mirroring the raw path semantics
+        if params.cursor:
+            cursor_ts, cursor_id, direction = decode_cursor(params.cursor)
+            if direction == "prev":
+                buckets = [b for b in buckets if (b.timestamp, b.sample_id) < (cursor_ts, cursor_id)]
+            else:
+                buckets = [b for b in buckets if (b.timestamp, b.sample_id) > (cursor_ts, cursor_id)]
+
+        has_more = len(buckets) > limit
+        if has_more:
+            buckets = buckets[-limit:] if is_backward else buckets[:limit]
+
+        next_cursor = None
+        previous_cursor = None
+        if buckets:
+            if has_more:
+                next_cursor = encode_cursor(buckets[-1].timestamp, buckets[-1].sample_id, "next")
+            if params.cursor:
+                if is_backward:
+                    if has_more:
+                        previous_cursor = encode_cursor(buckets[0].timestamp, buckets[0].sample_id, "prev")
+                else:
+                    previous_cursor = encode_cursor(buckets[0].timestamp, buckets[0].sample_id, "prev")
+
+        data = []
+        for bucket in buckets:
+            source = None
+            if bucket.data_source:
+                source = SourceMetadata(
+                    provider=bucket.data_source.source or "unknown",
+                    device=bucket.data_source.device_model,
+                )
+            data.append(
+                TimeSeriesSample(
+                    timestamp=bucket.timestamp,
+                    zone_offset=bucket.zone_offset,
+                    type=bucket.series_type,
+                    value=bucket.value,
+                    unit=get_series_type_unit(bucket.series_type),
+                    source=source,
+                    # A bucket is never a provider-reported daily total
+                    is_daily_total=None,
+                )
+            )
+
+        return PaginatedResponse(
+            data=data,
+            pagination=Pagination(
+                has_more=has_more,
+                next_cursor=next_cursor,
+                previous_cursor=previous_cursor,
+                total_count=total_count,
+            ),
+            metadata=TimeseriesMetadata(
+                resolution=params.resolution,
+                sample_count=len(data),
+                start_time=params.start_datetime,
+                end_time=params.end_datetime,
+            ),
+        )
+
+    @staticmethod
+    def _bucket_samples(
+        rows: list[tuple[DataPointSeries, DataSource]],
+        interval_seconds: int,
+    ) -> list[_SampleBucket]:
+        """Group raw samples into UTC-aligned buckets and aggregate each group.
+
+        Samples are bucketed per (bucket start, series type, data source), so
+        two devices reporting the same metric never merge into one value.
+        Returns buckets ordered by (timestamp, sample_id) for keyset pagination.
+        """
+        groups: dict[tuple[int, int, UUID], list[tuple[DataPointSeries, DataSource]]] = defaultdict(list)
+        for sample, data_source in rows:
+            bucket_start = int(sample.recorded_at.timestamp()) // interval_seconds * interval_seconds
+            key = (bucket_start, sample.series_type_definition_id, sample.data_source_id)
+            groups[key].append((sample, data_source))
+
+        buckets: list[_SampleBucket] = []
+        for (bucket_start, series_type_id, _), members in groups.items():
+            series_type = get_series_type_from_id(series_type_id)
+            method = get_aggregation_method(series_type)
+            values = [float(sample.value) for sample, _ in members]
+
+            if method is AggregationMethod.SUM:
+                value = sum(values)
+            elif method is AggregationMethod.MAX:
+                value = max(values)
+            else:
+                value = sum(values) / len(values)
+
+            # Members arrive in chronological order; the last one anchors the
+            # bucket's cursor identity and representative zone offset.
+            representative, data_source = members[-1]
+            buckets.append(
+                _SampleBucket(
+                    timestamp=datetime.fromtimestamp(bucket_start, tz=timezone.utc),
+                    sample_id=representative.id,
+                    series_type=series_type,
+                    value=value,
+                    zone_offset=representative.zone_offset,
+                    data_source=data_source,
+                )
+            )
+
+        buckets.sort(key=lambda b: (b.timestamp, b.sample_id))
+        return buckets
 
 
 timeseries_service = TimeSeriesService(log=getLogger(__name__))

--- a/backend/app/services/timeseries_service.py
+++ b/backend/app/services/timeseries_service.py
@@ -1,6 +1,6 @@
 import threading
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from logging import Logger, getLogger
 from typing import Any, NamedTuple
 from uuid import UUID
@@ -13,6 +13,7 @@ from app.repositories import DataPointSeriesRepository
 from app.repositories.data_point_series_repository import WriteCounts
 from app.schemas.enums import (
     RESOLUTION_BUCKET_SECONDS,
+    RESOLUTION_MAX_RANGE_DAYS,
     AggregationMethod,
     SeriesType,
     TimeseriesResolution,
@@ -37,7 +38,7 @@ from app.schemas.utils import (
 from app.services.outgoing_webhooks import svix as svix_service
 from app.services.outgoing_webhooks.events import on_timeseries_batch_saved
 from app.services.services import AppService
-from app.utils.exceptions import handle_exceptions
+from app.utils.exceptions import TimeseriesRangeTooLargeError, handle_exceptions
 from app.utils.pagination import decode_cursor, encode_cursor
 
 
@@ -253,6 +254,7 @@ class TimeSeriesService(
         distance, energy), AVG for rate/level metrics (heart rate, temperature),
         MAX for peak metrics.
         """
+        self._validate_downsampled_range(params)
         interval_seconds = RESOLUTION_BUCKET_SECONDS[params.resolution]
         rows = self.crud.get_samples_for_range(db_session, params, types, user_id)
         buckets = self._bucket_samples(rows, interval_seconds)
@@ -326,6 +328,23 @@ class TimeSeriesService(
         )
 
     @staticmethod
+    def _validate_downsampled_range(params: TimeSeriesQueryParams) -> None:
+        """Reject downsampled queries whose span exceeds the resolution's cap.
+
+        Downsampling loads every raw row of the requested range into memory
+        before bucketing (no raw-level pagination), so the span must be bounded
+        relative to the bucket width — see RESOLUTION_MAX_RANGE_DAYS. Raises
+        before any database fetch. Bounds are optional in the query params, so
+        a range that cannot be measured (missing bound) is left to the raw path
+        conventions and not validated here.
+        """
+        if params.start_datetime is None or params.end_datetime is None:
+            return
+        max_days = RESOLUTION_MAX_RANGE_DAYS[params.resolution]
+        if params.end_datetime - params.start_datetime > timedelta(days=max_days):
+            raise TimeseriesRangeTooLargeError(params.resolution, max_days)
+
+    @staticmethod
     def _bucket_samples(
         rows: list[tuple[DataPointSeries, DataSource]],
         interval_seconds: int,
@@ -346,14 +365,26 @@ class TimeSeriesService(
         for (bucket_start, series_type_id, _), members in groups.items():
             series_type = get_series_type_from_id(series_type_id)
             method = get_aggregation_method(series_type)
-            values = [float(sample.value) for sample, _ in members]
 
             if method is AggregationMethod.SUM:
-                value = sum(values)
+                # Providers can store BOTH a daily-total row (is_daily_total=True)
+                # and intraday samples for the same day/series (e.g. Garmin
+                # dailies alongside epochs). Summing both would double-count the
+                # day, so — mirroring the daily rollup's prefer_daily_sum
+                # semantics, where daily-total rows win over intraday samples at
+                # daily granularity — sub-day SUM buckets count intraday samples
+                # only and drop daily-total rows. None counts as intraday
+                # (legacy rows), matching prefer_daily_sum's NULL handling.
+                members = [(sample, ds) for sample, ds in members if sample.is_daily_total is not True]
+                if not members:
+                    # The bucket only held daily-total rows: nothing to report
+                    # at sub-day granularity.
+                    continue
+                value = sum(float(sample.value) for sample, _ in members)
             elif method is AggregationMethod.MAX:
-                value = max(values)
+                value = max(float(sample.value) for sample, _ in members)
             else:
-                value = sum(values) / len(values)
+                value = sum(float(sample.value) for sample, _ in members) / len(members)
 
             # Members arrive in chronological order; the last one anchors the
             # bucket's cursor identity and representative zone offset.

--- a/backend/app/utils/exceptions.py
+++ b/backend/app/utils/exceptions.py
@@ -39,7 +39,7 @@ class InvalidCursorError(Exception):
 
 
 class TimeseriesRangeTooLargeError(Exception):
-    def __init__(self, resolution: str, max_days: int):
+    def __init__(self, resolution: str, max_days: int) -> None:
         self.detail = (
             f"Requested time range exceeds the maximum of {max_days} days allowed for resolution '{resolution}'."
         )

--- a/backend/app/utils/exceptions.py
+++ b/backend/app/utils/exceptions.py
@@ -38,6 +38,14 @@ class InvalidCursorError(Exception):
         self.detail = f"Invalid cursor format: '{cursor}'. Expected 'timestamp|id'."
 
 
+class TimeseriesRangeTooLargeError(Exception):
+    def __init__(self, resolution: str, max_days: int):
+        self.detail = (
+            f"Requested time range exceeds the maximum of {max_days} days allowed for resolution '{resolution}'."
+        )
+        super().__init__(self.detail)
+
+
 class DatetimeParseError(ValueError):
     def __init__(self, value: str):
         self.detail = f"Invalid datetime format: '{value}'. Expected ISO 8601 format or Unix timestamp."
@@ -69,6 +77,11 @@ def _(exc: ResourceAlreadyExistsError, _: str) -> HTTPException:
 
 @handle_exception.register
 def _(exc: InvalidCursorError, _: str) -> HTTPException:
+    return HTTPException(status_code=400, detail=exc.detail)
+
+
+@handle_exception.register
+def _(exc: TimeseriesRangeTooLargeError, _: str) -> HTTPException:
     return HTTPException(status_code=400, detail=exc.detail)
 
 

--- a/backend/tests/api/v1/test_timeseries.py
+++ b/backend/tests/api/v1/test_timeseries.py
@@ -1,0 +1,84 @@
+"""Tests for the /users/{user_id}/timeseries endpoint resolution parameter."""
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from tests.factories import (
+    ApiKeyFactory,
+    DataPointSeriesFactory,
+    DataSourceFactory,
+    SeriesTypeDefinitionFactory,
+    UserFactory,
+)
+from tests.utils import api_key_headers
+
+
+class TestTimeseriesResolution:
+    """The endpoint must honor the resolution query parameter."""
+
+    def test_resolution_defaults_to_raw(self, client: TestClient, db: Session) -> None:
+        user = UserFactory()
+        mapping = DataSourceFactory(user=user)
+        hr_type = SeriesTypeDefinitionFactory.get_or_create_heart_rate()
+        recorded_at = datetime(2024, 1, 1, 10, 0, 13, tzinfo=timezone.utc)
+        DataPointSeriesFactory(mapping=mapping, series_type=hr_type, recorded_at=recorded_at, value=66)
+
+        api_key = ApiKeyFactory()
+        response = client.get(
+            f"/api/v1/users/{user.id}/timeseries",
+            headers=api_key_headers(api_key.id),
+            params={"start_time": "2024-01-01T00:00:00Z", "end_time": "2024-01-02T00:00:00Z"},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert len(payload["data"]) == 1
+        assert payload["data"][0]["timestamp"] == "2024-01-01T10:00:13Z"
+        assert payload["metadata"]["resolution"] is None
+
+    def test_resolution_is_forwarded_and_downsamples(self, client: TestClient, db: Session) -> None:
+        user = UserFactory()
+        mapping = DataSourceFactory(user=user)
+        hr_type = SeriesTypeDefinitionFactory.get_or_create_heart_rate()
+        for seconds, value in [(5, 60), (25, 90), (45, 90)]:
+            DataPointSeriesFactory(
+                mapping=mapping,
+                series_type=hr_type,
+                recorded_at=datetime(2024, 1, 1, 10, 0, seconds, tzinfo=timezone.utc),
+                value=value,
+            )
+
+        api_key = ApiKeyFactory()
+        response = client.get(
+            f"/api/v1/users/{user.id}/timeseries",
+            headers=api_key_headers(api_key.id),
+            params={
+                "start_time": "2024-01-01T00:00:00Z",
+                "end_time": "2024-01-02T00:00:00Z",
+                "resolution": "1min",
+            },
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert len(payload["data"]) == 1
+        assert payload["data"][0]["timestamp"] == "2024-01-01T10:00:00Z"
+        assert payload["data"][0]["value"] == 80.0
+        assert payload["metadata"]["resolution"] == "1min"
+
+    def test_invalid_resolution_is_rejected(self, client: TestClient, db: Session) -> None:
+        user = UserFactory()
+        api_key = ApiKeyFactory()
+        response = client.get(
+            f"/api/v1/users/{user.id}/timeseries",
+            headers=api_key_headers(api_key.id),
+            params={
+                "start_time": "2024-01-01T00:00:00Z",
+                "end_time": "2024-01-02T00:00:00Z",
+                "resolution": "42min",
+            },
+        )
+
+        assert response.status_code == 400

--- a/backend/tests/services/test_timeseries_resolution.py
+++ b/backend/tests/services/test_timeseries_resolution.py
@@ -13,9 +13,11 @@ Tests cover:
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from app.models import DataSource, SeriesTypeDefinition, User
+from app.repositories import DataPointSeriesRepository
 from app.schemas.enums import SeriesType, TimeseriesResolution
 from app.schemas.model_crud.activities import TimeSeriesQueryParams
 from app.services.timeseries_service import timeseries_service
@@ -295,3 +297,201 @@ class TestDownsampledEdgeCases:
         assert page2.pagination.has_more is False
         # No overlap and no gap between pages
         assert page1.data[-1].timestamp < page2.data[0].timestamp
+
+
+class TestDailyTotalRowsInSumBuckets:
+    """SUM buckets must not double-count daily-total rows with intraday samples.
+
+    Providers can write BOTH a daily-total row (is_daily_total=True) and
+    intraday samples for the same day/series. At sub-day resolutions only the
+    intraday samples count (mirroring prefer_daily_sum semantics).
+    """
+
+    def test_sum_bucket_excludes_daily_total_row(self, db: Session, user_setup: UserSetup) -> None:
+        user, mapping, _, steps_type = user_setup
+        # A provider-reported daily total of 5000 steps plus two intraday
+        # samples, all inside the same five-minute bucket.
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=steps_type,
+            recorded_at=datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            value=5000,
+            is_daily_total=True,
+        )
+        for seconds, value in [(30, 10), (90, 20)]:
+            DataPointSeriesFactory(
+                mapping=mapping,
+                series_type=steps_type,
+                recorded_at=datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc) + timedelta(seconds=seconds),
+                value=value,
+            )
+
+        result = timeseries_service.get_timeseries(
+            db, user.id, [SeriesType.steps], make_params(TimeseriesResolution.FIVE_MINUTES)
+        )
+
+        assert len(result.data) == 1
+        # 10 + 20 — the 5000 daily total must NOT be added on top
+        assert result.data[0].value == pytest.approx(30.0)
+
+    def test_active_time_daily_total_excluded_from_sum_bucket(self, db: Session, user_setup: UserSetup) -> None:
+        """Same double-count guard for active_time, a SUM series providers report daily."""
+        user, mapping, _, _ = user_setup
+        active_time_type = SeriesTypeDefinitionFactory.get_or_create_active_time()
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=active_time_type,
+            recorded_at=datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            value=480,
+            is_daily_total=True,
+        )
+        for seconds, value in [(30, 5), (90, 7)]:
+            DataPointSeriesFactory(
+                mapping=mapping,
+                series_type=active_time_type,
+                recorded_at=datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc) + timedelta(seconds=seconds),
+                value=value,
+            )
+
+        result = timeseries_service.get_timeseries(
+            db, user.id, [SeriesType.active_time], make_params(TimeseriesResolution.FIVE_MINUTES)
+        )
+
+        assert len(result.data) == 1
+        assert result.data[0].value == pytest.approx(12.0)  # 5 + 7, without the 480 daily total
+        assert result.data[0].unit == "minutes"
+
+    def test_bucket_with_only_daily_total_rows_is_dropped(self, db: Session, user_setup: UserSetup) -> None:
+        """A sub-day bucket holding only daily-total rows has nothing to report."""
+        user, mapping, _, steps_type = user_setup
+        # Daily total in the 10:00 bucket, one intraday sample in the 10:05 bucket
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=steps_type,
+            recorded_at=datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc),
+            value=5000,
+            is_daily_total=True,
+        )
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=steps_type,
+            recorded_at=datetime(2024, 1, 1, 10, 5, 30, tzinfo=timezone.utc),
+            value=42,
+        )
+
+        result = timeseries_service.get_timeseries(
+            db, user.id, [SeriesType.steps], make_params(TimeseriesResolution.FIVE_MINUTES)
+        )
+
+        assert len(result.data) == 1
+        assert result.pagination.total_count == 1
+        assert result.data[0].timestamp == datetime(2024, 1, 1, 10, 5, 0, tzinfo=timezone.utc)
+        assert result.data[0].value == pytest.approx(42.0)
+
+    def test_avg_series_still_uses_all_samples(self, db: Session, user_setup: UserSetup) -> None:
+        """The daily-total filter applies to SUM series only; AVG buckets are unchanged."""
+        user, mapping, hr_type, _ = user_setup
+        for seconds, value in [(5, 60), (25, 90)]:
+            DataPointSeriesFactory(
+                mapping=mapping,
+                series_type=hr_type,
+                recorded_at=datetime(2024, 1, 1, 10, 0, seconds, tzinfo=timezone.utc),
+                value=value,
+            )
+
+        result = timeseries_service.get_timeseries(
+            db, user.id, [SeriesType.heart_rate], make_params(TimeseriesResolution.ONE_MINUTE)
+        )
+
+        assert len(result.data) == 1
+        assert result.data[0].value == pytest.approx(75.0)
+
+
+class TestDownsampledRangeLimits:
+    """Downsampled queries reject spans beyond the resolution's maximum, before fetching."""
+
+    @pytest.fixture
+    def fail_on_fetch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Any call to the unpaginated range fetch fails the test (proves no fetch happened)."""
+
+        def _forbidden_fetch(*args: object, **kwargs: object) -> None:
+            raise AssertionError("get_samples_for_range must not be called for an oversized range")
+
+        monkeypatch.setattr(DataPointSeriesRepository, "get_samples_for_range", _forbidden_fetch)
+
+    @pytest.mark.parametrize(
+        ("resolution", "span_days"),
+        [
+            (TimeseriesResolution.ONE_MINUTE, 32),
+            (TimeseriesResolution.FIVE_MINUTES, 94),
+            (TimeseriesResolution.FIFTEEN_MINUTES, 94),
+            (TimeseriesResolution.ONE_HOUR, 367),
+        ],
+    )
+    def test_oversized_span_rejected_with_400(
+        self,
+        db: Session,
+        user_setup: UserSetup,
+        fail_on_fetch: None,
+        resolution: TimeseriesResolution,
+        span_days: int,
+    ) -> None:
+        user, _, _, _ = user_setup
+        params = TimeSeriesQueryParams(
+            start_datetime=RANGE_START,
+            end_datetime=RANGE_START + timedelta(days=span_days),
+            resolution=resolution,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            timeseries_service.get_timeseries(db, user.id, [], params)
+
+        assert exc_info.value.status_code == 400
+        assert "maximum" in exc_info.value.detail
+
+    @pytest.mark.parametrize(
+        ("resolution", "span_days"),
+        [
+            (TimeseriesResolution.ONE_MINUTE, 31),
+            (TimeseriesResolution.ONE_HOUR, 366),
+        ],
+    )
+    def test_max_allowed_span_is_accepted(
+        self, db: Session, user_setup: UserSetup, resolution: TimeseriesResolution, span_days: int
+    ) -> None:
+        user, mapping, hr_type, _ = user_setup
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=hr_type,
+            recorded_at=RANGE_START + timedelta(hours=1),
+            value=60,
+        )
+        params = TimeSeriesQueryParams(
+            start_datetime=RANGE_START,
+            end_datetime=RANGE_START + timedelta(days=span_days),
+            resolution=resolution,
+        )
+
+        result = timeseries_service.get_timeseries(db, user.id, [SeriesType.heart_rate], params)
+
+        assert len(result.data) == 1
+        assert result.metadata.resolution == resolution
+
+    def test_raw_resolution_has_no_span_cap(self, db: Session, user_setup: UserSetup) -> None:
+        """Raw reads paginate at the database level, so the span cap does not apply."""
+        user, mapping, hr_type, _ = user_setup
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=hr_type,
+            recorded_at=RANGE_START + timedelta(hours=1),
+            value=60,
+        )
+        params = TimeSeriesQueryParams(
+            start_datetime=RANGE_START,
+            end_datetime=RANGE_START + timedelta(days=400),
+            resolution=TimeseriesResolution.RAW,
+        )
+
+        result = timeseries_service.get_timeseries(db, user.id, [SeriesType.heart_rate], params)
+
+        assert len(result.data) == 1

--- a/backend/tests/services/test_timeseries_resolution.py
+++ b/backend/tests/services/test_timeseries_resolution.py
@@ -1,0 +1,297 @@
+"""
+Tests for server-side downsampling of the timeseries endpoint (resolution parameter).
+
+Tests cover:
+- The raw passthrough invariant (resolution="raw" returns stored samples unchanged)
+- Each downsampling resolution (1min, 5min, 15min, 1hour)
+- Aggregation semantics per series type (AVG for heart rate, SUM for steps)
+- UTC-aligned bucket boundaries
+- Empty ranges
+- Pagination over downsampled buckets
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models import DataSource, SeriesTypeDefinition, User
+from app.schemas.enums import SeriesType, TimeseriesResolution
+from app.schemas.model_crud.activities import TimeSeriesQueryParams
+from app.services.timeseries_service import timeseries_service
+from tests.factories import (
+    DataPointSeriesFactory,
+    DataSourceFactory,
+    SeriesTypeDefinitionFactory,
+    UserFactory,
+)
+
+RANGE_START = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+RANGE_END = datetime(2024, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+
+# (user, data source, heart_rate series type, steps series type)
+UserSetup = tuple[User, DataSource, SeriesTypeDefinition, SeriesTypeDefinition]
+
+
+def make_params(
+    resolution: TimeseriesResolution = TimeseriesResolution.RAW,
+    limit: int = 50,
+    cursor: str | None = None,
+) -> TimeSeriesQueryParams:
+    return TimeSeriesQueryParams(
+        start_datetime=RANGE_START,
+        end_datetime=RANGE_END,
+        limit=limit,
+        cursor=cursor,
+        resolution=resolution,
+    )
+
+
+@pytest.fixture
+def user_setup(db: Session) -> UserSetup:
+    """A user with one data source and the seeded heart_rate/steps series types."""
+    user = UserFactory()
+    mapping = DataSourceFactory(user=user, source="apple_health_sdk")
+    hr_type = SeriesTypeDefinitionFactory.get_or_create_heart_rate()
+    steps_type = SeriesTypeDefinitionFactory.get_or_create_steps()
+    return user, mapping, hr_type, steps_type
+
+
+class TestRawResolutionPassthrough:
+    """resolution="raw" (the default) must return stored samples unchanged."""
+
+    def test_raw_returns_stored_samples_unchanged(self, db: Session, user_setup: UserSetup) -> None:
+        user, mapping, hr_type, _ = user_setup
+        recorded_at = datetime(2024, 1, 1, 10, 0, 13, tzinfo=timezone.utc)
+        for i in range(5):
+            DataPointSeriesFactory(
+                mapping=mapping,
+                series_type=hr_type,
+                recorded_at=recorded_at + timedelta(seconds=17 * i),
+                value=60 + i,
+            )
+
+        result = timeseries_service.get_timeseries(db, user.id, [SeriesType.heart_rate], make_params())
+
+        assert len(result.data) == 5
+        assert result.pagination.total_count == 5
+        # Timestamps are NOT aligned to any bucket: raw passthrough
+        assert result.data[0].timestamp == recorded_at
+        assert [item.value for item in result.data] == [60.0, 61.0, 62.0, 63.0, 64.0]
+        # Raw responses do not advertise a resolution
+        assert result.metadata.resolution is None
+
+    def test_default_resolution_matches_explicit_raw(self, db: Session, user_setup: UserSetup) -> None:
+        user, mapping, hr_type, _ = user_setup
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=hr_type,
+            recorded_at=datetime(2024, 1, 1, 10, 0, 13, tzinfo=timezone.utc),
+            value=66,
+        )
+
+        default_params = TimeSeriesQueryParams(start_datetime=RANGE_START, end_datetime=RANGE_END)
+        explicit_raw = make_params(TimeseriesResolution.RAW)
+
+        default_result = timeseries_service.get_timeseries(db, user.id, [SeriesType.heart_rate], default_params)
+        raw_result = timeseries_service.get_timeseries(db, user.id, [SeriesType.heart_rate], explicit_raw)
+
+        assert default_result.model_dump() == raw_result.model_dump()
+
+
+class TestDownsamplingResolutions:
+    """Each non-raw resolution buckets and aggregates samples."""
+
+    def test_one_minute_resolution_averages_heart_rate(self, db: Session, user_setup: UserSetup) -> None:
+        user, mapping, hr_type, _ = user_setup
+        # Three samples in the 10:00 bucket, one in the 10:01 bucket
+        for seconds, value in [(5, 60), (25, 90), (45, 90)]:
+            DataPointSeriesFactory(
+                mapping=mapping,
+                series_type=hr_type,
+                recorded_at=datetime(2024, 1, 1, 10, 0, seconds, tzinfo=timezone.utc),
+                value=value,
+            )
+        DataPointSeriesFactory(
+            mapping=mapping,
+            series_type=hr_type,
+            recorded_at=datetime(2024, 1, 1, 10, 1, 5, tzinfo=timezone.utc),
+            value=72,
+        )
+
+        result = timeseries_service.get_timeseries(
+            db, user.id, [SeriesType.heart_rate], make_params(TimeseriesResolution.ONE_MINUTE)
+        )
+
+        assert len(result.data) == 2
+        assert result.pagination.total_count == 2
+        assert result.metadata.resolution == TimeseriesResolution.ONE_MINUTE
+        assert result.metadata.sample_count == 2
+        assert result.data[0].timestamp == datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        assert result.data[0].value == pytest.approx(80.0)  # (60 + 90 + 90) / 3
+        assert result.data[0].unit == "bpm"
+        assert result.data[1].timestamp == datetime(2024, 1, 1, 10, 1, 0, tzinfo=timezone.utc)
+        assert result.data[1].value == pytest.approx(72.0)
+
+    def test_five_minutes_resolution_sums_steps(self, db: Session, user_setup: UserSetup) -> None:
+        user, mapping, _, steps_type = user_setup
+        # 10:00:00, 10:00:59 and 10:04:59 all fall into the 10:00 five-minute bucket
+        for seconds, value in [(0, 10), (59, 20), (299, 30)]:
+            DataPointSeriesFactory(
+                mapping=mapping,
+                series_type=steps_type,
+                recorded_at=datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc) + timedelta(seconds=seconds),
+                value=value,
+            )
+
+        result = timeseries_service.get_timeseries(
+            db, user.id, [SeriesType.steps], make_params(TimeseriesResolution.FIVE_MINUTES)
+        )
+
+        assert len(result.data) == 1
+        assert result.data[0].timestamp == datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        assert result.data[0].value == pytest.approx(60.0)  # 10 + 20 + 30
+        assert result.data[0].unit == "count"
+
+    def test_fifteen_minutes_resolution_buckets(self, db: Session, user_setup: UserSetup) -> None:
+        user, mapping, hr_type, _ = user_setup
+        # One sample per quarter hour across one hour
+        for minute, value in [(0, 60), (15, 70), (30, 80), (45, 90)]:
+            DataPointSeriesFactory(
+                mapping=mapping,
+                series_type=hr_type,
+                recorded_at=datetime(2024, 1, 1, 10, minute, 0, tzinfo=timezone.utc),
+                value=value,
+            )
+
+        result = timeseries_service.get_timeseries(
+            db, user.id, [SeriesType.heart_rate], make_params(TimeseriesResolution.FIFTEEN_MINUTES)
+        )
+
+        assert [item.timestamp for item in result.data] == [
+            datetime(2024, 1, 1, 10, minute, 0, tzinfo=timezone.utc) for minute in (0, 15, 30, 45)
+        ]
+        assert [item.value for item in result.data] == [60.0, 70.0, 80.0, 90.0]
+
+    def test_one_hour_resolution_buckets(self, db: Session, user_setup: UserSetup) -> None:
+        user, mapping, hr_type, _ = user_setup
+        for hour, value in [(9, 55), (10, 65), (11, 75)]:
+            DataPointSeriesFactory(
+                mapping=mapping,
+                series_type=hr_type,
+                recorded_at=datetime(2024, 1, 1, hour, 30, 0, tzinfo=timezone.utc),
+                value=value,
+            )
+
+        result = timeseries_service.get_timeseries(
+            db, user.id, [SeriesType.heart_rate], make_params(TimeseriesResolution.ONE_HOUR)
+        )
+
+        assert [item.timestamp for item in result.data] == [
+            datetime(2024, 1, 1, hour, 0, 0, tzinfo=timezone.utc) for hour in (9, 10, 11)
+        ]
+
+
+class TestBucketBoundaries:
+    """Buckets are aligned on UTC epoch multiples of the interval."""
+
+    def test_sample_at_bucket_start_opens_new_bucket(self, db: Session, user_setup: UserSetup) -> None:
+        user, mapping, hr_type, _ = user_setup
+        # 10:04:59 belongs to the 10:00 bucket, 10:05:00 opens the 10:05 bucket
+        for minute, second, value in [(4, 59, 60), (5, 0, 70), (9, 59, 80)]:
+            DataPointSeriesFactory(
+                mapping=mapping,
+                series_type=hr_type,
+                recorded_at=datetime(2024, 1, 1, 10, minute, second, tzinfo=timezone.utc),
+                value=value,
+            )
+
+        result = timeseries_service.get_timeseries(
+            db, user.id, [SeriesType.heart_rate], make_params(TimeseriesResolution.FIVE_MINUTES)
+        )
+
+        assert len(result.data) == 2
+        assert result.data[0].timestamp == datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        assert result.data[0].value == pytest.approx(60.0)
+        assert result.data[1].timestamp == datetime(2024, 1, 1, 10, 5, 0, tzinfo=timezone.utc)
+        assert result.data[1].value == pytest.approx(75.0)  # (70 + 80) / 2
+
+    def test_buckets_do_not_merge_across_data_sources(self, db: Session, user_setup: UserSetup) -> None:
+        user, mapping, hr_type, _ = user_setup
+        other_mapping = DataSourceFactory(user=user, source="garmin_connect_api")
+        recorded_at = datetime(2024, 1, 1, 10, 0, 30, tzinfo=timezone.utc)
+        DataPointSeriesFactory(mapping=mapping, series_type=hr_type, recorded_at=recorded_at, value=60)
+        DataPointSeriesFactory(mapping=other_mapping, series_type=hr_type, recorded_at=recorded_at, value=70)
+
+        result = timeseries_service.get_timeseries(
+            db, user.id, [SeriesType.heart_rate], make_params(TimeseriesResolution.ONE_MINUTE)
+        )
+
+        assert len(result.data) == 2
+        assert {item.value for item in result.data} == {60.0, 70.0}
+        assert {item.source.provider for item in result.data} == {"apple_health_sdk", "garmin_connect_api"}
+
+    def test_mixed_series_types_bucket_independently(self, db: Session, user_setup: UserSetup) -> None:
+        user, mapping, hr_type, steps_type = user_setup
+        base = datetime(2024, 1, 1, 10, 0, 30, tzinfo=timezone.utc)
+        DataPointSeriesFactory(mapping=mapping, series_type=hr_type, recorded_at=base, value=60)
+        DataPointSeriesFactory(mapping=mapping, series_type=hr_type, recorded_at=base + timedelta(seconds=15), value=80)
+        DataPointSeriesFactory(mapping=mapping, series_type=steps_type, recorded_at=base, value=100)
+        DataPointSeriesFactory(
+            mapping=mapping, series_type=steps_type, recorded_at=base + timedelta(seconds=15), value=50
+        )
+
+        result = timeseries_service.get_timeseries(db, user.id, [], make_params(TimeseriesResolution.ONE_MINUTE))
+
+        by_type = {item.type: item for item in result.data}
+        assert by_type[SeriesType.heart_rate].value == pytest.approx(70.0)  # AVG
+        assert by_type[SeriesType.steps].value == pytest.approx(150.0)  # SUM
+
+
+class TestDownsampledEdgeCases:
+    def test_empty_range_returns_empty_page(self, db: Session, user_setup: UserSetup) -> None:
+        user, _, _, _ = user_setup
+
+        result = timeseries_service.get_timeseries(
+            db, user.id, [SeriesType.heart_rate], make_params(TimeseriesResolution.FIVE_MINUTES)
+        )
+
+        assert result.data == []
+        assert result.metadata.sample_count == 0
+        assert result.metadata.resolution == TimeseriesResolution.FIVE_MINUTES
+        assert result.pagination.total_count == 0
+        assert result.pagination.has_more is False
+        assert result.pagination.next_cursor is None
+
+    def test_downsampled_pagination_follows_next_cursor(self, db: Session, user_setup: UserSetup) -> None:
+        user, mapping, hr_type, _ = user_setup
+        # Three hourly buckets
+        for hour, value in [(8, 50), (9, 60), (10, 70)]:
+            DataPointSeriesFactory(
+                mapping=mapping,
+                series_type=hr_type,
+                recorded_at=datetime(2024, 1, 1, hour, 15, 0, tzinfo=timezone.utc),
+                value=value,
+            )
+
+        page1 = timeseries_service.get_timeseries(
+            db, user.id, [SeriesType.heart_rate], make_params(TimeseriesResolution.ONE_HOUR, limit=2)
+        )
+
+        assert len(page1.data) == 2
+        assert page1.pagination.has_more is True
+        assert page1.pagination.total_count == 3
+        assert page1.pagination.next_cursor is not None
+
+        page2 = timeseries_service.get_timeseries(
+            db,
+            user.id,
+            [SeriesType.heart_rate],
+            make_params(TimeseriesResolution.ONE_HOUR, limit=2, cursor=page1.pagination.next_cursor),
+        )
+
+        assert len(page2.data) == 1
+        assert page2.data[0].timestamp == datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        assert page2.pagination.has_more is False
+        # No overlap and no gap between pages
+        assert page1.data[-1].timestamp < page2.data[0].timestamp


### PR DESCRIPTION
## Description

`GET /api/v1/users/{user_id}/timeseries` accepts a `resolution` query parameter (`raw|1min|5min|15min|1hour`), but the route never forwarded it — every consumer received raw samples regardless.

This PR implements server-side downsampling: UTC-aligned buckets keyed by `(bucket, series type, data source)`, aggregation via the existing `get_aggregation_method()` mapping (SUM/AVG/MAX), keyset pagination over buckets, and `raw` (default) byte-identical to `main`.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

- [x] `uv run pre-commit run --all-files` passes (`ty` reports the same 9 pre-existing diagnostics as `main`, none introduced here)

## Testing Instructions

1. Seed timeseries data for a user.
2. `GET .../timeseries?...&types=heart_rate&resolution=5min` → 5-minute AVG buckets, `metadata.resolution="5min"`.
3. `resolution=raw` → identical response to `main`.

## Additional Notes

14 new tests (service + API). `make test` → 2053 passed, 2 skipped. Bucketing is done in the service layer to preserve keyset pagination; SQL-side (`date_bin`) is a possible follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `resolution` query parameter for timeseries (raw, 1-minute, 5-minute, 15-minute, 1-hour), including response metadata.
  * Implemented UTC-aligned downsampling with series-specific aggregation and cursor-based pagination for downsampled results.
  * Added max-range validation for downsampled queries.
* **Bug Fixes**
  * Prevented daily totals from being double-counted within sub-day buckets.
* **Tests**
  * Added end-to-end and service-level coverage for resolution defaults, invalid inputs, bucket boundaries, pagination, and range limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->