### PR TITLE
docs: clarify invitation code vs backend token onboarding flows

### DIFF
--- a/backend/app/api/routes/v1/user_invitation_code.py
+++ b/backend/app/api/routes/v1/user_invitation_code.py
@@ -23,12 +23,18 @@ def generate_invitation_code(
     db: DbSession,
     developer: DeveloperDep,
 ) -> UserInvitationCodeRead:
-    """Generate a single-use invitation code for SDK user onboarding.
+    """Generate a single-use invitation code for standalone SDK onboarding.
 
-    The code can be shared with a mobile app user who enters it to receive
-    SDK access and refresh tokens without manually entering user_id and tokens.
+    Issues a single-use code that a mobile app can redeem (via
+    `POST /api/v1/invitation-code/redeem`) to receive SDK access and refresh
+    tokens - without your backend having to mint and forward a token itself.
+    Any previously generated codes for this user are marked as expired.
 
-    Previously generated codes for this user are marked as expired.
+    This is a convenience mechanism for apps with no backend of their own (for
+    example the Open Wearables app or quick manual testing). It is not the
+    standard integration path: if your app authenticates users against your own
+    backend, mint a token directly with `POST /api/v1/users/{user_id}/token`
+    instead.
 
     Requires developer authentication.
     """
@@ -42,10 +48,15 @@ def redeem_invitation_code(
     payload: UserInvitationCodeRedeem,
     db: DbSession,
 ) -> InvitationCodeRedeemResponse:
-    """Redeem an invitation code for SDK tokens.
+    """Redeem a single-use invitation code for SDK tokens.
 
-    Public endpoint (no authentication required). Exchanges a valid,
-    non-expired, single-use invitation code for access_token, refresh_token,
-    and user_id.
+    Public endpoint (no authentication required). Exchanges a valid, non-expired,
+    single-use invitation code for `access_token`, `refresh_token`, and `user_id`.
+    The returned token is write-only to the `/sdk/*` endpoints.
+
+    This backs the standalone onboarding flow used by the Open Wearables app and
+    the SDK example apps. It is not the standard integration path - if your app
+    has its own backend, mint and forward a token with
+    `POST /api/v1/users/{user_id}/token` instead of redeeming codes on the client.
     """
     return user_invitation_code_service.redeem(db, payload.code)

--- a/docs/sdk/android/integration.mdx
+++ b/docs/sdk/android/integration.mdx
@@ -59,7 +59,7 @@ graph TD
 </Warning>
 
 <Note>
-  **Building a standalone app with no backend of your own?** There is a third onboarding option: the **invitation code** flow, where a single-use code is redeemed directly by the app - no live backend channel required. It powers the [Open Wearables app](/app/introduction) and the [example apps](/sdk/flutter/example-app). Use the backend token flow above when your app already authenticates users against your backend; use invitation codes for standalone onboarding. Both keep `app_secret` off the device and both are automatable via the API. See [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
+  **Building a standalone app with no backend of your own?** Invitation codes are an alternative - a single-use code the app redeems directly, no backend channel required. This is **not** the standard flow; it exists mainly for the [Open Wearables app](/app/introduction) and the [example apps](/sdk/flutter/example-app). If your app authenticates users against your own backend (the normal case), use the backend token flow above. See [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
 </Note>
 
 ## Step 1: Backend Setup

--- a/docs/sdk/android/integration.mdx
+++ b/docs/sdk/android/integration.mdx
@@ -58,6 +58,10 @@ graph TD
   **Never embed your `app_id` / `app_secret` in the mobile app.** App credentials should only exist on your backend server. Only the `access_token` and `refresh_token` are passed to the mobile app.
 </Warning>
 
+<Note>
+  **Building a standalone app with no backend of your own?** There is a third onboarding option: the **invitation code** flow, where a single-use code is redeemed directly by the app - no live backend channel required. It powers the [Open Wearables app](/app/introduction) and the [example apps](/sdk/flutter/example-app). Use the backend token flow above when your app already authenticates users against your backend; use invitation codes for standalone onboarding. Both keep `app_secret` off the device and both are automatable via the API. See [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
+</Note>
+
 ## Step 1: Backend Setup
 
 Your backend needs a single endpoint that generates access tokens for your users by calling the Open Wearables API and forwarding the tokens.

--- a/docs/sdk/flutter/example-app.mdx
+++ b/docs/sdk/flutter/example-app.mdx
@@ -38,9 +38,9 @@ The example app demonstrates the complete integration flow:
 8. **Log Viewer** - Browse SDK logs with search
 
 <Note>
-  **Which onboarding flow is this?** This example uses the **invitation code** flow: a single-use code is issued for a user, and the app redeems it directly against the public `POST /api/v1/invitation-code/redeem` endpoint. Redeeming on the client is fine here - the code is single-use and the resulting token is write-only to `/sdk/*`, so your `app_secret` never touches the device.
+  **Heads-up - this example uses the invitation code flow, which is not the standard way to integrate the SDK.** The example app has no backend of its own, so it redeems a single-use invitation code directly against the public [`POST /api/v1/invitation-code/redeem`](/api-reference/mobile-sdk/redeem-invitation-code) endpoint to get a session. That is fine for a self-contained demo - the code is single-use and the resulting token is write-only to `/sdk/*`, so your `app_secret` never touches the device.
 
-  If your app already signs users in against **your own backend**, prefer the [backend token flow](/sdk/flutter/integration#authentication-architecture), where your backend mints and forwards the token. Both flows are valid and equally automatable - see [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
+  When you build your own app, use the **backend token flow** instead, where your backend mints and forwards the token. See the [Integration Guide](/sdk/flutter/integration#authentication-architecture) and [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
 </Note>
 
 <Card title="See the full flow in action" icon="play" href="/app/introduction#see-it-in-action">

--- a/docs/sdk/flutter/example-app.mdx
+++ b/docs/sdk/flutter/example-app.mdx
@@ -37,6 +37,12 @@ The example app demonstrates the complete integration flow:
 7. **Sync Status** - Monitor sync progress and handle interruptions
 8. **Log Viewer** - Browse SDK logs with search
 
+<Note>
+  **Which onboarding flow is this?** This example uses the **invitation code** flow: a single-use code is issued for a user, and the app redeems it directly against the public `POST /api/v1/invitation-code/redeem` endpoint. Redeeming on the client is fine here - the code is single-use and the resulting token is write-only to `/sdk/*`, so your `app_secret` never touches the device.
+
+  If your app already signs users in against **your own backend**, prefer the [backend token flow](/sdk/flutter/integration#authentication-architecture), where your backend mints and forwards the token. Both flows are valid and equally automatable - see [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
+</Note>
+
 <Card title="See the full flow in action" icon="play" href="/app/introduction#see-it-in-action">
   Watch how data flows from device setup through syncing to the dashboard and API.
 </Card>
@@ -133,7 +139,9 @@ await OpenWearablesHealthSdk.configure(
 ```dart
 // Redeem invitation code to get credentials
 final response = await http.post(
-  Uri.parse('$host/api/v1/sdk/invitation-codes/$code/redeem'),
+  Uri.parse('$host/api/v1/invitation-code/redeem'),
+  headers: {'Content-Type': 'application/json'},
+  body: json.encode({'code': code}),
 );
 if (response.statusCode != 200) {
   throw Exception('Invitation redeem failed: ${response.statusCode}');

--- a/docs/sdk/flutter/example-app.mdx
+++ b/docs/sdk/flutter/example-app.mdx
@@ -38,7 +38,7 @@ The example app demonstrates the complete integration flow:
 8. **Log Viewer** - Browse SDK logs with search
 
 <Note>
-  **Heads-up - this example uses the invitation code flow, which is not the standard way to integrate the SDK.** The example app has no backend of its own, so it redeems a single-use invitation code directly against the public [`POST /api/v1/invitation-code/redeem`](/api-reference/mobile-sdk/redeem-invitation-code) endpoint to get a session. That is fine for a self-contained demo - the code is single-use and the resulting token is write-only to `/sdk/*`, so your `app_secret` never touches the device.
+  **Heads-up - this example uses the invitation code flow, which is not the standard way to integrate the SDK.** The example app has no backend of its own, so it redeems a single-use invitation code directly against the public [`POST /api/v1/invitation-code/redeem`](/api-reference/mobile-sdk/redeem-invitation-code) endpoint to get a session. That is fine for this self-contained demo: you generate the code in your own dashboard and enter it in the app yourself, it is single-use, and the resulting token is write-only to `/sdk/*`, so your `app_secret` never touches the device.
 
   When you build your own app, use the **backend token flow** instead, where your backend mints and forwards the token. See the [Integration Guide](/sdk/flutter/integration#authentication-architecture) and [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
 </Note>

--- a/docs/sdk/flutter/integration.mdx
+++ b/docs/sdk/flutter/integration.mdx
@@ -57,6 +57,10 @@ graph TD
   **Never embed your `app_id` / `app_secret` in the mobile app.** App credentials should only exist on your backend server. Only the `access_token` and `refresh_token` are passed to the mobile app.
 </Warning>
 
+<Note>
+  **Building a standalone app with no backend of your own?** There is a third onboarding option: the **invitation code** flow, where a single-use code is redeemed directly by the app - no live backend channel required. It powers the [Open Wearables app](/app/introduction) and the [Flutter example app](/sdk/flutter/example-app). Use the backend token flow above when your app already authenticates users against your backend; use invitation codes for standalone onboarding. Both keep `app_secret` off the device and both are automatable via the API. See [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
+</Note>
+
 ## Step 1: Backend Setup
 
 Your backend needs a single endpoint that generates access tokens for your users by calling the Open Wearables API and forwarding the tokens.

--- a/docs/sdk/flutter/integration.mdx
+++ b/docs/sdk/flutter/integration.mdx
@@ -58,7 +58,7 @@ graph TD
 </Warning>
 
 <Note>
-  **Building a standalone app with no backend of your own?** There is a third onboarding option: the **invitation code** flow, where a single-use code is redeemed directly by the app - no live backend channel required. It powers the [Open Wearables app](/app/introduction) and the [Flutter example app](/sdk/flutter/example-app). Use the backend token flow above when your app already authenticates users against your backend; use invitation codes for standalone onboarding. Both keep `app_secret` off the device and both are automatable via the API. See [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
+  **Building a standalone app with no backend of your own?** Invitation codes are an alternative - a single-use code the app redeems directly, no backend channel required. This is **not** the standard flow; it exists mainly for the [Open Wearables app](/app/introduction) and the [Flutter example app](/sdk/flutter/example-app). If your app authenticates users against your own backend (the normal case), use the backend token flow above. See [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
 </Note>
 
 ## Step 1: Backend Setup

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -72,20 +72,13 @@ Unlike cloud-based providers (Garmin, Polar, Suunto) that use webhooks and OAuth
 
 ## Choosing an onboarding flow
 
-There are two ways to get a session onto the device. Both hand the SDK the **same** short-lived, user-scoped token (write-only to the `/sdk/*` endpoints), both keep your `app_secret` off the device, and both are fully automatable via the API. They differ only in **how the credential reaches the app** - so choose based on whether your app already has an authenticated channel to your own backend on the device.
+For any real integration, use the **backend token flow**: your backend mints a short-lived, user-scoped token (write-only to the `/sdk/*` endpoints) via [`POST /api/v1/users/{user_id}/token`](/api-reference/mobile-sdk/create-user-token) and forwards it to the app over its own authenticated API. Your `app_secret` never touches the device. This is the standard path, covered in each platform's Integration Guide.
 
-<CardGroup cols={2}>
-  <Card title="Backend token" icon="server">
-    Your backend mints a token via [`POST /api/v1/users/{user_id}/token`](/n/create-user-token) and forwards it to the app over its own authenticated API. **Use this when your app already signs users in against your backend** - it is the default for building your own app. Covered in each platform's Integration Guide.
-  </Card>
-  <Card title="Invitation code" icon="ticket">
-    Your backend (or the dashboard) issues a single-use code with `POST /api/v1/users/{user_id}/invitation-code`; the app redeems it directly against the public `POST /api/v1/invitation-code/redeem`. **Use this for standalone apps with no backend channel on the device** - the [Open Wearables app](/app/introduction), a coach handing a code to a client, or quick testing.
-  </Card>
-</CardGroup>
+<Warning>
+  **Invitation codes are a niche mechanism, not a co-equal second option.** They exist for apps with **no backend of their own** to mint and forward tokens - in practice the [Open Wearables app](/app/introduction) and quick manual testing. If you are building your own app, use the backend token flow above.
+</Warning>
 
-<Note>
-  The distinction is architectural (where the handoff happens), **not** manual-vs-programmatic. Invitation codes can be generated programmatically per user via the developer-authenticated generate endpoint - the dashboard is just one way to do it.
-</Note>
+With an invitation code, your backend (or the dashboard) issues a single-use code via [`POST /api/v1/users/{user_id}/invitation-code`](/api-reference/mobile-sdk/generate-invitation-code); the app redeems it directly against the public [`POST /api/v1/invitation-code/redeem`](/api-reference/mobile-sdk/redeem-invitation-code) to obtain the same write-only SDK token. Redeeming on the client is acceptable only because the code is single-use and the token is write-only to `/sdk/*`.
 
 ## Security Model
 

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -75,17 +75,17 @@ Unlike cloud-based providers (Garmin, Polar, Suunto) that use webhooks and OAuth
 For any real integration, use the **backend token flow**: your backend mints a short-lived, user-scoped token (write-only to the `/sdk/*` endpoints) via [`POST /api/v1/users/{user_id}/token`](/api-reference/mobile-sdk/create-user-token) and forwards it to the app over its own authenticated API. Your `app_secret` never touches the device. This is the standard path, covered in each platform's Integration Guide.
 
 <Warning>
-  **Invitation codes are a niche mechanism, not a co-equal second option.** They exist for apps with **no backend of their own** to mint and forward tokens - in practice the [Open Wearables app](/app/introduction) and quick manual testing. If you are building your own app, use the backend token flow above.
+  **Invitation codes are a niche mechanism, not a co-equal second option.** They exist for apps with **no backend of their own** to mint and forward tokens. Right now the flow is aimed primarily at individual users self-hosting Open Wearables for their own data (and the [Open Wearables app](/app/introduction) / quick manual testing), not at multi-user production integrations. If you are building your own app with its own backend, use the backend token flow above.
 </Warning>
 
-With an invitation code, your backend (or the dashboard) issues a single-use code via [`POST /api/v1/users/{user_id}/invitation-code`](/api-reference/mobile-sdk/generate-invitation-code); the app redeems it directly against the public [`POST /api/v1/invitation-code/redeem`](/api-reference/mobile-sdk/redeem-invitation-code) to obtain the same write-only SDK token. Redeeming on the client is acceptable only because the code is single-use and the token is write-only to `/sdk/*`.
+With an invitation code, a single-use code is issued via [`POST /api/v1/users/{user_id}/invitation-code`](/api-reference/mobile-sdk/generate-invitation-code) - from the dashboard or the API - and the app redeems it directly against the public [`POST /api/v1/invitation-code/redeem`](/api-reference/mobile-sdk/redeem-invitation-code) to obtain SDK tokens. Two situations are possible: in the primary case the same person generates the code in their own dashboard and enters it in their own app, so it never leaves that person. A code can also be delegated - for example a coach or clinician issuing one for a client - and **only in that hand-off** does the code travel to someone else; when it does, use a **secure channel**, because the code is the sole credential (single-use blocks replay after redemption, but not first-use theft if the code is intercepted in transit).
 
 ## Security Model
 
 The SDK uses a secure token-based authentication flow that keeps your App credentials safe:
 
 1. **App credentials stay on your backend** - `app_id` and `app_secret` are never exposed to mobile apps
-2. **Short-lived access tokens** - Generated server-to-server via `POST /api/v1/users/{user_id}/token`, forwarded to the mobile SDK
+2. **Short-lived access tokens** - In the standard backend token flow, generated server-to-server via `POST /api/v1/users/{user_id}/token` and forwarded to the mobile SDK. With the invitation code flow, the app instead redeems a single-use code at `POST /api/v1/invitation-code/redeem` and receives the tokens directly.
 3. **Secure credential storage** - iOS Keychain / Android EncryptedSharedPreferences
 4. **Automatic token refresh** - SDK can automatically refresh expired tokens using the `refresh_token`
 5. **API key auth** - Alternative for internal tools (not recommended for production)

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -70,6 +70,23 @@ Unlike cloud-based providers (Garmin, Polar, Suunto) that use webhooks and OAuth
   </Card>
 </CardGroup>
 
+## Choosing an onboarding flow
+
+There are two ways to get a session onto the device. Both hand the SDK the **same** short-lived, user-scoped token (write-only to the `/sdk/*` endpoints), both keep your `app_secret` off the device, and both are fully automatable via the API. They differ only in **how the credential reaches the app** - so choose based on whether your app already has an authenticated channel to your own backend on the device.
+
+<CardGroup cols={2}>
+  <Card title="Backend token" icon="server">
+    Your backend mints a token via [`POST /api/v1/users/{user_id}/token`](/n/create-user-token) and forwards it to the app over its own authenticated API. **Use this when your app already signs users in against your backend** - it is the default for building your own app. Covered in each platform's Integration Guide.
+  </Card>
+  <Card title="Invitation code" icon="ticket">
+    Your backend (or the dashboard) issues a single-use code with `POST /api/v1/users/{user_id}/invitation-code`; the app redeems it directly against the public `POST /api/v1/invitation-code/redeem`. **Use this for standalone apps with no backend channel on the device** - the [Open Wearables app](/app/introduction), a coach handing a code to a client, or quick testing.
+  </Card>
+</CardGroup>
+
+<Note>
+  The distinction is architectural (where the handoff happens), **not** manual-vs-programmatic. Invitation codes can be generated programmatically per user via the developer-authenticated generate endpoint - the dashboard is just one way to do it.
+</Note>
+
 ## Security Model
 
 The SDK uses a secure token-based authentication flow that keeps your App credentials safe:

--- a/docs/sdk/ios/integration.mdx
+++ b/docs/sdk/ios/integration.mdx
@@ -58,7 +58,7 @@ graph TD
 </Warning>
 
 <Note>
-  **Building a standalone app with no backend of your own?** There is a third onboarding option: the **invitation code** flow, where a single-use code is redeemed directly by the app - no live backend channel required. It powers the [Open Wearables app](/app/introduction) and the [example apps](/sdk/flutter/example-app). Use the backend token flow above when your app already authenticates users against your backend; use invitation codes for standalone onboarding. Both keep `app_secret` off the device and both are automatable via the API. See [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
+  **Building a standalone app with no backend of your own?** Invitation codes are an alternative - a single-use code the app redeems directly, no backend channel required. This is **not** the standard flow; it exists mainly for the [Open Wearables app](/app/introduction) and the [example apps](/sdk/flutter/example-app). If your app authenticates users against your own backend (the normal case), use the backend token flow above. See [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
 </Note>
 
 ## Step 1: Backend Setup

--- a/docs/sdk/ios/integration.mdx
+++ b/docs/sdk/ios/integration.mdx
@@ -57,6 +57,10 @@ graph TD
   **Never embed your `app_id` / `app_secret` in the mobile app.** App credentials should only exist on your backend server. Only the `access_token` and `refresh_token` are passed to the mobile app.
 </Warning>
 
+<Note>
+  **Building a standalone app with no backend of your own?** There is a third onboarding option: the **invitation code** flow, where a single-use code is redeemed directly by the app - no live backend channel required. It powers the [Open Wearables app](/app/introduction) and the [example apps](/sdk/flutter/example-app). Use the backend token flow above when your app already authenticates users against your backend; use invitation codes for standalone onboarding. Both keep `app_secret` off the device and both are automatable via the API. See [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
+</Note>
+
 ## Step 1: Backend Setup
 
 Your backend needs a single endpoint that generates access tokens for your users by calling the Open Wearables API and forwarding the tokens.

--- a/docs/sdk/react-native/example-app.mdx
+++ b/docs/sdk/react-native/example-app.mdx
@@ -37,6 +37,12 @@ The example app demonstrates the complete integration flow:
 7. **Sync Status** - Monitor sync progress and handle interruptions
 8. **Log Viewer** - Browse SDK logs with search
 
+<Note>
+  **Which onboarding flow is this?** This example uses the **invitation code** flow: a single-use code is issued for a user, and the app redeems it directly against the public `POST /api/v1/invitation-code/redeem` endpoint. Redeeming on the client is fine here - the code is single-use and the resulting token is write-only to `/sdk/*`, so your `app_secret` never touches the device.
+
+  If your app already signs users in against **your own backend**, prefer the [backend token flow](/sdk/react-native/integration#authentication-architecture), where your backend mints and forwards the token. Both flows are valid and equally automatable - see [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
+</Note>
+
 <Card title="See the full flow in action" icon="play" href="/app/introduction#see-it-in-action">
   Watch how data flows from device setup through syncing to the dashboard and API.
 </Card>

--- a/docs/sdk/react-native/example-app.mdx
+++ b/docs/sdk/react-native/example-app.mdx
@@ -38,7 +38,7 @@ The example app demonstrates the complete integration flow:
 8. **Log Viewer** - Browse SDK logs with search
 
 <Note>
-  **Heads-up - this example uses the invitation code flow, which is not the standard way to integrate the SDK.** The example app has no backend of its own, so it redeems a single-use invitation code directly against the public [`POST /api/v1/invitation-code/redeem`](/api-reference/mobile-sdk/redeem-invitation-code) endpoint to get a session. That is fine for a self-contained demo - the code is single-use and the resulting token is write-only to `/sdk/*`, so your `app_secret` never touches the device.
+  **Heads-up - this example uses the invitation code flow, which is not the standard way to integrate the SDK.** The example app has no backend of its own, so it redeems a single-use invitation code directly against the public [`POST /api/v1/invitation-code/redeem`](/api-reference/mobile-sdk/redeem-invitation-code) endpoint to get a session. That is fine for this self-contained demo: you generate the code in your own dashboard and enter it in the app yourself, it is single-use, and the resulting token is write-only to `/sdk/*`, so your `app_secret` never touches the device.
 
   When you build your own app, use the **backend token flow** instead, where your backend mints and forwards the token. See the [Integration Guide](/sdk/react-native/integration#authentication-architecture) and [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
 </Note>

--- a/docs/sdk/react-native/example-app.mdx
+++ b/docs/sdk/react-native/example-app.mdx
@@ -38,9 +38,9 @@ The example app demonstrates the complete integration flow:
 8. **Log Viewer** - Browse SDK logs with search
 
 <Note>
-  **Which onboarding flow is this?** This example uses the **invitation code** flow: a single-use code is issued for a user, and the app redeems it directly against the public `POST /api/v1/invitation-code/redeem` endpoint. Redeeming on the client is fine here - the code is single-use and the resulting token is write-only to `/sdk/*`, so your `app_secret` never touches the device.
+  **Heads-up - this example uses the invitation code flow, which is not the standard way to integrate the SDK.** The example app has no backend of its own, so it redeems a single-use invitation code directly against the public [`POST /api/v1/invitation-code/redeem`](/api-reference/mobile-sdk/redeem-invitation-code) endpoint to get a session. That is fine for a self-contained demo - the code is single-use and the resulting token is write-only to `/sdk/*`, so your `app_secret` never touches the device.
 
-  If your app already signs users in against **your own backend**, prefer the [backend token flow](/sdk/react-native/integration#authentication-architecture), where your backend mints and forwards the token. Both flows are valid and equally automatable - see [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
+  When you build your own app, use the **backend token flow** instead, where your backend mints and forwards the token. See the [Integration Guide](/sdk/react-native/integration#authentication-architecture) and [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
 </Note>
 
 <Card title="See the full flow in action" icon="play" href="/app/introduction#see-it-in-action">

--- a/docs/sdk/react-native/integration.mdx
+++ b/docs/sdk/react-native/integration.mdx
@@ -57,6 +57,10 @@ graph TD
   **Never embed your `app_id` / `app_secret` in the mobile app.** App credentials should only exist on your backend server. Only the `access_token` and `refresh_token` are passed to the mobile app.
 </Warning>
 
+<Note>
+  **Building a standalone app with no backend of your own?** There is a third onboarding option: the **invitation code** flow, where a single-use code is redeemed directly by the app - no live backend channel required. It powers the [Open Wearables app](/app/introduction) and the [React Native example app](/sdk/react-native/example-app). Use the backend token flow above when your app already authenticates users against your backend; use invitation codes for standalone onboarding. Both keep `app_secret` off the device and both are automatable via the API. See [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
+</Note>
+
 ## Step 1: Backend Setup
 
 Your backend needs a single endpoint that generates access tokens for your users by calling the Open Wearables API and forwarding the tokens.

--- a/docs/sdk/react-native/integration.mdx
+++ b/docs/sdk/react-native/integration.mdx
@@ -58,7 +58,7 @@ graph TD
 </Warning>
 
 <Note>
-  **Building a standalone app with no backend of your own?** There is a third onboarding option: the **invitation code** flow, where a single-use code is redeemed directly by the app - no live backend channel required. It powers the [Open Wearables app](/app/introduction) and the [React Native example app](/sdk/react-native/example-app). Use the backend token flow above when your app already authenticates users against your backend; use invitation codes for standalone onboarding. Both keep `app_secret` off the device and both are automatable via the API. See [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
+  **Building a standalone app with no backend of your own?** Invitation codes are an alternative - a single-use code the app redeems directly, no backend channel required. This is **not** the standard flow; it exists mainly for the [Open Wearables app](/app/introduction) and the [React Native example app](/sdk/react-native/example-app). If your app authenticates users against your own backend (the normal case), use the backend token flow above. See [Choosing an onboarding flow](/sdk#choosing-an-onboarding-flow).
 </Note>
 
 ## Step 1: Backend Setup


### PR DESCRIPTION
## Description

The docs blurred two distinct SDK onboarding flows: they presented the **invitation code** flow (built for the Open Wearables first-party app and standalone onboarding) alongside the **backend token** flow (for apps with their own backend) without saying which is which or when to use each. This adds a decision section, labels the example apps, documents invitation code as a real third onboarding option, and fixes a broken redeem snippet.

The real axis is **whether an app has an authenticated channel to their own backend on the device**

## Changes

- [**Wearable Sync SDK overview**](https://openwearables.io/docs/sdk) - new "Choosing an onboarding flow" section (Backend token vs Invitation code) with a clear selection criterion.
- [**Flutter example app**](https://openwearables.io/docs/sdk/flutter/example-app) and [**React Native example app**](https://openwearables.io/docs/sdk/react-native/example-app) - callout labeling the example as the invitation-code flow, noting client-side redeem is safe here (single-use code, write-only `/sdk/*` token, `app_secret` never on device), and pointing to the backend token flow when appropriate.
- Integration guides for [**iOS**](https://openwearables.io/docs/sdk/ios/integration), [**Android**](https://openwearables.io/docs/sdk/android/integration), [**Flutter**](https://openwearables.io/docs/sdk/flutter/integration), and [**React Native**](https://openwearables.io/docs/sdk/react-native/integration) - documented invitation code as a third onboarding option (previously only token + API key were mentioned).
- **Fix:** the [Flutter example app](https://openwearables.io/docs/sdk/flutter/example-app) redeem snippet used a non-existent URL (`/api/v1/sdk/invitation-codes/{code}/redeem`, no body) - corrected to `POST /api/v1/invitation-code/redeem` with a JSON `{ code }` body, matching the backend and the RN example.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code

## Testing Instructions

**Steps to test:**
1. Run the docs site locally (`mint dev` in `docs/`).
2. Open `/sdk`, the two `example-app` pages, and the four `integration` pages.
3. Verify the new sections render and the in-page links resolve: `/sdk#choosing-an-onboarding-flow`, `/sdk/{flutter,react-native}/integration#authentication-architecture`, `/app/introduction`.

**Expected behavior:**
Each SDK page clearly distinguishes the invitation-code flow from the backend-token flow and states when to use each. No dead links.

## Additional Notes

- Live doc links above point to the **currently published** pages the changes affect (pre-merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for onboarding standalone apps with single-use invitation codes.
  * Clarified when to use invitation codes versus backend-issued token authentication.
  * Documented secure redemption flows that keep app secrets off devices.
  * Updated Flutter examples to redeem invitation codes through the public endpoint.
  * Expanded onboarding guidance and examples for Android, iOS, React Native, and Flutter integrations.
  * Clarified invitation-code issuance, redemption, delegation, and security considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->