### PR TITLE
fix(backend): include workout-only days in activity summaries

### DIFF
--- a/backend/app/services/summaries_service.py
+++ b/backend/app/services/summaries_service.py
@@ -484,6 +484,37 @@ class SummariesService:
             key = (wa["workout_date"], wa["source"], wa.get("device_model"))
             workout_lookup[key] = wa
 
+        # Days with a workout but no time-series data at all (e.g. Strava-only
+        # accounts, which never populate data_point_series) would otherwise be
+        # dropped entirely, since `results` only contains dates present in the
+        # time-series aggregates. Add an all-null placeholder row for those
+        # dates so they still surface below, enriched via workout_lookup.
+        existing_dates = {r["activity_date"] for r in results}
+        workout_only_dates = {wa["workout_date"] for wa in workout_aggregates} - existing_dates
+        if workout_only_dates:
+            for wa in workout_aggregates:
+                if wa["workout_date"] not in workout_only_dates:
+                    continue
+                results.append(
+                    {
+                        "activity_date": wa["workout_date"],
+                        "provider": wa["source"],
+                        "source": wa["source"],
+                        "device_model": wa.get("device_model"),
+                        "steps_sum": None,
+                        "active_energy_sum": None,
+                        "basal_energy_sum": None,
+                        "hr_avg": None,
+                        "hr_max": None,
+                        "hr_min": None,
+                        "distance_sum": None,
+                        "flights_climbed_sum": None,
+                        "active_time_minutes": None,
+                    }
+                )
+            results = self._filter_by_priority(db_session, user_id, results, date_key="activity_date")
+            results.sort(key=lambda r: r["activity_date"])
+
         # Get active/sedentary minutes from step data
         activity_minutes = self.data_point_repo.get_daily_active_minutes(
             db_session, user_id, start_date, end_date, active_threshold=ACTIVE_STEPS_THRESHOLD


### PR DESCRIPTION
## Summary
- `SummariesService.get_activity_summaries()` builds its per-day result list starting from `DataPointSeriesRepository.get_daily_activity_aggregates()`, which reads `data_point_series` (steps/HR/distance time-series). Workout data from `event_record`/`workout_details` (via `get_daily_workout_aggregates()`) was only used to *enrich* days that already had a time-series row for the same (date, source, device) key.
- For providers that only report discrete workouts and never write daily time-series (e.g. Strava, via the pull API), affected days had no time-series row at all, so they were silently dropped from `/summaries/activity` even though the workout was correctly synced and stored.
- This adds an all-null placeholder aggregate row for any workout date with no matching time-series date, re-applies the existing priority filter, and re-sorts by date, so those days now appear with workout-derived fields (e.g. `elevation_meters`) populated and time-series-only fields left `null`.

## Test plan
- [x] Manually reproduced: connected a Strava account, synced 6 historical activities (verified present in `event_record`/`workout_details`), confirmed `/summaries/activity` returned `data: []` for the date range containing them.
- [x] Applied the fix, rebuilt the backend image, confirmed `/summaries/activity` now returns all 6 days with correct `elevation_meters` and `null` time-series fields.
- [ ] No automated test added yet — happy to add a unit test against `SummariesService.get_activity_summaries` covering a workout-only day if useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Activity summaries now include workout dates even when time-series metrics are unavailable.
  * Summary results are enriched with available workout details and consistently sorted by activity date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->