### PR TITLE
fix(backend): accept SDK log timeRange without startDate

### DIFF
--- a/backend/app/schemas/providers/mobile_sdk/sdk_log_events.py
+++ b/backend/app/schemas/providers/mobile_sdk/sdk_log_events.py
@@ -16,7 +16,9 @@ class DataTypeCount(BaseModel):
 
 
 class TimeRange(BaseModel):
-    startDate: datetime
+    # startDate is absent when the SDK syncs the full available history (no syncDaysBack
+    # limit configured) — both the iOS and Android SDKs omit it in that case.
+    startDate: datetime | None = None
     endDate: datetime
 
 

--- a/backend/tests/api/v1/test_sdk_logs.py
+++ b/backend/tests/api/v1/test_sdk_logs.py
@@ -116,6 +116,24 @@ class TestSDKLogsHappyPath:
         assert mock_store.call_args.kwargs["provider"] == "unknown"
 
     @patch("app.api.routes.v1.sdk_logs.store_raw_payload")
+    def test_time_range_without_start_date_accepted(
+        self, mock_store: MagicMock, client: TestClient, db: Session
+    ) -> None:
+        """Full-history sync: the SDK omits startDate when no day limit is configured."""
+        api_key = ApiKeyFactory()
+        event = {
+            **SYNC_START_EVENT,
+            "timeRange": {"endDate": "2026-04-09T10:00:00Z"},
+        }
+        response = client.post(
+            _url(),
+            headers={"X-Open-Wearables-API-Key": api_key.id},
+            json=_payload(event, DEVICE_STATE_EVENT),
+        )
+        assert response.status_code == 202
+        mock_store.assert_called_once()
+
+    @patch("app.api.routes.v1.sdk_logs.store_raw_payload")
     def test_android_data_types_accepted(self, mock_store: MagicMock, client: TestClient, db: Session) -> None:
         api_key = ApiKeyFactory()
         event = {


### PR DESCRIPTION
## Description

The mobile SDKs omit `startDate` in the sync `timeRange` when they sync the full available history (no `syncDaysBack` limit configured), which made the SDK log endpoint reject those payloads with a 422. Made the field optional so full-history syncs get logged like any other.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. POST to the SDK logs endpoint with a `syncStart` event whose `timeRange` only has `endDate` (no `startDate`)
2. Or run `pytest tests/api/v1/test_sdk_logs.py -k without_start_date`

**Expected behavior:**

The request returns 202 and the payload is stored, instead of failing validation with a 422.

## Additional Notes

Nothing else reads `TimeRange.startDate` - the log events are stored raw - so no downstream null handling was needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Historical mobile SDK sync events can now be accepted when the time range includes an end date but omits the start date.
  * Such events are processed successfully and return an accepted response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->