### PR TITLE
feat(backend): remove all provider's data

### DIFF
--- a/backend/app/api/routes/v1/connections.py
+++ b/backend/app/api/routes/v1/connections.py
@@ -81,3 +81,16 @@ def disconnect_provider_endpoint(
     strategy = ProviderFactory().get_provider(provider.value)
     user_connection_service.disconnect(db, user_id, provider.value, oauth=strategy.oauth)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.delete("/users/{user_id}/connections/{provider}/data")
+def delete_provider_data_endpoint(
+    user_id: UUID,
+    provider: ProviderName,
+    db: DbSession,
+    _api_key: ApiKeyDep,
+) -> Response:
+    """Delete all of a user's data for a provider and revoke the connection."""
+    strategy = ProviderFactory().get_provider(provider.value)
+    user_connection_service.purge_provider_data(db, user_id, provider.value, oauth=strategy.oauth)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/repositories/data_source_repository.py
+++ b/backend/app/repositories/data_source_repository.py
@@ -1,11 +1,12 @@
+from typing import cast
 from uuid import UUID, uuid4
 
-from sqlalchemy import and_, asc, func
+from sqlalchemy import CursorResult, and_, asc, delete, func
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.sql.elements import ColumnElement
 
 from app.database import DbSession
-from app.models import DataSource, ProviderPriority
+from app.models import DataSource, HealthScore, ProviderPriority
 from app.repositories.provider_priority_repository import ProviderPriorityRepository
 from app.repositories.repositories import CrudRepository
 from app.schemas.enums import DeviceType, ProviderName, infer_device_type_from_model, infer_device_type_from_source_name
@@ -175,6 +176,36 @@ class DataSourceRepository(
             .order_by(asc(self.model.provider), asc(self.model.device_model))
             .all()
         )
+
+    def delete_user_provider_data(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        provider: ProviderName,
+    ) -> int:
+        """Delete all of a user's data for a single provider.
+
+        Deletes the user's health_score rows for the provider (some are not linked to
+        a data_source), then the data_source rows. ON DELETE CASCADE on the data_source
+        FK removes every dependent row - event_records, data_point_series (+ archive),
+        event/sleep/workout/menstrual details and health_scores linked via data_source
+        or event_record. Returns the number of data_source rows deleted.
+        """
+        db_session.execute(
+            delete(HealthScore).where(
+                and_(HealthScore.user_id == user_id, HealthScore.provider == provider),
+            ),
+        )
+        result = cast(
+            CursorResult,
+            db_session.execute(
+                delete(self.model).where(
+                    and_(self.model.user_id == user_id, self.model.provider == provider),
+                ),
+            ),
+        )
+        db_session.commit()
+        return result.rowcount
 
     def infer_provider_from_source(self, source: str | None) -> ProviderName:
         """Infer provider from source string.

--- a/backend/app/services/user_connection_service.py
+++ b/backend/app/services/user_connection_service.py
@@ -4,7 +4,9 @@ from uuid import UUID
 
 from app.database import DbSession
 from app.models import UserConnection
+from app.repositories.data_source_repository import DataSourceRepository
 from app.repositories.user_connection_repository import UserConnectionRepository
+from app.schemas.enums import ProviderName
 from app.schemas.model_crud.user_management import UserConnectionCreate, UserConnectionUpdate
 from app.schemas.responses.upload import ConnectionsCoverage, ProviderConnectionCount
 from app.services.outgoing_webhooks.events import on_connection_revoked
@@ -25,6 +27,7 @@ class UserConnectionService(
             log=log,
             **kwargs,
         )
+        self.data_source_crud = DataSourceRepository()
 
     def get_active_count_in_range(self, db_session: DbSession, start_date: datetime, end_date: datetime) -> int:
         """Get count of active connections created within a date range."""
@@ -85,6 +88,22 @@ class UserConnectionService(
         connection = self.crud.get_by_user_and_provider(db_session, user_id, provider)
         if not connection:
             raise ResourceNotFoundError("connection", user_id)
+
+    @handle_exceptions
+    def purge_provider_data(
+        self, db_session: DbSession, user_id: UUID, provider: str, oauth: BaseOAuthTemplate | None = None
+    ) -> int:
+        """Revoke the connection and delete all of the user's data for the provider.
+
+        Runs the standard disconnect (best-effort deregistration, revoke, webhook), then
+        deletes the user's data_source rows for the provider. ON DELETE CASCADE removes all
+        dependent event records, series, details and health scores. Returns the number of
+        data_source rows deleted. Safe to call on an already-revoked connection.
+        """
+        self.disconnect(db_session, user_id, provider, oauth=oauth)
+        deleted = self.data_source_crud.delete_user_provider_data(db_session, user_id, ProviderName(provider))
+        self.logger.info("Purged %s data sources for user %s from provider %s", deleted, user_id, provider)
+        return deleted
 
     @handle_exceptions
     def stamp_last_synced_at(self, db_session: DbSession, user_id: UUID, provider: str) -> None:

--- a/backend/tests/api/v1/test_connections.py
+++ b/backend/tests/api/v1/test_connections.py
@@ -15,9 +15,18 @@ from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app.models import UserConnection
+from app.models import DataPointSeries, DataSource, EventRecord, HealthScore, User, UserConnection, WorkoutDetails
 from app.schemas.auth import ConnectionStatus
-from tests.factories import ApiKeyFactory, UserConnectionFactory, UserFactory
+from tests.factories import (
+    ApiKeyFactory,
+    DataPointSeriesFactory,
+    DataSourceFactory,
+    EventRecordFactory,
+    HealthScoreFactory,
+    UserConnectionFactory,
+    UserFactory,
+    WorkoutDetailsFactory,
+)
 from tests.utils import api_key_headers
 
 
@@ -463,6 +472,129 @@ class TestDisconnectEndpoint:
         conn2 = db.query(UserConnection).filter_by(user_id=user2.id, provider="garmin").one()
         assert conn1.status == ConnectionStatus.REVOKED
         assert conn2.status == ConnectionStatus.ACTIVE
+
+
+class TestDeleteProviderDataEndpoint:
+    """Test suite for DELETE /api/v1/users/{user_id}/connections/{provider}/data."""
+
+    def _seed_provider_data(self, user: User, provider: str) -> DataSource:
+        """Create a data_source with a workout (+details), a time series and a health score."""
+        data_source = DataSourceFactory(user=user, provider=provider)
+        event = EventRecordFactory(data_source=data_source, category="workout")
+        WorkoutDetailsFactory(event_record=event)
+        DataPointSeriesFactory(data_source=data_source)
+        HealthScoreFactory(user_id=user.id, data_source_id=data_source.id, provider=provider)
+        return data_source
+
+    def test_delete_data_removes_all_provider_data_and_revokes(self, client: TestClient, db: Session) -> None:
+        """Deleting provider data removes every dependent row (via cascade) and revokes the connection."""
+        # Arrange
+        user = UserFactory()
+        UserConnectionFactory(user=user, provider="apple", status=ConnectionStatus.ACTIVE)
+        ds = self._seed_provider_data(user, "apple")
+        ds_id = ds.id
+        api_key = ApiKeyFactory()
+        headers = api_key_headers(api_key.id)
+
+        # Act
+        response = client.delete(f"/api/v1/users/{user.id}/connections/apple/data", headers=headers)
+
+        # Assert
+        assert response.status_code == 204
+        db.expire_all()
+        assert db.query(DataSource).filter_by(user_id=user.id, provider="apple").count() == 0
+        assert db.query(EventRecord).filter_by(data_source_id=ds_id).count() == 0
+        assert db.query(WorkoutDetails).count() == 0
+        assert db.query(DataPointSeries).filter_by(data_source_id=ds_id).count() == 0
+        assert db.query(HealthScore).filter_by(user_id=user.id, provider="apple").count() == 0
+        conn = db.query(UserConnection).filter_by(user_id=user.id, provider="apple").one()
+        assert conn.status == ConnectionStatus.REVOKED
+
+    def test_delete_data_does_not_affect_other_providers(self, client: TestClient, db: Session) -> None:
+        """Deleting Apple data leaves Suunto's data and connection untouched."""
+        # Arrange
+        user = UserFactory()
+        UserConnectionFactory(user=user, provider="apple", status=ConnectionStatus.ACTIVE)
+        UserConnectionFactory(user=user, provider="suunto", status=ConnectionStatus.ACTIVE)
+        self._seed_provider_data(user, "apple")
+        suunto_ds = self._seed_provider_data(user, "suunto")
+        suunto_ds_id = suunto_ds.id
+        api_key = ApiKeyFactory()
+        headers = api_key_headers(api_key.id)
+
+        # Act
+        response = client.delete(f"/api/v1/users/{user.id}/connections/apple/data", headers=headers)
+
+        # Assert
+        assert response.status_code == 204
+        db.expire_all()
+        assert db.query(DataSource).filter_by(user_id=user.id, provider="apple").count() == 0
+        assert db.query(DataSource).filter_by(user_id=user.id, provider="suunto").count() == 1
+        assert db.query(EventRecord).filter_by(data_source_id=suunto_ds_id).count() == 1
+        assert db.query(HealthScore).filter_by(user_id=user.id, provider="suunto").count() == 1
+        suunto_conn = db.query(UserConnection).filter_by(user_id=user.id, provider="suunto").one()
+        assert suunto_conn.status == ConnectionStatus.ACTIVE
+
+    def test_delete_data_only_affects_target_user(self, client: TestClient, db: Session) -> None:
+        """Deleting user1's Apple data leaves user2's Apple data intact."""
+        # Arrange
+        user1 = UserFactory()
+        user2 = UserFactory()
+        UserConnectionFactory(user=user1, provider="apple", status=ConnectionStatus.ACTIVE)
+        self._seed_provider_data(user1, "apple")
+        self._seed_provider_data(user2, "apple")
+        api_key = ApiKeyFactory()
+        headers = api_key_headers(api_key.id)
+
+        # Act
+        response = client.delete(f"/api/v1/users/{user1.id}/connections/apple/data", headers=headers)
+
+        # Assert
+        assert response.status_code == 204
+        db.expire_all()
+        assert db.query(DataSource).filter_by(user_id=user1.id, provider="apple").count() == 0
+        assert db.query(DataSource).filter_by(user_id=user2.id, provider="apple").count() == 1
+
+    def test_delete_data_on_revoked_connection_still_deletes(self, client: TestClient, db: Session) -> None:
+        """Data can be purged even when the connection is already revoked."""
+        # Arrange
+        user = UserFactory()
+        UserConnectionFactory(user=user, provider="apple", status=ConnectionStatus.REVOKED)
+        self._seed_provider_data(user, "apple")
+        api_key = ApiKeyFactory()
+        headers = api_key_headers(api_key.id)
+
+        # Act
+        response = client.delete(f"/api/v1/users/{user.id}/connections/apple/data", headers=headers)
+
+        # Assert
+        assert response.status_code == 204
+        db.expire_all()
+        assert db.query(DataSource).filter_by(user_id=user.id, provider="apple").count() == 0
+
+    def test_delete_data_nonexistent_connection_returns_404(self, client: TestClient, db: Session) -> None:
+        """Purging a provider the user was never connected to returns 404."""
+        # Arrange
+        user = UserFactory()
+        api_key = ApiKeyFactory()
+        headers = api_key_headers(api_key.id)
+
+        # Act
+        response = client.delete(f"/api/v1/users/{user.id}/connections/garmin/data", headers=headers)
+
+        # Assert
+        assert response.status_code == 404
+
+    def test_delete_data_missing_api_key(self, client: TestClient, db: Session) -> None:
+        """Request without API key is rejected."""
+        # Arrange
+        user = UserFactory()
+
+        # Act
+        response = client.delete(f"/api/v1/users/{user.id}/connections/apple/data")
+
+        # Assert
+        assert response.status_code == 401
 
 
 class TestDisconnectDeregistration:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -191,7 +191,8 @@
             "group": "Connections",
             "pages": [
               "GET /api/v1/users/{user_id}/connections",
-              "DELETE /api/v1/users/{user_id}/connections/{provider}"
+              "DELETE /api/v1/users/{user_id}/connections/{provider}",
+              "DELETE /api/v1/users/{user_id}/connections/{provider}/data"
             ]
           },
           {

--- a/frontend/src/components/user/connection-card.tsx
+++ b/frontend/src/components/user/connection-card.tsx
@@ -12,6 +12,7 @@ import {
   RefreshCw,
   RotateCcw,
   Timer,
+  Trash2,
   TriangleAlert,
   Unlink,
   XCircle,
@@ -56,6 +57,7 @@ import {
 } from '@/lib/utils/sync-format';
 import {
   useDisconnectProvider,
+  usePurgeProviderData,
   useSynchronizeDataFromProvider,
   useSyncHistoricalData,
   useGarminBackfillStatus,
@@ -253,6 +255,7 @@ export function ConnectionCard({
   recentRuns,
 }: ConnectionCardProps) {
   const [showDisconnectDialog, setShowDisconnectDialog] = useState(false);
+  const [showDeleteDataDialog, setShowDeleteDataDialog] = useState(false);
   const [showLastSyncs, setShowLastSyncs] = useState(false);
   const [imageError, setImageError] = useState(false);
 
@@ -263,6 +266,9 @@ export function ConnectionCard({
 
   const { mutate: disconnectProvider, isPending: isDisconnecting } =
     useDisconnectProvider(connection.provider, connection.user_id);
+
+  const { mutate: purgeProviderData, isPending: isPurgingData } =
+    usePurgeProviderData(connection.provider, connection.user_id);
 
   const { mutate: synchronizeDataFromProvider, isPending: isSynchronizing } =
     useSynchronizeDataFromProvider(connection.provider, connection.user_id);
@@ -483,6 +489,14 @@ export function ConnectionCard({
                     Disconnect
                   </DropdownMenuItem>
                 )}
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive cursor-pointer"
+                  disabled={isPurgingData}
+                  onClick={() => setShowDeleteDataDialog(true)}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete all data
+                </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
             <AlertDialog
@@ -501,6 +515,33 @@ export function ConnectionCard({
                   <AlertDialogCancel>Cancel</AlertDialogCancel>
                   <AlertDialogAction onClick={() => disconnectProvider()}>
                     Disconnect
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+            <AlertDialog
+              open={showDeleteDataDialog}
+              onOpenChange={setShowDeleteDataDialog}
+            >
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    Delete all {displayName} data?
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This permanently deletes every record synced from{' '}
+                    {displayName} for this user — activities, sleep, time series
+                    and health scores — and revokes the connection. Data from
+                    other providers is not affected. This cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    onClick={() => purgeProviderData()}
+                  >
+                    Delete all data
                   </AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>

--- a/frontend/src/hooks/api/use-health.ts
+++ b/frontend/src/hooks/api/use-health.ts
@@ -38,6 +38,28 @@ export function useDisconnectProvider(provider: string, userId: string) {
 }
 
 /**
+ * Delete all of a user's data for a provider (also revokes the connection)
+ * Uses DELETE /api/v1/users/{user_id}/connections/{provider}/data
+ */
+export function usePurgeProviderData(provider: string, userId: string) {
+  return useMutation({
+    mutationFn: () => healthService.purgeProviderData(userId, provider),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.connections.all(userId),
+      });
+      queryClient.invalidateQueries({ queryKey: queryKeys.health.all });
+      toast.success(`Deleted all ${provider} data`);
+    },
+    onError: (error: unknown) => {
+      const message =
+        error instanceof Error ? error.message : 'Failed to delete data';
+      toast.error(message);
+    },
+  });
+}
+
+/**
  * Get user connections for a user
  * Uses GET /api/v1/users/{user_id}/connections
  */

--- a/frontend/src/lib/api/config.ts
+++ b/frontend/src/lib/api/config.ts
@@ -23,6 +23,8 @@ export const API_ENDPOINTS = {
   userConnections: (userId: string) => `/api/v1/users/${userId}/connections`,
   userConnectionDisconnect: (userId: string, provider: string) =>
     `/api/v1/users/${userId}/connections/${provider}`,
+  userConnectionPurgeData: (userId: string, provider: string) =>
+    `/api/v1/users/${userId}/connections/${provider}/data`,
   providerSetting: (provider: string) => `/api/v1/oauth/providers/${provider}`,
   userWorkouts: (userId: string) => `/api/v1/users/${userId}/events/workouts`,
   userWorkoutDetail: (userId: string, workoutId: string) =>

--- a/frontend/src/lib/api/services/health.service.ts
+++ b/frontend/src/lib/api/services/health.service.ts
@@ -132,6 +132,15 @@ export const healthService = {
   },
 
   /**
+   * Delete all of a user's data for a provider (also revokes the connection)
+   */
+  async purgeProviderData(userId: string, provider: string): Promise<void> {
+    await apiClient.delete(
+      API_ENDPOINTS.userConnectionPurgeData(userId, provider)
+    );
+  },
+
+  /**
    * Get user connections for a user
    */
   async getUserConnections(userId: string): Promise<UserConnection[]> {


### PR DESCRIPTION
<img width="217" height="138" alt="image" src="https://github.com/user-attachments/assets/224b2963-22fb-46ff-a951-a532c9d392e4" />
<img width="798" height="291" alt="image" src="https://github.com/user-attachments/assets/474fe1ab-1386-4465-bddc-8704efda65aa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to delete all synced data for a connected provider.
  * Deleting provider data also revokes the connection.
  * Added a confirmation dialog to prevent accidental deletion.
  * The operation safely handles already-revoked connections and preserves data for other providers and users.

* **Documentation**
  * Updated the API reference with connection deletion endpoints.

* **Tests**
  * Added coverage for successful deletion, authorization, missing connections, and data isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->