### PR TITLE
fix(infra): single-source DB_PASSWORD for db + app (was hardcoded)

### DIFF
--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -27,6 +27,9 @@ DB_PORT=5432
 DB_NAME=open-wearables
 DB_USER=open-wearables
 DB_PASSWORD=open-wearables
+# NOTE: docker-compose.prod.yml overrides this value for the db and app services via
+# ${DB_PASSWORD} interpolation (env_file values are invisible to compose interpolation).
+# To use a custom password, set DB_PASSWORD in the project .env next to the compose file.
 
 #--- REDIS ---#
 REDIS_HOST=redis

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,7 +5,7 @@ services:
     environment:
       POSTGRES_DB: open-wearables
       POSTGRES_USER: open-wearables
-      POSTGRES_PASSWORD: open-wearables
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-open-wearables}
     ports:
       - "${DB_PORT:-5432}:5432"
     healthcheck:
@@ -31,6 +31,7 @@ services:
     environment:
       - DB_HOST=db
       - REDIS_HOST=redis
+      - DB_PASSWORD=${DB_PASSWORD:-open-wearables}
     ports:
       - "${API_PORT:-8000}:8000"
     depends_on:


### PR DESCRIPTION
Closes #1410

`POSTGRES_PASSWORD` was hardcoded to `open-wearables` while the backend reads its DB password from `backend/config/.env` (`DB_PASSWORD`). On a fresh deploy with a real password, the postgres volume initialized with the hardcoded value and the backend failed auth:

```
FATAL: password authentication failed for user "open-wearables"
```

**This PR makes `DB_PASSWORD` the single source of the database password:**
- db: `POSTGRES_PASSWORD: ${DB_PASSWORD:-open-wearables}` (postgres env var, value from DB_PASSWORD)
- app: `DB_PASSWORD: ${DB_PASSWORD:-open-wearables}` in `environment:` (overrides the env_file value — same source)

With both services interpolating the same variable, database initialization and backend connections can no longer drift. The default stays `open-wearables` for out-of-the-box parity with `backend/config/.env.example`.

**Note for operators:** compose interpolation reads the **project `.env`**, not `backend/config/.env` (env_file values are injected at runtime and are invisible to interpolation). To use a custom password, set `DB_PASSWORD` in a `.env` next to the compose file. Prefer fail-fast deployments? Change `:-open-wearables` to `:?`.

Related: #570 / #1380 (port exposure in the same file).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production deployments can now use a custom database password through the `DB_PASSWORD` environment variable.
  * Added configuration guidance for setting the password in the project environment file.

* **Bug Fixes**
  * Ensured the application and PostgreSQL service use the same configured database password.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->