### PR TITLE
feat(backend): adding root cause of error to the logs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -110,14 +110,13 @@ async def datetime_parse_exception_handler(_: Request, exc: DatetimeParseError) 
 async def http_exception_handler_with_body_log(request: Request, exc: StarletteHTTPException) -> Response:
     # request.state survives the middleware boundary, so the access log can read it.
     _capture_error_body(request, exc.status_code, exc.detail)
-    # FastAPI raises the HTTPException `from` the real error — e.g. a body-parse failure does
-    # `raise HTTPException(400, "There was an error parsing the body") from e` — and that cause
-    # is otherwise lost. Stash it so the access log shows what actually happened (e.g.
-    # ClientDisconnect = truncated upload vs UnicodeDecodeError = bad encoding).
-    if exc.__cause__ is not None:
-        request.state.error_cause_type = type(exc.__cause__).__name__
+    # real cause behind an opaque HTTPException (e.g. FastAPI's body-parse 400): explicit
+    # `from e`, else the implicitly-chained exception unless suppressed via `from None`.
+    cause = exc.__cause__ or (exc.__context__ if not exc.__suppress_context__ else None)
+    if cause is not None:
+        request.state.error_cause_type = type(cause).__name__
         try:
-            request.state.error_cause_msg = str(exc.__cause__)[:300]
+            request.state.error_cause_msg = str(cause)[:300]
         except Exception:
             request.state.error_cause_msg = "<unavailable>"
     return await http_exception_handler(request, exc)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -110,6 +110,16 @@ async def datetime_parse_exception_handler(_: Request, exc: DatetimeParseError) 
 async def http_exception_handler_with_body_log(request: Request, exc: StarletteHTTPException) -> Response:
     # request.state survives the middleware boundary, so the access log can read it.
     _capture_error_body(request, exc.status_code, exc.detail)
+    # FastAPI raises the HTTPException `from` the real error — e.g. a body-parse failure does
+    # `raise HTTPException(400, "There was an error parsing the body") from e` — and that cause
+    # is otherwise lost. Stash it so the access log shows what actually happened (e.g.
+    # ClientDisconnect = truncated upload vs UnicodeDecodeError = bad encoding).
+    if exc.__cause__ is not None:
+        request.state.error_cause_type = type(exc.__cause__).__name__
+        try:
+            request.state.error_cause_msg = str(exc.__cause__)[:300]
+        except Exception:
+            request.state.error_cause_msg = "<unavailable>"
     return await http_exception_handler(request, exc)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -112,7 +112,9 @@ async def http_exception_handler_with_body_log(request: Request, exc: StarletteH
     _capture_error_body(request, exc.status_code, exc.detail)
     # real cause behind an opaque HTTPException (e.g. FastAPI's body-parse 400): explicit
     # `from e`, else the implicitly-chained exception unless suppressed via `from None`.
-    cause = exc.__cause__ or (exc.__context__ if not exc.__suppress_context__ else None)
+    cause = exc.__cause__
+    if cause is None and not exc.__suppress_context__:
+        cause = exc.__context__
     if cause is not None:
         request.state.error_cause_type = type(cause).__name__
         try:

--- a/backend/app/middlewares.py
+++ b/backend/app/middlewares.py
@@ -80,6 +80,19 @@ def add_access_log_middleware(app: FastAPI) -> None:
                 attributes["request_bytes"] = content_length
         if response_body is not None:
             attributes["response_body"] = response_body
+        if status >= 400:
+            # Extra 4xx/5xx context: content headers + the underlying cause of a body-parse
+            # HTTPException (stashed on request.state by the exception handler).
+            content_type = request.headers.get("content-type")
+            if content_type:
+                attributes["content_type"] = content_type
+            content_encoding = request.headers.get("content-encoding")
+            if content_encoding:
+                attributes["content_encoding"] = content_encoding
+            cause_type = getattr(request.state, "error_cause_type", None)
+            if cause_type:
+                attributes["error_cause_type"] = cause_type
+                attributes["error_cause_msg"] = getattr(request.state, "error_cause_msg", None)
         if error is not None:
             # Attach the cause so a 500 is diagnosable from our own logs (stdout),
             # which — unlike Sentry — is not subject to rate-limiting/quota drops.


### PR DESCRIPTION
new fields in logs:
- `error_cause_type,`
- `error_cause_msg`
- `content_type`
- `content_encoding`

app:
```
{"timestamp": "2026-07-30T17:41:05.671050+00:00", "level": "error", "message": "http_request", "provider": null, "method": "POST", "path": "/api/v1/sdk/users/00000000-0000-0000-0000-0000000000bb/sync", "status": 400, "duration_ms": 17.7, "request_bytes": 3, "response_body": "There was an error parsing the body", "content_type": "application/json", "error_cause_type": "UnicodeDecodeError", "error_cause_msg": "'utf-8' codec can't decode byte 0x80 in position 0: invalid start byte"}
{"timestamp": "2026-07-30T17:41:05.681616+00:00", "level": "error", "message": "http_request", "provider": null, "method": "POST", "path": "/api/v1/sdk/users/00000000-0000-0000-0000-0000000000bb/sync", "status": 400, "duration_ms": 0.6, "request_bytes": 62, "response_body": "There was an error parsing the body", "content_type": "application/json", "content_encoding": "gzip", "error_cause_type": "UnicodeDecodeError", "error_cause_msg": "'utf-8' codec can't decode byte 0x8b in position 1: invalid start byte"}
{"timestamp": "2026-07-30T17:41:05.732281+00:00", "level": "error", "message": "http_request", "provider": null, "method": "POST", "path": "/api/v1/sdk/users/00000000-0000-0000-0000-0000000000bb/sync", "status": 400, "duration_ms": 0.9, "request_bytes": 1000000, "response_body": "There was an error parsing the body", "content_type": "application/json", "error_cause_type": "ClientDisconnect", "error_cause_msg": ""}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP error handling by capturing the most relevant underlying cause (or context) and storing a truncated, human-readable cause message when available.
  * Enhanced access logs for HTTP responses with status 400+ by including request `content-type`/`content-encoding` details and structured error-cause information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->