### PR TITLE
feat(integrations): allow provider API base URL overrides

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -137,6 +137,7 @@ class Settings(BaseSettings):
     suunto_subscription_key: SecretStr | None = None
     suunto_default_scope: str = ""
     suunto_webhook_secret: SecretStr | None = None
+    suunto_api_base_url: AnyHttpUrl | None = None
     # Derived from secret_key if not set — configure the same value in Suunto developer portal.
 
     # GARMIN OAUTH SETTINGS
@@ -144,22 +145,26 @@ class Settings(BaseSettings):
     garmin_client_secret: SecretStr | None = None
     garmin_redirect_uri: str | None = None  # Deprecated: use API_BASE_URL
     garmin_default_scope: str = ""  # Scope is managed at app creation in Garmin Developer Portal
+    garmin_api_base_url: AnyHttpUrl | None = None
 
     # POLAR OAUTH SETTINGS
     polar_client_id: str | None = None
     polar_client_secret: SecretStr | None = None
     polar_redirect_uri: str | None = None  # Deprecated: use API_BASE_URL
     polar_default_scope: str = "accesslink.read_all"
+    polar_api_base_url: AnyHttpUrl | None = None
 
     # WHOOP OAUTH SETTINGS
     whoop_client_id: str | None = None
     whoop_client_secret: SecretStr | None = None
     whoop_redirect_uri: str | None = None  # Deprecated: use API_BASE_URL
     whoop_default_scope: str = "offline read:cycles read:sleep read:recovery read:workout"
+    whoop_api_base_url: AnyHttpUrl | None = None
 
     # SENSORBIO OAUTH SETTINGS
     sensorbio_client_id: str | None = None
     sensorbio_client_secret: SecretStr | None = None
+    sensorbio_api_base_url: AnyHttpUrl | None = None
     # Sensor Bio OAuth currently has no granular scopes defined in the developer portal.
     # Leave empty so the authorize URL omits scope= (mirrors Garmin/Suunto).
     sensorbio_default_scope: str = ""
@@ -169,6 +174,7 @@ class Settings(BaseSettings):
     fitbit_client_secret: SecretStr | None = None
     fitbit_redirect_uri: str | None = None  # Deprecated: use API_BASE_URL
     fitbit_default_scope: str = "activity heartrate sleep profile"
+    fitbit_api_base_url: AnyHttpUrl | None = None
 
     # OURA OAUTH SETTINGS
     oura_client_id: str | None = None
@@ -176,6 +182,7 @@ class Settings(BaseSettings):
     oura_redirect_uri: str | None = None  # Deprecated: use API_BASE_URL
     oura_default_scope: str = "personal daily activity heartrate workout session spo2 ring_configuration heart_health"
     oura_webhook_verification_token: SecretStr | None = None
+    oura_api_base_url: AnyHttpUrl | None = None
 
     # STRAVA OAUTH SETTINGS
     strava_client_id: str | None = None
@@ -184,6 +191,7 @@ class Settings(BaseSettings):
     strava_default_scope: str = "activity:read_all,profile:read_all"
     strava_webhook_verify_token: SecretStr | None = None
     strava_webhook_signature_tolerance_seconds: int = Field(300, ge=0)
+    strava_api_base_url: AnyHttpUrl | None = None
     # Strava API max is 200 activities per page
     strava_events_per_page: int = 200
 
@@ -192,6 +200,7 @@ class Settings(BaseSettings):
     ultrahuman_client_secret: SecretStr | None = None
     ultrahuman_redirect_uri: str | None = None  # Deprecated: use API_BASE_URL
     ultrahuman_default_scope: str = "ring_data cgm_data profile"
+    ultrahuman_api_base_url: AnyHttpUrl | None = None
 
     # GOOGLE OAUTH SETTINGS
     google_client_id: str | None = None
@@ -215,6 +224,7 @@ class Settings(BaseSettings):
     # with RAW granularity, either list or reconcile is used
     # true - reconcile, false - list; for details check docs
     google_use_reconcile: bool = True
+    google_api_base_url: AnyHttpUrl | None = None
 
     # EMAIL SETTINGS (Resend)
     resend_api_key: SecretStr | None = None
@@ -315,6 +325,29 @@ class Settings(BaseSettings):
             return None
         return parse_duration(str(v))  # "2d" / "20h" / "1d12h" → timedelta (fail fast at startup)
 
+    @field_validator(
+        "fitbit_api_base_url",
+        "garmin_api_base_url",
+        "google_api_base_url",
+        "oura_api_base_url",
+        "polar_api_base_url",
+        "sensorbio_api_base_url",
+        "strava_api_base_url",
+        "suunto_api_base_url",
+        "ultrahuman_api_base_url",
+        "whoop_api_base_url",
+    )
+    @classmethod
+    def validate_provider_api_base_url(cls, value: AnyHttpUrl | None) -> AnyHttpUrl | None:
+        """Reject URL parts that would make endpoint joining unsafe or ambiguous."""
+        if value is None:
+            return None
+        if value.username is not None or value.password is not None:
+            raise ValueError("provider API base URLs must not contain credentials")
+        if value.query is not None or value.fragment is not None:
+            raise ValueError("provider API base URLs must not contain a query string or fragment")
+        return value
+
     def oauth_redirect_uri(self, provider: ProviderName) -> str:
         """Build OAuth redirect URI for a provider.
 
@@ -331,6 +364,11 @@ class Settings(BaseSettings):
             )
             return legacy_value
         return f"{self.api_base_url}/api/v1/oauth/{provider.value}/callback"
+
+    def resolve_provider_api_base_url(self, provider: str, default: str) -> str:
+        """Return an operator-configured provider API URL or its built-in default."""
+        override = getattr(self, f"{provider}_api_base_url", None)
+        return str(override or default).rstrip("/")
 
     @property
     def redis_url(self) -> str:

--- a/backend/app/services/providers/base_strategy.py
+++ b/backend/app/services/providers/base_strategy.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from celery import current_app as celery_app
 
+from app.config import settings
 from app.models import EventRecord, User
 from app.repositories.event_record_repository import EventRecordRepository
 from app.repositories.user_connection_repository import UserConnectionRepository
@@ -142,6 +143,10 @@ class BaseProviderStrategy(ABC):
     @abstractmethod
     def api_base_url(self) -> str:
         """Returns the base URL for the provider's API."""
+
+    def _resolve_api_base_url(self, default: str) -> str:
+        """Resolve this provider's optional deployment-level API URL override."""
+        return settings.resolve_provider_api_base_url(self.name, default)
 
     @property
     def api_version(self) -> str:

--- a/backend/app/services/providers/fitbit/strategy.py
+++ b/backend/app/services/providers/fitbit/strategy.py
@@ -32,7 +32,7 @@ class FitbitStrategy(BaseProviderStrategy):
     @property
     def api_base_url(self) -> str:
         """Base URL for the Fitbit Web API."""
-        return "https://api.fitbit.com"
+        return self._resolve_api_base_url("https://api.fitbit.com")
 
     @property
     def coverage(self) -> ProviderCoverage:

--- a/backend/app/services/providers/garmin/strategy.py
+++ b/backend/app/services/providers/garmin/strategy.py
@@ -61,7 +61,7 @@ class GarminStrategy(BaseProviderStrategy):
 
     @property
     def api_base_url(self) -> str:
-        return "https://apis.garmin.com"
+        return self._resolve_api_base_url("https://apis.garmin.com")
 
     @property
     def capabilities(self) -> ProviderCapabilities:

--- a/backend/app/services/providers/google/health_api/webhook_service.py
+++ b/backend/app/services/providers/google/health_api/webhook_service.py
@@ -85,7 +85,8 @@ GOOGLE_WEBHOOK_DATA_TYPES = [
 def _subscribers_url() -> str:
     if not settings.google_project_id:
         raise ValueError("GOOGLE_PROJECT_ID is not configured; cannot manage Health API subscribers")
-    return f"{GOOGLE_HEALTH_API_BASE}{SUBSCRIBERS_ENDPOINT.format(project=settings.google_project_id)}"
+    api_base_url = settings.resolve_provider_api_base_url("google", GOOGLE_HEALTH_API_BASE)
+    return f"{api_base_url}{SUBSCRIBERS_ENDPOINT.format(project=settings.google_project_id)}"
 
 
 def _error_result(subscription_id: str, action: str, error: httpx.HTTPError) -> WebhookOperationResult:

--- a/backend/app/services/providers/google/strategy.py
+++ b/backend/app/services/providers/google/strategy.py
@@ -44,7 +44,7 @@ class GoogleStrategy(BaseProviderStrategy):
 
     @property
     def api_base_url(self) -> str:
-        return "https://health.googleapis.com"
+        return self._resolve_api_base_url("https://health.googleapis.com")
 
     @property
     def capabilities(self) -> ProviderCapabilities:

--- a/backend/app/services/providers/oura/oauth.py
+++ b/backend/app/services/providers/oura/oauth.py
@@ -26,7 +26,7 @@ class OuraOAuth(BaseOAuthTemplate):
         """OAuth endpoints for authorization and token exchange."""
         return ProviderEndpoints(
             authorize_url="https://cloud.ouraring.com/oauth/authorize",
-            token_url="https://api.ouraring.com/oauth/token",
+            token_url=f"{self.api_base_url}/oauth/token",
         )
 
     @property

--- a/backend/app/services/providers/oura/strategy.py
+++ b/backend/app/services/providers/oura/strategy.py
@@ -51,7 +51,7 @@ class OuraStrategy(BaseProviderStrategy):
     @property
     def api_base_url(self) -> str:
         """Base URL for the provider's API."""
-        return "https://api.ouraring.com"
+        return self._resolve_api_base_url("https://api.ouraring.com")
 
     @property
     def capabilities(self) -> ProviderCapabilities:

--- a/backend/app/services/providers/oura/webhook_service.py
+++ b/backend/app/services/providers/oura/webhook_service.py
@@ -26,7 +26,13 @@ from app.utils.structured_logging import log_structured
 
 logger = getLogger(__name__)
 
-OURA_WEBHOOK_API_URL = "https://api.ouraring.com/v2/webhook/subscription"
+_OURA_API_BASE_URL = "https://api.ouraring.com"
+
+
+def _oura_webhook_api_url() -> str:
+    api_base_url = settings.resolve_provider_api_base_url("oura", _OURA_API_BASE_URL)
+    return f"{api_base_url}/v2/webhook/subscription"
+
 
 OURA_WEBHOOK_DATA_TYPES = [
     "workout",
@@ -107,7 +113,7 @@ class OuraWebhookService(BaseWebhookService):
             # Build index of existing subscriptions keyed by (data_type, event_type) → (id, callback_url)
             existing: dict[tuple[str, str], tuple[str, str]] = {}
             try:
-                list_resp = await client.get(OURA_WEBHOOK_API_URL, headers=headers, timeout=30.0)
+                list_resp = await client.get(_oura_webhook_api_url(), headers=headers, timeout=30.0)
                 list_resp.raise_for_status()
                 for sub in list_resp.json() or []:
                     key = (sub.get("data_type", ""), sub.get("event_type", ""))
@@ -140,7 +146,7 @@ class OuraWebhookService(BaseWebhookService):
                     # callback_url changed — update the subscription
                     try:
                         response = await client.put(
-                            f"{OURA_WEBHOOK_API_URL}/{sub_id}",
+                            f"{_oura_webhook_api_url()}/{sub_id}",
                             headers=headers,
                             json=body,
                             timeout=30.0,
@@ -167,7 +173,7 @@ class OuraWebhookService(BaseWebhookService):
 
                 try:
                     response = await client.post(
-                        OURA_WEBHOOK_API_URL,
+                        _oura_webhook_api_url(),
                         headers=headers,
                         json=body,
                         timeout=30.0,
@@ -213,7 +219,7 @@ class OuraWebhookService(BaseWebhookService):
 
         async with httpx.AsyncClient() as client:
             response = await client.get(
-                OURA_WEBHOOK_API_URL,
+                _oura_webhook_api_url(),
                 headers=headers,
                 timeout=30.0,
             )
@@ -241,7 +247,7 @@ class OuraWebhookService(BaseWebhookService):
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.get(
-                    f"{OURA_WEBHOOK_API_URL}/{subscription_id}",
+                    f"{_oura_webhook_api_url()}/{subscription_id}",
                     headers=headers,
                     timeout=30.0,
                 )
@@ -279,7 +285,7 @@ class OuraWebhookService(BaseWebhookService):
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.delete(
-                    f"{OURA_WEBHOOK_API_URL}/{subscription_id}",
+                    f"{_oura_webhook_api_url()}/{subscription_id}",
                     headers=headers,
                     timeout=30.0,
                 )
@@ -340,7 +346,7 @@ class OuraWebhookService(BaseWebhookService):
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.put(
-                    f"{OURA_WEBHOOK_API_URL}/{subscription_id}",
+                    f"{_oura_webhook_api_url()}/{subscription_id}",
                     headers=headers,
                     json=body,
                     timeout=30.0,
@@ -379,7 +385,7 @@ class OuraWebhookService(BaseWebhookService):
 
         async with httpx.AsyncClient() as client:
             list_response = await client.get(
-                OURA_WEBHOOK_API_URL,
+                _oura_webhook_api_url(),
                 headers=headers,
                 timeout=30.0,
             )
@@ -396,7 +402,7 @@ class OuraWebhookService(BaseWebhookService):
 
                 try:
                     renew_response = await client.put(
-                        f"{OURA_WEBHOOK_API_URL}/renew/{sub_id}",
+                        f"{_oura_webhook_api_url()}/renew/{sub_id}",
                         headers=headers,
                         timeout=30.0,
                     )

--- a/backend/app/services/providers/polar/strategy.py
+++ b/backend/app/services/providers/polar/strategy.py
@@ -39,7 +39,7 @@ class PolarStrategy(BaseProviderStrategy):
 
     @property
     def api_base_url(self) -> str:
-        return "https://www.polaraccesslink.com"
+        return self._resolve_api_base_url("https://www.polaraccesslink.com")
 
     @property
     def capabilities(self) -> ProviderCapabilities:

--- a/backend/app/services/providers/polar/webhook_service.py
+++ b/backend/app/services/providers/polar/webhook_service.py
@@ -41,6 +41,11 @@ logger = getLogger(__name__)
 
 _POLAR_API_URL = "https://www.polaraccesslink.com"
 
+
+def _polar_api_url() -> str:
+    return settings.resolve_provider_api_base_url("polar", _POLAR_API_URL)
+
+
 _ALL_EVENTS = [e for e in PolarWebhookEventType if e is not PolarWebhookEventType.PING]
 
 
@@ -59,7 +64,7 @@ class PolarWebhookService(BaseWebhookService):
         auth = self._get_basic_auth()
         try:
             async with httpx.AsyncClient() as client:
-                resp = await client.get(f"{_POLAR_API_URL}/v3/webhooks", auth=auth, timeout=30.0)
+                resp = await client.get(f"{_polar_api_url()}/v3/webhooks", auth=auth, timeout=30.0)
                 resp.raise_for_status()
                 data = resp.json()
                 webhooks = data.get("data", [])
@@ -144,7 +149,7 @@ class PolarWebhookService(BaseWebhookService):
         try:
             async with httpx.AsyncClient() as client:
                 resp = await client.delete(
-                    f"{_POLAR_API_URL}/v3/webhooks/{subscription_id}",
+                    f"{_polar_api_url()}/v3/webhooks/{subscription_id}",
                     auth=auth,
                     timeout=30.0,
                 )
@@ -181,7 +186,7 @@ class PolarWebhookService(BaseWebhookService):
         try:
             async with httpx.AsyncClient() as client:
                 resp = await client.patch(
-                    f"{_POLAR_API_URL}/v3/webhooks/{subscription_id}",
+                    f"{_polar_api_url()}/v3/webhooks/{subscription_id}",
                     auth=auth,
                     json={"events": _ALL_EVENTS, "url": callback_url},
                     timeout=30.0,
@@ -216,7 +221,7 @@ class PolarWebhookService(BaseWebhookService):
     async def _create_webhook(self, auth: httpx.BasicAuth, callback_url: str) -> dict[str, Any]:
         async with httpx.AsyncClient() as client:
             resp = await client.post(
-                f"{_POLAR_API_URL}/v3/webhooks",
+                f"{_polar_api_url()}/v3/webhooks",
                 auth=auth,
                 json={"events": _ALL_EVENTS, "url": callback_url},
                 timeout=30.0,
@@ -250,7 +255,7 @@ class PolarWebhookService(BaseWebhookService):
         """Activate a deactivated Polar webhook."""
         auth = self._get_basic_auth()
         async with httpx.AsyncClient() as client:
-            resp = await client.post(f"{_POLAR_API_URL}/v3/webhooks/activate", auth=auth, timeout=30.0)
+            resp = await client.post(f"{_polar_api_url()}/v3/webhooks/activate", auth=auth, timeout=30.0)
             resp.raise_for_status()
             log_structured(logger, "info", "Polar webhook activated", provider="polar")
             return {"status": "activated"}
@@ -259,7 +264,7 @@ class PolarWebhookService(BaseWebhookService):
         """Deactivate the active Polar webhook."""
         auth = self._get_basic_auth()
         async with httpx.AsyncClient() as client:
-            resp = await client.post(f"{_POLAR_API_URL}/v3/webhooks/deactivate", auth=auth, timeout=30.0)
+            resp = await client.post(f"{_polar_api_url()}/v3/webhooks/deactivate", auth=auth, timeout=30.0)
             resp.raise_for_status()
             log_structured(logger, "info", "Polar webhook deactivated", provider="polar")
             return {"status": "deactivated"}

--- a/backend/app/services/providers/sensorbio/strategy.py
+++ b/backend/app/services/providers/sensorbio/strategy.py
@@ -39,7 +39,7 @@ class SensorBioStrategy(BaseProviderStrategy):
 
     @property
     def api_base_url(self) -> str:
-        return "https://api.sensorbio.com"
+        return self._resolve_api_base_url("https://api.sensorbio.com")
 
     @property
     def capabilities(self) -> ProviderCapabilities:

--- a/backend/app/services/providers/strava/strategy.py
+++ b/backend/app/services/providers/strava/strategy.py
@@ -43,7 +43,7 @@ class StravaStrategy(BaseProviderStrategy):
     @property
     def api_base_url(self) -> str:
         """Base URL for the provider's API."""
-        return "https://www.strava.com"
+        return self._resolve_api_base_url("https://www.strava.com")
 
     # two properties below not used in oauth and workouts - update with base template changes
     @property

--- a/backend/app/services/providers/strava/webhook_service.py
+++ b/backend/app/services/providers/strava/webhook_service.py
@@ -28,8 +28,7 @@ from app.utils.structured_logging import log_structured
 
 logger = getLogger(__name__)
 
-# hard-coded value - update with base template changes
-_STRAVA_API_URL = "https://www.strava.com/api/v3"
+_STRAVA_API_BASE_URL = "https://www.strava.com"
 
 
 class StravaWebhookService(BaseWebhookService):
@@ -37,7 +36,8 @@ class StravaWebhookService(BaseWebhookService):
 
     @property
     def api_current_url(self) -> str:
-        return _STRAVA_API_URL
+        api_base_url = settings.resolve_provider_api_base_url("strava", _STRAVA_API_BASE_URL)
+        return f"{api_base_url}/api/v3"
 
     def _get_strava_credentials(self) -> tuple[str, str]:
         """Get Strava client credentials. Raises ValueError if not configured."""

--- a/backend/app/services/providers/suunto/strategy.py
+++ b/backend/app/services/providers/suunto/strategy.py
@@ -40,7 +40,7 @@ class SuuntoStrategy(BaseProviderStrategy):
 
     @property
     def api_base_url(self) -> str:
-        return "https://cloudapi.suunto.com"
+        return self._resolve_api_base_url("https://cloudapi.suunto.com")
 
     @property
     def coverage(self) -> ProviderCoverage:

--- a/backend/app/services/providers/ultrahuman/strategy.py
+++ b/backend/app/services/providers/ultrahuman/strategy.py
@@ -49,4 +49,4 @@ class UltrahumanStrategy(BaseProviderStrategy):
         Base URL for data endpoints: https://partner.ultrahuman.com/api/partners/v1
         OAuth authorization is on: https://auth.ultrahuman.com
         """
-        return "https://partner.ultrahuman.com/api/partners/v1"
+        return self._resolve_api_base_url("https://partner.ultrahuman.com/api/partners/v1")

--- a/backend/app/services/providers/whoop/strategy.py
+++ b/backend/app/services/providers/whoop/strategy.py
@@ -49,7 +49,7 @@ class WhoopStrategy(BaseProviderStrategy):
     @property
     def api_base_url(self) -> str:
         """Base URL for the provider's API."""
-        return "https://api.prod.whoop.com/developer"
+        return self._resolve_api_base_url("https://api.prod.whoop.com/developer")
 
     @property
     def coverage(self) -> ProviderCoverage:

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -127,34 +127,40 @@ API_BASE_URL=http://localhost:8000
 SUUNTO_CLIENT_ID=public-client-id
 SUUNTO_CLIENT_SECRET=private-secret-id
 SUUNTO_SUBSCRIPTION_KEY=private-subscription-id
+# SUUNTO_API_BASE_URL=https://cloudapi.suunto.com
 # SUUNTO_DEFAULT_SCOPE=
 # SUUNTO_WEBHOOK_SECRET=your-secret  # Optional: defaults to SECRET_KEY; configure the same value in the Suunto developer portal
 
 #--- Polar ---#
 POLAR_CLIENT_ID=public-client-id
 POLAR_CLIENT_SECRET=private-secret-id
+# POLAR_API_BASE_URL=https://www.polaraccesslink.com
 # POLAR_DEFAULT_SCOPE=accesslink.read_all
 
 #--- Garmin ---#
 GARMIN_CLIENT_ID=your-garmin-client-id
 GARMIN_CLIENT_SECRET=your-garmin-client-secret
+# GARMIN_API_BASE_URL=https://apis.garmin.com
 # GARMIN_DEFAULT_SCOPE=  # Scope is managed at app creation in the Garmin Developer Portal
 
 #--- Whoop ---#
 WHOOP_CLIENT_ID=public-client-id
 WHOOP_CLIENT_SECRET=private-secret-id
 WHOOP_DEFAULT_SCOPE=offline read:cycles read:sleep read:recovery read:workout read:body_measurement read:profile
+# WHOOP_API_BASE_URL=https://api.prod.whoop.com/developer
 
 #--- Oura ---#
 OURA_CLIENT_ID=your-oura-client-id
 OURA_CLIENT_SECRET=your-oura-client-secret
 OURA_DEFAULT_SCOPE=personal daily activity heartrate workout session spo2 ring_configuration heart_health
+# OURA_API_BASE_URL=https://api.ouraring.com
 # OURA_WEBHOOK_VERIFICATION_TOKEN=your-token  # Optional: defaults to SECRET_KEY
 
 #--- Strava ---#
 STRAVA_CLIENT_ID=your-strava-client-id
 STRAVA_CLIENT_SECRET=your-strava-client-secret
 STRAVA_DEFAULT_SCOPE=activity:read_all,profile:read_all
+# STRAVA_API_BASE_URL=https://www.strava.com
 STRAVA_WEBHOOK_VERIFY_TOKEN=your-strava-webhook-verify-token
 # STRAVA_WEBHOOK_SIGNATURE_TOLERANCE_SECONDS=300  # Max allowed webhook signature timestamp skew
 # STRAVA_EVENTS_PER_PAGE=200  # Strava API max is 200 activities per page
@@ -163,21 +169,25 @@ STRAVA_WEBHOOK_VERIFY_TOKEN=your-strava-webhook-verify-token
 FITBIT_CLIENT_ID=your-fitbit-client-id
 FITBIT_CLIENT_SECRET=your-fitbit-client-secret
 FITBIT_DEFAULT_SCOPE=activity heartrate sleep profile
+# FITBIT_API_BASE_URL=https://api.fitbit.com
 
 #--- Ultrahuman ---#
 ULTRAHUMAN_CLIENT_ID=your-ultrahuman-client-id
 ULTRAHUMAN_CLIENT_SECRET=your-ultrahuman-client-secret
 ULTRAHUMAN_DEFAULT_SCOPE=ring_data cgm_data profile
+# ULTRAHUMAN_API_BASE_URL=https://partner.ultrahuman.com/api/partners/v1
 
 #--- Sensor Bio ---#
 SENSORBIO_CLIENT_ID=your-sensorbio-client-id
 SENSORBIO_CLIENT_SECRET=your-sensorbio-client-secret
+# SENSORBIO_API_BASE_URL=https://api.sensorbio.com
 # Empty: Sensor Bio OAuth has no granular scopes defined (portal shows "No Scopes Defined").
 SENSORBIO_DEFAULT_SCOPE=
 
 #--- Google ---#
 GOOGLE_CLIENT_ID=your-google-client-id
 GOOGLE_CLIENT_SECRET=your-google-client-secret
+# GOOGLE_API_BASE_URL=https://health.googleapis.com
 GOOGLE_DEFAULT_SCOPE=openid email https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly https://www.googleapis.com/auth/googlehealth.nutrition.readonly https://www.googleapis.com/auth/googlehealth.sleep.readonly https://www.googleapis.com/auth/googlehealth.settings.readonly
 GOOGLE_PROJECT_ID=your-project-number  # numeric project NUMBER (not the ID) — required by the subscriber API
 # with RAW granularity, either list or reconcile is used

--- a/backend/tests/providers/test_api_base_url_overrides.py
+++ b/backend/tests/providers/test_api_base_url_overrides.py
@@ -1,0 +1,114 @@
+"""Tests for deployment-level provider API base URL overrides."""
+
+from collections.abc import Callable
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings, settings
+from app.services.providers.base_strategy import BaseProviderStrategy
+from app.services.providers.fitbit.strategy import FitbitStrategy
+from app.services.providers.garmin.strategy import GarminStrategy
+from app.services.providers.google.health_api.webhook_service import _subscribers_url
+from app.services.providers.google.strategy import GoogleStrategy
+from app.services.providers.oura.strategy import OuraStrategy
+from app.services.providers.oura.webhook_service import _oura_webhook_api_url
+from app.services.providers.polar.strategy import PolarStrategy
+from app.services.providers.polar.webhook_service import _polar_api_url
+from app.services.providers.sensorbio.strategy import SensorBioStrategy
+from app.services.providers.strava.strategy import StravaStrategy
+from app.services.providers.strava.webhook_service import strava_webhook_service
+from app.services.providers.suunto.strategy import SuuntoStrategy
+from app.services.providers.ultrahuman.strategy import UltrahumanStrategy
+from app.services.providers.whoop.strategy import WhoopStrategy
+
+StrategyFactory = Callable[[], BaseProviderStrategy]
+
+PROVIDERS: tuple[tuple[StrategyFactory, str, str], ...] = (
+    (FitbitStrategy, "fitbit_api_base_url", "https://api.fitbit.com"),
+    (GarminStrategy, "garmin_api_base_url", "https://apis.garmin.com"),
+    (GoogleStrategy, "google_api_base_url", "https://health.googleapis.com"),
+    (OuraStrategy, "oura_api_base_url", "https://api.ouraring.com"),
+    (PolarStrategy, "polar_api_base_url", "https://www.polaraccesslink.com"),
+    (SensorBioStrategy, "sensorbio_api_base_url", "https://api.sensorbio.com"),
+    (StravaStrategy, "strava_api_base_url", "https://www.strava.com"),
+    (SuuntoStrategy, "suunto_api_base_url", "https://cloudapi.suunto.com"),
+    (UltrahumanStrategy, "ultrahuman_api_base_url", "https://partner.ultrahuman.com/api/partners/v1"),
+    (WhoopStrategy, "whoop_api_base_url", "https://api.prod.whoop.com/developer"),
+)
+
+
+@pytest.mark.parametrize(("strategy_factory", "setting_name", "default_url"), PROVIDERS)
+def test_provider_uses_default_api_base_url(
+    strategy_factory: StrategyFactory,
+    setting_name: str,
+    default_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, setting_name, None)
+
+    assert strategy_factory().api_base_url == default_url
+
+
+@pytest.mark.parametrize(("strategy_factory", "setting_name", "_default_url"), PROVIDERS)
+def test_provider_propagates_api_base_url_override(
+    strategy_factory: StrategyFactory,
+    setting_name: str,
+    _default_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    override = "http://provider-gateway.local/custom/prefix/"
+    monkeypatch.setattr(settings, setting_name, override)
+
+    strategy = strategy_factory()
+
+    assert strategy.api_base_url == override.rstrip("/")
+    for component_name in ("oauth", "workouts", "data_247"):
+        component = getattr(strategy, component_name)
+        if component is not None and hasattr(component, "api_base_url"):
+            assert component.api_base_url == override.rstrip("/")
+
+
+def test_provider_api_base_url_loads_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OURA_API_BASE_URL", "https://gateway.example.com/oura/")
+
+    configured = Settings(_env_file=None, secret_key="test-secret")
+
+    assert configured.resolve_provider_api_base_url("oura", "https://api.ouraring.com") == (
+        "https://gateway.example.com/oura"
+    )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://user:password@gateway.example.com/oura",
+        "https://gateway.example.com/oura?tenant=example",
+        "https://gateway.example.com/oura#api",
+    ],
+)
+def test_provider_api_base_url_rejects_ambiguous_urls(url: str) -> None:
+    with pytest.raises(ValidationError, match="provider API base URLs must not contain"):
+        Settings(_env_file=None, secret_key="test-secret", oura_api_base_url=url)
+
+
+def test_webhook_services_use_provider_api_base_url_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "google_api_base_url", "https://gateway.example.com/google")
+    monkeypatch.setattr(settings, "google_project_id", "123456")
+    monkeypatch.setattr(settings, "oura_api_base_url", "https://gateway.example.com/oura")
+    monkeypatch.setattr(settings, "polar_api_base_url", "https://gateway.example.com/polar")
+    monkeypatch.setattr(settings, "strava_api_base_url", "https://gateway.example.com/strava")
+
+    assert _subscribers_url().startswith("https://gateway.example.com/google/")
+    assert _oura_webhook_api_url() == "https://gateway.example.com/oura/v2/webhook/subscription"
+    assert _polar_api_url() == "https://gateway.example.com/polar"
+    assert strava_webhook_service.api_current_url == "https://gateway.example.com/strava/api/v3"
+
+
+def test_oura_token_endpoint_uses_api_base_url_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "oura_api_base_url", "https://gateway.example.com/oura")
+
+    strategy = OuraStrategy()
+
+    assert strategy.oauth is not None
+    assert strategy.oauth.endpoints.token_url == "https://gateway.example.com/oura/oauth/token"

--- a/docs/deployment/provider-api-base-urls.mdx
+++ b/docs/deployment/provider-api-base-urls.mdx
@@ -1,0 +1,89 @@
+---
+title: "Provider API base URLs"
+description: "Route server-to-server wearable provider requests through reverse proxies, API gateways, or compatible endpoints."
+---
+
+## Override provider API endpoints
+
+Open Wearables uses each wearable provider's official API endpoint by default. Self-hosted deployments can replace an
+individual provider's server-to-server API base URL with an environment variable. This is useful for reverse proxies,
+egress gateways, compatible API implementations, and development emulators.
+
+<Warning>
+  Provider access tokens are sent to the configured endpoint. Only use an endpoint controlled by your deployment
+  operator, and use HTTPS outside local development.
+</Warning>
+
+| Provider | Environment variable | Default |
+| --- | --- | --- |
+| Fitbit | `FITBIT_API_BASE_URL` | `https://api.fitbit.com` |
+| Garmin | `GARMIN_API_BASE_URL` | `https://apis.garmin.com` |
+| Google Health | `GOOGLE_API_BASE_URL` | `https://health.googleapis.com` |
+| Oura | `OURA_API_BASE_URL` | `https://api.ouraring.com` |
+| Polar | `POLAR_API_BASE_URL` | `https://www.polaraccesslink.com` |
+| Sensor Bio | `SENSORBIO_API_BASE_URL` | `https://api.sensorbio.com` |
+| Strava | `STRAVA_API_BASE_URL` | `https://www.strava.com` |
+| Suunto | `SUUNTO_API_BASE_URL` | `https://cloudapi.suunto.com` |
+| Ultrahuman | `ULTRAHUMAN_API_BASE_URL` | `https://partner.ultrahuman.com/api/partners/v1` |
+| Whoop | `WHOOP_API_BASE_URL` | `https://api.prod.whoop.com/developer` |
+
+Apple Health and Samsung Health do not expose cloud APIs, so they have no corresponding setting.
+
+## Configure a reverse proxy
+
+<Steps>
+  <Step title="Set the provider URL">
+    Add only the providers you want to override to `backend/config/.env`. Path prefixes are preserved.
+
+    ```dotenv backend/config/.env
+    OURA_API_BASE_URL=https://wearables-gateway.example.com/oura
+    WHOOP_API_BASE_URL=https://wearables-gateway.example.com/whoop/developer
+    ```
+  </Step>
+
+  <Step title="Restart the backend and workers">
+    Provider strategies read the settings when each process starts.
+
+    ```bash
+    docker compose restart app celery-worker celery-beat
+    ```
+  </Step>
+
+  <Step title="Verify the resolved endpoints">
+    Run this command in the application container:
+
+    ```bash
+    docker compose exec app python -c "from app.services.providers.factory import ProviderFactory; factory = ProviderFactory(); print(factory.get_provider('oura').api_base_url); print(factory.get_provider('whoop').api_base_url)"
+    ```
+
+    Expected output:
+
+    ```text
+    https://wearables-gateway.example.com/oura
+    https://wearables-gateway.example.com/whoop/developer
+    ```
+  </Step>
+</Steps>
+
+The override is used by the provider's API-facing OAuth, webhook-registration, workout, and continuous-data
+components. OAuth URLs hosted on a separate domain remain unchanged. When a provider normally serves an OAuth URL
+from its API base, such as Strava's authorization endpoint or Oura's token endpoint, that request also uses the
+override.
+
+## Configure a forward proxy
+
+Base URL overrides are not required for a conventional HTTP forward proxy. The backend uses HTTPX, which reads the
+standard proxy environment variables. Configure them on both the API and Celery worker processes:
+
+```dotenv backend/config/.env
+HTTPS_PROXY=http://proxy.internal:3128
+NO_PROXY=db,redis,svix-server,localhost,127.0.0.1
+```
+
+Use `SSL_CERT_FILE` when the proxy terminates TLS with a private certificate authority:
+
+```dotenv backend/config/.env
+SSL_CERT_FILE=/etc/ssl/certs/company-ca-bundle.pem
+```
+
+Mount that certificate file into every container that performs provider requests.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -136,6 +136,7 @@
             "group": "Deployment",
             "pages": [
               "deployment/docker-images",
+              "deployment/provider-api-base-urls",
               "deployment/railway"
             ]
           },


### PR DESCRIPTION
## Summary

- add explicit `<PROVIDER>_API_BASE_URL` environment variables for all cloud integrations
- apply configured base URLs to provider API clients, webhook registration, and applicable OAuth endpoints
- validate overrides and reject URLs containing credentials, query parameters, or fragments
- document reverse-proxy and custom API gateway configuration
- add coverage for defaults, overrides, validation, and provider-specific URL handling

## Motivation

Deployments may need to route provider API traffic through reverse proxies, API gateways, recording proxies, or compatible internal services. Provider-specific environment variables make this configuration explicit while preserving the official provider endpoints as defaults.

## Testing

- provider regression suite: 130 passed
- Ruff lint and formatting: passed
- generated documentation check: passed
- documentation JSON validation: passed
- `git diff --check`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable API base URLs for supported wearable and health providers.
  - Added support for custom deployments, reverse proxies, and forward proxies.
  - Provider integrations now use configured endpoints while retaining existing defaults.

- **Documentation**
  - Added deployment guidance, security recommendations, environment configuration examples, and proxy setup instructions.
  - Documented supported providers and excluded integrations.

- **Bug Fixes**
  - Improved endpoint handling for webhooks and OAuth flows when custom URLs are configured.

- **Tests**
  - Added coverage for defaults, overrides, validation, environment loading, webhooks, and OAuth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->