### PR TITLE
fix(backend): store webhook-fetched payloads from Oura to raw storage

### DIFF
--- a/backend/app/services/providers/oura/webhook_handler.py
+++ b/backend/app/services/providers/oura/webhook_handler.py
@@ -322,7 +322,8 @@ class OuraWebhookHandler(BaseWebhookHandler):
             return self.workouts.save_by_id(db, user_id, object_id)
 
         collection = _COLLECTION_NAME.get(data_type, data_type)
-        raw = self.data_247._make_api_request(db, user_id, f"/v2/usercollection/{collection}/{object_id}")
+        endpoint = f"/v2/usercollection/{collection}/{object_id}"
+        raw = self.data_247._make_api_request(db, user_id, endpoint)
         if not raw or not isinstance(raw, dict):
             log_structured(
                 logger,
@@ -336,6 +337,14 @@ class OuraWebhookHandler(BaseWebhookHandler):
                 object_id=object_id,
             )
             return 0
+
+        store_raw_payload(
+            source="api_response",
+            provider="oura",
+            payload=raw,
+            user_id=str(user_id),
+            trace_id=endpoint,
+        )
 
         docs = [raw]
 

--- a/backend/app/services/providers/oura/webhook_handler.py
+++ b/backend/app/services/providers/oura/webhook_handler.py
@@ -319,7 +319,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
             return 0
 
         if data_type == "workout":
-            return self.workouts.save_by_id(db, user_id, object_id)
+            return self.workouts.save_by_id(db, user_id, object_id, trace_id=trace_id)
 
         collection = _COLLECTION_NAME.get(data_type, data_type)
         endpoint = f"/v2/usercollection/{collection}/{object_id}"
@@ -343,7 +343,7 @@ class OuraWebhookHandler(BaseWebhookHandler):
             provider="oura",
             payload=raw,
             user_id=str(user_id),
-            trace_id=endpoint,
+            trace_id=trace_id,
         )
 
         docs = [raw]

--- a/backend/app/services/providers/oura/workouts.py
+++ b/backend/app/services/providers/oura/workouts.py
@@ -110,6 +110,13 @@ class OuraWorkouts(BaseWorkoutsTemplate):
         raw = self.get_workout_detail_from_api(db, user_id, workout_id)
         if not raw or not isinstance(raw, dict):
             return 0
+        store_raw_payload(
+            source="api_response",
+            provider="oura",
+            payload=raw,
+            user_id=str(user_id),
+            trace_id=f"/v2/usercollection/workout/{workout_id}",
+        )
         count = 0
         for record, details in self._build_bundles([OuraWorkoutJSON(**raw)], user_id):
             created = event_record_service.create(db, record)

--- a/backend/app/services/providers/oura/workouts.py
+++ b/backend/app/services/providers/oura/workouts.py
@@ -105,7 +105,7 @@ class OuraWorkouts(BaseWorkoutsTemplate):
         """Get detailed workout data from Oura API."""
         return self._make_api_request(db, user_id, f"/v2/usercollection/workout/{workout_id}")
 
-    def save_by_id(self, db: DbSession, user_id: UUID, workout_id: str) -> int:
+    def save_by_id(self, db: DbSession, user_id: UUID, workout_id: str, trace_id: str | None = None) -> int:
         """Fetch a single workout by ID and save it."""
         raw = self.get_workout_detail_from_api(db, user_id, workout_id)
         if not raw or not isinstance(raw, dict):
@@ -115,7 +115,7 @@ class OuraWorkouts(BaseWorkoutsTemplate):
             provider="oura",
             payload=raw,
             user_id=str(user_id),
-            trace_id=f"/v2/usercollection/workout/{workout_id}",
+            trace_id=trace_id,
         )
         count = 0
         for record, details in self._build_bundles([OuraWorkoutJSON(**raw)], user_id):


### PR DESCRIPTION
In webhook mode, Oura data fetched after a ping wasn't archived to `raw-payloads/oura/api_response/` like the polling path is - this stores those payloads too. Closes #1427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Data Handling**
  * Improved Oura data processing by preserving raw API responses before normalization.
  * Raw workout and collection data now includes relevant request context for improved traceability and reliability.
  * Enhanced data integrity and troubleshooting for synchronized Oura workout information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->