### PR TITLE
chore: More detailed SDK and sync status logs

### DIFF
--- a/backend/app/api/routes/v1/sdk_logs.py
+++ b/backend/app/api/routes/v1/sdk_logs.py
@@ -1,9 +1,15 @@
 import uuid
 from logging import getLogger
+from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
 
-from app.schemas.providers.mobile_sdk import SDKLogRequest
+from app.schemas.providers.mobile_sdk import (
+    DeviceStateEvent,
+    HistoricalDataSyncStartEvent,
+    HistoricalDataTypeSyncEndEvent,
+    SDKLogRequest,
+)
 from app.schemas.responses.upload import UploadDataResponse
 from app.services.raw_payload_storage import store_raw_payload
 from app.utils.auth import SDKAuthDep
@@ -11,6 +17,45 @@ from app.utils.structured_logging import log_structured
 
 router = APIRouter()
 logger = getLogger(__name__)
+
+# Only for single-outcome batches: the SDK posts one event plus a device_state snapshot,
+# so this flattens onto the line already emitted rather than adding any.
+_MAX_FLATTENED_EVENTS = 2
+
+
+def _event_fields(body: SDKLogRequest) -> dict[str, Any]:
+    """Per-event fields worth having queryable in the deployment logs.
+
+    Without these the log records only that an event arrived, so per-type outcomes and
+    the foreground/background split are readable only by fetching the S3 payload.
+    durationMs is left out: the SDK measures it from the start of the whole run, so every
+    type in a run reports the same value.
+    """
+    fields: dict[str, Any] = {}
+    flatten_outcome = len(body.events) <= _MAX_FLATTENED_EVENTS
+
+    for event in body.events:
+        match event:
+            case DeviceStateEvent():
+                fields |= {
+                    "task_type": event.taskType,
+                    "low_power": event.isLowPowerMode,
+                    "thermal_state": event.thermalState,
+                }
+            case HistoricalDataSyncStartEvent():
+                populated = [count for count in event.dataTypeCounts if count.count > 0]
+                fields |= {
+                    "types_declared": len(populated),
+                    "samples_expected": sum(count.count for count in populated),
+                }
+            case HistoricalDataTypeSyncEndEvent() if flatten_outcome:
+                fields |= {
+                    "data_type": event.dataType,
+                    "success": event.success,
+                    "record_count": event.recordCount,
+                }
+
+    return {key: value for key, value in fields.items() if value is not None}
 
 
 @router.post("/sdk/users/{user_id}/logs", status_code=status.HTTP_202_ACCEPTED)
@@ -45,6 +90,7 @@ def submit_sdk_logs(
         event_count=len(body.events),
         event_types=event_types,
         sdk_version=body.sdkVersion,
+        **_event_fields(body),
     )
 
     store_raw_payload(

--- a/backend/app/api/routes/v1/sdk_logs.py
+++ b/backend/app/api/routes/v1/sdk_logs.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException, status
 
+from app.constants.series_types.sdk import get_series_type_from_metric_type
 from app.schemas.providers.mobile_sdk import (
     DeviceStateEvent,
     HistoricalDataSyncStartEvent,
@@ -49,8 +50,11 @@ def _event_fields(body: SDKLogRequest) -> dict[str, Any]:
                     "samples_expected": sum(count.count for count in populated),
                 }
             case HistoricalDataTypeSyncEndEvent() if flatten_outcome:
+                # Sleep and workout identifiers have no series type, so they keep the native one.
+                series_type = get_series_type_from_metric_type(event.dataType)
                 fields |= {
-                    "data_type": event.dataType,
+                    "data_type": series_type.value if series_type else event.dataType,
+                    "native_data_type": event.dataType,
                     "success": event.success,
                     "record_count": event.recordCount,
                 }

--- a/backend/app/api/routes/v1/sdk_logs.py
+++ b/backend/app/api/routes/v1/sdk_logs.py
@@ -33,7 +33,10 @@ def _event_fields(body: SDKLogRequest) -> dict[str, Any]:
     type in a run reports the same value.
     """
     fields: dict[str, Any] = {}
-    flatten_outcome = len(body.events) <= _MAX_FLATTENED_EVENTS
+    # Several outcomes in one batch cannot share these fields without overwriting
+    # each other, so they stay in the stored payload only.
+    outcome_count = sum(isinstance(event, HistoricalDataTypeSyncEndEvent) for event in body.events)
+    flatten_outcome = len(body.events) <= _MAX_FLATTENED_EVENTS and outcome_count == 1
 
     for event in body.events:
         match event:

--- a/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
+++ b/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
@@ -1,5 +1,6 @@
 import uuid
 from logging import getLogger
+from typing import Any
 from uuid import UUID
 
 from celery import shared_task
@@ -34,7 +35,7 @@ def process_sdk_upload(
     user_id: str,
     provider: str,
     batch_id: str | None = None,
-) -> dict[str, int | str]:
+) -> dict[str, Any]:
     """
     Process SDK data import asynchronously.
 

--- a/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
+++ b/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
@@ -136,6 +136,7 @@ def process_sdk_upload(
         workouts_saved = int(result.get("workouts_saved", 0) or 0)
         sleep_saved = int(result.get("sleep_saved", 0) or 0)
         dropped_count = int(result.get("dropped_count", 0) or 0)
+        types = result.get("types") or []
         items_total = records_saved + workouts_saved + sleep_saved
 
         if isinstance(status_code, int) and 200 <= status_code < 300:
@@ -155,6 +156,7 @@ def process_sdk_upload(
                     "records_saved": records_saved,
                     "workouts_saved": workouts_saved,
                     "sleep_saved": sleep_saved,
+                    "types": types,
                     "dropped_count": dropped_count,
                 },
             )

--- a/backend/app/schemas/providers/mobile_sdk/__init__.py
+++ b/backend/app/schemas/providers/mobile_sdk/__init__.py
@@ -1,4 +1,7 @@
 from .sdk_log_events import (
+    DeviceStateEvent,
+    HistoricalDataSyncStartEvent,
+    HistoricalDataTypeSyncEndEvent,
     SDKLogRequest,
 )
 from .sleep_state import (
@@ -18,6 +21,9 @@ from .sync_request import (
 __all__ = [
     # SDKLogEvents
     "SDKLogRequest",
+    "DeviceStateEvent",
+    "HistoricalDataSyncStartEvent",
+    "HistoricalDataTypeSyncEndEvent",
     # SleepState
     "SleepState",
     "SleepStateStage",

--- a/backend/app/schemas/responses/upload/upload_response.py
+++ b/backend/app/schemas/responses/upload/upload_response.py
@@ -13,6 +13,12 @@ class UploadDataResponse(BaseModel):
     user_id: str | None = Field(None, description="User ID associated with the import operation")
     dropped_count: int = Field(0, description="Number of individual records dropped by per-record validation")
     records_saved: int = Field(0, description="Time-series samples saved")
-    types: list[str] = Field(default_factory=list, description="Series types written by this batch")
+    types: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Canonical SeriesType identifiers written by this batch (e.g. 'heart_rate'), "
+            "sorted. Empty when the batch saved no time-series samples."
+        ),
+    )
     workouts_saved: int = Field(0, description="Workouts saved")
     sleep_saved: int = Field(0, description="Sleep records saved")

--- a/backend/app/schemas/responses/upload/upload_response.py
+++ b/backend/app/schemas/responses/upload/upload_response.py
@@ -13,5 +13,6 @@ class UploadDataResponse(BaseModel):
     user_id: str | None = Field(None, description="User ID associated with the import operation")
     dropped_count: int = Field(0, description="Number of individual records dropped by per-record validation")
     records_saved: int = Field(0, description="Time-series samples saved")
+    types: list[str] = Field(default_factory=list, description="Series types written by this batch")
     workouts_saved: int = Field(0, description="Workouts saved")
     sleep_saved: int = Field(0, description="Sleep records saved")

--- a/backend/app/services/apple/healthkit/import_service.py
+++ b/backend/app/services/apple/healthkit/import_service.py
@@ -68,6 +68,7 @@ class InvalidRecord(TypedDict):
 class LoadDataResult(TypedDict):
     workouts_saved: int
     records_saved: int
+    types: list[str]  # series types written
     sleep_saved: int
     dropped: list[InvalidRecord]
     validation_ms: float
@@ -357,6 +358,7 @@ class ImportService:
         workouts_saved = 0
         records_saved = 0
         sleep_saved = 0
+        types: set[str] = set()
 
         # Process workouts in batch
         workout_bundles = list(self._build_workout_bundles(request, user_id))
@@ -382,12 +384,14 @@ class ImportService:
             if time_series_samples:
                 self.timeseries_service.bulk_create_samples(db_session, time_series_samples)
                 records_saved += len(time_series_samples)
+                types.update(sample.series_type.value for sample in time_series_samples)
 
         # Process time series samples (records)
         samples = self._build_statistic_bundles(request, user_id)
         if samples:
             self.timeseries_service.bulk_create_samples(db_session, samples)
             records_saved += len(samples)
+            types.update(sample.series_type.value for sample in samples)
 
         # Commit all workout and timeseries changes in one transaction
         db_session.commit()
@@ -400,6 +404,7 @@ class ImportService:
         return {
             "workouts_saved": workouts_saved,
             "records_saved": records_saved,
+            "types": sorted(types),
             "sleep_saved": sleep_saved,
             "dropped": dropped,
             "validation_ms": validation_ms,
@@ -514,6 +519,7 @@ class ImportService:
                 user_id=user_id,
                 dropped_count=len(dropped),
                 records_saved=saved_counts["records_saved"],
+                types=saved_counts["types"],
                 workouts_saved=saved_counts["workouts_saved"],
                 sleep_saved=saved_counts["sleep_saved"],
             )

--- a/backend/app/services/sync_status_service.py
+++ b/backend/app/services/sync_status_service.py
@@ -98,6 +98,7 @@ def emit(event: SyncStatusEvent) -> None:
             "items_total": event.items_total,
             "inserted": event.metadata.get("inserted"),
             "updated": event.metadata.get("updated"),
+            "types": event.metadata.get("types"),
             "detail": event.message,
             "error": event.error,
         }.items()

--- a/backend/tests/api/v1/test_sdk_logs.py
+++ b/backend/tests/api/v1/test_sdk_logs.py
@@ -187,6 +187,23 @@ class TestSDKLogsEventFields:
         assert fields["data_type"] == "HKWorkoutTypeIdentifier"
         assert fields["native_data_type"] == "HKWorkoutTypeIdentifier"
 
+    def test_two_outcome_events_are_not_flattened(self) -> None:
+        """Sharing the fields would silently report only the last outcome."""
+        second = {**SYNC_END_EVENT, "dataType": "HKQuantityTypeIdentifierStepCount", "recordCount": 200}
+
+        fields = _event_fields(SDKLogRequest(**_payload(SYNC_END_EVENT, second)))
+
+        for key in ("data_type", "native_data_type", "success", "record_count"):
+            assert key not in fields
+
+    def test_two_outcome_events_still_report_device_state(self) -> None:
+        second = {**SYNC_END_EVENT, "dataType": "HKQuantityTypeIdentifierStepCount"}
+
+        fields = _event_fields(SDKLogRequest(**_payload(SYNC_END_EVENT, second, DEVICE_STATE_EVENT)))
+
+        assert "data_type" not in fields
+        assert fields["task_type"] == "background"
+
     def test_start_event_reports_declared_totals(self) -> None:
         fields = _event_fields(SDKLogRequest(**_payload(SYNC_START_EVENT)))
 

--- a/backend/tests/api/v1/test_sdk_logs.py
+++ b/backend/tests/api/v1/test_sdk_logs.py
@@ -5,6 +5,9 @@ from unittest.mock import MagicMock, patch
 from sqlalchemy.orm import Session
 from starlette.testclient import TestClient
 
+from app.api.routes.v1.sdk_logs import _event_fields
+from app.schemas.enums import SeriesType
+from app.schemas.providers.mobile_sdk import SDKLogRequest
 from app.services.sdk_token_service import create_sdk_user_token
 from tests.factories import ApiKeyFactory
 
@@ -150,6 +153,46 @@ class TestSDKLogsHappyPath:
             json=_payload(event),
         )
         assert response.status_code == 202
+
+
+class TestSDKLogsEventFields:
+    """The flattened fields are what makes per-type outcomes queryable in the logs."""
+
+    def test_data_type_is_normalised_native_kept(self) -> None:
+        fields = _event_fields(SDKLogRequest(**_payload(SYNC_END_EVENT, DEVICE_STATE_EVENT)))
+
+        assert fields["data_type"] == SeriesType.heart_rate.value
+        assert fields["native_data_type"] == "HKQuantityTypeIdentifierHeartRate"
+        assert fields["success"] is True
+        assert fields["record_count"] == 500
+        assert fields["task_type"] == "background"
+        assert fields["low_power"] is False
+        assert fields["thermal_state"] == "nominal"
+
+    def test_android_data_type_maps_to_same_series_type(self) -> None:
+        """Health Connect and HealthKit heart rate must land on one series for a shared panel."""
+        event = {**SYNC_END_EVENT, "dataType": "HEART_RATE"}
+
+        fields = _event_fields(SDKLogRequest(**_payload(event)))
+
+        assert fields["data_type"] == SeriesType.heart_rate.value
+        assert fields["native_data_type"] == "HEART_RATE"
+
+    def test_unmappable_data_type_falls_back_to_native(self) -> None:
+        """Sleep and workout identifiers are not series types."""
+        event = {**SYNC_END_EVENT, "dataType": "HKWorkoutTypeIdentifier"}
+
+        fields = _event_fields(SDKLogRequest(**_payload(event)))
+
+        assert fields["data_type"] == "HKWorkoutTypeIdentifier"
+        assert fields["native_data_type"] == "HKWorkoutTypeIdentifier"
+
+    def test_start_event_reports_declared_totals(self) -> None:
+        fields = _event_fields(SDKLogRequest(**_payload(SYNC_START_EVENT)))
+
+        assert fields["types_declared"] == 4
+        assert fields["samples_expected"] == 715
+        assert "data_type" not in fields
 
 
 class TestSDKLogsAuth:

--- a/backend/tests/integrations/test_apple_sdk_import.py
+++ b/backend/tests/integrations/test_apple_sdk_import.py
@@ -4,6 +4,7 @@ Integration tests for Apple SDK (HealthKit) data import.
 Tests the full import flow for Apple HealthKit data via SDK.
 """
 
+import json
 import logging
 from decimal import Decimal
 from typing import Any
@@ -342,6 +343,21 @@ class TestAppleSDKImport:
         result = import_service.load_data(db, sample_sdk_payload, str(user.id))
 
         assert result["records_saved"] >= 0
+
+    def test_types_written_reach_the_response(
+        self,
+        db: Session,
+        import_service: ImportService,
+        sample_sdk_payload: dict[str, Any],
+    ) -> None:
+        """types lists the series types the batch wrote, for absence-alerting in the logs."""
+        user = UserFactory()
+        payload = {**SDK_ENVELOPE, "data": {"records": sample_sdk_payload["data"]["records"]}}
+
+        response = import_service.import_data_from_request(db, json.dumps(payload), "application/json", str(user.id))
+
+        assert response.types == [SeriesType.steps.value]
+        assert response.model_dump()["types"] == [SeriesType.steps.value]
 
     def test_import_empty_payload(
         self,

--- a/docs/api-reference/guides/sync-status-stream.mdx
+++ b/docs/api-reference/guides/sync-status-stream.mdx
@@ -90,6 +90,7 @@ Every event is a JSON object emitted as the `data` field of an SSE message with 
 | `progress`        | `number \| null`      | Optional 0..1 fraction. Not all syncs report this.                                                                   |
 | `items_processed` | `number \| null`      | Optional count of items processed so far.                                                                            |
 | `items_total`     | `number \| null`      | Optional total when known.                                                                                           |
+| `metadata`        | `object`              | Provider-specific detail, e.g. `types` (SeriesType slugs written), `inserted`, `updated`.                             |
 | `started_at`      | `string \| null`      | ISO-8601 timestamp when the run started.                                                                             |
 | `ended_at`        | `string \| null`      | ISO-8601 timestamp when the run reached a terminal status.                                                           |
 | `timestamp`       | `string`              | ISO-8601 timestamp of this individual event.                                                                         |


### PR DESCRIPTION
## Description

As of now, the logs from the SDK landing on the `sdk/logs` (or similar) endpoint just show the event types contained, and land on s3.

This PR makes it so that the logs from there are actually passed onto the logs queryable in Grafana / docker compose logs.

Another change is sync status expansion - it also includes the data types that were received in the payload.

Before and after for SDK logs:

```json
before:

{"timestamp": "2026-08-10T14:25:39.081643+00:00", "level": "info", "message": "SDK log events received",
 "provider": "apple", "action": "sdk_logs_received", "batch_id": "8ac457f0-a7bb-419d-....",
 "user_id": "d771d1c3-3098-....", "event_count": 2,
 "event_types": ["historical_data_type_sync_end", "device_state"], "sdk_version": "0.13.0"}

after:

{"timestamp": "2026-08-11T11:20:50.019232+00:00", "level": "info", "message": "SDK log events received",
 "provider": "apple", "action": "sdk_logs_received", "batch_id": "823f86a1-b76a-4f48-....",
 "user_id": "d771d1c3-3098-....", "event_count": 2,
 "event_types": ["historical_data_type_sync_end", "device_state"], "sdk_version": "0.13.0",
 "data_type": "HKQuantityTypeIdentifierWalkingStepLength", "success": true, "record_count": 966,
 "task_type": "foreground", "low_power": false, "thermal_state": "nominal"}
```

Sync status:

```json
before:

{"timestamp": "...", "level": "info", "message": "Sync status", "provider": "apple",
 "action": "sync_status", "status": "success", "source": "sdk", "stage": "completed",
 "run_id": "a899503a-e7bb-....", "user_id": "d771d1c3-...",
 "items_processed": 1439, "detail": "Apple batch saved"}

after:

{"timestamp": "2026-08-11T11:21:33.975802+00:00", "level": "info", "message": "Sync status",
 "provider": "apple", "action": "sync_status", "status": "success", "source": "sdk",
 "stage": "completed", "run_id": "a899503a-e7bb-....", "user_id": "d771d1c3-...",
 "items_processed": 1439, "types": ["basal_energy", "energy", "heart_rate", "steps"],
 "detail": "Apple batch saved"}

```

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sync completion responses now report the data series types written during an upload.
  * Sync status and SDK event logs include relevant device, historical sync, outcome, and series-type details when available.
  * Added support for additional SDK event categories in structured logging.

* **Documentation**
  * Expanded sync status documentation to describe available event metadata.

* **Tests**
  * Added coverage confirming series types appear in typed and serialized upload responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->