### PR TITLE
refactor: data points count K->M->B->T

### DIFF
--- a/frontend/src/components/pages/dashboard/data-metrics-section.tsx
+++ b/frontend/src/components/pages/dashboard/data-metrics-section.tsx
@@ -1,5 +1,6 @@
 import { BarChart3 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatCompactNumber } from '@/lib/utils/format';
 import { SourceBadge } from '@/components/common/source-badge';
 import type { ConnectionsCoverage } from '@/lib/api/types';
 
@@ -100,23 +101,25 @@ export function DataMetricsSection({
                 <span className="flex items-center gap-1.5">
                   <span className="h-2 w-2 rounded-full bg-[hsl(var(--success-muted))]" />
                   <span className="font-mono font-semibold text-foreground">
-                    {connectionsCoverage.users_with_active.toLocaleString()}
+                    {formatCompactNumber(connectionsCoverage.users_with_active)}
                   </span>{' '}
                   connected
                 </span>
                 <span className="flex items-center gap-1.5">
                   <span className="inline-block h-0 w-0 border-l-[6px] border-r-[6px] border-b-[8px] border-l-transparent border-r-transparent border-b-[hsl(var(--primary)/0.8)]" />
                   <span className="font-mono font-semibold text-foreground">
-                    {connectionsCoverage.users_with_multi_active.toLocaleString()}
+                    {formatCompactNumber(
+                      connectionsCoverage.users_with_multi_active
+                    )}
                   </span>{' '}
                   multiple connections
                 </span>
                 <span className="flex items-center gap-1.5">
                   <span className="h-2 w-2 rounded-full bg-[hsl(var(--destructive-muted))]" />
                   <span className="font-mono font-semibold text-foreground">
-                    {(
+                    {formatCompactNumber(
                       totalUsers - connectionsCoverage.users_with_active
-                    ).toLocaleString()}
+                    )}
                   </span>{' '}
                   not connected
                 </span>
@@ -139,7 +142,7 @@ export function DataMetricsSection({
                     >
                       <SourceBadge provider={provider} />
                       <p className="font-mono text-2xl font-bold tabular-nums leading-none text-foreground">
-                        {count.toLocaleString()}
+                        {formatCompactNumber(count)}
                       </p>
                       <p className="text-[10px] leading-none text-muted-foreground">
                         connections

--- a/frontend/src/components/pages/dashboard/stats-card.tsx
+++ b/frontend/src/components/pages/dashboard/stats-card.tsx
@@ -11,6 +11,7 @@ export interface StatsCardProps {
   description: string;
   icon: LucideIcon;
   decimalPlaces?: number;
+  format?: (value: number) => string;
   accent?: StatsCardAccent;
   className?: string;
 }
@@ -52,6 +53,7 @@ export function StatsCard({
   description,
   icon: Icon,
   decimalPlaces = 0,
+  format,
   accent = 'cyan',
   className,
 }: StatsCardProps) {
@@ -87,6 +89,7 @@ export function StatsCard({
           <NumberTicker
             value={value}
             decimalPlaces={decimalPlaces}
+            format={format}
             className="text-foreground"
           />
         </span>

--- a/frontend/src/components/pages/dashboard/stats-grid.tsx
+++ b/frontend/src/components/pages/dashboard/stats-grid.tsx
@@ -1,6 +1,7 @@
 import { Users, Activity, Database } from 'lucide-react';
 import { StatsCard, type StatsCardAccent } from './stats-card';
 import { cn } from '@/lib/utils';
+import { formatCompactNumber } from '@/lib/utils/format';
 import type { DashboardStats } from '@/lib/api/types';
 
 export interface StatsGridProps {
@@ -12,16 +13,13 @@ export function StatsGrid({ stats, className }: StatsGridProps) {
   const statCards: Array<{
     title: string;
     value: number;
-    suffix: string;
     description: string;
     icon: typeof Users;
-    decimalPlaces?: number;
     accent: StatsCardAccent;
   }> = [
     {
       title: 'Total Users',
       value: stats.total_users.count,
-      suffix: '',
       description: 'Registered users',
       icon: Users,
       accent: 'cyan',
@@ -29,18 +27,15 @@ export function StatsGrid({ stats, className }: StatsGridProps) {
     {
       title: 'Active Connections',
       value: stats.active_conn.count,
-      suffix: '',
       description: 'Connected wearables',
       icon: Activity,
       accent: 'magenta',
     },
     {
       title: 'Data Points',
-      value: stats.data_points.count / 1000,
-      suffix: 'K',
+      value: stats.data_points.count,
       description: 'Health data collected',
       icon: Database,
-      decimalPlaces: 1,
       accent: 'purple',
     },
   ];
@@ -52,10 +47,9 @@ export function StatsGrid({ stats, className }: StatsGridProps) {
           key={stat.title}
           title={stat.title}
           value={stat.value}
-          suffix={stat.suffix}
           description={stat.description}
           icon={stat.icon}
-          decimalPlaces={stat.decimalPlaces}
+          format={formatCompactNumber}
           accent={stat.accent}
         />
       ))}

--- a/frontend/src/components/ui/number-ticker.tsx
+++ b/frontend/src/components/ui/number-ticker.tsx
@@ -9,6 +9,8 @@ interface NumberTickerProps extends ComponentPropsWithoutRef<'span'> {
   direction?: 'up' | 'down';
   delay?: number;
   decimalPlaces?: number;
+  /** Custom formatter for the displayed value (e.g. compact K/M/B). Overrides decimalPlaces. */
+  format?: (value: number) => string;
 }
 
 export function NumberTicker({
@@ -18,6 +20,7 @@ export function NumberTicker({
   delay = 0,
   className,
   decimalPlaces = 0,
+  format,
   ...props
 }: NumberTickerProps) {
   const ref = useRef<HTMLSpanElement>(null);
@@ -51,12 +54,15 @@ export function NumberTicker({
     () =>
       springValue.on('change', (latest) => {
         if (ref.current) {
-          ref.current.textContent = formatter.format(
-            Number(latest.toFixed(decimalPlaces))
-          );
+          // Quantize the mid-animation spring value to whole units (decimalPlaces defaults to 0)
+          // before formatting, so counts don't flash fractional values like "4.8" while animating.
+          const current = Number(latest.toFixed(decimalPlaces));
+          ref.current.textContent = format
+            ? format(current)
+            : formatter.format(current);
         }
       }),
-    [springValue, formatter, decimalPlaces]
+    [springValue, formatter, decimalPlaces, format]
   );
 
   return (
@@ -68,7 +74,7 @@ export function NumberTicker({
       )}
       {...props}
     >
-      {startValue}
+      {format ? format(startValue) : startValue}
     </span>
   );
 }

--- a/frontend/src/components/user/data-summary-section.tsx
+++ b/frontend/src/components/user/data-summary-section.tsx
@@ -1,7 +1,7 @@
 import { Database, Dumbbell, Moon, ChevronDown, ChevronUp } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
 import { useUserDataSummary } from '@/hooks/api/use-health';
-import { formatNumber } from '@/lib/utils/format';
+import { formatCompactNumber } from '@/lib/utils/format';
 import { cn } from '@/lib/utils';
 import { DateFilter } from '@/components/ui/date-filter';
 import type { DataSummaryParams, ProviderDataCount } from '@/lib/api/types';
@@ -44,7 +44,7 @@ function StatCard({
         <Icon className="h-4 w-4" />
       </div>
       <p className="text-2xl font-bold tabular-nums text-foreground">
-        {formatNumber(value)}
+        {formatCompactNumber(value)}
       </p>
       <p className="mt-0.5 text-xs text-muted-foreground">{label}</p>
     </div>
@@ -83,7 +83,7 @@ const TypeGrid = memo(function TypeGrid({
             #{i + 1}
           </span>
           <p className="text-2xl font-bold tabular-nums leading-none text-foreground">
-            {formatNumber(count)}
+            {formatCompactNumber(count)}
           </p>
           <p
             className="truncate text-xs text-muted-foreground"
@@ -125,7 +125,7 @@ const ProviderCard = memo(function ProviderCard({
               {formatProvider(provider.provider)}
             </span>
             <span className="ml-2 rounded-full border border-border/60 bg-muted/40 px-1.5 py-0.5 text-[10px] tabular-nums text-muted-foreground">
-              {formatNumber(totalRecords)}
+              {formatCompactNumber(totalRecords)}
             </span>
           </div>
         </div>
@@ -149,7 +149,7 @@ const ProviderCard = memo(function ProviderCard({
                 className="flex flex-col items-center gap-1 rounded-xl border border-border/60 bg-card/40 p-3 text-center"
               >
                 <p className="text-xl font-bold tabular-nums leading-none text-foreground">
-                  {formatNumber(value)}
+                  {formatCompactNumber(value)}
                 </p>
                 <p className="text-[11px] text-muted-foreground">{label}</p>
               </div>

--- a/frontend/src/lib/utils/format.ts
+++ b/frontend/src/lib/utils/format.ts
@@ -75,6 +75,22 @@ export function formatNumber(value: number | null | undefined): string {
   return value.toLocaleString();
 }
 
+const compactNumberFormatter = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+});
+
+/**
+ * Format a large aggregate count compactly: 8_432 -> "8.4K", 1_450_000 -> "1.5M",
+ * 2.3e9 -> "2.3B". Values below 1000 are shown in full. Rolls K -> M -> B -> T automatically
+ * (never "1000K"). Use for counts (data points, records, per-type/provider totals); for precise
+ * physical quantities (steps, calories, distance) use formatNumber instead.
+ */
+export function formatCompactNumber(value: number | null | undefined): string {
+  if (value === null || value === undefined) return '-';
+  return compactNumberFormatter.format(value);
+}
+
 /**
  * Format distance in meters to a human-readable string.
  * Shows km if >= 1000m, otherwise shows meters.


### PR DESCRIPTION
- Large numbers now show as 2.1M / 8.4K / 2.3B instead of confusing values like 145,159.9K.
- Applied to all count metrics; precise values (steps, calories, distance) unchanged

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Large dashboard and data-summary counts now use compact notation such as K, M, and B for easier scanning.
  * Statistics and animated number displays consistently apply the updated compact formatting.
  * Missing count values are displayed as “-” instead of appearing blank or undefined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->