### PR TITLE
fix(frontend): load theme colors under Tailwind v4

### DIFF
--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -13,13 +13,13 @@ const badgeVariants = cva(
         secondary:
           'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80 shadow-[0_0_10px_hsla(315,100%,60%,0.2)]',
         destructive:
-          'border-transparent bg-destructive text-[hsl(var(--destructive-muted))] hover:bg-destructive/80 shadow-[0_0_10px_hsla(350,100%,55%,0.3)]',
+          'border-destructive/30 bg-destructive/10 text-destructive-glow hover:bg-destructive/20',
         outline:
           'text-foreground border-primary/30 hover:border-primary/50 hover:shadow-[0_0_8px_hsla(185,100%,50%,0.2)]',
         success:
-          'border-transparent bg-success text-green-300 hover:bg-success/80 shadow-[0_0_10px_hsla(145,100%,50%,0.3)]',
+          'border-success/30 bg-success/10 text-success-glow hover:bg-success/20',
         warning:
-          'border-transparent bg-warning text-orange-300 hover:bg-warning/80 shadow-[0_0_10px_hsla(45,100%,55%,0.3)]',
+          'border-warning/30 bg-warning/10 text-warning-glow hover:bg-warning/20',
       },
     },
     defaultVariants: {

--- a/frontend/src/components/user/connection-card.tsx
+++ b/frontend/src/components/user/connection-card.tsx
@@ -331,21 +331,21 @@ export function ConnectionCard({
       case 'active':
         return (
           <Badge variant="success" className="flex items-center gap-1">
-            <CheckCircle2 className="h-3 w-3 text-green-400" />
+            <CheckCircle2 className="h-3 w-3" />
             Active
           </Badge>
         );
       case 'revoked':
         return (
           <Badge variant="destructive" className="flex items-center gap-1">
-            <XCircle className="h-3 w-3 text-[hsl(var(--destructive-muted))]" />
+            <XCircle className="h-3 w-3" />
             Revoked
           </Badge>
         );
       case 'expired':
         return (
           <Badge variant="warning" className="flex items-center gap-1">
-            <TriangleAlert className="h-3 w-3 text-orange-400" />
+            <TriangleAlert className="h-3 w-3" />
             Expired
           </Badge>
         );

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,5 +1,7 @@
 @import 'tailwindcss';
 
+@config '../tailwind.config.ts';
+
 /* ============================================
    ELECTRIC NEON DESIGN SYSTEM
    Open Wearables - 2025 Modern Redesign


### PR DESCRIPTION
## Description

The frontend runs Tailwind v4 (`tailwindcss@4.3.3` + `@tailwindcss/vite`), but the semantic color palette is declared in `tailwind.config.ts`. Tailwind v4 does not auto-load that file, and `src/styles.css` had no `@config` directive, so every utility built on those tokens generated **no CSS at all**: `bg-popover`, `bg-card`, `bg-muted`, `bg-accent`, `bg-sidebar-*`, `text-muted-foreground`, `border-input`, `ring-ring`. Probing the running app's stylesheet for those selectors returned zero rules; only Tailwind's built-in palette (`bg-white`, `bg-red-500`) worked.

The visible symptom reported in #1359 is the **Sync History** dropdown rendering with no background, so page content behind it shows through and overlaps the menu options. The same defect affects every other dropdown (the connection card ⋮ menu, the user page ⋯ menu) and every tooltip (`bg-card/90` in `tooltip.tsx`). Dialogs, alert dialogs and sheets were unaffected only because they had already been worked around with `bg-[hsl(var(--x))]` arbitrary values — there are 56 such workarounds across 25 files.

**Fix:** reference the existing config from the stylesheet so the palette is generated again. No color values change — they still resolve from the same CSS variables already defined in `styles.css`.

**Follow-on change:** with the palette live again, the status badge variants started rendering their intended solid neon backgrounds, which were unreadable against the foreground colors they had been paired with while the classes were dead (e.g. `bg-success` + `text-green-300`). `success`/`warning`/`destructive` are restyled as tinted chips — `bg-*/10`, `border-*/30`, `text-*-glow` — consistent with each other and with the tinted treatment used elsewhere in the app. Three hard-coded icon colors in `connection-card.tsx` were removed so icons inherit the badge color.

Fixes #1359

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Frontend Changes

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

## Testing Instructions

**Steps to test:**
1. Open a user's page that has a connected provider with `max_historical_days` unset (e.g. Polar or WHOOP, status Active).
2. Click the **Sync History** button on the connection card.
3. Check the menu against the content behind it, and confirm the status badges and tooltips elsewhere on the page still read correctly.

**Expected behavior:**

The dropdown is drawn on a solid `--popover` background with only its own options readable. Verified in the built output that the utility is now emitted: `.bg-popover{background-color:hsl(var(--popover))}`.

## Screenshots

Before:

<img width="1129" height="531" alt="Screenshot 2026-07-31 at 01 54 38" src="https://github.com/user-attachments/assets/f80bb496-2242-4f6a-97b9-a375987b252f" />

After:

<img width="1119" height="571" alt="Screenshot 2026-07-31 at 01 53 44" src="https://github.com/user-attachments/assets/1ae2a96a-ddb4-4d61-864a-5f45228f5976" />



## Additional Notes

The `@config` directive also activates the `borderRadius`, `boxShadow` (`glow-*` / `neon-*`) and `fontFamily` overrides declared in `tailwind.config.ts`, which were dead for the same reason. A pass over Dashboard, Users, Syncs, Settings, Webhooks and the user detail tabs showed no regressions beyond the badge contrast fixed here, but the surface is wider than the dropdown alone and is worth a look during review.

The 56 existing `bg-[hsl(var(--x))]` workarounds are now redundant and could be collapsed back to plain utilities, but that is left out of this PR to keep the diff focused.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated status badges with translucent backgrounds, colored borders, glowing text, and refined hover states.
  * Improved visual consistency for connection status icons by aligning their colors with badge variants.
  * Added Tailwind configuration support for consistent styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->