### PR TITLE
fix(integrations): retry Strava stream ingestion when the webhook precedes stream processing

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -4,14 +4,14 @@ import warnings
 from datetime import timedelta
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 from urllib.parse import quote
 
 if TYPE_CHECKING:
     from app.schemas.enums import ProviderName
 
 from pydantic import AnyHttpUrl, Field, SecretStr, ValidationInfo, field_validator, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from app.utils.config_utils import (
     EncryptedField,
@@ -97,6 +97,12 @@ class Settings(BaseSettings):
     # Pre-0.4.2 behaviour. Set to false once your integration calls /sync/historical explicitly.
     # Will default to false in a future release.
     historical_sync_on_connect: bool = True
+
+    # Delayed-retry backoff for Strava per-sample stream ingestion when the activity
+    # webhook precedes Strava's stream processing. One retry per entry, seconds after
+    # the previous attempt; the list length is the attempt budget. Env accepts JSON
+    # ("[300, 900, 2700]") or a comma-separated string ("300,900,2700").
+    strava_stream_retry_countdown_seconds: Annotated[list[int], NoDecode] = [300, 900, 2700]
 
     # Whether to ingest per-second workout samples (speed, cadence, power, GPS, etc.) into
     # data_point_series on workout webhook arrival. Significantly increases DB storage.
@@ -248,6 +254,20 @@ class Settings(BaseSettings):
 
         # This should never be reached given the type annotation, but ensures type safety
         raise ValueError(f"Unexpected type for cors_origins: {type(v)}")
+
+    @field_validator("strava_stream_retry_countdown_seconds", mode="before")
+    @classmethod
+    def _parse_stream_retry_countdowns(cls, v: Any) -> Any:
+        # NoDecode disables pydantic-settings' JSON pre-parse; accept JSON or a
+        # plain comma-separated env value ("300,900,2700").
+        if isinstance(v, str):
+            stripped = v.strip()
+            if stripped.startswith("["):
+                import json
+
+                return json.loads(stripped)
+            return [int(part) for part in stripped.split(",") if part.strip()]
+        return v
 
     @field_validator("pull_sync_lookback", mode="before")
     @classmethod

--- a/backend/app/integrations/celery/tasks/__init__.py
+++ b/backend/app/integrations/celery/tasks/__init__.py
@@ -43,6 +43,7 @@ from .register_provider_webhooks_task import register_provider_webhooks
 from .renew_oura_webhooks_task import renew_oura_webhooks
 from .seed_data_task import generate_seed_data
 from .send_email_task import send_invitation_email_task
+from .strava_stream_retry_task import retry_strava_stream_ingest
 from .sync_vendor_data_task import sync_vendor_data
 from .webhook_push_task import process_webhook_push
 
@@ -72,6 +73,7 @@ __all__ = [
     "process_xml_upload",
     "sync_vendor_data",
     "sync_all_users",
+    "retry_strava_stream_ingest",
     "generate_seed_data",
     "send_invitation_email_task",
     "process_webhook_push",

--- a/backend/app/integrations/celery/tasks/strava_stream_retry_task.py
+++ b/backend/app/integrations/celery/tasks/strava_stream_retry_task.py
@@ -18,7 +18,6 @@ from celery import shared_task
 
 from app.database import DbSession, SessionLocal
 from app.schemas.providers.strava import ActivityJSON as StravaActivityJSON
-from app.services.providers.factory import ProviderFactory
 from app.services.timeseries_service import timeseries_service
 from app.utils.sentry_helpers import log_and_capture_error
 from app.utils.structured_logging import log_structured
@@ -37,10 +36,18 @@ def retry_strava_stream_ingest(user_id: str, activity_id: str, attempt: int = 1)
         with SessionLocal() as db:
             _retry_ingest(db, UUID(user_id), str(activity_id), attempt)
     except Exception as e:
+        # A transient failure (detail fetch, token refresh, DB hiccup) must not
+        # end the retry sequence — keep rescheduling until MAX_ATTEMPTS.
         log_and_capture_error(e, logger, "Strava stream retry failed", extra={"activity_id": activity_id})
+        if attempt < MAX_ATTEMPTS:
+            schedule_stream_retry(user_id, str(activity_id), attempt + 1)
 
 
 def _retry_ingest(db: DbSession, user_uuid: UUID, activity_id: str, attempt: int) -> None:
+    # Imported lazily: factory -> strategies -> strava modules; a module-level
+    # import here would participate in that cycle via the tasks package init.
+    from app.services.providers.factory import ProviderFactory
+
     workouts = ProviderFactory().get_provider("strava").workouts
     record = workouts.workout_repo.get_by_external_id(db, user_uuid, activity_id, source="strava")
     if record is None:

--- a/backend/app/integrations/celery/tasks/strava_stream_retry_task.py
+++ b/backend/app/integrations/celery/tasks/strava_stream_retry_task.py
@@ -1,0 +1,122 @@
+"""Delayed retry for Strava per-sample stream ingestion.
+
+Strava fires the activity webhook seconds after upload, before stream
+processing on their side has finished — the immediate /streams fetch in the
+webhook path then comes back empty and the workout is saved without samples.
+The hourly pull can't repair it either: the webhook bumps last_synced_at past
+the activity's start time, so the pull window never re-covers the workout.
+
+This task re-fetches the streams a few minutes later, when Strava has
+finished processing. It is idempotent (skips if samples already exist) and
+self-limits to MAX_ATTEMPTS.
+"""
+
+from logging import getLogger
+from uuid import UUID
+
+from celery import shared_task
+
+from app.database import DbSession, SessionLocal
+from app.schemas.providers.strava import ActivityJSON as StravaActivityJSON
+from app.services.providers.factory import ProviderFactory
+from app.services.timeseries_service import timeseries_service
+from app.utils.sentry_helpers import log_and_capture_error
+from app.utils.structured_logging import log_structured
+
+logger = getLogger(__name__)
+
+MAX_ATTEMPTS = 3
+# Backoff between attempts, seconds: webhook +5min, then +15min, then +45min.
+RETRY_COUNTDOWNS = {1: 300, 2: 900, 3: 2700}
+
+
+@shared_task
+def retry_strava_stream_ingest(user_id: str, activity_id: str, attempt: int = 1) -> None:
+    """Fetch and persist streams for an already-saved Strava workout."""
+    try:
+        with SessionLocal() as db:
+            _retry_ingest(db, UUID(user_id), str(activity_id), attempt)
+    except Exception as e:
+        log_and_capture_error(e, logger, "Strava stream retry failed", extra={"activity_id": activity_id})
+
+
+def _retry_ingest(db: DbSession, user_uuid: UUID, activity_id: str, attempt: int) -> None:
+    workouts = ProviderFactory().get_provider("strava").workouts
+    record = workouts.workout_repo.get_by_external_id(db, user_uuid, activity_id, source="strava")
+    if record is None:
+        log_structured(
+            logger,
+            "warning",
+            "Strava stream retry: workout no longer exists, giving up",
+            provider="strava",
+            action="stream_retry_no_record",
+            activity_id=activity_id,
+        )
+        return
+
+    if record.end_datetime is not None and timeseries_service.has_samples_in_range(
+        db, user_uuid, "strava", record.start_datetime, record.end_datetime
+    ):
+        log_structured(
+            logger,
+            "info",
+            "Strava stream retry: samples already ingested, nothing to do",
+            provider="strava",
+            action="stream_retry_already_done",
+            activity_id=activity_id,
+        )
+        return
+
+    activity_data = workouts.get_workout_detail_from_api(db, user_uuid, activity_id)
+    ingested = 0
+    if activity_data:
+        activity = StravaActivityJSON(**activity_data)
+        record_create, _ = workouts._normalize_workout(activity, user_uuid)
+        ingested = workouts._ingest_workout_streams(db, activity, user_uuid, record_create)
+
+    if ingested > 0:
+        db.commit()
+        log_structured(
+            logger,
+            "info",
+            "Strava stream retry: ingested samples",
+            provider="strava",
+            action="stream_retry_success",
+            activity_id=activity_id,
+            sample_count=ingested,
+            attempt=attempt,
+        )
+        return
+
+    if attempt >= MAX_ATTEMPTS:
+        log_structured(
+            logger,
+            "warning",
+            "Strava stream retry: still no streams after final attempt, giving up",
+            provider="strava",
+            action="stream_retry_exhausted",
+            activity_id=activity_id,
+            attempt=attempt,
+        )
+        return
+
+    schedule_stream_retry(str(user_uuid), activity_id, attempt + 1)
+
+
+def schedule_stream_retry(user_id: str, activity_id: str, attempt: int) -> None:
+    """Schedule a (re)try with the attempt's backoff."""
+    countdown = RETRY_COUNTDOWNS.get(attempt, RETRY_COUNTDOWNS[MAX_ATTEMPTS])
+    retry_strava_stream_ingest.apply_async(
+        kwargs={"user_id": user_id, "activity_id": activity_id, "attempt": attempt},
+        countdown=countdown,
+    )
+    log_structured(
+        logger,
+        "info",
+        "Strava streams not ready; scheduled delayed ingest",
+        provider="strava",
+        action="stream_retry_scheduled",
+        activity_id=activity_id,
+        attempt=attempt,
+        countdown_seconds=countdown,
+    )

--- a/backend/app/integrations/celery/tasks/strava_stream_retry_task.py
+++ b/backend/app/integrations/celery/tasks/strava_stream_retry_task.py
@@ -6,9 +6,12 @@ webhook path then comes back empty and the workout is saved without samples.
 The hourly pull can't repair it either: the webhook bumps last_synced_at past
 the activity's start time, so the pull window never re-covers the workout.
 
-This task re-fetches the streams a few minutes later, when Strava has
-finished processing. It is idempotent (skips if samples already exist) and
-self-limits to MAX_ATTEMPTS.
+This task simply re-runs the regular webhook processing flow
+(``get_workout_detail_from_api`` + ``process_push_activity``) a few minutes
+later, when Strava has finished processing. The flow is idempotent (workout
+upsert + skip-if-samples-exist guard) and re-schedules itself with backoff
+until samples land or the attempt budget (``len(settings.
+strava_stream_retry_countdown_seconds)``) is exhausted.
 """
 
 from logging import getLogger
@@ -16,103 +19,63 @@ from uuid import UUID
 
 from celery import shared_task
 
+from app.config import settings
 from app.database import DbSession, SessionLocal
 from app.schemas.providers.strava import ActivityJSON as StravaActivityJSON
-from app.services.timeseries_service import timeseries_service
 from app.utils.sentry_helpers import log_and_capture_error
 from app.utils.structured_logging import log_structured
 
 logger = getLogger(__name__)
 
-MAX_ATTEMPTS = 3
-# Backoff between attempts, seconds: webhook +5min, then +15min, then +45min.
-RETRY_COUNTDOWNS = {1: 300, 2: 900, 3: 2700}
+
+def max_stream_retry_attempts() -> int:
+    """One attempt per configured countdown."""
+    return len(settings.strava_stream_retry_countdown_seconds)
 
 
 @shared_task
 def retry_strava_stream_ingest(user_id: str, activity_id: str, attempt: int = 1) -> None:
-    """Fetch and persist streams for an already-saved Strava workout."""
+    """Re-run the webhook processing flow for an activity whose streams weren't ready."""
     try:
         with SessionLocal() as db:
             _retry_ingest(db, UUID(user_id), str(activity_id), attempt)
     except Exception as e:
         # A transient failure (detail fetch, token refresh, DB hiccup) must not
-        # end the retry sequence — keep rescheduling until MAX_ATTEMPTS.
+        # end the retry sequence — keep rescheduling until the budget runs out.
         log_and_capture_error(e, logger, "Strava stream retry failed", extra={"activity_id": activity_id})
-        if attempt < MAX_ATTEMPTS:
+        if attempt < max_stream_retry_attempts():
             schedule_stream_retry(user_id, str(activity_id), attempt + 1)
 
 
 def _retry_ingest(db: DbSession, user_uuid: UUID, activity_id: str, attempt: int) -> None:
-    # Imported lazily: factory -> strategies -> strava modules; a module-level
-    # import here would participate in that cycle via the tasks package init.
+    # Imported lazily: factory -> strategies -> strava.workouts imports this
+    # module for schedule_stream_retry, so a module-level import would cycle.
     from app.services.providers.factory import ProviderFactory
 
     workouts = ProviderFactory().get_provider("strava").workouts
-    record = workouts.workout_repo.get_by_external_id(db, user_uuid, activity_id, source="strava")
-    if record is None:
-        log_structured(
-            logger,
-            "warning",
-            "Strava stream retry: workout no longer exists, giving up",
-            provider="strava",
-            action="stream_retry_no_record",
-            activity_id=activity_id,
-        )
-        return
-
-    if record.end_datetime is not None and timeseries_service.has_samples_in_range(
-        db, user_uuid, "strava", record.start_datetime, record.end_datetime
-    ):
-        log_structured(
-            logger,
-            "info",
-            "Strava stream retry: samples already ingested, nothing to do",
-            provider="strava",
-            action="stream_retry_already_done",
-            activity_id=activity_id,
-        )
-        return
-
     activity_data = workouts.get_workout_detail_from_api(db, user_uuid, activity_id)
-    ingested = 0
-    if activity_data:
-        activity = StravaActivityJSON(**activity_data)
-        record_create, _ = workouts._normalize_workout(activity, user_uuid)
-        ingested = workouts._ingest_workout_streams(db, activity, user_uuid, record_create)
-
-    if ingested > 0:
-        db.commit()
-        log_structured(
-            logger,
-            "info",
-            "Strava stream retry: ingested samples",
-            provider="strava",
-            action="stream_retry_success",
-            activity_id=activity_id,
-            sample_count=ingested,
-            attempt=attempt,
-        )
-        return
-
-    if attempt >= MAX_ATTEMPTS:
+    if not activity_data:
         log_structured(
             logger,
             "warning",
-            "Strava stream retry: still no streams after final attempt, giving up",
+            "Strava stream retry: no data returned for activity, giving up",
             provider="strava",
-            action="stream_retry_exhausted",
+            action="stream_retry_no_activity",
             activity_id=activity_id,
-            attempt=attempt,
         )
         return
 
-    schedule_stream_retry(str(user_uuid), activity_id, attempt + 1)
+    activity = StravaActivityJSON(**activity_data)
+    # The regular webhook flow: upserts the workout (idempotent), ingests streams
+    # with the skip-if-samples-exist guard, and — when streams are still not
+    # ready — schedules the next attempt itself (or logs exhaustion).
+    workouts.process_push_activity(db=db, activity=activity, user_id=user_uuid, stream_retry_attempt=attempt + 1)
 
 
 def schedule_stream_retry(user_id: str, activity_id: str, attempt: int) -> None:
-    """Schedule a (re)try with the attempt's backoff."""
-    countdown = RETRY_COUNTDOWNS.get(attempt, RETRY_COUNTDOWNS[MAX_ATTEMPTS])
+    """Schedule attempt N with its configured backoff."""
+    countdowns = settings.strava_stream_retry_countdown_seconds
+    countdown = countdowns[min(attempt, len(countdowns)) - 1]
     retry_strava_stream_ingest.apply_async(
         kwargs={"user_id": user_id, "activity_id": activity_id, "attempt": attempt},
         countdown=countdown,

--- a/backend/app/repositories/data_point_series_repository.py
+++ b/backend/app/repositories/data_point_series_repository.py
@@ -336,6 +336,27 @@ class DataPointSeriesRepository(
         limit = params.limit or 50
         return query.limit(limit + 1).all(), total_count  # ty:ignore[invalid-return-type]
 
+    def has_samples_in_range(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        source: str,
+        start_datetime: datetime,
+        end_datetime: datetime,
+    ) -> bool:
+        """Whether any sample from `source` exists for the user in [start, end)."""
+        query = (
+            db_session.query(self.model.id)
+            .join(DataSource, self.model.data_source_id == DataSource.id)
+            .filter(
+                DataSource.user_id == user_id,
+                DataSource.source == source,
+                self.model.recorded_at >= start_datetime,
+                self.model.recorded_at < end_datetime,
+            )
+        )
+        return bool(db_session.query(query.exists()).scalar())
+
     def get_total_count(self, db_session: DbSession) -> int:
         """Get total count of all data points."""
         return db_session.query(func.count(self.model.id)).scalar() or 0

--- a/backend/app/services/providers/strava/workouts.py
+++ b/backend/app/services/providers/strava/workouts.py
@@ -309,6 +309,19 @@ class StravaWorkouts(BaseWorkoutsTemplate):
         """Fetch + persist per-sample streams on workout arrival, flag-gated and failure-isolated."""
         if not settings.ingest_workout_samples:
             return 0
+        # Workouts are re-upserted whenever a sync window re-covers them (webhook
+        # arrival followed by the periodic pull is the common case). Streams are
+        # immutable once the activity is uploaded, so if samples already exist in
+        # the workout window skip the extra API call instead of re-fetching and
+        # re-upserting identical rows.
+        if record.end_datetime is not None and timeseries_service.has_samples_in_range(
+            db,
+            user_id,
+            "strava",
+            record.start_datetime,
+            record.end_datetime,
+        ):
+            return 0
         try:
             samples = self._build_workout_samples(
                 db,

--- a/backend/app/services/providers/strava/workouts.py
+++ b/backend/app/services/providers/strava/workouts.py
@@ -460,6 +460,10 @@ class StravaWorkouts(BaseWorkoutsTemplate):
                 db, user_id, "strava", record.start_datetime, record.end_datetime
             )
         ):
+            # Imported lazily: importing any module under the celery tasks package
+            # triggers tasks/__init__, which imports tasks that import the provider
+            # factory — and the factory imports this module (same pattern as
+            # outgoing_webhooks/events._dispatch).
             from app.integrations.celery.tasks.strava_stream_retry_task import schedule_stream_retry
 
             schedule_stream_retry(str(user_id), str(activity.id), attempt=1)

--- a/backend/app/services/providers/strava/workouts.py
+++ b/backend/app/services/providers/strava/workouts.py
@@ -427,6 +427,8 @@ class StravaWorkouts(BaseWorkoutsTemplate):
         db: DbSession,
         activity: StravaActivityJSON,
         user_id: UUID,
+        *,
+        stream_retry_attempt: int = 1,
     ) -> list[UUID]:
         """Process a single activity from webhook and save to database.
 
@@ -434,6 +436,9 @@ class StravaWorkouts(BaseWorkoutsTemplate):
             db: Database session
             activity: Parsed Strava activity data
             user_id: Internal user ID (already mapped from Strava athlete ID)
+            stream_retry_attempt: which delayed stream-ingest attempt to schedule
+                if streams are still empty (1 on the webhook path; the retry task
+                passes attempt+1 so the backoff chain terminates)
 
         Returns:
             List of created event record IDs
@@ -464,8 +469,21 @@ class StravaWorkouts(BaseWorkoutsTemplate):
             # triggers tasks/__init__, which imports tasks that import the provider
             # factory — and the factory imports this module (same pattern as
             # outgoing_webhooks/events._dispatch).
-            from app.integrations.celery.tasks.strava_stream_retry_task import schedule_stream_retry
+            from app.integrations.celery.tasks.strava_stream_retry_task import (
+                max_stream_retry_attempts,
+                schedule_stream_retry,
+            )
 
-            schedule_stream_retry(str(user_id), str(activity.id), attempt=1)
+            if stream_retry_attempt <= max_stream_retry_attempts():
+                schedule_stream_retry(str(user_id), str(activity.id), attempt=stream_retry_attempt)
+            else:
+                log_structured(
+                    self.logger,
+                    "warning",
+                    "Strava streams still empty after final retry, giving up",
+                    provider="strava",
+                    action="stream_retry_exhausted",
+                    activity_id=str(activity.id),
+                )
 
         return created_ids

--- a/backend/app/services/providers/strava/workouts.py
+++ b/backend/app/services/providers/strava/workouts.py
@@ -445,6 +445,23 @@ class StravaWorkouts(BaseWorkoutsTemplate):
         detail_for_record = detail.model_copy(update={"record_id": created_record.id})
         event_record_service.create_detail(db, detail_for_record)
         created_ids.append(created_record.id)
-        self._ingest_workout_streams(db, activity, user_id, record)
+        ingested = self._ingest_workout_streams(db, activity, user_id, record)
+
+        # Strava's webhook typically fires seconds after upload, before their
+        # stream processing finishes — the immediate fetch above then returns
+        # empty and, because the webhook bumps last_synced_at past the
+        # activity's start, the periodic pull never re-covers the workout.
+        # Schedule a delayed retry so the samples land once Strava is done.
+        if (
+            ingested == 0
+            and settings.ingest_workout_samples
+            and record.end_datetime is not None
+            and not timeseries_service.has_samples_in_range(
+                db, user_id, "strava", record.start_datetime, record.end_datetime
+            )
+        ):
+            from app.integrations.celery.tasks.strava_stream_retry_task import schedule_stream_retry
+
+            schedule_stream_retry(str(user_id), str(activity.id), attempt=1)
 
         return created_ids

--- a/backend/app/services/timeseries_service.py
+++ b/backend/app/services/timeseries_service.py
@@ -70,6 +70,17 @@ class TimeSeriesService(
 
         return counts
 
+    def has_samples_in_range(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        source: str,
+        start_datetime: datetime,
+        end_datetime: datetime,
+    ) -> bool:
+        """Whether any sample from `source` already exists for the user in [start, end)."""
+        return self.crud.has_samples_in_range(db_session, user_id, source, start_datetime, end_datetime)
+
     @staticmethod
     def _emit_timeseries_webhooks(
         samples: list[TimeSeriesSampleCreate] | list[HeartRateSampleCreate] | list[StepSampleCreate],

--- a/backend/tests/providers/strava/test_strava_stream_retry.py
+++ b/backend/tests/providers/strava/test_strava_stream_retry.py
@@ -2,8 +2,10 @@
 
 Covers the race where the activity webhook fires before Strava finishes
 processing streams: the immediate fetch returns empty, and a delayed retry
-task must be scheduled (and itself re-schedule with backoff until samples
-land or attempts are exhausted).
+must be scheduled. The retry task re-runs the regular webhook flow
+(get_workout_detail_from_api + process_push_activity), which re-schedules
+with backoff until samples land or the configured attempt budget
+(len(settings.strava_stream_retry_countdown_seconds)) is exhausted.
 """
 
 from unittest.mock import MagicMock, patch
@@ -11,9 +13,9 @@ from uuid import uuid4
 
 import pytest
 
+from app.config import settings
 from app.integrations.celery.tasks.strava_stream_retry_task import (
-    MAX_ATTEMPTS,
-    _retry_ingest,
+    max_stream_retry_attempts,
     retry_strava_stream_ingest,
     schedule_stream_retry,
 )
@@ -44,7 +46,13 @@ def workouts() -> StravaWorkouts:
 
 
 class TestWebhookSchedulesRetry:
-    def _process(self, workouts: StravaWorkouts, ingested: int, has_samples: bool) -> MagicMock:
+    def _process(
+        self,
+        workouts: StravaWorkouts,
+        ingested: int,
+        has_samples: bool,
+        attempt: int = 1,
+    ) -> MagicMock:
         user_id = uuid4()
         with (
             patch("app.services.providers.strava.workouts.event_record_service") as mock_service,
@@ -58,7 +66,9 @@ class TestWebhookSchedulesRetry:
         ):
             mock_settings.ingest_workout_samples = True
             mock_service.create.return_value = MagicMock(id=uuid4())
-            workouts.process_push_activity(db=MagicMock(), activity=_ACTIVITY, user_id=user_id)
+            workouts.process_push_activity(
+                db=MagicMock(), activity=_ACTIVITY, user_id=user_id, stream_retry_attempt=attempt
+            )
         return mock_schedule
 
     def test_empty_streams_schedule_delayed_retry(self, workouts: StravaWorkouts) -> None:
@@ -67,6 +77,10 @@ class TestWebhookSchedulesRetry:
         args, kwargs = mock_schedule.call_args
         assert str(_ACTIVITY.id) in args or kwargs.get("activity_id") == str(_ACTIVITY.id)
         assert kwargs.get("attempt", args[-1] if args else None) == 1
+
+    def test_retry_attempt_is_propagated(self, workouts: StravaWorkouts) -> None:
+        mock_schedule = self._process(workouts, ingested=0, has_samples=False, attempt=2)
+        assert mock_schedule.call_args.kwargs.get("attempt") == 2
 
     def test_no_retry_when_samples_ingested(self, workouts: StravaWorkouts) -> None:
         mock_schedule = self._process(workouts, ingested=4752, has_samples=True)
@@ -77,67 +91,41 @@ class TestWebhookSchedulesRetry:
         mock_schedule = self._process(workouts, ingested=0, has_samples=True)
         mock_schedule.assert_not_called()
 
+    def test_gives_up_after_attempt_budget(self, workouts: StravaWorkouts) -> None:
+        exhausted = max_stream_retry_attempts() + 1
+        mock_schedule = self._process(workouts, ingested=0, has_samples=False, attempt=exhausted)
+        mock_schedule.assert_not_called()
+
 
 class TestRetryTask:
-    def _run(
-        self,
-        record: MagicMock | None,
-        has_samples: bool,
-        ingested: int,
-        attempt: int,
-    ) -> tuple[MagicMock, MagicMock]:
-        user_id = uuid4()
+    """The task must reuse the regular workouts-module flow, not reimplement it."""
+
+    def _run(self, activity_data: dict | None, attempt: int = 1) -> MagicMock:
         mock_workouts = MagicMock()
-        mock_workouts.workout_repo.get_by_external_id.return_value = record
-        mock_workouts.get_workout_detail_from_api.return_value = _ACTIVITY.model_dump() if record else None
-        mock_workouts._normalize_workout.return_value = (MagicMock(), MagicMock())
-        mock_workouts._ingest_workout_streams.return_value = ingested
+        mock_workouts.get_workout_detail_from_api.return_value = activity_data
         mock_strategy = MagicMock(workouts=mock_workouts)
         with (
             patch("app.services.providers.factory.ProviderFactory") as mock_factory,
-            patch(
-                "app.integrations.celery.tasks.strava_stream_retry_task.timeseries_service.has_samples_in_range",
-                return_value=has_samples,
-            ),
-            patch("app.integrations.celery.tasks.strava_stream_retry_task.schedule_stream_retry") as mock_schedule,
+            patch("app.integrations.celery.tasks.strava_stream_retry_task.SessionLocal"),
         ):
             mock_factory.return_value.get_provider.return_value = mock_strategy
-            _retry_ingest(MagicMock(), user_id, str(_ACTIVITY.id), attempt)
-        return mock_workouts, mock_schedule
+            retry_strava_stream_ingest(str(uuid4()), str(_ACTIVITY.id), attempt=attempt)
+        return mock_workouts
 
-    def _record(self) -> MagicMock:
-        record = MagicMock()
-        record.start_datetime = _ACTIVITY.start_date
-        record.end_datetime = "2026-08-16T17:15:59Z"
-        return record
+    def test_reruns_webhook_flow_with_next_attempt(self) -> None:
+        mock_workouts = self._run(_ACTIVITY.model_dump(), attempt=1)
+        mock_workouts.process_push_activity.assert_called_once()
+        kwargs = mock_workouts.process_push_activity.call_args.kwargs
+        assert str(kwargs["activity"].id) == str(_ACTIVITY.id)
+        assert kwargs["stream_retry_attempt"] == 2
 
-    def test_skips_when_samples_already_ingested(self) -> None:
-        mock_workouts, mock_schedule = self._run(self._record(), has_samples=True, ingested=0, attempt=1)
-        mock_workouts.get_workout_detail_from_api.assert_not_called()
-        mock_schedule.assert_not_called()
-
-    def test_ingests_when_streams_ready(self) -> None:
-        mock_workouts, mock_schedule = self._run(self._record(), has_samples=False, ingested=4752, attempt=1)
-        mock_workouts._ingest_workout_streams.assert_called_once()
-        mock_schedule.assert_not_called()
-
-    def test_reschedules_with_backoff_when_still_empty(self) -> None:
-        _, mock_schedule = self._run(self._record(), has_samples=False, ingested=0, attempt=1)
-        mock_schedule.assert_called_once()
-        assert mock_schedule.call_args.args[2] == 2  # next attempt
-
-    def test_gives_up_after_max_attempts(self) -> None:
-        _, mock_schedule = self._run(self._record(), has_samples=False, ingested=0, attempt=MAX_ATTEMPTS)
-        mock_schedule.assert_not_called()
-
-    def test_gives_up_when_record_deleted(self) -> None:
-        mock_workouts, mock_schedule = self._run(None, has_samples=False, ingested=0, attempt=1)
-        mock_workouts.get_workout_detail_from_api.assert_not_called()
-        mock_schedule.assert_not_called()
+    def test_gives_up_when_activity_gone(self) -> None:
+        mock_workouts = self._run(None, attempt=1)
+        mock_workouts.process_push_activity.assert_not_called()
 
 
 class TestTransientFailureReschedule:
-    def test_task_reschedules_on_transient_error(self) -> None:
+    def _run_with_error(self, attempt: int) -> MagicMock:
         with (
             patch(
                 "app.integrations.celery.tasks.strava_stream_retry_task._retry_ingest",
@@ -146,30 +134,29 @@ class TestTransientFailureReschedule:
             patch("app.integrations.celery.tasks.strava_stream_retry_task.SessionLocal"),
             patch("app.integrations.celery.tasks.strava_stream_retry_task.schedule_stream_retry") as mock_schedule,
         ):
-            retry_strava_stream_ingest(str(uuid4()), "a-1", attempt=1)
+            retry_strava_stream_ingest(str(uuid4()), "a-1", attempt=attempt)
+        return mock_schedule
+
+    def test_task_reschedules_on_transient_error(self) -> None:
+        mock_schedule = self._run_with_error(attempt=1)
         mock_schedule.assert_called_once()
         assert mock_schedule.call_args.args[2] == 2
 
-    def test_task_gives_up_on_transient_error_at_max_attempts(self) -> None:
-        with (
-            patch(
-                "app.integrations.celery.tasks.strava_stream_retry_task._retry_ingest",
-                side_effect=RuntimeError("strava 500"),
-            ),
-            patch("app.integrations.celery.tasks.strava_stream_retry_task.SessionLocal"),
-            patch("app.integrations.celery.tasks.strava_stream_retry_task.schedule_stream_retry") as mock_schedule,
-        ):
-            retry_strava_stream_ingest(str(uuid4()), "a-1", attempt=MAX_ATTEMPTS)
+    def test_task_gives_up_on_transient_error_at_budget(self) -> None:
+        mock_schedule = self._run_with_error(attempt=max_stream_retry_attempts())
         mock_schedule.assert_not_called()
 
 
 class TestScheduleStreamRetry:
-    def test_schedules_with_backoff_countdown(self) -> None:
+    def test_uses_configured_backoff_per_attempt(self) -> None:
+        countdowns = settings.strava_stream_retry_countdown_seconds
         with patch(
             "app.integrations.celery.tasks.strava_stream_retry_task.retry_strava_stream_ingest.apply_async"
         ) as mock_apply:
             schedule_stream_retry("u-1", "a-1", attempt=2)
-        mock_apply.assert_called_once()
         kwargs = mock_apply.call_args.kwargs
-        assert kwargs["countdown"] == 900
+        assert kwargs["countdown"] == countdowns[1]
         assert kwargs["kwargs"]["attempt"] == 2
+
+    def test_budget_matches_countdown_list(self) -> None:
+        assert max_stream_retry_attempts() == len(settings.strava_stream_retry_countdown_seconds)

--- a/backend/tests/providers/strava/test_strava_stream_retry.py
+++ b/backend/tests/providers/strava/test_strava_stream_retry.py
@@ -14,6 +14,7 @@ import pytest
 from app.integrations.celery.tasks.strava_stream_retry_task import (
     MAX_ATTEMPTS,
     _retry_ingest,
+    retry_strava_stream_ingest,
     schedule_stream_retry,
 )
 from app.schemas.providers.strava import ActivityJSON as StravaActivityJSON
@@ -93,7 +94,7 @@ class TestRetryTask:
         mock_workouts._ingest_workout_streams.return_value = ingested
         mock_strategy = MagicMock(workouts=mock_workouts)
         with (
-            patch("app.integrations.celery.tasks.strava_stream_retry_task.ProviderFactory") as mock_factory,
+            patch("app.services.providers.factory.ProviderFactory") as mock_factory,
             patch(
                 "app.integrations.celery.tasks.strava_stream_retry_task.timeseries_service.has_samples_in_range",
                 return_value=has_samples,
@@ -132,6 +133,33 @@ class TestRetryTask:
     def test_gives_up_when_record_deleted(self) -> None:
         mock_workouts, mock_schedule = self._run(None, has_samples=False, ingested=0, attempt=1)
         mock_workouts.get_workout_detail_from_api.assert_not_called()
+        mock_schedule.assert_not_called()
+
+
+class TestTransientFailureReschedule:
+    def test_task_reschedules_on_transient_error(self) -> None:
+        with (
+            patch(
+                "app.integrations.celery.tasks.strava_stream_retry_task._retry_ingest",
+                side_effect=RuntimeError("strava 500"),
+            ),
+            patch("app.integrations.celery.tasks.strava_stream_retry_task.SessionLocal"),
+            patch("app.integrations.celery.tasks.strava_stream_retry_task.schedule_stream_retry") as mock_schedule,
+        ):
+            retry_strava_stream_ingest(str(uuid4()), "a-1", attempt=1)
+        mock_schedule.assert_called_once()
+        assert mock_schedule.call_args.args[2] == 2
+
+    def test_task_gives_up_on_transient_error_at_max_attempts(self) -> None:
+        with (
+            patch(
+                "app.integrations.celery.tasks.strava_stream_retry_task._retry_ingest",
+                side_effect=RuntimeError("strava 500"),
+            ),
+            patch("app.integrations.celery.tasks.strava_stream_retry_task.SessionLocal"),
+            patch("app.integrations.celery.tasks.strava_stream_retry_task.schedule_stream_retry") as mock_schedule,
+        ):
+            retry_strava_stream_ingest(str(uuid4()), "a-1", attempt=MAX_ATTEMPTS)
         mock_schedule.assert_not_called()
 
 

--- a/backend/tests/providers/strava/test_strava_stream_retry.py
+++ b/backend/tests/providers/strava/test_strava_stream_retry.py
@@ -1,0 +1,147 @@
+"""Tests for the delayed Strava stream-ingestion retry.
+
+Covers the race where the activity webhook fires before Strava finishes
+processing streams: the immediate fetch returns empty, and a delayed retry
+task must be scheduled (and itself re-schedule with backoff until samples
+land or attempts are exhausted).
+"""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.integrations.celery.tasks.strava_stream_retry_task import (
+    MAX_ATTEMPTS,
+    _retry_ingest,
+    schedule_stream_retry,
+)
+from app.schemas.providers.strava import ActivityJSON as StravaActivityJSON
+from app.services.providers.strava.workouts import StravaWorkouts
+
+_ACTIVITY = StravaActivityJSON(
+    id=19769960003,
+    name="Evening Ride",
+    type="Ride",
+    sport_type="Ride",
+    start_date="2026-08-16T15:39:19Z",
+    elapsed_time=5800,
+    utc_offset=7200.0,
+    device_name="Apple Watch",
+)
+
+
+@pytest.fixture
+def workouts() -> StravaWorkouts:
+    return StravaWorkouts(
+        workout_repo=MagicMock(),
+        connection_repo=MagicMock(),
+        provider_name="strava",
+        api_base_url="https://www.strava.com",
+        oauth=MagicMock(),
+    )
+
+
+class TestWebhookSchedulesRetry:
+    def _process(self, workouts: StravaWorkouts, ingested: int, has_samples: bool) -> MagicMock:
+        user_id = uuid4()
+        with (
+            patch("app.services.providers.strava.workouts.event_record_service") as mock_service,
+            patch.object(workouts, "_ingest_workout_streams", return_value=ingested),
+            patch(
+                "app.services.providers.strava.workouts.timeseries_service.has_samples_in_range",
+                return_value=has_samples,
+            ),
+            patch("app.integrations.celery.tasks.strava_stream_retry_task.schedule_stream_retry") as mock_schedule,
+            patch("app.services.providers.strava.workouts.settings") as mock_settings,
+        ):
+            mock_settings.ingest_workout_samples = True
+            mock_service.create.return_value = MagicMock(id=uuid4())
+            workouts.process_push_activity(db=MagicMock(), activity=_ACTIVITY, user_id=user_id)
+        return mock_schedule
+
+    def test_empty_streams_schedule_delayed_retry(self, workouts: StravaWorkouts) -> None:
+        mock_schedule = self._process(workouts, ingested=0, has_samples=False)
+        mock_schedule.assert_called_once()
+        args, kwargs = mock_schedule.call_args
+        assert str(_ACTIVITY.id) in args or kwargs.get("activity_id") == str(_ACTIVITY.id)
+        assert kwargs.get("attempt", args[-1] if args else None) == 1
+
+    def test_no_retry_when_samples_ingested(self, workouts: StravaWorkouts) -> None:
+        mock_schedule = self._process(workouts, ingested=4752, has_samples=True)
+        mock_schedule.assert_not_called()
+
+    def test_no_retry_when_samples_already_exist(self, workouts: StravaWorkouts) -> None:
+        # skip-guard returned 0 because samples are already there — nothing to retry
+        mock_schedule = self._process(workouts, ingested=0, has_samples=True)
+        mock_schedule.assert_not_called()
+
+
+class TestRetryTask:
+    def _run(
+        self,
+        record: MagicMock | None,
+        has_samples: bool,
+        ingested: int,
+        attempt: int,
+    ) -> tuple[MagicMock, MagicMock]:
+        user_id = uuid4()
+        mock_workouts = MagicMock()
+        mock_workouts.workout_repo.get_by_external_id.return_value = record
+        mock_workouts.get_workout_detail_from_api.return_value = _ACTIVITY.model_dump() if record else None
+        mock_workouts._normalize_workout.return_value = (MagicMock(), MagicMock())
+        mock_workouts._ingest_workout_streams.return_value = ingested
+        mock_strategy = MagicMock(workouts=mock_workouts)
+        with (
+            patch("app.integrations.celery.tasks.strava_stream_retry_task.ProviderFactory") as mock_factory,
+            patch(
+                "app.integrations.celery.tasks.strava_stream_retry_task.timeseries_service.has_samples_in_range",
+                return_value=has_samples,
+            ),
+            patch("app.integrations.celery.tasks.strava_stream_retry_task.schedule_stream_retry") as mock_schedule,
+        ):
+            mock_factory.return_value.get_provider.return_value = mock_strategy
+            _retry_ingest(MagicMock(), user_id, str(_ACTIVITY.id), attempt)
+        return mock_workouts, mock_schedule
+
+    def _record(self) -> MagicMock:
+        record = MagicMock()
+        record.start_datetime = _ACTIVITY.start_date
+        record.end_datetime = "2026-08-16T17:15:59Z"
+        return record
+
+    def test_skips_when_samples_already_ingested(self) -> None:
+        mock_workouts, mock_schedule = self._run(self._record(), has_samples=True, ingested=0, attempt=1)
+        mock_workouts.get_workout_detail_from_api.assert_not_called()
+        mock_schedule.assert_not_called()
+
+    def test_ingests_when_streams_ready(self) -> None:
+        mock_workouts, mock_schedule = self._run(self._record(), has_samples=False, ingested=4752, attempt=1)
+        mock_workouts._ingest_workout_streams.assert_called_once()
+        mock_schedule.assert_not_called()
+
+    def test_reschedules_with_backoff_when_still_empty(self) -> None:
+        _, mock_schedule = self._run(self._record(), has_samples=False, ingested=0, attempt=1)
+        mock_schedule.assert_called_once()
+        assert mock_schedule.call_args.args[2] == 2  # next attempt
+
+    def test_gives_up_after_max_attempts(self) -> None:
+        _, mock_schedule = self._run(self._record(), has_samples=False, ingested=0, attempt=MAX_ATTEMPTS)
+        mock_schedule.assert_not_called()
+
+    def test_gives_up_when_record_deleted(self) -> None:
+        mock_workouts, mock_schedule = self._run(None, has_samples=False, ingested=0, attempt=1)
+        mock_workouts.get_workout_detail_from_api.assert_not_called()
+        mock_schedule.assert_not_called()
+
+
+class TestScheduleStreamRetry:
+    def test_schedules_with_backoff_countdown(self) -> None:
+        with patch(
+            "app.integrations.celery.tasks.strava_stream_retry_task.retry_strava_stream_ingest.apply_async"
+        ) as mock_apply:
+            schedule_stream_retry("u-1", "a-1", attempt=2)
+        mock_apply.assert_called_once()
+        kwargs = mock_apply.call_args.kwargs
+        assert kwargs["countdown"] == 900
+        assert kwargs["kwargs"]["attempt"] == 2

--- a/backend/tests/providers/strava/test_strava_workout_samples.py
+++ b/backend/tests/providers/strava/test_strava_workout_samples.py
@@ -265,6 +265,7 @@ class TestIngestionWiring:
             patch.object(strava_workouts, "_make_api_request", return_value=_STRAVA_STREAMS_3S),
             patch("app.services.providers.strava.workouts.timeseries_service") as mock_ts,
         ):
+            mock_ts.has_samples_in_range.return_value = False
             count = strava_workouts._ingest_workout_streams(db, _SAMPLE_ACTIVITY, user_id, record_mock)
 
         mock_ts.bulk_create_samples.assert_called_once()
@@ -273,6 +274,66 @@ class TestIngestionWiring:
         assert len(saved_samples) == 6
         assert count == 6
         assert all(s.device_model == _DEVICE_MODEL for s in saved_samples)
+
+    def test_existing_samples_skip_fetch(
+        self,
+        strava_workouts: StravaWorkouts,
+        db: Session,
+    ) -> None:
+        """Samples already in the workout window: no API call, no save, 0 returned."""
+        user_id = uuid4()
+        record_mock = MagicMock()
+        record_mock.start_datetime = _START_DT
+        record_mock.end_datetime = _START_DT + timedelta(seconds=3600)
+        record_mock.zone_offset = _ZONE_OFFSET
+
+        with (
+            patch(
+                "app.services.providers.strava.workouts.settings",
+                ingest_workout_samples=True,
+            ),
+            patch.object(strava_workouts, "_make_api_request") as mock_api,
+            patch("app.services.providers.strava.workouts.timeseries_service") as mock_ts,
+        ):
+            mock_ts.has_samples_in_range.return_value = True
+            count = strava_workouts._ingest_workout_streams(db, _SAMPLE_ACTIVITY, user_id, record_mock)
+
+        mock_api.assert_not_called()
+        mock_ts.bulk_create_samples.assert_not_called()
+        assert count == 0
+        mock_ts.has_samples_in_range.assert_called_once_with(
+            db,
+            user_id,
+            "strava",
+            record_mock.start_datetime,
+            record_mock.end_datetime,
+        )
+
+    def test_no_end_datetime_skips_probe_and_fetches(
+        self,
+        strava_workouts: StravaWorkouts,
+        db: Session,
+    ) -> None:
+        """Record without end_datetime: existence probe bypassed, streams fetched as before."""
+        user_id = uuid4()
+        record_mock = MagicMock()
+        record_mock.start_datetime = _START_DT
+        record_mock.end_datetime = None
+        record_mock.zone_offset = _ZONE_OFFSET
+
+        with (
+            patch(
+                "app.services.providers.strava.workouts.settings",
+                ingest_workout_samples=True,
+            ),
+            patch.object(strava_workouts, "_make_api_request", return_value=_STRAVA_STREAMS_3S),
+            patch("app.services.providers.strava.workouts.timeseries_service") as mock_ts,
+        ):
+            count = strava_workouts._ingest_workout_streams(db, _SAMPLE_ACTIVITY, user_id, record_mock)
+
+        mock_ts.has_samples_in_range.assert_not_called()
+        mock_ts.bulk_create_samples.assert_called_once()
+        assert count == 6
 
     def test_save_raises_swallowed_returns_zero(
         self,
@@ -293,6 +354,7 @@ class TestIngestionWiring:
             patch.object(strava_workouts, "_make_api_request", return_value=_STRAVA_STREAMS_3S),
             patch("app.services.providers.strava.workouts.timeseries_service") as mock_ts,
         ):
+            mock_ts.has_samples_in_range.return_value = False
             mock_ts.bulk_create_samples.side_effect = RuntimeError("db write failure")
             count = strava_workouts._ingest_workout_streams(db, _SAMPLE_ACTIVITY, user_id, record_mock)
 
@@ -321,6 +383,7 @@ class TestIngestionWiring:
             ),
             patch("app.services.providers.strava.workouts.timeseries_service") as mock_ts,
         ):
+            mock_ts.has_samples_in_range.return_value = False
             count = strava_workouts._ingest_workout_streams(db, _SAMPLE_ACTIVITY, user_id, record_mock)
 
         mock_ts.bulk_create_samples.assert_not_called()
@@ -346,6 +409,7 @@ class TestIngestionWiring:
             patch.object(strava_workouts, "_make_api_request", return_value=streams_no_time),
             patch("app.services.providers.strava.workouts.timeseries_service") as mock_ts,
         ):
+            mock_ts.has_samples_in_range.return_value = False
             count = strava_workouts._ingest_workout_streams(db, _SAMPLE_ACTIVITY, user_id, record_mock)
 
         mock_ts.bulk_create_samples.assert_not_called()


### PR DESCRIPTION
Hi!

Follow-up to #1298, found while debugging why workouts synced without per-sample streams in our production.

## Problem

Strava fires the activity webhook seconds after upload, often before its stream processing has finished. The webhook path saves the workout, but the immediate `/streams` fetch comes back empty - silently, because an empty stream set is a normal response. And since webhook processing bumps `last_synced_at` past the activity's start time, the periodic pull never re-covers that workout. Net effect: every webhook-delivered workout stays permanently without samples. In our prod not a single webhook workout got streams since we enabled `INGEST_WORKOUT_SAMPLES`.

## Fix

When the webhook-path stream ingest lands zero samples (and none exist for the workout window), schedule a delayed retry task with backoff (5m, 15m, 45m, 3 attempts). The task re-checks `has_samples_in_range` before fetching so it is idempotent, handles a deleted workout, and gives up with a warning log after the last attempt.

Stacked on #1298 (uses its `has_samples_in_range` guard) - the first commit here is that PR, only the second one is new. Happy to rebase once #1298 lands.

## Verification

- `uv run pytest tests/providers/strava/` - 25 passed (9 new)
- `ruff check` / `ruff format --check` clean
- Running in our production: previously stream-less workouts now get samples on the delayed retry

Please let me know if you want the backoff timings configurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EY3bZLVL41Q5SHG4uW39Xo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic delayed retries when Strava workout streams are temporarily unavailable.
  - Retry timing and maximum attempts can now be configured through application settings.
- **Bug Fixes**
  - Prevented redundant stream fetching when workout samples already exist.
  - Improved handling for missing workouts, empty stream responses, and ingestion failures.
  - Retries now follow the standard workout processing flow for more consistent results.
- **Tests**
  - Added coverage for retry scheduling, backoff behavior, duplicate-fetch prevention, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->