### PR TITLE
fix: remove `handle_duplicates` decorator from `event_record_detail_service`'s `create`

### DIFF
--- a/backend/app/repositories/event_record_detail_repository.py
+++ b/backend/app/repositories/event_record_detail_repository.py
@@ -1,6 +1,7 @@
 from typing import Any, cast
 from uuid import UUID
 
+from psycopg.errors import UniqueViolation
 from sqlalchemy import Table, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
@@ -55,9 +56,12 @@ class EventRecordDetailRepository(
             db_session.commit()
             db_session.refresh(detail)
             return detail
-        except IntegrityError:
+        except IntegrityError as exc:
             db_session.rollback()
-            if existing := self.get_by_record_id(db_session, creator.record_id, detail_type):
+            # record_id is the only unique index here; FK and other violations are real errors
+            if isinstance(exc.orig, UniqueViolation) and (
+                existing := self.get_by_record_id(db_session, creator.record_id, detail_type)
+            ):
                 return existing
             raise
 
@@ -79,9 +83,11 @@ class EventRecordDetailRepository(
             db_session.flush()
             nested.commit()
             return detail
-        except IntegrityError:
+        except IntegrityError as exc:
             nested.rollback()
-            if existing := self.get_by_record_id(db_session, creator.record_id, detail_type):
+            if isinstance(exc.orig, UniqueViolation) and (
+                existing := self.get_by_record_id(db_session, creator.record_id, detail_type)
+            ):
                 return existing
             raise
 

--- a/backend/app/repositories/event_record_detail_repository.py
+++ b/backend/app/repositories/event_record_detail_repository.py
@@ -17,7 +17,6 @@ from app.schemas.model_crud.activities import (
     EventRecordDetailCreate,
     EventRecordDetailUpdate,
 )
-from app.utils.duplicates import handle_duplicates
 from app.utils.exceptions import handle_exceptions
 
 
@@ -40,19 +39,27 @@ class EventRecordDetailRepository(
         return model(**creation_data)
 
     @handle_exceptions
-    @handle_duplicates
     def create(
         self,
         db_session: DbSession,
         creator: EventRecordDetailCreate,
         detail_type: DetailType = "workout",
     ) -> EventRecordDetail:
-        """Create a detail record using the appropriate polymorphic model."""
+        """Create a detail record using the appropriate polymorphic model.
+
+        Idempotent on record_id: returns the existing row on duplicate insert.
+        """
         detail = self._build_detail(creator, detail_type)
-        db_session.add(detail)
-        db_session.commit()
-        db_session.refresh(detail)
-        return detail
+        try:
+            db_session.add(detail)
+            db_session.commit()
+            db_session.refresh(detail)
+            return detail
+        except IntegrityError:
+            db_session.rollback()
+            if existing := self.get_by_record_id(db_session, creator.record_id, detail_type):
+                return existing
+            raise
 
     def create_and_flush(
         self,

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -10,6 +10,7 @@ from app.database import DbSession
 from app.models import (
     DataPointSeries,
     DataSource,
+    DetailType,
     EventRecord,
     EventRecordDetail,
     HealthScore,
@@ -124,7 +125,7 @@ class EventRecordService(
         self,
         db_session: DbSession,
         detail: EventRecordDetailCreate,
-        detail_type: str = "workout",
+        detail_type: DetailType = "workout",
     ) -> EventRecordDetail:
         result = self.event_record_detail_repo.create(db_session, detail, detail_type=detail_type)
         # event_record_detail_repo.create commits internally, so data is already persisted.
@@ -137,7 +138,7 @@ class EventRecordService(
             if data_source is not None:
                 self._emit_event_record_webhook(record, data_source, detail)
 
-        return result  # ty:ignore[invalid-return-type]
+        return result
 
     @staticmethod
     def _local_sleep_date(start_datetime: datetime, zone_offset: str | None) -> date:

--- a/backend/tests/repositories/test_event_record_detail_repository.py
+++ b/backend/tests/repositories/test_event_record_detail_repository.py
@@ -15,6 +15,9 @@ from typing import get_args
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
+from psycopg.errors import ForeignKeyViolation
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models import DETAIL_MODELS, DetailType, EventRecordDetail, SleepDetails, WorkoutDetails
@@ -159,6 +162,34 @@ class TestEventRecordDetailRepository:
         assert isinstance(duplicate, WorkoutDetails)
         assert duplicate.record_id == first.record_id
         assert duplicate.steps_count == 8500
+
+    def test_create_unrelated_integrity_error_reraises(
+        self,
+        db: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A non-duplicate IntegrityError must surface even when a detail row already exists."""
+        # Arrange
+        repo = EventRecordDetailRepository(EventRecordDetail)
+        event_record = EventRecordFactory(category="workout")
+        repo.create(
+            db,
+            EventRecordDetailCreate(record_id=event_record.id, steps_count=8500),
+            detail_type="workout",
+        )
+
+        def fail_with_fk_violation() -> None:
+            raise IntegrityError("stmt", {}, ForeignKeyViolation("fk violation"))
+
+        monkeypatch.setattr(db, "commit", fail_with_fk_violation)
+
+        # Act & Assert - handle_exceptions maps the re-raised error, no silent recovery
+        with pytest.raises(HTTPException):
+            repo.create(
+                db,
+                EventRecordDetailCreate(record_id=event_record.id, steps_count=9999),
+                detail_type="workout",
+            )
 
     def test_get_by_record_id_workout(self, db: Session, detail_repo: EventRecordDetailRepository) -> None:
         """Test getting workout details by record_id."""

--- a/backend/tests/repositories/test_event_record_detail_repository.py
+++ b/backend/tests/repositories/test_event_record_detail_repository.py
@@ -109,6 +109,57 @@ class TestEventRecordDetailRepository:
         with pytest.raises(ValueError, match="Unknown detail type: invalid"):
             detail_repo.create(db, detail_data, detail_type="invalid")
 
+    def test_create_duplicate_returns_existing(self, db: Session) -> None:
+        """Re-syncing the same record_id returns the existing detail instead of raising.
+
+        Regression for #1375: production wires the repo with the abstract
+        ``EventRecordDetail`` base, so the old ``@handle_duplicates`` recovery blew up
+        with ``NoInspectionAvailable`` on the unique-violation retry.
+        """
+        # Arrange - repo built with the abstract base, mirroring production wiring
+        repo = EventRecordDetailRepository(EventRecordDetail)
+        event_record = EventRecordFactory(category="workout")
+        first = repo.create(
+            db,
+            EventRecordDetailCreate(record_id=event_record.id, steps_count=8500),
+            detail_type="workout",
+        )
+
+        # Act - inserting the same record_id again must not raise
+        duplicate = repo.create(
+            db,
+            EventRecordDetailCreate(record_id=event_record.id, steps_count=9999),
+            detail_type="workout",
+        )
+
+        # Assert - existing row returned unchanged, not a new/overwritten one
+        assert isinstance(duplicate, WorkoutDetails)
+        assert duplicate.record_id == first.record_id
+        assert duplicate.steps_count == 8500
+
+    def test_create_and_flush_duplicate_returns_existing(self, db: Session) -> None:
+        """create_and_flush is idempotent on record_id via its savepoint recovery."""
+        # Arrange
+        repo = EventRecordDetailRepository(EventRecordDetail)
+        event_record = EventRecordFactory(category="workout")
+        first = repo.create(
+            db,
+            EventRecordDetailCreate(record_id=event_record.id, steps_count=8500),
+            detail_type="workout",
+        )
+
+        # Act
+        duplicate = repo.create_and_flush(
+            db,
+            EventRecordDetailCreate(record_id=event_record.id, steps_count=9999),
+            detail_type="workout",
+        )
+
+        # Assert
+        assert isinstance(duplicate, WorkoutDetails)
+        assert duplicate.record_id == first.record_id
+        assert duplicate.steps_count == 8500
+
     def test_get_by_record_id_workout(self, db: Session, detail_repo: EventRecordDetailRepository) -> None:
         """Test getting workout details by record_id."""
         # Arrange


### PR DESCRIPTION
## Description

After we changed our approach to the `event_record_detail` abstract table (with pr #1314), the decorator starts throwing uncaught errors because of the lack of model associated - we also noticed this on our sentry instance:
```
NoInspectionAvailable
No inspection system is available for object of type <class 'app.utils.mappings_meta.AutoRelMeta'>
```

The change is that the scope is smaller than the decorator used before (now the only unique constraint on the table is queried - which doesn't necessarily remove any overhead, but simplifies the code a bit)

The functionality stays the same as before the changes, but errors should not be raised further up anymore


Also added some tests to prevent this from firing in the future (hopefully)

Resolves #1375

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate event detail submissions.
  * Existing matching details are now reused without overwriting their original values.
  * Genuine database errors continue to be reported appropriately.
  * Improved consistency when creating event details through different workflows.
  * Event detail types are now validated more reliably, reducing invalid submissions and unexpected errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->