### PR TITLE
fix(backend): surface Google Health 24/7 total sync failure instead of clean empty success

### DIFF
--- a/backend/app/services/providers/google/health_api/data_247.py
+++ b/backend/app/services/providers/google/health_api/data_247.py
@@ -14,6 +14,8 @@ from decimal import Decimal
 from typing import Any, NoReturn
 from uuid import UUID, uuid4
 
+from fastapi import HTTPException
+
 from app.config import settings
 from app.constants.google_health_endpoints import LIST_ENDPOINT, RECONCILE_ENDPOINT, ROLLUP_ENDPOINT
 from app.database import DbSession
@@ -66,11 +68,21 @@ class GoogleHealth247Data(Base247DataTemplate):
         end_time: datetime,
         is_first_sync: bool = False,
     ) -> dict[str, WriteCounts]:
-        """Fetch + persist every registered metric; failures are isolated per metric."""
+        """Fetch + persist every registered metric; failures are isolated per metric.
+
+        Raises HTTPException(502) when every unit (all registered metrics and
+        sleep) failed — otherwise a totally failed run would return an empty
+        result indistinguishable from a linked account with no data, and no
+        caller could ever report it (the sync task's FAILED/PARTIAL machinery
+        keys off sub-result success flags that this method's per-metric
+        isolation would never let it see). Partial failures still return
+        normally: per-metric isolation is deliberate and unchanged.
+        """
         granularity = (
             self.settings_repo.get_data_granularity(db, self.provider_name) or settings.default_data_granularity
         )
         results: dict[str, WriteCounts] = {}
+        failures: dict[str, str] = {}
 
         for metric in METRICS:
             # Confine each metric (fetch + write) to a savepoint so a failed write rolls
@@ -84,6 +96,7 @@ class GoogleHealth247Data(Base247DataTemplate):
                     counts = timeseries_service.bulk_create_samples(db, samples) if samples else None
             except Exception as e:
                 self._log_metric_failure(metric.data_type, user_id, e)
+                failures[metric.data_type] = str(e)
                 continue
             if counts is not None:
                 results[metric.data_type] = counts
@@ -92,7 +105,21 @@ class GoogleHealth247Data(Base247DataTemplate):
             sleep_count = self.sleep.load_and_save(db, user_id, start_time, end_time)
         except Exception as e:
             self._log_metric_failure("sleep", user_id, e)
+            failures["sleep"] = str(e)
             sleep_count = 0
+
+        # len(METRICS) + 1 = every registered metric plus the sleep unit above.
+        # A metric that succeeds with no samples records no failure, so an
+        # empty `results` alone does NOT mean the run failed — only a failure
+        # recorded for every single unit does.
+        if len(failures) == len(METRICS) + 1:
+            raise HTTPException(
+                status_code=502,
+                detail=(
+                    f"Google 24/7 sync failed for all {len(failures)} data types "
+                    f"({', '.join(failures)}); first error: {next(iter(failures.values()))}"
+                ),
+            )
 
         if results or sleep_count:
             db.commit()

--- a/backend/tests/providers/google/test_google_247_failures.py
+++ b/backend/tests/providers/google/test_google_247_failures.py
@@ -1,0 +1,122 @@
+"""Failure-surfacing tests for GoogleHealth247Data.load_and_save_all.
+
+A run where every unit (all registered metrics and sleep) fails must raise —
+previously it returned an empty result indistinguishable from a linked
+account with no data, so neither the sync task's FAILED/PARTIAL machinery
+nor the manual sync route could ever report it (#1361). Partial failures
+keep the existing per-metric isolation and return normally.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.providers.google.health_api import data_247 as data_247_module
+from app.services.providers.google.health_api.data_247 import GoogleHealth247Data
+from app.services.providers.google.strategy import GoogleStrategy
+
+_END = datetime.now(timezone.utc)
+_START = _END - timedelta(days=30)
+
+
+def _fake_metric(name: str) -> MagicMock:
+    metric = MagicMock()
+    metric.data_type = name
+    metric.use_list.return_value = False  # rollup path; _rollup_samples is stubbed either way
+    return metric
+
+
+@pytest.fixture
+def sleep_mock() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def data_247(sleep_mock: MagicMock) -> GoogleHealth247Data:
+    instance = GoogleStrategy().data_247
+    assert isinstance(instance, GoogleHealth247Data)
+    settings_repo = MagicMock()
+    settings_repo.get_data_granularity.return_value = None  # fall back to default granularity
+    instance.settings_repo = settings_repo
+    instance.sleep = sleep_mock
+    return instance
+
+
+@pytest.fixture
+def metrics(monkeypatch: pytest.MonkeyPatch) -> list[MagicMock]:
+    fakes = [_fake_metric("steps"), _fake_metric("weight")]
+    monkeypatch.setattr(data_247_module, "METRICS", fakes)
+    return fakes
+
+
+@pytest.fixture
+def timeseries_service_mock(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock = MagicMock()
+    monkeypatch.setattr(data_247_module, "timeseries_service", mock)
+    return mock
+
+
+class TestLoadAndSaveAllFailureSurfacing:
+    def test_all_units_failed_raises_instead_of_clean_empty_success(
+        self, data_247: GoogleHealth247Data, metrics: list[MagicMock], sleep_mock: MagicMock
+    ) -> None:
+        db = MagicMock()
+        boom = HTTPException(400, "Google API error: ACCOUNT_NOT_LINKED")
+        data_247._rollup_samples = MagicMock(side_effect=boom)
+        sleep_mock.load_and_save.side_effect = boom
+
+        with pytest.raises(HTTPException) as exc_info:
+            data_247.load_and_save_all(db, uuid4(), start_time=_START, end_time=_END)
+
+        assert exc_info.value.status_code == 502
+        assert "all 3 data types" in exc_info.value.detail
+        for unit in ("steps", "weight", "sleep"):
+            assert unit in exc_info.value.detail
+        assert "ACCOUNT_NOT_LINKED" in exc_info.value.detail
+        db.commit.assert_not_called()
+
+    def test_sleep_success_alone_prevents_the_raise(
+        self, data_247: GoogleHealth247Data, metrics: list[MagicMock], sleep_mock: MagicMock
+    ) -> None:
+        db = MagicMock()
+        data_247._rollup_samples = MagicMock(side_effect=HTTPException(500, "boom"))
+        sleep_mock.load_and_save.return_value = 0  # succeeded, found nothing
+
+        result = data_247.load_and_save_all(db, uuid4(), start_time=_START, end_time=_END)
+
+        assert result == {}
+
+    def test_one_metric_success_keeps_partial_isolation(
+        self,
+        data_247: GoogleHealth247Data,
+        metrics: list[MagicMock],
+        timeseries_service_mock: MagicMock,
+        sleep_mock: MagicMock,
+    ) -> None:
+        db = MagicMock()
+        counts = MagicMock()
+        # First metric yields samples, second fails — existing isolation behavior.
+        data_247._rollup_samples = MagicMock(side_effect=[[MagicMock()], HTTPException(500, "boom")])
+        timeseries_service_mock.bulk_create_samples.return_value = counts
+        sleep_mock.load_and_save.side_effect = HTTPException(500, "boom")
+
+        result = data_247.load_and_save_all(db, uuid4(), start_time=_START, end_time=_END)
+
+        assert result == {"steps": counts}
+        db.commit.assert_called_once()
+
+    def test_all_units_empty_but_successful_is_not_a_failure(
+        self, data_247: GoogleHealth247Data, metrics: list[MagicMock], sleep_mock: MagicMock
+    ) -> None:
+        """Empty results ≠ failed run — a linked account with no data must not raise."""
+        db = MagicMock()
+        data_247._rollup_samples = MagicMock(return_value=[])
+        sleep_mock.load_and_save.return_value = 0
+
+        result = data_247.load_and_save_all(db, uuid4(), start_time=_START, end_time=_END)
+
+        assert result == {}
+        db.commit.assert_not_called()


### PR DESCRIPTION
Fixes #1361

## Problem

`GoogleHealth247Data.load_and_save_all` catches every per-metric exception one level below where `sync_vendor_data` records sub-result success (`except → _log_metric_failure → continue`, and the sleep unit's `except → sleep_count = 0`). Failed metrics simply don't appear in `results`, the method returns normally, and the task then stamps `params["data_247"] = {"success": True, ...}` unconditionally.

Consequence: the `all_failed`/`any_failed` FAILED/PARTIAL machinery introduced in #986 can never see a Google 24/7 failure — a run in which **every single request failed** is indistinguishable, at every layer above the log line, from a linked account with no data. Observed live on a self-hosted instance (we're building a health app for women that integrates wearable data through Open Wearables): a first-time connection whose Google account had no Google Health profile failed all 7 data types with `ACCOUNT_NOT_LINKED`, yet the sync-runs log recorded a clean success and API consumers had no way to detect it. The workouts path already handles this correctly (`params["workouts"] = {"success": False, "error": ...}`), which is what suggested the fix shape.

## Fix

Track per-unit failures in `load_and_save_all`; when a failure was recorded for **every registered metric and the sleep unit**, raise `HTTPException(502)` listing the failed data types and the first underlying error (502 per the precedent in `oura_webhooks.py`).

Both existing callers already handle this with **zero changes**:
- `sync_vendor_data`'s existing `except` around the data_247 call marks the sub-result `{"success": False, "error": ...}` → `all_failed` → `SyncStatus.FAILED` emitted to the sync-runs log.
- The manual sync route (`POST /providers/{provider}/users/{user_id}/sync`) propagates it as a proper HTTP error instead of `{"success": true, "details": {...}}`.

Deliberately unchanged:
- **Partial failures** keep the existing per-metric isolation and return normally.
- A metric that succeeds with no samples records no failure — so **empty results alone never count as a failed run** (a linked account with no data still syncs cleanly). The all-failed condition is `len(failures) == len(METRICS) + 1`, not `not results`.

## Tests

New `tests/providers/google/test_google_247_failures.py` (4 cases): all-units-failed raises with all data types + underlying error in the detail and no commit; sleep succeeding alone prevents the raise; one metric succeeding keeps partial isolation (returns its counts, commits); all-units-empty-but-successful returns `{}` without raising.

## Checklist

- [x] Code follows the project's code style
- [x] Self-review completed
- [x] Tests added
- [x] All tests pass locally — `pytest tests/providers/ tests/tasks/` → **642 passed** (includes `test_sync_vendor_data_task.py`)
- [x] `ruff check` and `ruff format --check` pass on the changed files; `ty check` passes on the changed files (ran the individual tools rather than the full `pre-commit run --all-files` — happy to re-run if CI flags anything)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health data synchronization error handling.
  * Clearly reports when all health data sources fail, including the affected data types.
  * Preserves successfully loaded metrics when only some sources encounter errors.
  * Prevents empty database commits when no data is successfully loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->