### PR TITLE
fix(backend): remove invalid 'activity' OAuth scope from default

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -174,7 +174,7 @@ class Settings(BaseSettings):
     oura_client_id: str | None = None
     oura_client_secret: SecretStr | None = None
     oura_redirect_uri: str | None = None  # Deprecated: use API_BASE_URL
-    oura_default_scope: str = "personal daily activity heartrate workout session spo2 ring_configuration heart_health"
+    oura_default_scope: str = "personal daily heartrate workout session spo2 ring_configuration heart_health"
     oura_webhook_verification_token: SecretStr | None = None
 
     # STRAVA OAUTH SETTINGS

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -148,7 +148,7 @@ WHOOP_DEFAULT_SCOPE=offline read:cycles read:sleep read:recovery read:workout re
 #--- Oura ---#
 OURA_CLIENT_ID=your-oura-client-id
 OURA_CLIENT_SECRET=your-oura-client-secret
-OURA_DEFAULT_SCOPE=personal daily activity heartrate workout session spo2 ring_configuration heart_health
+OURA_DEFAULT_SCOPE=personal daily heartrate workout session spo2 ring_configuration heart_health
 # OURA_WEBHOOK_VERIFICATION_TOKEN=your-token  # Optional: defaults to SECRET_KEY
 
 #--- Strava ---#


### PR DESCRIPTION
## Description

`activity` doesn't seem to be a real Oura scope, but it was sitting in our default `OURA_DEFAULT_SCOPE`. Dropped it from `config.py` and `.env.example`.

It's not in [Oura's auth docs](https://cloud.ouraring.com/docs/authentication) and it's not offered in the developer portal when you set up the app either (screenshot below). Daily activity comes in via the `daily` scope anyway, so we lose nothing.

## Screenshot

Portal scopes - no "Activity" anywhere:

<img width="1076" height="887" alt="image" src="https://github.com/user-attachments/assets/2cb3832e-b67d-4b5f-b962-77e698b424ed" />

Oura docs:

<img width="958" height="676" alt="image" src="https://github.com/user-attachments/assets/12452a07-9d41-4b95-8305-0ec6f4d00d0e" />

## Notes

- Oura's docs and portal don't even agree with each other: the docs list 8 scopes, the portal offers a few more (`ring_configuration`, `stress`, `heart_health`). `activity` is in neither.
- Passing a non-existent scope often makes OAuth providers reject the whole request with `invalid_scope`. Oura currently lets it slide, which is why we never noticed - worth fixing before that changes and the flow breaks.

## Checklist

- [x] Self-reviewed
- [x] Tests pass locally

## Testing

Start an Oura OAuth flow, check the generated `authorization_url` - `scope` no longer contains `activity`, and daily activity still syncs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the default Oura authorization permissions to no longer request activity data.
  * Updated the example configuration to reflect the revised permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->