### PR TITLE
feat(frontend): make sidebar responsive on mobile

### DIFF
--- a/frontend/src/components/layout/simple-sidebar.tsx
+++ b/frontend/src/components/layout/simple-sidebar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link, useLocation } from '@tanstack/react-router';
 import {
   Home,
@@ -66,7 +67,7 @@ const menuItems = [
   },
 ];
 
-function SidebarContent() {
+function SidebarContent({ onNavigate }: { onNavigate?: () => void }) {
   const location = useLocation();
   const { logout, isLoggingOut } = useAuth();
 
@@ -89,6 +90,7 @@ function SidebarContent() {
                 href={item.url}
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={onNavigate}
                 className="flex items-center gap-3 px-3 py-2 rounded-md text-sm text-muted-foreground hover:bg-card/40 hover:text-foreground transition-all duration-200"
               >
                 <item.icon className="h-4 w-4 text-muted-foreground" />
@@ -102,6 +104,7 @@ function SidebarContent() {
             <Link
               key={item.title}
               to={item.url}
+              onClick={onNavigate}
               className={cn(
                 'flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-all duration-200',
                 isActive
@@ -150,24 +153,30 @@ function SidebarContent() {
 
 export function SimpleSidebar() {
   const isMobile = useIsMobile();
+  const [openMobile, setOpenMobile] = useState(false);
 
   if (isMobile) {
     return (
       <div className="sticky top-0 z-40 flex items-center justify-between border-b border-border/40 bg-black px-4 py-3 md:hidden">
         <img src={logotype} alt="Open Wearables" className="h-6" />
-        <Sheet>
+        <Sheet open={openMobile} onOpenChange={setOpenMobile}>
           <SheetTrigger asChild>
             <Button variant="ghost" size="icon" aria-label="Open menu">
               <Menu className="h-5 w-5" />
             </Button>
           </SheetTrigger>
-          <SheetContent side="left" className="w-64 bg-black p-0 text-sidebar-foreground">
+          <SheetContent
+            side="left"
+            className="w-64 bg-black p-0 text-sidebar-foreground"
+          >
             <SheetHeader className="sr-only">
               <SheetTitle>Navigation</SheetTitle>
-              <SheetDescription>Open Wearables navigation menu</SheetDescription>
+              <SheetDescription>
+                Open Wearables navigation menu
+              </SheetDescription>
             </SheetHeader>
             <div className="flex h-full w-full flex-col">
-              <SidebarContent />
+              <SidebarContent onNavigate={() => setOpenMobile(false)} />
             </div>
           </SheetContent>
         </Sheet>

--- a/frontend/src/components/layout/simple-sidebar.tsx
+++ b/frontend/src/components/layout/simple-sidebar.tsx
@@ -9,12 +9,22 @@ import {
   Webhook,
   RefreshCw,
   LayoutGrid,
+  Menu,
 } from 'lucide-react';
 import logotype from '@/logotype.svg';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/hooks/use-auth';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { ROUTES } from '@/lib/constants/routes';
 import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
 
 const menuItems = [
   {
@@ -56,12 +66,12 @@ const menuItems = [
   },
 ];
 
-export function SimpleSidebar() {
+function SidebarContent() {
   const location = useLocation();
   const { logout, isLoggingOut } = useAuth();
 
   return (
-    <aside className="relative w-64 bg-black flex flex-col border-r border-border/40">
+    <>
       {/* Header */}
       <div className="p-4 border-b border-border/40">
         <img src={logotype} alt="Open Wearables" className="h-auto" />
@@ -134,6 +144,40 @@ export function SimpleSidebar() {
           v{__APP_VERSION__}
         </p>
       </div>
+    </>
+  );
+}
+
+export function SimpleSidebar() {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <div className="sticky top-0 z-40 flex items-center justify-between border-b border-border/40 bg-black px-4 py-3 md:hidden">
+        <img src={logotype} alt="Open Wearables" className="h-6" />
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant="ghost" size="icon" aria-label="Open menu">
+              <Menu className="h-5 w-5" />
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="left" className="w-64 bg-black p-0 text-sidebar-foreground">
+            <SheetHeader className="sr-only">
+              <SheetTitle>Navigation</SheetTitle>
+              <SheetDescription>Open Wearables navigation menu</SheetDescription>
+            </SheetHeader>
+            <div className="flex h-full w-full flex-col">
+              <SidebarContent />
+            </div>
+          </SheetContent>
+        </Sheet>
+      </div>
+    );
+  }
+
+  return (
+    <aside className="relative hidden w-64 bg-black flex-col border-r border-border/40 md:flex">
+      <SidebarContent />
     </aside>
   );
 }

--- a/frontend/src/routes/_authenticated.tsx
+++ b/frontend/src/routes/_authenticated.tsx
@@ -19,9 +19,9 @@ export const Route = createFileRoute('/_authenticated')({
 
 function AuthenticatedLayout() {
   return (
-    <div className="flex min-h-screen w-full bg-black">
+    <div className="flex min-h-screen w-full flex-col bg-black md:flex-row">
       <SimpleSidebar />
-      <main className="flex-1 overflow-auto bg-zinc-950 border-l border-zinc-800/50">
+      <main className="flex-1 overflow-auto bg-zinc-950 md:border-l md:border-zinc-800/50">
         <Outlet />
       </main>
     </div>


### PR DESCRIPTION
## Summary

The authenticated layout uses a fixed 256px sidebar on all screen sizes with no way to hide it on small screens. On mobile (<768px) the sidebar now collapses into a slim top bar with a hamburger button that opens a slide-out navigation drawer (using the existing `Sheet` component). Desktop layout is unchanged.

## What Changed

- `frontend/src/components/layout/simple-sidebar.tsx`:
  - Extracted the sidebar content into a reusable `SidebarContent` component
  - On mobile (<768px, via the existing `useIsMobile` hook): renders a top bar with the logo and a hamburger `SheetTrigger` that opens a left-side drawer
  - On desktop (≥768px): renders the original fixed sidebar, now with `hidden md:flex` so it only shows on desktop
- `frontend/src/routes/_authenticated.tsx`:
  - Layout now stacks vertically on mobile (`flex-col`) and side-by-side on desktop (`md:flex-row`)

## Behavior / Compatibility

- No changes to navigation items, auth, or routing
- Desktop experience is identical to before
- Mobile now gets a proper hamburger menu instead of a permanently-visible sidebar

## Validation

- Tested on a phone-sized viewport: sidebar hidden, hamburger opens/closes the drawer, navigation works
- Desktop viewport: sidebar renders exactly as before
- Frontend builds successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive sidebar navigation for mobile and desktop layouts.
  * Mobile users can open navigation from a sticky header menu button in a left-side drawer.
  * Navigation closes automatically after selecting a mobile menu item.
  * Desktop users retain a fixed sidebar experience.

* **Style**
  * Improved authenticated page layout responsiveness across screen sizes.
  * Adjusted content borders to appear appropriately on larger displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->