### PR TITLE
feat(frontend): event records in dashboard

### DIFF
--- a/backend/app/repositories/data_point_series_repository.py
+++ b/backend/app/repositories/data_point_series_repository.py
@@ -8,7 +8,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError as SQLAIntegrityError
 
 from app.database import DbSession
-from app.models import DataPointSeries, DataSource, DeviceTypePriority, ProviderPriority
+from app.models import DataPointSeries, DataPointSeriesArchive, DataSource, DeviceTypePriority, ProviderPriority
 from app.models.series_type_definition import SeriesTypeDefinition
 from app.repositories.data_source_repository import DataSourceRepository
 from app.repositories.repositories import CrudRepository
@@ -340,19 +340,28 @@ class DataPointSeriesRepository(
         """Get total count of all data points."""
         return db_session.query(func.count(self.model.id)).scalar() or 0
 
-    def get_approximate_total_count(self, db_session: DbSession) -> int:
-        """Approximate total row count from planner statistics (``pg_class.reltuples``).
+    @staticmethod
+    def _approximate_row_count(db_session: DbSession, table_name: str) -> int:
+        """Approximate row count of ``table_name`` from planner statistics (``pg_class.reltuples``).
 
-        Instant (metadata lookup, no table scan), unlike ``get_total_count`` which is a full
-        ``COUNT(*)`` over the whole table. The estimate is refreshed by (auto)VACUUM/ANALYZE and
-        may lag by a few percent, so it is only suitable for a non-critical dashboard figure.
+        Instant (metadata lookup, no table scan), unlike a full ``COUNT(*)``. The estimate is
+        refreshed by (auto)VACUUM/ANALYZE and may lag by a few percent, so it is only suitable for a
+        non-critical dashboard figure. Postgres reports reltuples = -1 for a never-ANALYZEd table;
+        clamp to 0.
         """
         result = db_session.execute(
             text("SELECT reltuples::bigint FROM pg_class WHERE oid = to_regclass(:table)"),
-            {"table": self.model.__tablename__},
+            {"table": table_name},
         ).scalar()
-        # Postgres reports reltuples = -1 for a table that has never been ANALYZEd; clamp to 0.
         return max(int(result or 0), 0)
+
+    def get_approximate_total_count(self, db_session: DbSession) -> int:
+        """Approximate total row count of the (hot) data point table."""
+        return self._approximate_row_count(db_session, self.model.__tablename__)
+
+    def get_approximate_archived_count(self, db_session: DbSession) -> int:
+        """Approximate row count of the archive table (archived data points)."""
+        return self._approximate_row_count(db_session, DataPointSeriesArchive.__tablename__)
 
     def get_count_in_range(self, db_session: DbSession, start_datetime: datetime, end_datetime: datetime) -> int:
         """Get count of data points within a datetime range."""

--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -474,6 +474,19 @@ class EventRecordRepository(
         )
         return [(provider, category, event_type, count) for provider, category, event_type, count in results]
 
+    def get_category_counts(self, db_session: DbSession) -> list[tuple[str, int]]:
+        """Count event records grouped by category (workout, sleep, menstrual_cycle, ...).
+
+        Cheap: ``event_record`` is a small table, so this is a quick aggregate (no big scan).
+        Returns list of (category, count) tuples.
+        """
+        results = (
+            db_session.query(self.model.category, func.count(self.model.id).label("count"))
+            .group_by(self.model.category)
+            .all()
+        )
+        return [(category, count) for category, count in results]
+
     def get_sleep_stage_stats_via_json(self, db_session: DbSession, record_id: UUID) -> list[dict]:
         """
         Calculates sleep stage statistics directly from the JSONB column using SQL/JSON standard.

--- a/backend/app/schemas/responses/upload/__init__.py
+++ b/backend/app/schemas/responses/upload/__init__.py
@@ -6,6 +6,7 @@ from .sync_results import (
 from .system_info import (
     ConnectionsCoverage,
     DataPointsInfo,
+    EventRecordsInfo,
     MetricCount,
     ProviderConnectionCount,
     SystemInfoResponse,
@@ -24,6 +25,7 @@ __all__ = [
     # System info
     "ConnectionsCoverage",
     "DataPointsInfo",
+    "EventRecordsInfo",
     "MetricCount",
     "ProviderConnectionCount",
     "SystemInfoResponse",

--- a/backend/app/schemas/responses/upload/system_info.py
+++ b/backend/app/schemas/responses/upload/system_info.py
@@ -8,9 +8,23 @@ class MetricCount(BaseModel):
 
 
 class DataPointsInfo(BaseModel):
-    """Data points information."""
+    """Data points information.
+
+    ``count`` is the live (hot) ``data_point_series`` table; ``archived`` is the separate archive
+    table. Both are approximate on a cold cache / from planner statistics.
+    """
 
     count: int
+    archived: int
+
+
+class EventRecordsInfo(BaseModel):
+    """Event record counts with a breakdown by category."""
+
+    count: int
+    workouts: int
+    sleep: int
+    menstrual_cycles: int
 
 
 class ProviderConnectionCount(BaseModel):
@@ -30,4 +44,5 @@ class SystemInfoResponse(BaseModel):
     total_users: MetricCount
     active_conn: MetricCount
     data_points: DataPointsInfo
+    event_records: EventRecordsInfo
     connections_coverage: ConnectionsCoverage

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -660,6 +660,10 @@ class EventRecordService(
 
         return [self._build_response(record, data_source) for record, data_source in records]
 
+    def get_category_counts(self, db_session: DbSession) -> list[tuple[str, int]]:
+        """Count event records grouped by category (cheap aggregate on a small table)."""
+        return self.crud.get_category_counts(db_session)
+
     def _map_source(self, data_source: DataSource) -> DataSourceSchema:
         return DataSourceSchema(
             provider=data_source.source or "unknown",

--- a/backend/app/services/system_info_service.py
+++ b/backend/app/services/system_info_service.py
@@ -7,6 +7,7 @@ from app.database import DbSession
 from app.schemas.responses.dashboard import ProviderDataCount, UserDataSummaryResponse
 from app.schemas.responses.upload import (
     DataPointsInfo,
+    EventRecordsInfo,
     MetricCount,
     SystemInfoResponse,
 )
@@ -41,10 +42,22 @@ class SystemInfoService:
         multi-second full scan on every dashboard load; the remaining figures are cheap counts on
         small tables.
         """
+        category_counts = dict(self.event_record_service.get_category_counts(db_session))
+        event_records = EventRecordsInfo(
+            count=sum(category_counts.values()),
+            workouts=category_counts.get("workout", 0),
+            sleep=category_counts.get("sleep", 0),
+            menstrual_cycles=category_counts.get("menstrual_cycle", 0),
+        )
+
         return SystemInfoResponse(
             total_users=MetricCount(count=self.user_service.crud.get_total_count(db_session)),
             active_conn=MetricCount(count=self.user_connection_service.crud.get_active_count(db_session)),
-            data_points=DataPointsInfo(count=get_total_data_points(db_session)),
+            data_points=DataPointsInfo(
+                count=get_total_data_points(db_session),
+                archived=self.timeseries_service.get_approximate_archived_count(db_session),
+            ),
+            event_records=event_records,
             connections_coverage=self.user_connection_service.get_connections_coverage(db_session),
         )
 

--- a/backend/app/services/timeseries_service.py
+++ b/backend/app/services/timeseries_service.py
@@ -118,6 +118,10 @@ class TimeSeriesService(
         """Get an approximate total count of all data points (planner statistics, no scan)."""
         return self.crud.get_approximate_total_count(db_session)
 
+    def get_approximate_archived_count(self, db_session: DbSession) -> int:
+        """Get an approximate count of archived data points (planner statistics, no scan)."""
+        return self.crud.get_approximate_archived_count(db_session)
+
     def get_count_in_range(self, db_session: DbSession, start_datetime: datetime, end_datetime: datetime) -> int:
         """Get count of data points within a datetime range."""
         return self.crud.get_count_in_range(db_session, start_datetime, end_datetime)

--- a/backend/app/services/user_connection_service.py
+++ b/backend/app/services/user_connection_service.py
@@ -40,7 +40,7 @@ class UserConnectionService(
             users_with_multi_active=self.crud.get_users_with_multi_active_conn_count(db_session),
             top_providers=[
                 ProviderConnectionCount(provider=p, count=c)
-                for p, c in self.crud.get_top_providers_by_active_conn(db_session)
+                for p, c in self.crud.get_top_providers_by_active_conn(db_session, limit=6)
             ],
         )
 

--- a/backend/tests/api/v1/test_dashboard.py
+++ b/backend/tests/api/v1/test_dashboard.py
@@ -174,13 +174,19 @@ class TestGetDashboardStats:
         data = response.json()
 
         # Validate complete schema
-        required_keys = ["total_users", "active_conn", "data_points", "connections_coverage"]
+        required_keys = ["total_users", "active_conn", "data_points", "event_records", "connections_coverage"]
         for key in required_keys:
             assert key in data, f"Missing required key: {key}"
 
         for key in ["total_users", "active_conn", "data_points"]:
             assert "count" in data[key]
             assert isinstance(data[key]["count"], int)
+
+        assert isinstance(data["data_points"]["archived"], int)
+
+        event_records = data["event_records"]
+        for key in ["count", "workouts", "sleep", "menstrual_cycles"]:
+            assert isinstance(event_records[key], int)
 
         coverage = data["connections_coverage"]
         assert "users_with_active" in coverage

--- a/backend/tests/services/test_system_info_service.py
+++ b/backend/tests/services/test_system_info_service.py
@@ -15,6 +15,7 @@ from app.services.system_info_service import system_info_service
 from tests.factories import (
     DataPointSeriesFactory,
     DataSourceFactory,
+    EventRecordFactory,
     SeriesTypeDefinitionFactory,
     UserConnectionFactory,
     UserFactory,
@@ -90,6 +91,24 @@ class TestSystemInfoServiceGetSystemInfo:
         # Assert
         assert isinstance(info.data_points.count, int)
         assert info.data_points.count >= 0
+
+    def test_get_system_info_event_records(self, db: Session) -> None:
+        """Should report event-record totals with a per-category breakdown."""
+        # Arrange
+        initial = system_info_service.get_system_info(db).event_records
+        mapping = DataSourceFactory()
+        EventRecordFactory(mapping=mapping, category="workout", type_="running")
+        EventRecordFactory(mapping=mapping, category="workout", type_="cycling")
+        EventRecordFactory(mapping=mapping, category="sleep", type_=None)
+
+        # Act
+        event_records = system_info_service.get_system_info(db).event_records
+
+        # Assert
+        assert event_records.workouts == initial.workouts + 2
+        assert event_records.sleep == initial.sleep + 1
+        assert event_records.count == initial.count + 3
+        assert isinstance(event_records.menstrual_cycles, int)
 
     def test_get_system_info_connections_coverage(self, db: Session) -> None:
         """Should include connections coverage in the response."""

--- a/frontend/src/components/pages/dashboard/recent-users-section.tsx
+++ b/frontend/src/components/pages/dashboard/recent-users-section.tsx
@@ -74,7 +74,7 @@ export function RecentUsersSection({
   isLoadingLastSynced,
   className,
 }: RecentUsersSectionProps) {
-  const [tab, setTab] = useState<'recent' | 'last-synced'>('recent');
+  const [tab, setTab] = useState<'recent' | 'last-synced'>('last-synced');
 
   return (
     <div

--- a/frontend/src/components/pages/dashboard/stats-card.tsx
+++ b/frontend/src/components/pages/dashboard/stats-card.tsx
@@ -1,5 +1,6 @@
 import type { LucideIcon } from 'lucide-react';
 import { NumberTicker } from '@/components/ui/number-ticker';
+import { formatCompactNumber } from '@/lib/utils/format';
 import { cn } from '@/lib/utils';
 
 export type StatsCardAccent = 'cyan' | 'magenta' | 'purple' | 'green';
@@ -8,10 +9,11 @@ export interface StatsCardProps {
   title: string;
   value: number;
   suffix?: string;
-  description: string;
   icon: LucideIcon;
   decimalPlaces?: number;
   format?: (value: number) => string;
+  /** Optional compact sub-metrics shown as a small row at the bottom. */
+  breakdown?: { label: string; value: number }[];
   accent?: StatsCardAccent;
   className?: string;
 }
@@ -50,19 +52,20 @@ export function StatsCard({
   title,
   value,
   suffix,
-  description,
   icon: Icon,
   decimalPlaces = 0,
   format,
+  breakdown,
   accent = 'cyan',
   className,
 }: StatsCardProps) {
   const styles = ACCENT_STYLES[accent];
+  const hasBreakdown = !!breakdown?.length;
 
   return (
     <div
       className={cn(
-        'group relative overflow-hidden rounded-2xl p-6',
+        'group relative flex flex-col overflow-hidden rounded-2xl p-5',
         'bg-gradient-to-br from-card/80 to-card/40 backdrop-blur-xl',
         'border border-border/60',
         'transition-all duration-300 ease-out',
@@ -70,38 +73,63 @@ export function StatsCard({
         className
       )}
     >
-      <div className="flex items-start justify-between mb-5">
+      <div className="flex items-start justify-between">
         <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
           {title}
         </span>
         <div
           className={cn(
-            'flex h-10 w-10 items-center justify-center rounded-xl border',
+            'flex h-9 w-9 items-center justify-center rounded-xl border',
             styles.iconBg
           )}
         >
-          <Icon className={cn('h-5 w-5', styles.iconColor)} />
+          <Icon className={cn('h-4 w-4', styles.iconColor)} />
         </div>
       </div>
 
-      <div className="flex items-baseline gap-1">
-        <span className="text-4xl font-semibold tracking-tight text-foreground tabular-nums">
-          <NumberTicker
-            value={value}
-            decimalPlaces={decimalPlaces}
-            format={format}
-            className="text-foreground"
-          />
-        </span>
-        {suffix && (
-          <span className="text-xl font-medium text-muted-foreground">
-            {suffix}
+      {/* Value centered in the flexible middle so cards stay balanced even when stretched. */}
+      <div className="flex flex-1 items-center justify-center py-4">
+        <div className="flex items-baseline gap-1">
+          <span className="text-3xl font-semibold tracking-tight text-foreground tabular-nums">
+            <NumberTicker
+              value={value}
+              decimalPlaces={decimalPlaces}
+              format={format}
+              className="text-foreground"
+            />
           </span>
-        )}
+          {suffix && (
+            <span className="text-xl font-medium text-muted-foreground">
+              {suffix}
+            </span>
+          )}
+        </div>
       </div>
 
-      <div className="mt-4">
-        <p className="text-xs text-muted-foreground">{description}</p>
+      {/* Always reserve the bottom row (invisible placeholder when there's no breakdown) so the
+          centered value sits at the same height on every card, with or without sub-metrics. */}
+      <div
+        className={cn(
+          'flex border-t border-border/60 pt-4',
+          !hasBreakdown && 'invisible'
+        )}
+        aria-hidden={!hasBreakdown || undefined}
+      >
+        {(hasBreakdown ? breakdown! : [{ label: ' ', value: 0 }]).map(
+          (item) => (
+            <div
+              key={item.label}
+              className="flex flex-1 flex-col items-center gap-0.5 text-center"
+            >
+              <span className="text-sm font-semibold tabular-nums text-foreground">
+                {formatCompactNumber(item.value)}
+              </span>
+              <span className="text-[10px] text-muted-foreground">
+                {item.label}
+              </span>
+            </div>
+          )
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/pages/dashboard/stats-grid.tsx
+++ b/frontend/src/components/pages/dashboard/stats-grid.tsx
@@ -1,5 +1,5 @@
-import { Users, Activity, Database } from 'lucide-react';
-import { StatsCard, type StatsCardAccent } from './stats-card';
+import { Users, Activity, Database, CalendarClock } from 'lucide-react';
+import { StatsCard, type StatsCardProps } from './stats-card';
 import { cn } from '@/lib/utils';
 import { formatCompactNumber } from '@/lib/utils/format';
 import type { DashboardStats } from '@/lib/api/types';
@@ -10,48 +10,47 @@ export interface StatsGridProps {
 }
 
 export function StatsGrid({ stats, className }: StatsGridProps) {
-  const statCards: Array<{
-    title: string;
-    value: number;
-    description: string;
-    icon: typeof Users;
-    accent: StatsCardAccent;
-  }> = [
+  const cards: StatsCardProps[] = [
     {
       title: 'Total Users',
       value: stats.total_users.count,
-      description: 'Registered users',
       icon: Users,
       accent: 'cyan',
+      format: formatCompactNumber,
     },
     {
       title: 'Active Connections',
       value: stats.active_conn.count,
-      description: 'Connected wearables',
       icon: Activity,
       accent: 'magenta',
+      format: formatCompactNumber,
     },
     {
       title: 'Data Points',
       value: stats.data_points.count,
-      description: 'Health data collected',
       icon: Database,
       accent: 'purple',
+      format: formatCompactNumber,
+      breakdown: [{ label: 'Archived', value: stats.data_points.archived }],
+    },
+    {
+      title: 'Event Records',
+      value: stats.event_records.count,
+      icon: CalendarClock,
+      accent: 'green',
+      format: formatCompactNumber,
+      breakdown: [
+        { label: 'Workouts', value: stats.event_records.workouts },
+        { label: 'Sleep', value: stats.event_records.sleep },
+        { label: 'Cycles', value: stats.event_records.menstrual_cycles },
+      ],
     },
   ];
 
   return (
-    <div className={cn('grid gap-4 md:grid-cols-2 lg:grid-cols-3', className)}>
-      {statCards.map((stat) => (
-        <StatsCard
-          key={stat.title}
-          title={stat.title}
-          value={stat.value}
-          description={stat.description}
-          icon={stat.icon}
-          format={formatCompactNumber}
-          accent={stat.accent}
-        />
+    <div className={cn('grid gap-4 md:grid-cols-2 lg:grid-cols-4', className)}>
+      {cards.map((card) => (
+        <StatsCard key={card.title} {...card} />
       ))}
     </div>
   );

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -160,6 +160,14 @@ export interface MetricCount {
 
 export interface DataPointsInfo {
   count: number;
+  archived: number;
+}
+
+export interface EventRecordsInfo {
+  count: number;
+  workouts: number;
+  sleep: number;
+  menstrual_cycles: number;
 }
 
 export interface ProviderConnectionCount {
@@ -177,6 +185,7 @@ export interface DashboardStats {
   total_users: MetricCount;
   active_conn: MetricCount;
   data_points: DataPointsInfo;
+  event_records: EventRecordsInfo;
   connections_coverage: ConnectionsCoverage;
 }
 


### PR DESCRIPTION
- Added an Event Records card (with Workouts / Sleep / Cycles) and an Archived count under Data Points.
- Connection coverage now shows up to 6 providers.
- Recent-users section defaults to Last synced.
- Cleaner stat cards (removed descriptions, aligned/centered numbers) and fixed a misleading "Active Connections" label.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dashboard statistics now show archived data-point totals and event-record counts, including workout, sleep, and menstrual-cycle breakdowns.
  - Added compact number formatting and breakdown metrics to statistic cards.
  - Dashboard now displays four statistic cards at larger screen sizes.
- **Improvements**
  - Recent users now opens on the “Last synced” tab by default.
  - Provider coverage now includes up to six top active providers.
- **Tests**
  - Added coverage for dashboard statistics and event-record metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->