### PR TITLE
docs: describe supported providers without a fixed count

### DIFF
--- a/docs/providers/supported.mdx
+++ b/docs/providers/supported.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Supported Wearable Device Integrations"
-description: "10 providers: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Oura, Ultrahuman, Apple Health, and Google Health Connect. Cloud OAuth and mobile SDK integrations."
+description: "Supported wearable and fitness integrations including Garmin, Whoop, Polar, Oura, Fitbit, Apple Health, and Google Health Connect. Cloud OAuth and mobile SDK integrations, with more added regularly."
 keywords: ["wearable device integrations", "supported wearables api", "wearable api providers", "open wearables"]
 "og:title": "Supported Wearable Device Integrations | Open Wearables"
-"og:description": "10 providers supported: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Oura, Ultrahuman, Apple Health, and Google Health Connect."
+"og:description": "Connect wearables and fitness platforms - Garmin, Whoop, Polar, Oura, Fitbit, Apple Health, Google Health Connect, and more - via cloud OAuth and mobile SDKs."
 "og:url": "https://docs.openwearables.io/providers/supported"
 "og:type": "article"
 "twitter:title": "Supported Wearable Device Integrations | Open Wearables"
-"twitter:description": "10 providers supported: Garmin, Whoop, Polar, Suunto, Strava, Fitbit, Oura, Ultrahuman, Apple Health, and Google Health Connect."
+"twitter:description": "Connect wearables and fitness platforms - Garmin, Whoop, Polar, Oura, Fitbit, Apple Health, Google Health Connect, and more - via cloud OAuth and mobile SDKs."
 "twitter:card": "summary_large_image"
 ---
 


### PR DESCRIPTION
## Description

The supported providers page hardcoded "10 providers" in its SEO metadata, which drifts out of date every time we add a provider. Reworded the `description`, `og:description`, and `twitter:description` to describe the integrations without a fixed count or full name list, so metadata no longer needs updating on each new provider.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

## Testing Instructions

**Steps to test:**
1. Open `docs/providers/supported.mdx` and check the frontmatter metadata.

**Expected behavior:**
No hardcoded provider count; metadata reads naturally and stays accurate as providers are added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated supported integrations documentation to cover wearable and fitness platforms more broadly.
  * Highlighted Garmin, Whoop, Polar, Oura, Fitbit, Apple Health, and Google Health Connect.
  * Added references to cloud OAuth and mobile SDK integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->