### PR TITLE
fix: resolve race condition in token refresh using distributed lock

### DIFF
--- a/backend/app/services/providers/api_client.py
+++ b/backend/app/services/providers/api_client.py
@@ -10,10 +10,10 @@ import httpx
 from fastapi import HTTPException, status
 
 from app.database import DbSession
+from app.integrations.redis_client import get_redis_client
 from app.repositories import UserConnectionRepository
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
 from app.utils.structured_logging import log_structured
-from app.integrations.redis_client import get_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -59,27 +59,39 @@ def _get_valid_token(
         redis_client = get_redis_client()
         lock_key = f"token_refresh_lock:{provider_name}:{user_id}"
 
-        with redis_client.lock(lock_key, timeout=60, sleep=0.2):
-          # Fetch and refresh connection instance inside the lock
-          connection = connection_repo.get_by_user_and_provider(db, user_id, provider_name)
-          if not connection or not connection.access_token:
-              raise ValueError(f"No valid connection found for {provider_name}:{user_id}")
+        with redis_client.lock(lock_key, timeout=60, blocking_timeout=10, sleep=0.2):
+            # Fetch and refresh connection instance inside the lock
+            connection = connection_repo.get_by_user_and_provider(db, user_id, provider_name)
+            if not connection:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail=f"User not connected to {provider_name}",
+                )
+            if not connection.access_token:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail=f"No access token available for {provider_name} (SDK-based provider?)",
+                )
 
-          db.refresh(connection)
+            db.refresh(connection)
 
-          # 1. If the token never expires, return it directly
-          # 2. If it expires in the future (> 5 min buffer), return existing token
-          now = datetime.now(timezone.utc)
-          if not connection.token_expires_at or connection.token_expires_at >= now + timedelta(minutes=5):
-              return connection.access_token
+            # 1. If the token never expires, return it directly
+            # 2. If it expires in the future (> 5 min buffer), return existing token
+            now = datetime.now(timezone.utc)
+            if not connection.token_expires_at or connection.token_expires_at >= now + timedelta(minutes=5):
+                return connection.access_token
 
-          # Guard against missing refresh token before attempting OAuth refresh
-          if not connection.refresh_token:
-              raise ValueError(f"Missing refresh token for {provider_name}:{user_id}")
+            # Guard against missing refresh token before attempting OAuth refresh
+            if not connection.refresh_token:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail=f"Token expired and no refresh token available for {provider_name}",
+                )
 
-          token_response = oauth.refresh_access_token(db, user_id, connection.refresh_token)
-          return token_response.access_token
-          return connection.access_token
+            token_response = oauth.refresh_access_token(db, user_id, connection.refresh_token)
+            return token_response.access_token
+
+    return connection.access_token
 
 
 def make_authenticated_request(

--- a/backend/app/services/providers/api_client.py
+++ b/backend/app/services/providers/api_client.py
@@ -53,8 +53,27 @@ def _get_valid_token(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail=f"Token expired and no refresh token available for {provider_name}",
             )
-        token_response = oauth.refresh_access_token(db, user_id, connection.refresh_token)
-        return token_response.access_token
+        # Scope distributed lock per user/provider to avoid concurrent refresh race conditions.
+        from app.integrations.redis_client import get_redis_client
+
+        redis_client = get_redis_client()
+        lock_key = f"token_refresh_lock:{provider_name}:{user_id}"
+
+        # redis.lock context manager handles acquisition, auto-retry, and token-verified release safely.
+        with redis_client.lock(lock_key, timeout=30, sleep=0.2):
+            # Expire cached objects so SQLAlchemy fetches fresh data from DB.
+            # Without this, the identity map returns the stale connection loaded before lock.
+            db.expire_all()
+            connection = connection_repo.get_by_user_and_provider(db, user_id, provider_name)
+            if (
+                connection
+                and connection.token_expires_at
+                and connection.token_expires_at >= datetime.now(timezone.utc) + timedelta(minutes=5)
+            ):
+                return connection.access_token
+
+            token_response = oauth.refresh_access_token(db, user_id, connection.refresh_token)
+            return token_response.access_token
 
     return connection.access_token
 

--- a/backend/app/services/providers/api_client.py
+++ b/backend/app/services/providers/api_client.py
@@ -59,23 +59,27 @@ def _get_valid_token(
         redis_client = get_redis_client()
         lock_key = f"token_refresh_lock:{provider_name}:{user_id}"
 
-        # redis.lock context manager handles acquisition, auto-retry, and token-verified release safely.
         with redis_client.lock(lock_key, timeout=60, sleep=0.2):
-            # Refresh only this connection object to pull fresh tokens without discarding unrelated session changes
-            if connection:
-                db.refresh(connection)
+          # Fetch and refresh connection instance inside the lock
+          connection = connection_repo.get_by_user_and_provider(db, user_id, provider_name)
+          if not connection or not connection.access_token:
+              raise ValueError(f"No valid connection found for {provider_name}:{user_id}")
 
-            if (
-                connection
-                and connection.token_expires_at
-                and connection.token_expires_at >= datetime.now(timezone.utc) + timedelta(minutes=5)
-            ):
-                return connection.access_token
+          db.refresh(connection)
 
-            token_response = oauth.refresh_access_token(db, user_id, connection.refresh_token)
-            return token_response.access_token
+          # 1. If the token never expires, return it directly
+          # 2. If it expires in the future (> 5 min buffer), return existing token
+          now = datetime.now(timezone.utc)
+          if not connection.token_expires_at or connection.token_expires_at >= now + timedelta(minutes=5):
+              return connection.access_token
 
-    return connection.access_token
+          # Guard against missing refresh token before attempting OAuth refresh
+          if not connection.refresh_token:
+              raise ValueError(f"Missing refresh token for {provider_name}:{user_id}")
+
+          token_response = oauth.refresh_access_token(db, user_id, connection.refresh_token)
+          return token_response.access_token
+          return connection.access_token
 
 
 def make_authenticated_request(

--- a/backend/app/services/providers/api_client.py
+++ b/backend/app/services/providers/api_client.py
@@ -60,7 +60,7 @@ def _get_valid_token(
         lock_key = f"token_refresh_lock:{provider_name}:{user_id}"
 
         # redis.lock context manager handles acquisition, auto-retry, and token-verified release safely.
-        with redis_client.lock(lock_key, timeout=30, sleep=0.2):
+        with redis_client.lock(lock_key, timeout=60, sleep=0.2):
             # Expire cached objects so SQLAlchemy fetches fresh data from DB.
             # Without this, the identity map returns the stale connection loaded before lock.
             db.expire_all()

--- a/backend/app/services/providers/api_client.py
+++ b/backend/app/services/providers/api_client.py
@@ -61,10 +61,10 @@ def _get_valid_token(
 
         # redis.lock context manager handles acquisition, auto-retry, and token-verified release safely.
         with redis_client.lock(lock_key, timeout=60, sleep=0.2):
-            # Expire cached objects so SQLAlchemy fetches fresh data from DB.
-            # Without this, the identity map returns the stale connection loaded before lock.
-            db.expire_all()
-            connection = connection_repo.get_by_user_and_provider(db, user_id, provider_name)
+            # Refresh only this connection object to pull fresh tokens without discarding unrelated session changes
+            if connection:
+                db.refresh(connection)
+
             if (
                 connection
                 and connection.token_expires_at

--- a/backend/app/services/providers/api_client.py
+++ b/backend/app/services/providers/api_client.py
@@ -13,6 +13,7 @@ from app.database import DbSession
 from app.repositories import UserConnectionRepository
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
 from app.utils.structured_logging import log_structured
+from app.integrations.redis_client import get_redis_client
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +55,6 @@ def _get_valid_token(
                 detail=f"Token expired and no refresh token available for {provider_name}",
             )
         # Scope distributed lock per user/provider to avoid concurrent refresh race conditions.
-        from app.integrations.redis_client import get_redis_client
 
         redis_client = get_redis_client()
         lock_key = f"token_refresh_lock:{provider_name}:{user_id}"


### PR DESCRIPTION
## Description

This PR resolves a race condition during concurrent OAuth token refresh requests (e.g., when multiple incoming webhooks for the same user arrive simultaneously).
Previously, concurrent webhooks could trigger redundant token rotation requests with stale refresh tokens, leading to HTTP 400 errors from provider OAuth servers and spurious connection revocations.

**Solution:**
1. **Distributed Lock (`redis_client.lock`)**: Scopes a Redis lock per user and provider (`token_refresh_lock:{provider_name}:{user_id}`) to serialize token refresh attempts.
2. **Session Eviction (`db.expire_all()`)**: Invalidates stale SQLAlchemy identity map objects before fetching the connection inside the lock.
3. **Double-Checked Refresh**: Reloads connection data inside the lock and verifies whether another worker refreshed the token while waiting. If refreshed, it reuses the newly issued access token immediately.
4. **Safety**: Replaced custom polling and deletion with `redis-py`'s built-in lock context manager to ensure safe Lua-backed token-verified release.
## Checklist
### General
- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes
- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

<!-- If your PR includes frontend changes, please verify: -->

- [ ] `pnpm run lint` passes
- [ ] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds

## Testing Instructions

**Steps to test:**
1. Connect any provider. e.g **Whoop**.
2. Go to **user_connections** table and set token expiration date to past.
3. Update anything in provider (e.g I updated my "Whoop Sleep")
4. Now, that Webhook should trigger/update data in open-wearables db.
5. Check in **user_connections** table tokens and expiry should be updated while connection status should be active only.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication reliability when multiple requests refresh the same provider connection simultaneously.
  * Prevented unnecessary token refreshes by reusing a valid token refreshed by another process.
  * Added clearer handling for missing or invalid connections and unavailable refresh tokens during authentication.
  * Ensured token refresh operations use the latest connection information before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->