### PR TITLE
fix(backend): verify Strava webhook HMAC-SHA256 signature

### DIFF
--- a/backend/app/services/providers/strava/webhook_handler.py
+++ b/backend/app/services/providers/strava/webhook_handler.py
@@ -73,11 +73,23 @@ class StravaWebhookHandler(BaseWebhookHandler):
     # ------------------------------------------------------------------
 
     def verify_signature(self, request: Request, body: bytes) -> bool:
-        """Validate timestamp from X-Strava-Signature; skip HMAC.
+        """Verify X-Strava-Signature using HMAC-SHA256 over the raw body.
 
-        Security relies on the hub.challenge handshake at subscription time.
-        Replays are rejected using the timestamp in X-Strava-Signature.
+        Strava signs the message ``{t}.{raw_request_body}`` with
+        HMAC-SHA256(strava_client_secret) and sends the hex digest as ``v1``.
+        The timestamp is also checked for freshness to bound replay windows.
         """
+        secret_setting = settings.strava_client_secret
+        if not secret_setting:
+            log_structured(
+                logger,
+                "error",
+                "STRAVA_CLIENT_SECRET not configured; rejecting webhook",
+                provider="strava",
+                action="webhook_signature_missing_secret",
+            )
+            return False
+
         header = request.headers.get("X-Strava-Signature", "")
         if not header:
             return False
@@ -85,6 +97,7 @@ class StravaWebhookHandler(BaseWebhookHandler):
         try:
             parts = dict(p.split("=", 1) for p in header.split(","))
             timestamp = int(parts["t"])
+            provided_signature = parts["v1"]
         except (KeyError, ValueError):
             return False
 
@@ -98,7 +111,13 @@ class StravaWebhookHandler(BaseWebhookHandler):
             )
             return False
 
-        return True
+        secret = secret_setting.get_secret_value()
+        return self._verify_hmac_sha256(
+            secret,
+            body,
+            provided_signature,
+            prefix=f"{timestamp}.".encode(),
+        )
 
     def parse_payload(self, body: bytes) -> StravaWebhookEvent:
         try:

--- a/backend/tests/providers/strava/test_strava_webhook_handler.py
+++ b/backend/tests/providers/strava/test_strava_webhook_handler.py
@@ -1,0 +1,117 @@
+"""Tests for StravaWebhookHandler.verify_signature.
+
+Regression coverage for the Strava webhook signature verification fix:
+X-Strava-Signature was previously only checked for a fresh timestamp and the
+HMAC-SHA256 digest (``v1``) was never verified, so anyone could forge events
+(activity delete / athlete deauthorize) against ``POST /providers/strava/webhooks``.
+"""
+
+import hashlib
+import hmac
+import time
+from unittest.mock import MagicMock, patch
+
+from pydantic import SecretStr
+from starlette.requests import Request
+
+from app.config import settings
+from app.services.providers.strava.webhook_handler import StravaWebhookHandler
+
+SECRET = "test-strava-client-secret"
+
+
+def _request(headers: dict[str, str]) -> Request:
+    scope: dict[str, object] = {
+        "type": "http",
+        "method": "POST",
+        "path": "/",
+        "raw_path": b"/",
+        "query_string": b"",
+        "headers": [(k.lower().encode(), v.encode()) for k, v in headers.items()],
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("testclient", 12345),
+        "root_path": "",
+        "http_version": "1.1",
+    }
+    return Request(scope)
+
+
+def _sign(secret: str, body: bytes, timestamp: int) -> str:
+    message = f"{timestamp}.".encode() + body
+    digest = hmac.new(secret.encode(), message, hashlib.sha256).hexdigest()
+    return f"t={timestamp},v1={digest}"
+
+
+def _handler() -> StravaWebhookHandler:
+    return StravaWebhookHandler(workouts=MagicMock())
+
+
+def _verify(
+    handler: StravaWebhookHandler,
+    body: bytes,
+    *,
+    secret: str = SECRET,
+    timestamp: int | None = None,
+    signature: str | None = None,
+    header_name: str = "X-Strava-Signature",
+) -> bool:
+    ts = timestamp if timestamp is not None else int(time.time())
+    sig = signature if signature is not None else _sign(secret, body, ts)
+    return handler.verify_signature(_request({header_name: sig}), body)
+
+
+def test_valid_signature_accepted() -> None:
+    with patch.object(settings, "strava_client_secret", SecretStr(SECRET)):
+        body = b'{"object_type":"activity","aspect_type":"create","object_id":1,"owner_id":2}'
+        assert _verify(_handler(), body) is True
+
+
+def test_missing_secret_rejects() -> None:
+    with patch.object(settings, "strava_client_secret", None):
+        body = b"{}"
+        assert _verify(_handler(), body) is False
+
+
+def test_missing_header_rejects() -> None:
+    with patch.object(settings, "strava_client_secret", SecretStr(SECRET)):
+        body = b"{}"
+        assert _verify(_handler(), body, header_name="X-Missing-Header") is False
+
+
+def test_malformed_header_rejects() -> None:
+    with patch.object(settings, "strava_client_secret", SecretStr(SECRET)):
+        body = b"{}"
+        for bad in ("garbage", "t=notanumber,v1=abc", "v1=abc", "t=123"):
+            assert _verify(_handler(), body, signature=bad) is False
+
+
+def test_wrong_digest_rejects() -> None:
+    with patch.object(settings, "strava_client_secret", SecretStr(SECRET)):
+        body = b"{}"
+        ts = int(time.time())
+        forged = f"t={ts},v1={'0' * 64}"
+        assert _verify(_handler(), body, signature=forged) is False
+
+
+def test_tampered_body_rejects() -> None:
+    """An attacker-modifying the body invalidates the signature for the same t."""
+    with patch.object(settings, "strava_client_secret", SecretStr(SECRET)):
+        original = b'{"object_type":"activity","aspect_type":"create","object_id":1,"owner_id":2}'
+        tampered = b'{"object_type":"athlete","aspect_type":"delete","object_id":1,"owner_id":2}'
+        ts = int(time.time())
+        request = _request({"X-Strava-Signature": _sign(SECRET, original, ts)})
+        assert _handler().verify_signature(request, tampered) is False
+
+
+def test_stale_timestamp_rejects() -> None:
+    with patch.object(settings, "strava_client_secret", SecretStr(SECRET)):
+        body = b"{}"
+        stale = int(time.time()) - (settings.strava_webhook_signature_tolerance_seconds + 60)
+        assert _verify(_handler(), body, timestamp=stale) is False
+
+
+def test_wrong_secret_rejects() -> None:
+    with patch.object(settings, "strava_client_secret", SecretStr("other-secret")):
+        body = b"{}"
+        assert _verify(_handler(), body) is False


### PR DESCRIPTION
## Description

Strava's `X-Strava-Signature` header was only checked for timestamp freshness — the `v1` HMAC-SHA256 digest was never verified. Anyone able to reach `POST /providers/strava/webhooks` could forge activity create/update/delete and athlete deauthorize events, injecting attacker-controlled data and activity records.

`verify_signature` now validates the digest against `HMAC-SHA256(strava_client_secret, "{t}.{raw_request_body}")` using the shared `_verify_hmac_sha256` base helper (same pattern as the Whoop and Oura handlers), rejects requests when `strava_client_secret` is unset, and keeps the existing timestamp-freshness check.

Related to #1380 (same class of webhook signature gap on Garmin).

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. `cd backend`
2. `uv run pytest tests/providers/strava/ -q` (all 22 tests pass, 8 new)
3. `uv run ruff check app/services/providers/strava/webhook_handler.py tests/providers/strava/test_strava_webhook_handler.py`
4. `uv run --group code-quality ty check app/services/providers/strava/webhook_handler.py tests/providers/strava/test_strava_webhook_handler.py`

**Expected behavior:**
- A correctly signed Strava webhook (fresh timestamp + valid digest) is accepted.
- Forged signatures, tampered bodies, stale timestamps, missing headers, malformed headers, an unset client secret, or a wrong client secret are all rejected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened Strava webhook validation using HMAC-SHA256 signatures.
  * Webhooks are rejected when the client secret or signature is missing, invalid, stale, or does not match the request body.
* **Bug Fixes**
  * Prevented acceptance of tampered webhook requests that previously passed timestamp checks alone.
* **Tests**
  * Added coverage for valid signatures and common invalid or tampered request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->