### PR TITLE
docs: fix incorrect SDK availability for Apple Health, Health Connect & Samsung Health

### DIFF
--- a/docs/providers/apple-health.mdx
+++ b/docs/providers/apple-health.mdx
@@ -1,13 +1,13 @@
 ---
 title: "HealthKit Integration with Open Wearables"
-description: "Integrate Apple Health via HealthKit using the Open Wearables Flutter SDK. Push-based sync for steps, heart rate, sleep, and workouts. iOS 13+ required."
+description: "Integrate Apple Health via HealthKit using the Open Wearables iOS, Flutter, and React Native SDKs. Push-based sync for steps, heart rate, sleep, and workouts. iOS 13+ required."
 keywords: ["healthkit integration", "apple health api", "apple health data", "healthkit open source"]
 "og:title": "HealthKit Integration with Open Wearables | Apple Health"
-"og:description": "Sync Apple Health via HealthKit with the Flutter SDK. Covers steps, heart rate, sleep, workouts, HRV. iOS 13+, push-based."
+"og:description": "Sync Apple Health via HealthKit with the iOS, Flutter, and React Native SDKs. Covers steps, heart rate, sleep, workouts, HRV. iOS 13+, push-based."
 "og:url": "https://docs.openwearables.io/providers/apple-health"
 "og:type": "article"
 "twitter:title": "HealthKit Integration with Open Wearables | Apple Health"
-"twitter:description": "Sync Apple Health via HealthKit with the Flutter SDK. Covers steps, heart rate, sleep, workouts, HRV. iOS 13+, push-based."
+"twitter:description": "Sync Apple Health via HealthKit with the iOS, Flutter, and React Native SDKs. Covers steps, heart rate, sleep, workouts, HRV. iOS 13+, push-based."
 "twitter:card": "summary_large_image"
 ---
 
@@ -22,8 +22,14 @@ Apple Health integration uses a **push-based model** where health data is sent f
 ## Integration Options
 
 <CardGroup cols={2}>
+  <Card title="iOS SDK (Swift)" icon="apple" href="/sdk/ios">
+    Native iOS SDK — the core implementation for Apple HealthKit sync.
+  </Card>
   <Card title="Flutter SDK" icon="mobile" href="/sdk/flutter">
-    Cross-platform SDK for iOS and Android. Recommended for most applications.
+    Cross-platform wrapper around the native iOS and Android SDKs.
+  </Card>
+  <Card title="React Native SDK" icon="mobile" href="/sdk/react-native">
+    Cross-platform wrapper around the native iOS and Android SDKs.
   </Card>
   <Card title="XML Import" icon="file-import" href="/api-reference/guides/apple-xml-import">
     Import Apple Health data from XML exports. Useful for one-time migrations.

--- a/docs/providers/apple-health.mdx
+++ b/docs/providers/apple-health.mdx
@@ -26,10 +26,10 @@ Apple Health integration uses a **push-based model** where health data is sent f
     Native iOS SDK — the core implementation for Apple HealthKit sync.
   </Card>
   <Card title="Flutter SDK" icon="mobile" href="/sdk/flutter">
-    Cross-platform wrapper around the native iOS and Android SDKs.
+    Cross-platform wrapper — syncs Apple Health on iOS via the native iOS SDK.
   </Card>
   <Card title="React Native SDK" icon="mobile" href="/sdk/react-native">
-    Cross-platform wrapper around the native iOS and Android SDKs.
+    Cross-platform wrapper — syncs Apple Health on iOS via the native iOS SDK.
   </Card>
   <Card title="XML Import" icon="file-import" href="/api-reference/guides/apple-xml-import">
     Import Apple Health data from XML exports. Useful for one-time migrations.

--- a/docs/providers/supported.mdx
+++ b/docs/providers/supported.mdx
@@ -33,9 +33,9 @@ Connect your wearable devices and fitness platforms to Open Wearables. Click on 
 
 | Provider | Setup Guide | Notes |
 |----------|-------------|--------|
-| **Apple Health** | [Setup Guide →](/providers/apple-health) | Mobile SDK coming soon! |
-| **Google Health Connect** | [Setup Guide →](/sdk/android/integration) | Via Android SDK |
-| **Samsung Health** | [Setup Guide →](/sdk/android/integration) | Via Android SDK |
+| **Apple Health** | [Setup Guide →](/providers/apple-health) | Via iOS, Flutter & React Native SDK |
+| **Google Health Connect** | [Setup Guide →](/sdk/android/integration) | Via Android, Flutter & React Native SDK |
+| **Samsung Health** | [Setup Guide →](/sdk/android/integration) | Via Android, Flutter & React Native SDK |
 
 ## Adding New Providers
 


### PR DESCRIPTION
## Description

The Supported Providers docs page misrepresented which mobile SDKs are actually available for on-device health stores. This corrects the SDK availability for Apple Health, Google Health Connect, and Samsung Health.

**What was wrong:**
- Apple Health was marked as "Mobile SDK coming soon!" - but Apple HealthKit is already supported today via the iOS (Swift), Flutter, and React Native SDKs.
- Google Health Connect and Samsung Health were marked as "Via Android SDK" only - but both are also available through the Flutter and React Native wrappers.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code

## Testing Instructions

**Steps to test:**
1. Open `docs/providers/supported.mdx` and check the SDK-based providers table.
2. Open `docs/providers/apple-health.mdx` and check the Integration Options.

**Expected behavior:**
- Apple Health / Health Connect / Samsung Health show the correct set of SDKs (no "coming soon", no Android-only wording).
- Apple Health Integration Options lists iOS, Flutter, and React Native SDKs alongside XML Import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Apple Health documentation with iOS, Flutter, and React Native integration options.
  * Clarified that the Flutter integration is a cross-platform wrapper.
  * Added Android, Flutter, and React Native SDK support details for Google Health Connect and Samsung Health.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->