### PR TITLE
feat(backend): drop & log incorrect rows from SDK sync

### DIFF
--- a/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
+++ b/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
@@ -135,22 +135,27 @@ def process_sdk_upload(
         records_saved = int(result.get("records_saved", 0) or 0)
         workouts_saved = int(result.get("workouts_saved", 0) or 0)
         sleep_saved = int(result.get("sleep_saved", 0) or 0)
+        dropped_count = int(result.get("dropped_count", 0) or 0)
         items_total = records_saved + workouts_saved + sleep_saved
 
         if isinstance(status_code, int) and 200 <= status_code < 300:
+            message = f"{provider.capitalize()} batch saved"
+            if dropped_count:
+                message += f" ({dropped_count} record(s) dropped by validation)"
             completed(
                 user_uuid,
                 provider,
                 SyncSource.SDK,
                 run_id=batch_id,
                 status=SyncStatus.SUCCESS,
-                message=f"{provider.capitalize()} batch saved",
+                message=message,
                 items_processed=items_total,
                 metadata={
                     "batch_id": batch_id,
                     "records_saved": records_saved,
                     "workouts_saved": workouts_saved,
                     "sleep_saved": sleep_saved,
+                    "dropped_count": dropped_count,
                 },
             )
         else:

--- a/backend/app/schemas/responses/upload/upload_response.py
+++ b/backend/app/schemas/responses/upload/upload_response.py
@@ -12,3 +12,6 @@ class UploadDataResponse(BaseModel):
     response: str = Field(..., description="Human-readable response message")
     user_id: str | None = Field(None, description="User ID associated with the import operation")
     dropped_count: int = Field(0, description="Number of individual records dropped by per-record validation")
+    records_saved: int = Field(0, description="Time-series samples saved")
+    workouts_saved: int = Field(0, description="Workouts saved")
+    sleep_saved: int = Field(0, description="Sleep records saved")

--- a/backend/app/schemas/responses/upload/upload_response.py
+++ b/backend/app/schemas/responses/upload/upload_response.py
@@ -11,3 +11,4 @@ class UploadDataResponse(BaseModel):
     status_code: int = Field(..., description="HTTP status code (typically 202 for async operations)")
     response: str = Field(..., description="Human-readable response message")
     user_id: str | None = Field(None, description="User ID associated with the import operation")
+    dropped_count: int = Field(0, description="Number of individual records dropped by per-record validation")

--- a/backend/app/services/apple/healthkit/import_service.py
+++ b/backend/app/services/apple/healthkit/import_service.py
@@ -74,29 +74,28 @@ class LoadDataResult(TypedDict):
 
 
 def _parse_sync_request(raw: dict) -> tuple[SDKSyncRequest, list[InvalidRecord]]:
-    """Parse a raw sync payload into a SyncRequest, keeping valid records when items fail.
+    """Parse a raw payload into a SyncRequest, salvaging valid records when items fail.
 
-    Fast path: the whole payload validates in one shot — no per-item cost when clean.
-    On failure, validate the envelope plus each record independently, keep the valid
-    ones, and return the per-item failures (loc/msg/type only — no record values, so
-    the result is PII-free). Raises ``ValidationError`` only when the envelope itself
-    (provider/sdkVersion/syncTimestamp/data shape) is invalid — i.e. nothing is
-    salvageable, so the whole batch is legitimately rejected.
+    Fast path validates in one shot. On failure, valid records are kept and the per-item
+    failures returned (PII-free: loc/msg/type). Raises ValidationError when the envelope or
+    a container shape is invalid — nothing salvageable, so the batch is rejected (400).
     """
     try:
         return SDKSyncRequest(**raw), []
     except ValidationError:
         pass  # fall through to per-item validation
 
-    inner = raw.get("data")
-    inner = inner if isinstance(inner, dict) else {}
+    # Only individual records are salvageable. A malformed container shape (data not a dict,
+    # or a collection not a list) is not — re-validate to re-raise the real ValidationError.
+    data = raw.get("data")
+    if not isinstance(data, dict) or any(not isinstance(data.get(key, []), list) for key, _ in _SDK_ITEM_MODELS):
+        return SDKSyncRequest(**raw), []
+
     kept: dict[str, list] = {}
     dropped: list[InvalidRecord] = []
     for key, model in _SDK_ITEM_MODELS:
-        items = inner.get(key)
-        items = items if isinstance(items, list) else []
         good: list = []
-        for idx, item in enumerate(items):
+        for idx, item in enumerate(data.get(key, [])):
             try:
                 good.append(model.model_validate(item))
             except ValidationError as exc:
@@ -112,10 +111,8 @@ def _parse_sync_request(raw: dict) -> tuple[SDKSyncRequest, list[InvalidRecord]]
                 )
         kept[key] = good
 
-    # The envelope must still validate on its own; if it does not, nothing is
-    # salvageable and this raises ValidationError (handled by the caller as a 400).
-    # model_validate (vs kwargs) keeps the raw envelope values as-is and lets Pydantic
-    # reject a bad provider/sdkVersion/syncTimestamp, while `data` carries the kept records.
+    # Reconstruct via model_validate so Pydantic still rejects a bad envelope; `data` now
+    # carries only the kept records.
     request = SDKSyncRequest.model_validate(
         {**raw, "data": SyncRequestData(records=kept["records"], sleep=kept["sleep"], workouts=kept["workouts"])}
     )
@@ -509,6 +506,9 @@ class ImportService:
                 response="Import successful",
                 user_id=user_id,
                 dropped_count=len(dropped),
+                records_saved=saved_counts["records_saved"],
+                workouts_saved=saved_counts["workouts_saved"],
+                sleep_saved=saved_counts["sleep_saved"],
             )
 
         except ValidationError as e:

--- a/backend/app/services/apple/healthkit/import_service.py
+++ b/backend/app/services/apple/healthkit/import_service.py
@@ -1,10 +1,12 @@
 import json
+import time
 from datetime import datetime
 from decimal import Decimal
 from logging import Logger, getLogger
-from typing import Iterable
+from typing import Iterable, TypedDict
 from uuid import UUID, uuid4
 
+import sentry_sdk
 from pydantic import ValidationError
 
 from app.constants.series_types.sdk import (
@@ -31,6 +33,12 @@ from app.schemas.providers.mobile_sdk import (
 from app.schemas.providers.mobile_sdk import (
     WorkoutStatistic,
 )
+from app.schemas.providers.mobile_sdk.sync_request import (
+    MetricRecord,
+    SleepRecord,
+    SyncRequestData,
+    Workout,
+)
 from app.schemas.responses.upload import UploadDataResponse
 from app.services.event_record_service import event_record_service
 from app.services.timeseries_service import timeseries_service
@@ -43,6 +51,75 @@ from .sleep_service import handle_sleep_data
 # Health Connect's own mg/dL converter uses exactly 18.0, so values written to HC
 # in mg/dL round-trip with a ~0.1% offset under this factor.
 MMOL_L_TO_MG_DL = Decimal("18.0182")
+
+_SDK_ITEM_MODELS = (("records", MetricRecord), ("sleep", SleepRecord), ("workouts", Workout))
+
+
+class InvalidRecord(TypedDict):
+    """A single record dropped by per-record validation (PII-free — only the location, no values)."""
+
+    collection: str  # "records" | "sleep" | "workouts"
+    index: int
+    loc: str
+    msg: str | None
+    type: str | None
+
+
+class LoadDataResult(TypedDict):
+    workouts_saved: int
+    records_saved: int
+    sleep_saved: int
+    dropped: list[InvalidRecord]
+    validation_ms: float
+
+
+def _parse_sync_request(raw: dict) -> tuple[SDKSyncRequest, list[InvalidRecord]]:
+    """Parse a raw sync payload into a SyncRequest, keeping valid records when items fail.
+
+    Fast path: the whole payload validates in one shot — no per-item cost when clean.
+    On failure, validate the envelope plus each record independently, keep the valid
+    ones, and return the per-item failures (loc/msg/type only — no record values, so
+    the result is PII-free). Raises ``ValidationError`` only when the envelope itself
+    (provider/sdkVersion/syncTimestamp/data shape) is invalid — i.e. nothing is
+    salvageable, so the whole batch is legitimately rejected.
+    """
+    try:
+        return SDKSyncRequest(**raw), []
+    except ValidationError:
+        pass  # fall through to per-item validation
+
+    inner = raw.get("data")
+    inner = inner if isinstance(inner, dict) else {}
+    kept: dict[str, list] = {}
+    dropped: list[InvalidRecord] = []
+    for key, model in _SDK_ITEM_MODELS:
+        items = inner.get(key)
+        items = items if isinstance(items, list) else []
+        good: list = []
+        for idx, item in enumerate(items):
+            try:
+                good.append(model.model_validate(item))
+            except ValidationError as exc:
+                err = (exc.errors() or [{}])[0]
+                dropped.append(
+                    {
+                        "collection": key,
+                        "index": idx,
+                        "loc": ".".join(str(x) for x in err.get("loc", [])),
+                        "msg": err.get("msg"),
+                        "type": err.get("type"),
+                    }
+                )
+        kept[key] = good
+
+    # The envelope must still validate on its own; if it does not, nothing is
+    # salvageable and this raises ValidationError (handled by the caller as a 400).
+    # model_validate (vs kwargs) keeps the raw envelope values as-is and lets Pydantic
+    # reject a bad provider/sdkVersion/syncTimestamp, while `data` carries the kept records.
+    request = SDKSyncRequest.model_validate(
+        {**raw, "data": SyncRequestData(records=kept["records"], sleep=kept["sleep"], workouts=kept["workouts"])}
+    )
+    return request, dropped
 
 
 class ImportService:
@@ -269,14 +346,17 @@ class ImportService:
         raw: dict,
         user_id: str,
         batch_id: str | None = None,
-    ) -> dict[str, int]:
+    ) -> LoadDataResult:
         """
-        Load data into database and return counts of saved items.
-
-        Returns:
-            dict with counts: {"workouts_saved": int, "records_saved": int, "sleep_saved": int}
+        Load data into database and return counts of saved items plus per-record failures.
         """
-        request = SDKSyncRequest(**raw)
+        # Per-record validation: keep valid records, drop+report the invalid ones instead
+        # of failing the whole batch. Raises ValidationError only if the envelope is invalid.
+        # validation_ms measures the parse/per-record pass so we can watch the cost of a
+        # malformed payload in the logs.
+        started = time.perf_counter()
+        request, dropped = _parse_sync_request(raw)
+        validation_ms = round((time.perf_counter() - started) * 1000, 1)
         workouts_saved = 0
         records_saved = 0
         sleep_saved = 0
@@ -324,6 +404,8 @@ class ImportService:
             "workouts_saved": workouts_saved,
             "records_saved": records_saved,
             "sleep_saved": sleep_saved,
+            "dropped": dropped,
+            "validation_ms": validation_ms,
         }
 
     def import_data_from_request(
@@ -388,10 +470,52 @@ class ImportService:
                 records_saved=saved_counts["records_saved"],
                 workouts_saved=saved_counts["workouts_saved"],
                 sleep_saved=saved_counts["sleep_saved"],
+                validation_ms=saved_counts["validation_ms"],
+            )
+
+            dropped = saved_counts.get("dropped") or []
+            if dropped:
+                # Partial success: some records failed per-record validation. The good
+                # ones are already saved above; report the exact field errors to Sentry
+                # (PII-free: loc/msg/type) so we keep full visibility into what was lost.
+                with sentry_sdk.push_scope() as scope:
+                    scope.set_level("warning")
+                    scope.set_context(
+                        "dropped_records",
+                        {
+                            "batch_id": batch_id,
+                            "user_id": user_id,
+                            "provider": provider,
+                            "dropped_count": len(dropped),
+                            "errors": dropped[:20],
+                        },
+                    )
+                    sentry_sdk.capture_message(f"{provider} SDK payload: dropped invalid records, kept the rest")
+                log_structured(
+                    self.log,
+                    "warning",
+                    f"{provider.capitalize()} SDK dropped invalid records",
+                    provider=f"{provider}",
+                    action=f"{provider}_sdk_records_dropped",
+                    batch_id=batch_id,
+                    user_id=user_id,
+                    dropped_count=len(dropped),
+                    first_error_loc=dropped[0].get("loc"),
+                    first_error_msg=dropped[0].get("msg"),
+                )
+
+            return UploadDataResponse(
+                status_code=200,
+                response="Import successful",
+                user_id=user_id,
+                dropped_count=len(dropped),
             )
 
         except ValidationError as e:
-            # Payload failed schema validation; report to Sentry with the field-level errors.
+            # Reached ONLY when the envelope itself is invalid (provider/sdkVersion/
+            # syncTimestamp/data shape) — _parse_sync_request re-raised because nothing was
+            # salvageable. Per-record failures never reach here: they are collected inside
+            # load_data and handled above as a partial success. Report + 400 the whole batch.
             errors = e.errors()
             first = errors[0] if errors else {}
             # Drop `input` (raw record value — may contain health data/PII) and `url`
@@ -449,8 +573,6 @@ class ImportService:
                 response=f"Import failed: {str(e)}",
                 user_id=user_id,
             )
-
-        return UploadDataResponse(status_code=200, response="Import successful", user_id=user_id)
 
     def _parse_multipart_content(self, content: str) -> dict | None:
         """Parse multipart form data to extract JSON."""


### PR DESCRIPTION
Resolves #1353 

## What it solves
- only incorrect rows are dropped and send to sentry
- the rest of the rows from the same batch will be saved to database now

Before:
- sync status
<img width="1064" height="106" alt="image" src="https://github.com/user-attachments/assets/57c83eda-7687-4b86-81cc-2070421e95af" />

Now:
- sync status
<img width="1049" height="169" alt="image" src="https://github.com/user-attachments/assets/048be7cb-81cc-4c7a-8a8a-d33e1a4715f9" />

- sentry
<img width="499" height="565" alt="image" src="https://github.com/user-attachments/assets/00ace217-8737-4f94-904b-5fd632acbfcc" />

- logs (validation time included)
```
{"timestamp": "2026-07-28T18:28:46.985898+00:00", "level": "info", "message": "Apple data import completed", "provider": "apple", "action": "apple_sdk_import_complete", "batch_id": "3ae2170f-cf9a-4858-83dc-3f4856cf7f6c", "user_id": "699e1c0c-7f75-43fd-8539-02aaefd0036d", "incoming_records": 1750, "incoming_workouts": 125, "incoming_sleep": 125, "records_saved": 2023, "workouts_saved": 124, "sleep_saved": 124, "validation_ms": 98.8, "trace_id": "981b9b04"}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Apple HealthKit imports now keep valid items even when some individual records fail validation.
  * Upload/sync responses now report `dropped_count`, along with `records_saved`, `workouts_saved`, and `sleep_saved`.
  * Success messaging now indicates when records were excluded due to validation.

* **Bug Fixes**
  * Isolated invalid records no longer cause an otherwise valid import batch to fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->