### PR TITLE
feat(backend): raise upload limit to 5 GiB and add upload progress dialog for uploading Apple's XML

### DIFF
--- a/backend/app/schemas/providers/apple/apple_xml/aws.py
+++ b/backend/app/schemas/providers/apple/apple_xml/aws.py
@@ -4,7 +4,7 @@ MIN_EXPIRATION_SECONDS = 60  # 1 minute
 MAX_EXPIRATION_SECONDS = 3600  # 1 hour
 DEFAULT_EXPIRATION_SECONDS = 300  # 5 minutes
 MIN_FILE_SIZE = 1024  # 1KB
-MAX_FILE_SIZE = 1024 * 1024 * 1024  # 500MB
+MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024  # 5GiB (S3 presigned POST ceiling for a single upload)
 DEFAULT_FILE_SIZE = 50 * 1024 * 1024  # 50MB
 
 
@@ -20,7 +20,7 @@ class PresignedURLRequest(BaseModel):
         default=DEFAULT_FILE_SIZE,
         ge=MIN_FILE_SIZE,
         le=MAX_FILE_SIZE,
-        description="Maximum file size in bytes (1KB - 500MB)",
+        description="Maximum file size in bytes (1KB - 5GiB)",
     )
 
 

--- a/docs/api-reference/guides/apple-xml-import.mdx
+++ b/docs/api-reference/guides/apple-xml-import.mdx
@@ -135,7 +135,7 @@ const presignedData = await response.json();
 </ParamField>
 
 <ParamField body="max_file_size" type="integer" default="52428800">
-  Maximum file size in bytes (1KB - 500MB). Default is 50MB.
+  Maximum file size in bytes (1KB - 5GiB). Default is 50MB.
 </ParamField>
 
 <ResponseExample>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@radix-ui/react-label": "^2.1.15",
+    "@radix-ui/react-progress": "^1.1.16",
     "@radix-ui/react-select": "^2.3.7",
     "@radix-ui/react-separator": "^1.1.15",
     "@radix-ui/react-slot": "^1.3.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.15
         version: 2.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@radix-ui/react-progress':
+        specifier: ^1.1.16
+        version: 1.1.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-select':
         specifier: ^2.3.7
         version: 2.3.7(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1064,6 +1067,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.10':
     resolution: {integrity: sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.16':
+    resolution: {integrity: sha512-5XnomAsoZZCY+KNTxbIghpGqPruZvKFNlvcAljVAOdDRDsH4/OZQxhtwo5wdtoDM5R6MhJBb2sPnDuRFep3lzg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3819,6 +3835,16 @@ snapshots:
   '@radix-ui/react-primitive@2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@radix-ui/react-slot': 1.3.3(@types/react@19.2.18)(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
+
+  '@radix-ui/react-progress@1.1.16(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.18)(react@19.2.8)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import * as ProgressPrimitive from '@radix-ui/react-progress';
+
+import { cn } from '@/lib/utils';
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> & {
+    indicatorClassName?: string;
+  }
+>(({ className, indicatorClassName, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className={cn(
+        'h-full w-full flex-1 bg-primary transition-all',
+        indicatorClassName
+      )}
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
+
+export { Progress };

--- a/frontend/src/components/user/upload-progress-dialog.tsx
+++ b/frontend/src/components/user/upload-progress-dialog.tsx
@@ -1,0 +1,145 @@
+import { CheckCircle2, AlertCircle, Loader2, FileText } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Progress } from '@/components/ui/progress';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { UploadProgressState } from '@/hooks/api/use-users';
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(value >= 10 || unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+interface UploadProgressDialogProps {
+  progress: UploadProgressState;
+  /** Called when the dialog is dismissed (only possible once not uploading). */
+  onClose: () => void;
+}
+
+export function UploadProgressDialog({
+  progress,
+  onClose,
+}: UploadProgressDialogProps) {
+  const { phase, percent, fileName, fileSize, errorMessage } = progress;
+  const open = phase !== 'idle';
+  const isUploading = phase === 'uploading';
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // Block dismissal while the upload is in flight.
+        if (!next && !isUploading) onClose();
+      }}
+    >
+      <DialogContent
+        // Radix focuses the panel on open; with no focusable control inside during
+        // upload, the browser's focus outline would show — suppress it here.
+        // Also hide the close (X) button while uploading so the transfer isn't interrupted.
+        className={cn(
+          'outline-none focus:outline-none focus-visible:outline-none',
+          isUploading && '[&>button:last-of-type]:hidden'
+        )}
+        onEscapeKeyDown={(e) => isUploading && e.preventDefault()}
+        onInteractOutside={(e) => isUploading && e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>
+            {phase === 'success'
+              ? 'Upload complete'
+              : phase === 'error'
+                ? 'Upload failed'
+                : 'Uploading Apple Health XML'}
+          </DialogTitle>
+          <DialogDescription>
+            {phase === 'success'
+              ? 'The file was uploaded. Processing will continue in the background.'
+              : phase === 'error'
+                ? 'The file could not be uploaded.'
+                : 'Keep this tab open until the upload finishes.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex items-start gap-3 rounded-lg border border-border/60 bg-muted/40 p-3">
+          <FileText className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-foreground">
+              {fileName ?? 'File'}
+            </p>
+            {fileSize !== null && (
+              <p className="text-xs text-muted-foreground">
+                {formatBytes(fileSize)}
+              </p>
+            )}
+          </div>
+          <StatusIcon phase={phase} />
+        </div>
+
+        {phase === 'error' ? (
+          <p className="text-sm text-destructive">
+            {errorMessage ?? 'Something went wrong during the upload.'}
+          </p>
+        ) : (
+          <div className="space-y-2">
+            <Progress
+              value={percent}
+              className="h-2 bg-white/10"
+              indicatorClassName={cn(
+                'transition-all',
+                phase === 'success' ? 'bg-emerald-400/90' : 'bg-foreground'
+              )}
+            />
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>
+                {phase === 'success'
+                  ? 'Done'
+                  : fileSize !== null
+                    ? `${formatBytes((fileSize * percent) / 100)} of ${formatBytes(fileSize)}`
+                    : 'Uploading…'}
+              </span>
+              <span className="tabular-nums">{percent}%</span>
+            </div>
+          </div>
+        )}
+
+        {!isUploading && (
+          <DialogFooter>
+            <Button
+              variant={phase === 'error' ? 'secondary' : 'default'}
+              onClick={onClose}
+            >
+              {phase === 'error' ? 'Close' : 'Done'}
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function StatusIcon({ phase }: { phase: UploadProgressState['phase'] }) {
+  if (phase === 'success') {
+    return <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-400/90" />;
+  }
+  if (phase === 'error') {
+    return <AlertCircle className="h-5 w-5 shrink-0 text-destructive" />;
+  }
+  return (
+    <Loader2 className="h-5 w-5 shrink-0 animate-spin text-muted-foreground" />
+  );
+}

--- a/frontend/src/hooks/api/use-users.ts
+++ b/frontend/src/hooks/api/use-users.ts
@@ -152,8 +152,15 @@ export function useUploadAppleXml() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ userId, file }: { userId: string; file: File }) =>
-      usersService.uploadAppleXml(userId, file),
+    mutationFn: ({
+      userId,
+      file,
+      onProgress,
+    }: {
+      userId: string;
+      file: File;
+      onProgress?: (percent: number) => void;
+    }) => usersService.uploadAppleXml(userId, file, onProgress),
     onSuccess: (_data, { userId }) => {
       // Invalidate user data to show new imported data
       queryClient.invalidateQueries({
@@ -177,7 +184,15 @@ export function useUploadAppleXmlViaS3() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ userId, file }: { userId: string; file: File }) => {
+    mutationFn: async ({
+      userId,
+      file,
+      onProgress,
+    }: {
+      userId: string;
+      file: File;
+      onProgress?: (percent: number) => void;
+    }) => {
       // Step 1: Get presigned URL from backend
       const presignedData = await usersService.getAppleXmlPresignedUrl(userId, {
         filename: file.name,
@@ -188,7 +203,8 @@ export function useUploadAppleXmlViaS3() {
       await usersService.uploadToS3(
         presignedData.upload_url,
         presignedData.form_fields,
-        file
+        file,
+        onProgress
       );
 
       return presignedData;
@@ -221,16 +237,39 @@ interface UseAppleXmlUploadOptions {
   onError?: (error: Error) => void;
 }
 
+export type UploadPhase = 'idle' | 'uploading' | 'success' | 'error';
+
+export interface UploadProgressState {
+  phase: UploadPhase;
+  /** 0-100 during upload; 100 on success. */
+  percent: number;
+  fileName: string | null;
+  fileSize: number | null;
+  errorMessage: string | null;
+}
+
+const IDLE_PROGRESS: UploadProgressState = {
+  phase: 'idle',
+  percent: 0,
+  fileName: null,
+  fileSize: null,
+  errorMessage: null,
+};
+
 /**
  * Custom hook for handling Apple Health XML file uploads
  * Automatically selects between direct upload and S3 based on file size
- * Includes file type and size validation
+ * Includes file type and size validation, and exposes live upload progress
+ * for a progress dialog.
  */
 export function useAppleXmlUpload(options: UseAppleXmlUploadOptions = {}) {
   const [uploadingUserId, setUploadingUserId] = useState<string | null>(null);
+  const [progress, setProgress] = useState<UploadProgressState>(IDLE_PROGRESS);
 
   const { mutate: uploadDirect } = useUploadAppleXml();
   const { mutate: uploadViaS3 } = useUploadAppleXmlViaS3();
+
+  const resetProgress = () => setProgress(IDLE_PROGRESS);
 
   const handleUpload = (
     userId: string,
@@ -269,20 +308,36 @@ export function useAppleXmlUpload(options: UseAppleXmlUploadOptions = {}) {
     }
 
     setUploadingUserId(userId);
+    setProgress({
+      phase: 'uploading',
+      percent: 0,
+      fileName: file.name,
+      fileSize: file.size,
+      errorMessage: null,
+    });
+
+    const onProgress = (percent: number) =>
+      setProgress((prev) => ({ ...prev, percent }));
 
     // Choose upload method based on file size
     const uploadMutation =
       file.size > S3_UPLOAD_THRESHOLD ? uploadViaS3 : uploadDirect;
 
     uploadMutation(
-      { userId, file },
+      { userId, file, onProgress },
       {
         onSuccess: () => {
+          setProgress((prev) => ({ ...prev, phase: 'success', percent: 100 }));
           if (options.onSuccess) {
             options.onSuccess(userId);
           }
         },
         onError: (error) => {
+          setProgress((prev) => ({
+            ...prev,
+            phase: 'error',
+            errorMessage: (error as Error).message,
+          }));
           if (options.onError) {
             options.onError(error as Error);
           }
@@ -298,5 +353,7 @@ export function useAppleXmlUpload(options: UseAppleXmlUploadOptions = {}) {
     handleUpload,
     uploadingUserId,
     isUploading: (userId: string) => uploadingUserId === userId,
+    progress,
+    resetProgress,
   };
 }

--- a/frontend/src/lib/api/services/users.service.ts
+++ b/frontend/src/lib/api/services/users.service.ts
@@ -1,5 +1,6 @@
 import { apiClient } from '../client';
-import { API_ENDPOINTS } from '../config';
+import { API_ENDPOINTS, API_CONFIG } from '../config';
+import { getToken } from '@/lib/auth/session';
 import { appendSearchParams } from '@/lib/utils/url';
 import type {
   UserRead,
@@ -52,13 +53,31 @@ export const usersService = {
     return apiClient.delete<void>(API_ENDPOINTS.userDetail(id));
   },
 
-  async uploadAppleXml(userId: string, file: File): Promise<void> {
+  async uploadAppleXml(
+    userId: string,
+    file: File,
+    onProgress?: (percent: number) => void
+  ): Promise<void> {
     const formData = new FormData();
     formData.append('file', file);
-    return apiClient.postMultipart<void>(
-      API_ENDPOINTS.userAppleXmlImport(userId),
-      formData
-    );
+
+    // Without a progress callback, keep the shared fetch path (401 handling, retries).
+    if (!onProgress) {
+      return apiClient.postMultipart<void>(
+        API_ENDPOINTS.userAppleXmlImport(userId),
+        formData
+      );
+    }
+
+    const token = getToken();
+    const url = `${API_CONFIG.baseUrl}${API_ENDPOINTS.userAppleXmlImport(userId)}`;
+    const { status, statusText } = await uploadWithProgress(url, formData, {
+      onProgress,
+      headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+    });
+    if (status < 200 || status >= 300) {
+      throw new Error(`Upload failed (${status} ${statusText})`);
+    }
   },
 
   async getAppleXmlPresignedUrl(
@@ -74,11 +93,12 @@ export const usersService = {
   async uploadToS3(
     uploadUrl: string,
     formFields: Record<string, string>,
-    file: File
+    file: File,
+    onProgress?: (percent: number) => void
   ): Promise<void> {
     const formData = new FormData();
 
-    // Add all form fields first (AWS requires these before the file)
+    // Add all form fields first (S3 requires these before the file)
     Object.entries(formFields).forEach(([key, value]) => {
       formData.append(key, value);
     });
@@ -86,14 +106,18 @@ export const usersService = {
     // Add the file last
     formData.append('file', file);
 
-    // Upload directly to S3 (no auth needed, using presigned URL)
-    const response = await fetch(uploadUrl, {
-      method: 'POST',
-      body: formData,
-    });
+    // Upload directly to S3 (no auth needed, using presigned URL). XHR is used
+    // instead of fetch so upload progress can be reported.
+    const { status, statusText } = await uploadWithProgress(
+      uploadUrl,
+      formData,
+      {
+        onProgress,
+      }
+    );
 
-    if (!response.ok) {
-      throw new Error(`S3 upload failed: ${response.statusText}`);
+    if (status < 200 || status >= 300) {
+      throw new Error(`S3 upload failed: ${status} ${statusText}`);
     }
   },
 
@@ -102,3 +126,51 @@ export const usersService = {
     return apiClient.post<InvitationCode>(endpoint, null);
   },
 };
+
+interface UploadWithProgressOptions {
+  onProgress?: (percent: number) => void;
+  headers?: Record<string, string>;
+}
+
+/**
+ * POST a FormData body via XMLHttpRequest so upload progress can be reported.
+ * `fetch` cannot observe request-body upload progress, which is why this exists.
+ * Resolves with the final status even for 4xx/5xx — callers decide how to react.
+ */
+function uploadWithProgress(
+  url: string,
+  formData: FormData,
+  { onProgress, headers }: UploadWithProgressOptions = {}
+): Promise<{ status: number; statusText: string }> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', url);
+
+    if (headers) {
+      Object.entries(headers).forEach(([key, value]) => {
+        xhr.setRequestHeader(key, value);
+      });
+    }
+
+    if (onProgress) {
+      xhr.upload.addEventListener('progress', (event) => {
+        if (event.lengthComputable) {
+          onProgress(Math.round((event.loaded / event.total) * 100));
+        }
+      });
+    }
+
+    xhr.addEventListener('load', () => {
+      resolve({ status: xhr.status, statusText: xhr.statusText });
+    });
+    xhr.addEventListener('error', () =>
+      reject(new Error('Network error during upload'))
+    );
+    xhr.addEventListener('abort', () => reject(new Error('Upload cancelled')));
+    xhr.addEventListener('timeout', () =>
+      reject(new Error('Upload timed out'))
+    );
+
+    xhr.send(formData);
+  });
+}

--- a/frontend/src/lib/api/services/users.service.ts
+++ b/frontend/src/lib/api/services/users.service.ts
@@ -1,6 +1,7 @@
 import { apiClient } from '../client';
 import { API_ENDPOINTS, API_CONFIG } from '../config';
-import { getToken } from '@/lib/auth/session';
+import { getToken, clearSession } from '@/lib/auth/session';
+import { DEFAULT_REDIRECTS } from '@/lib/constants/routes';
 import { appendSearchParams } from '@/lib/utils/url';
 import type {
   UserRead,
@@ -74,6 +75,8 @@ export const usersService = {
     const { status, statusText } = await uploadWithProgress(url, formData, {
       onProgress,
       headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+      // This hits our authenticated backend, so treat a 401 like apiClient does.
+      handleUnauthorized: true,
     });
     if (status < 200 || status >= 300) {
       throw new Error(`Upload failed (${status} ${statusText})`);
@@ -130,17 +133,24 @@ export const usersService = {
 interface UploadWithProgressOptions {
   onProgress?: (percent: number) => void;
   headers?: Record<string, string>;
+  /**
+   * When true, a 401 clears the session and redirects to login — mirroring
+   * `apiClient`. Only enable for requests to our own authenticated backend;
+   * a 401/403 from a presigned S3/MinIO URL is not an app-auth failure.
+   */
+  handleUnauthorized?: boolean;
 }
 
 /**
  * POST a FormData body via XMLHttpRequest so upload progress can be reported.
  * `fetch` cannot observe request-body upload progress, which is why this exists.
- * Resolves with the final status even for 4xx/5xx — callers decide how to react.
+ * Resolves with the final status even for 4xx/5xx — callers decide how to react,
+ * except a 401 with `handleUnauthorized` which triggers the shared re-login flow.
  */
 function uploadWithProgress(
   url: string,
   formData: FormData,
-  { onProgress, headers }: UploadWithProgressOptions = {}
+  { onProgress, headers, handleUnauthorized }: UploadWithProgressOptions = {}
 ): Promise<{ status: number; statusText: string }> {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
@@ -161,6 +171,14 @@ function uploadWithProgress(
     }
 
     xhr.addEventListener('load', () => {
+      if (handleUnauthorized && xhr.status === 401) {
+        clearSession();
+        if (typeof window !== 'undefined') {
+          window.location.href = DEFAULT_REDIRECTS.unauthenticated;
+        }
+        reject(new Error('Session expired — please sign in again.'));
+        return;
+      }
       resolve({ status: xhr.status, statusText: xhr.statusText });
     });
     xhr.addEventListener('error', () =>

--- a/frontend/src/lib/constants/upload.ts
+++ b/frontend/src/lib/constants/upload.ts
@@ -1,6 +1,6 @@
 /**
  * File upload configuration constants
- * These match the backend limits defined in backend/app/schemas/apple/apple_xml/aws.py
+ * These match the backend limits defined in backend/app/schemas/providers/apple/apple_xml/aws.py
  */
 
 /**
@@ -14,4 +14,4 @@ export const S3_UPLOAD_THRESHOLD = 10 * 1024 * 1024; // 10MB
  * Maximum file size allowed for uploads
  * Matches backend MAX_FILE_SIZE limit
  */
-export const MAX_FILE_SIZE = 1024 * 1024 * 1024; // 1GB
+export const MAX_FILE_SIZE = 5 * 1024 * 1024 * 1024; // 5GiB (S3 presigned POST ceiling for a single upload)

--- a/frontend/src/routes/_authenticated/users/$userId.tsx
+++ b/frontend/src/routes/_authenticated/users/$userId.tsx
@@ -31,6 +31,7 @@ import { API_CONFIG } from '@/lib/api/config';
 import { copyToClipboard } from '@/lib/utils/clipboard';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { ProfileSection } from '@/components/user/profile-section';
+import { UploadProgressDialog } from '@/components/user/upload-progress-dialog';
 import { SleepSection } from '@/components/user/sleep-section';
 import { ActivitySection } from '@/components/user/activity-section';
 import { BodySection } from '@/components/user/body-section';
@@ -101,7 +102,12 @@ function UserDetailPage() {
     useState<DateRangeValue>(90);
 
   const { mutate: deleteUser, isPending: isDeleting } = useDeleteUser();
-  const { handleUpload, isUploading: isUploadingFile } = useAppleXmlUpload();
+  const {
+    handleUpload,
+    isUploading: isUploadingFile,
+    progress: uploadProgress,
+    resetProgress,
+  } = useAppleXmlUpload();
   const {
     mutate: generateInvitationCode,
     data: invitationCodeData,
@@ -338,6 +344,10 @@ function UserDetailPage() {
             accept=".xml"
             onChange={(e) => handleUpload(userId, e)}
             className="hidden"
+          />
+          <UploadProgressDialog
+            progress={uploadProgress}
+            onClose={resetProgress}
           />
           <AlertDialog
             open={isDeleteDialogOpen}


### PR DESCRIPTION
## Description

Frontend and backend enforced a 1 GiB cap on Apple Health XML uploads, while the API docs stated 500 MB — and a user needs to import a ~4 GB export (#1413). This raises the maximum to **5 GiB**, the ceiling for a single S3 presigned POST, so large exports upload without needing multipart. It also aligns the docs and the stale `500MB`/`1GB` code comments with the real value, and fixes an outdated backend-schema path referenced from the frontend constants.

**Changes**
- `MAX_FILE_SIZE`: `1 GiB` → `5 GiB` — enforced by the backend `PresignedURLRequest.max_file_size` `le=` bound and the frontend upload validation
- Backend field description and API docs now read `1KB - 5GiB`
- No change to the 50 MB default `max_file_size` or the 10 MB direct-vs-S3 routing threshold

Closes #1413

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable) <!-- N/A: constant/bound change; existing presigned-URL tests still cover the endpoint -->
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes <!-- run locally before merge -->

### Frontend Changes

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

## Testing Instructions

**Steps to test:**
1. On a user's detail page, use the **Upload Apple Health XML** action and select an export larger than 1 GiB (up to 5 GiB).
2. Confirm it is accepted — the previous `File is too large … Maximum size is 1GB` rejection no longer fires.
3. Try a file larger than 5 GiB and confirm it is still rejected against the new limit.
4. (API) `POST /api/v1/users/{user_id}/import/apple/xml/s3` now accepts `max_file_size` up to `5368709120`; a value above that returns a 422.

**Expected behavior:**

Files up to 5 GiB are accepted end to end; the presigned POST's `content-length-range` upper bound reflects the requested size. Behavior for files ≤ 1 GiB is unchanged.

## Screenshots

<img width="1353" height="808" alt="Screenshot 2026-08-14 at 12 29 55" src="https://github.com/user-attachments/assets/a9773f92-28b8-4001-a5b4-656a96c3cdef" />

## Additional Notes

5 GiB is the hard limit for a single S3 presigned POST; anything larger would require multipart uploads as explained in [Amazon S3 multipart upload limits](https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html), which is out of scope here. Full suite verified locally before opening: backend `pytest` (1995 passed, 2 skipped) and frontend `vitest` (12 passed), plus `lint`/`format:check`/`build`. The `pre-commit` hook still needs to be run in a local shell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Apple Health XML uploads now display real-time progress, file details, transfer status, and success or error messages.
  - Upload progress can be dismissed after completion, while active uploads prevent accidental closure.
- **Improvements**
  - Supported Apple Health XML file size increased to 5 GiB.
  - Progress tracking now works for both standard and S3-based uploads.
- **Documentation**
  - Updated upload size guidance to reflect the new 5 GiB limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->