### PR TITLE
feat(backend): add traceback for HTTP 500

### DIFF
--- a/backend/app/middlewares.py
+++ b/backend/app/middlewares.py
@@ -1,6 +1,7 @@
 import contextlib
 import logging
 import time
+import traceback
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -54,7 +55,13 @@ def add_access_log_middleware(app: FastAPI) -> None:
     capture_body = settings.log_error_response_body
     body_window = _RateWindow(settings.log_error_response_body_max_per_minute)
 
-    def emit(request: Request, status: int, duration_ms: float, response_body: str | None = None) -> None:
+    def emit(
+        request: Request,
+        status: int,
+        duration_ms: float,
+        response_body: str | None = None,
+        error: BaseException | None = None,
+    ) -> None:
         if level == AccessLogLevel.ERRORS and status < 400:
             return
         path = f"{request.url.path}?{request.url.query}" if request.url.query else request.url.path
@@ -66,6 +73,12 @@ def add_access_log_middleware(app: FastAPI) -> None:
         }
         if response_body is not None:
             attributes["response_body"] = response_body
+        if error is not None:
+            # Attach the cause so a 500 is diagnosable from our own logs (stdout),
+            # which — unlike Sentry — is not subject to rate-limiting/quota drops.
+            attributes["error_type"] = type(error).__name__
+            attributes["error_message"] = str(error)
+            attributes["traceback"] = "".join(traceback.format_exception(error))
         # a logging failure must never break request handling
         with contextlib.suppress(Exception):
             log_structured(logger, "error" if status >= 400 else "info", "http_request", **attributes)
@@ -75,10 +88,11 @@ def add_access_log_middleware(app: FastAPI) -> None:
         start = time.perf_counter()
         try:
             response = await call_next(request)
-        except Exception:
-            # Unhandled exception → 500; log the line, then re-raise so the ASGI
-            # Sentry integration still captures it.
-            emit(request, 500, round((time.perf_counter() - start) * 1000, 1))
+        except Exception as exc:
+            # Unhandled exception → 500; log the line WITH the traceback so the cause
+            # lands in our own logs, then re-raise so the ASGI Sentry integration still
+            # captures it (single source — we don't capture here, to avoid duplicates).
+            emit(request, 500, round((time.perf_counter() - start) * 1000, 1), error=exc)
             raise
 
         # 4xx detail stashed on request.state by the HTTPException handler; rate-capped.

--- a/backend/app/middlewares.py
+++ b/backend/app/middlewares.py
@@ -76,9 +76,17 @@ def add_access_log_middleware(app: FastAPI) -> None:
         if error is not None:
             # Attach the cause so a 500 is diagnosable from our own logs (stdout),
             # which — unlike Sentry — is not subject to rate-limiting/quota drops.
+            # Formatting runs before the suppress() block below, so guard it here: a
+            # broken __str__/__repr__ must not raise and mask the original exception.
+            try:
+                error_message = str(error)
+                formatted_traceback = "".join(traceback.format_exception(error))
+            except Exception:
+                error_message = "<unavailable>"
+                formatted_traceback = "<unavailable>"
             attributes["error_type"] = type(error).__name__
-            attributes["error_message"] = str(error)
-            attributes["traceback"] = "".join(traceback.format_exception(error))
+            attributes["error_message"] = error_message
+            attributes["traceback"] = formatted_traceback
         # a logging failure must never break request handling
         with contextlib.suppress(Exception):
             log_structured(logger, "error" if status >= 400 else "info", "http_request", **attributes)


### PR DESCRIPTION
Resolves #1350 

Before this PR:
```
HTTP status returned to client : 500
Sentry error events captured   : 1
Access-log line keys           : ['duration_ms', 'level', 'message', 'method', 'path', 'provider', 'status', 'timestamp']
--- structured access-log line (stdout) ---
{
  "timestamp": "2026-07-28T11:10:57.020123+00:00",
  "level": "error",
  "message": "http_request",
  "provider": null,
  "method": "POST",
  "path": "/api/v1/sdk/users/11bff329-09f3-4f19-996e-f3498aebb900/sync",
  "status": 500,
  "duration_ms": 0.6
}
```

After this PR:
```
HTTP status returned to client : 500
Sentry error events captured   : 1
Access-log line keys           : ['duration_ms', 'error_message', 'error_type', 'level', 'message', 'method', 'path', 'provider', 'status', 'timestamp', 'traceback']
--- structured access-log line (stdout) ---
{
  "timestamp": "2026-07-28T11:10:21.017665+00:00",
  "level": "error",
  "message": "http_request",
  "provider": null,
  "method": "POST",
  "path": "/api/v1/sdk/users/11bff329-09f3-4f19-996e-f3498aebb900/sync",
  "status": 500,
  "duration_ms": 0.4,
  "error_type": "OperationalError",
  "error_message": "Error 'OOM command not allowed when used memory > maxmemory' while writing to socket",
  "traceback": "Traceback (most recent call last):\n  File \"/Users/sk/Projects/OpenWearables/backend/app/middlewares.py\", line 90, in access_log\n    response = await call_next(request)\n               ^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/starlette/middleware/base.py\", line 168, in call_next\n    raise app_exc from app_exc.__cause__ or app_exc.__context__\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/starlette/middleware/base.py\", line 144, in coro\n    await self.app(scope, receive_or_disconnect, send_no_error)\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/starlette.py\", line 195, in _create_span_call\n    return await old_call(app, scope, receive, send, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/starlette/middleware/cors.py\", line 88, in __call__\n    await self.app(scope, receive, send)\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/starlette.py\", line 362, in _sentry_exceptionmiddleware_call\n    await old_call(self, scope, receive, send)\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/starlette.py\", line 195, in _create_span_call\n    return await old_call(app, scope, receive, send, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/starlette/middleware/exceptions.py\", line 63, in __call__\n    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py\", line 53, in wrapped_app\n    raise exc\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py\", line 42, in wrapped_app\n    await app(scope, receive, sender)\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/starlette.py\", line 195, in _create_span_call\n    return await old_call(app, scope, receive, send, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/fastapi/middleware/asyncexitstack.py\", line 18, in __call__\n    await self.app(scope, receive, send)\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/starlette/routing.py\", line 660, in __call__\n    await self.middleware_stack(scope, receive, send)\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/fastapi/routing.py\", line 2685, in app\n    await route.handle(scope, receive, send)\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/fastapi/routing.py\", line 1267, in handle\n    await super().handle(scope, receive, send)\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/starlette/routing.py\", line 276, in handle\n    await self.app(scope, receive, send)\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/fastapi/routing.py\", line 151, in app\n    await wrap_app_handling_exceptions(app, request)(scope, receive, send)\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py\", line 53, in wrapped_app\n    raise exc\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/starlette/_exception_handler.py\", line 42, in wrapped_app\n    await app(scope, receive, sender)\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/fastapi/routing.py\", line 137, in app\n    response = await f(request)\n               ^^^^^^^^^^^^^^^^\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/fastapi.py\", line 197, in _sentry_app\n    return await _wrap_async_handler(old_app, *args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/fastapi.py\", line 137, in _wrap_async_handler\n    return await handler(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/fastapi/routing.py\", line 691, in app\n    raw_response = await run_endpoint_function(\n                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    ...<3 lines>...\n    )\n    ^\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/fastapi/routing.py\", line 347, in run_endpoint_function\n    return await run_in_threadpool(dependant.call, **values)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/starlette/concurrency.py\", line 34, in run_in_threadpool\n    return await anyio.to_thread.run_sync(func)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/anyio/to_thread.py\", line 65, in run_sync\n    return await get_async_backend().run_sync_in_worker_thread(\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n        func, args, abandon_on_cancel=abandon_on_cancel, limiter=limiter\n        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n    )\n    ^\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/anyio/_backends/_asyncio.py\", line 2641, in run_sync_in_worker_thread\n    return await future\n           ^^^^^^^^^^^^\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/anyio/_backends/_asyncio.py\", line 1033, in run\n    result = context.run(func, *args)\n  File \"/Users/sk/Projects/OpenWearables/backend/.venv/lib/python3.13/site-packages/sentry_sdk/integrations/fastapi.py\", line 189, in _sentry_call\n    return old_call(*args, **kwargs)\n  File \"/private/tmp/claude-501/-Users-sk-Projects-OpenWearables/98422dc1-ff84-4e30-9d9e-72f23da0bcca/scratchpad/verify_access_log.py\", line 38, in sync\n    raise OperationalError(\"Error 'OOM command not allowed when used memory > maxmemory' while writing to socket\")\nkombu.exceptions.OperationalError: Error 'OOM command not allowed when used memory > maxmemory' while writing to socket"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured access logging for unhandled server exceptions.
  * Logs now include the error type, message, and full traceback for easier troubleshooting, while preserving existing exception-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->