### PR TITLE
fix: Update Whoop workout type mappings

### DIFF
--- a/backend/app/constants/workout_types/whoop.py
+++ b/backend/app/constants/workout_types/whoop.py
@@ -164,16 +164,6 @@ WHOOP_ID_TO_UNIFIED: dict[int, WorkoutType] = {
     sport_id: unified_type for _, sport_id, unified_type in WHOOP_WORKOUT_TYPE_MAPPINGS
 }
 
-# Alternate spellings for slugs where WHOOP's rendering of "&", "/" and "'" is unverified.
-# The sport_id fallback covers these too; these keep name-only lookups working.
-WHOOP_TO_UNIFIED.update(
-    {
-        "track-and-field": WorkoutType.RUNNING,  # 35
-        "barry-s": WorkoutType.GROUP_EXERCISE,  # 250
-        "hurling-and-camogie": WorkoutType.SPORT,  # 112
-    }
-)
-
 
 def get_unified_workout_type(whoop_sport_name: str | None, whoop_sport_id: int | None = None) -> WorkoutType:
     """

--- a/backend/app/constants/workout_types/whoop.py
+++ b/backend/app/constants/workout_types/whoop.py
@@ -1,6 +1,7 @@
 import logging
 
 from app.schemas.enums import WorkoutType
+from app.utils.structured_logging import log_structured
 
 logger = logging.getLogger(__name__)
 
@@ -205,9 +206,13 @@ def get_unified_workout_type(whoop_sport_name: str | None, whoop_sport_id: int |
             return unified_type
 
     if whoop_sport_name or whoop_sport_id is not None:
-        logger.warning(
+        log_structured(
+            logger,
+            "warning",
             "Unmapped Whoop sport, falling back to OTHER",
-            extra={"provider": "whoop", "sport_name": whoop_sport_name, "sport_id": whoop_sport_id},
+            provider="whoop",
+            sport_name=whoop_sport_name,
+            sport_id=whoop_sport_id,
         )
 
     return WorkoutType.OTHER

--- a/backend/app/constants/workout_types/whoop.py
+++ b/backend/app/constants/workout_types/whoop.py
@@ -1,170 +1,191 @@
+import logging
+
 from app.schemas.enums import WorkoutType
 
-# WHOOP workout type mappings based on WHOOP API documentation
+logger = logging.getLogger(__name__)
+
+# WHOOP sports. sport_name is a lowercase hyphenated slug ("hiking-rucking"), not the
+# display name the docs table shows. sport_id is deprecated (nominally removed after
+# 09/01/2025) but still sent, so it is kept as a fallback for unlisted slugs.
 # Reference: https://developer.whoop.com/docs/developing/user-data/workout
-# WHOOP uses lowercase sport_name strings (e.g., "running", "cycling")
-# Format: (whoop_sport_name, unified_type)
-WHOOP_WORKOUT_TYPE_MAPPINGS: list[tuple[str, WorkoutType]] = [
-    # Running & Walking
-    ("running", WorkoutType.RUNNING),
-    ("walking", WorkoutType.WALKING),
-    ("hiking/rucking", WorkoutType.HIKING),
-    ("track & field", WorkoutType.RUNNING),
-    ("stroller walking", WorkoutType.WALKING),
-    ("stroller jogging", WorkoutType.RUNNING),
-    ("dog walking", WorkoutType.WALKING),
-    ("caddying", WorkoutType.WALKING),
-    ("toddlerwearing", WorkoutType.WALKING),
-    ("babywearing", WorkoutType.WALKING),
+# Format: (whoop_sport_name, whoop_sport_id, unified_type)
+WHOOP_WORKOUT_TYPE_MAPPINGS: list[tuple[str, int, WorkoutType]] = [
+    # Generic / catch-all
+    ("activity", -1, WorkoutType.GENERIC),
+    ("other", 71, WorkoutType.GENERIC),
+    # Running & walking
+    ("running", 0, WorkoutType.RUNNING),
+    ("walking", 63, WorkoutType.WALKING),
+    ("hiking-rucking", 52, WorkoutType.HIKING),
+    ("track-field", 35, WorkoutType.RUNNING),
+    ("stroller-walking", 252, WorkoutType.WALKING),
+    ("stroller-jogging", 253, WorkoutType.RUNNING),
+    ("dog-walking", 266, WorkoutType.WALKING),
+    ("caddying", 93, WorkoutType.WALKING),
+    ("toddlerwearing", 254, WorkoutType.WALKING),
+    ("babywearing", 255, WorkoutType.WALKING),
+    ("wheelchair-pushing", 105, WorkoutType.WHEELCHAIR),
     # Cycling
-    ("cycling", WorkoutType.CYCLING),
-    ("mountain biking", WorkoutType.MOUNTAIN_BIKING),
-    ("spin", WorkoutType.INDOOR_CYCLING),
-    ("assault bike", WorkoutType.INDOOR_CYCLING),
-    # Swimming & Water Sports
-    ("swimming", WorkoutType.SWIMMING),
-    ("water polo", WorkoutType.WATER_POLO),
-    ("rowing", WorkoutType.ROWING),
-    ("kayaking", WorkoutType.KAYAKING),
-    ("paddleboarding", WorkoutType.STAND_UP_PADDLEBOARDING),
-    ("surfing", WorkoutType.SURFING),
-    ("sailing", WorkoutType.SAILING),
-    ("diving", WorkoutType.DIVING),
-    ("water skiing", WorkoutType.WATER_SKIING),
-    ("wakeboarding", WorkoutType.WAKEBOARDING),
-    ("kite boarding", WorkoutType.KITESURFING),
-    ("operations - water", WorkoutType.OPERATIONS),
-    # Strength & Gym
-    ("weightlifting", WorkoutType.STRENGTH_TRAINING),
-    ("powerlifting", WorkoutType.STRENGTH_TRAINING),
-    ("strength trainer", WorkoutType.STRENGTH_TRAINING),
-    ("functional fitness", WorkoutType.CARDIO_TRAINING),
-    ("elliptical", WorkoutType.ELLIPTICAL),
-    ("stairmaster", WorkoutType.STAIR_CLIMBING),
-    ("climber", WorkoutType.STAIR_CLIMBING),
-    ("stadium steps", WorkoutType.STAIR_CLIMBING),
-    ("hiit", WorkoutType.CARDIO_TRAINING),
-    ("jumping rope", WorkoutType.CARDIO_TRAINING),
-    ("obstacle course racing", WorkoutType.CARDIO_TRAINING),
-    ("parkour", WorkoutType.PARKOUR),
-    # Flexibility & Mind-Body
-    ("yoga", WorkoutType.YOGA),
-    ("hot yoga", WorkoutType.YOGA),
-    ("pilates", WorkoutType.PILATES),
-    ("stretching", WorkoutType.STRETCHING),
-    ("meditation", WorkoutType.MEDITATION),
-    ("barre", WorkoutType.GROUP_EXERCISE),
-    ("barre3", WorkoutType.GROUP_EXERCISE),
-    # Winter Sports
-    ("skiing", WorkoutType.ALPINE_SKIING),
-    ("cross country skiing", WorkoutType.CROSS_COUNTRY_SKIING),
-    ("snowboarding", WorkoutType.SNOWBOARDING),
-    ("ice skating", WorkoutType.ICE_SKATING),
-    # Team Sports - Ball Sports
-    ("soccer", WorkoutType.SOCCER),
-    ("basketball", WorkoutType.BASKETBALL),
-    ("football", WorkoutType.AMERICAN_FOOTBALL),
-    ("australian football", WorkoutType.FOOTBALL),
-    ("gaelic football", WorkoutType.FOOTBALL),
-    ("baseball", WorkoutType.BASEBALL),
-    ("softball", WorkoutType.BASEBALL),
-    ("volleyball", WorkoutType.VOLLEYBALL),
-    ("rugby", WorkoutType.RUGBY),
-    ("lacrosse", WorkoutType.LACROSSE),
-    ("cricket", WorkoutType.CRICKET),
-    ("netball", WorkoutType.SPORT),
-    ("ultimate", WorkoutType.SPORT),
-    ("spikeball", WorkoutType.SPORT),
-    ("hurling/camogie", WorkoutType.SPORT),
-    # Team Sports - Hockey
-    ("ice hockey", WorkoutType.HOCKEY),
-    ("field hockey", WorkoutType.HOCKEY),
-    # Racket Sports
-    ("tennis", WorkoutType.TENNIS),
-    ("squash", WorkoutType.SQUASH),
-    ("badminton", WorkoutType.BADMINTON),
-    ("table tennis", WorkoutType.TABLE_TENNIS),
-    ("padel", WorkoutType.PADEL),
-    ("pickleball", WorkoutType.PICKLEBALL),
-    ("paddle tennis", WorkoutType.PADEL),
-    # Combat Sports
-    ("boxing", WorkoutType.BOXING),
-    ("kickboxing", WorkoutType.BOXING),
-    ("box fitness", WorkoutType.BOXING),
-    ("martial arts", WorkoutType.MARTIAL_ARTS),
-    ("jiu jitsu", WorkoutType.MARTIAL_ARTS),
-    ("wrestling", WorkoutType.WRESTLING),
-    ("fencing", WorkoutType.FENCING),
+    ("cycling", 1, WorkoutType.CYCLING),
+    ("mountain-biking", 57, WorkoutType.MOUNTAIN_BIKING),
+    ("spin", 97, WorkoutType.INDOOR_CYCLING),
+    ("assault-bike", 126, WorkoutType.INDOOR_CYCLING),
+    # Swimming & water sports
+    ("swimming", 33, WorkoutType.SWIMMING),
+    ("water-polo", 37, WorkoutType.WATER_POLO),
+    ("rowing", 18, WorkoutType.ROWING),
+    ("kayaking", 55, WorkoutType.KAYAKING),
+    ("paddleboarding", 61, WorkoutType.STAND_UP_PADDLEBOARDING),
+    ("surfing", 64, WorkoutType.SURFING),
+    ("sailing", 28, WorkoutType.SAILING),
+    ("diving", 73, WorkoutType.DIVING),
+    ("water-skiing", 267, WorkoutType.WATER_SKIING),
+    ("wakeboarding", 268, WorkoutType.WAKEBOARDING),
+    ("kite-boarding", 264, WorkoutType.KITESURFING),
+    ("operations-water", 77, WorkoutType.OPERATIONS),
+    # Strength & gym
+    ("weightlifting", 45, WorkoutType.STRENGTH_TRAINING),
+    ("powerlifting", 59, WorkoutType.STRENGTH_TRAINING),
+    ("strength-trainer", 123, WorkoutType.STRENGTH_TRAINING),
+    ("functional-fitness", 48, WorkoutType.CARDIO_TRAINING),
+    ("elliptical", 65, WorkoutType.ELLIPTICAL),
+    ("stairmaster", 66, WorkoutType.STAIR_CLIMBING),
+    ("climber", 83, WorkoutType.STAIR_CLIMBING),
+    ("stadium-steps", 261, WorkoutType.STAIR_CLIMBING),
+    ("hiit", 96, WorkoutType.CARDIO_TRAINING),
+    ("jumping-rope", 84, WorkoutType.CARDIO_TRAINING),
+    ("obstacle-course-racing", 94, WorkoutType.CARDIO_TRAINING),
+    ("parkour", 110, WorkoutType.PARKOUR),
+    # Flexibility & mind-body
+    ("yoga", 44, WorkoutType.YOGA),
+    ("hot-yoga", 259, WorkoutType.YOGA),
+    ("pilates", 43, WorkoutType.PILATES),
+    ("stretching", 128, WorkoutType.STRETCHING),
+    ("meditation", 70, WorkoutType.MEDITATION),
+    ("barre", 107, WorkoutType.GROUP_EXERCISE),
+    ("barre3", 258, WorkoutType.GROUP_EXERCISE),
+    # Winter sports
+    ("skiing", 29, WorkoutType.ALPINE_SKIING),
+    ("cross-country-skiing", 47, WorkoutType.CROSS_COUNTRY_SKIING),
+    ("snowboarding", 91, WorkoutType.SNOWBOARDING),
+    ("ice-skating", 239, WorkoutType.ICE_SKATING),
+    # Team sports - ball sports
+    ("soccer", 30, WorkoutType.SOCCER),
+    ("basketball", 17, WorkoutType.BASKETBALL),
+    ("football", 21, WorkoutType.AMERICAN_FOOTBALL),
+    ("australian-football", 85, WorkoutType.FOOTBALL),
+    ("gaelic-football", 111, WorkoutType.FOOTBALL),
+    ("baseball", 16, WorkoutType.BASEBALL),
+    ("softball", 31, WorkoutType.BASEBALL),
+    ("volleyball", 36, WorkoutType.VOLLEYBALL),
+    ("rugby", 27, WorkoutType.RUGBY),
+    ("lacrosse", 25, WorkoutType.LACROSSE),
+    ("cricket", 100, WorkoutType.CRICKET),
+    ("netball", 232, WorkoutType.SPORT),
+    ("ultimate", 82, WorkoutType.SPORT),
+    ("spikeball", 104, WorkoutType.SPORT),
+    ("hurling-camogie", 112, WorkoutType.SPORT),
+    ("paintball", 238, WorkoutType.SPORT),
+    # Team sports - hockey
+    ("ice-hockey", 24, WorkoutType.HOCKEY),
+    ("field-hockey", 20, WorkoutType.HOCKEY),
+    ("handball", 240, WorkoutType.HANDBALL),
+    # Racket sports
+    ("tennis", 34, WorkoutType.TENNIS),
+    ("squash", 32, WorkoutType.SQUASH),
+    ("badminton", 231, WorkoutType.BADMINTON),
+    ("table-tennis", 230, WorkoutType.TABLE_TENNIS),
+    ("padel", 249, WorkoutType.PADEL),
+    ("paddle-tennis", 106, WorkoutType.PADEL),
+    ("pickleball", 101, WorkoutType.PICKLEBALL),
+    # Combat sports
+    ("boxing", 39, WorkoutType.BOXING),
+    ("kickboxing", 127, WorkoutType.BOXING),
+    ("box-fitness", 103, WorkoutType.BOXING),
+    ("martial-arts", 56, WorkoutType.MARTIAL_ARTS),
+    ("jiu-jitsu", 98, WorkoutType.MARTIAL_ARTS),
+    ("wrestling", 38, WorkoutType.WRESTLING),
+    ("fencing", 19, WorkoutType.FENCING),
     # Climbing
-    ("rock climbing", WorkoutType.ROCK_CLIMBING),
+    ("rock-climbing", 60, WorkoutType.ROCK_CLIMBING),
     # Golf
-    ("golf", WorkoutType.GOLF),
-    ("disc golf", WorkoutType.DISC_SPORTS),
+    ("golf", 22, WorkoutType.GOLF),
+    ("disc-golf", 234, WorkoutType.DISC_SPORTS),
     # Skating
-    ("inline skating", WorkoutType.INLINE_SKATING),
-    ("skateboarding", WorkoutType.SKATEBOARDING),
+    ("inline-skating", 102, WorkoutType.INLINE_SKATING),
+    ("skateboarding", 86, WorkoutType.SKATEBOARDING),
     # Equestrian
-    ("horseback riding", WorkoutType.HORSEBACK_RIDING),
-    ("polo", WorkoutType.HORSEBACK_RIDING),
+    ("horseback-riding", 53, WorkoutType.HORSEBACK_RIDING),
+    ("polo", 262, WorkoutType.HORSEBACK_RIDING),
     # Multisport
-    ("triathlon", WorkoutType.TRIATHLON),
-    ("duathlon", WorkoutType.MULTISPORT),
-    # Motor Sports
-    ("motocross", WorkoutType.MOTORCYCLING),
-    ("motor racing", WorkoutType.MOTOR_SPORTS),
-    # Dance & Group Fitness
-    ("dance", WorkoutType.DANCE),
-    ("circus arts", WorkoutType.DANCE),
-    ("stage performance", WorkoutType.DANCE),
-    ("f45 training", WorkoutType.GROUP_EXERCISE),
-    ("barry's", WorkoutType.GROUP_EXERCISE),
+    ("triathlon", 62, WorkoutType.TRIATHLON),
+    ("duathlon", 49, WorkoutType.MULTISPORT),
+    # Motor sports
+    ("motocross", 92, WorkoutType.MOTORCYCLING),
+    ("motor-racing", 95, WorkoutType.MOTOR_SPORTS),
+    # Dance & group fitness
+    ("dance", 42, WorkoutType.DANCE),
+    ("circus-arts", 113, WorkoutType.DANCE),
+    ("stage-performance", 108, WorkoutType.DANCE),
+    ("f45-training", 248, WorkoutType.GROUP_EXERCISE),
+    ("barrys", 250, WorkoutType.GROUP_EXERCISE),
     # Gymnastics
-    ("gymnastics", WorkoutType.GYMNASTICS),
-    # Handball
-    ("handball", WorkoutType.HANDBALL),
-    # Recovery & Wellness
-    ("ice bath", WorkoutType.RECOVERY),
-    ("sauna", WorkoutType.RECOVERY),
-    ("massage therapy", WorkoutType.RECOVERY),
-    ("air compression", WorkoutType.RECOVERY),
-    ("percussive massage", WorkoutType.RECOVERY),
-    # Military / Operations
-    ("operations - tactical", WorkoutType.OPERATIONS),
-    ("operations - medical", WorkoutType.OPERATIONS),
-    ("operations - flying", WorkoutType.OPERATIONS),
-    # Work & Daily Activities
-    ("manual labor", WorkoutType.WORK),
-    ("high stress work", WorkoutType.WORK),
-    ("coaching", WorkoutType.WORK),
-    ("watching sports", WorkoutType.LIFESTYLE),
-    ("commuting", WorkoutType.LIFESTYLE),
-    ("gaming", WorkoutType.GAMING),
-    ("yard work", WorkoutType.CHORES),
-    ("cooking", WorkoutType.CHORES),
-    ("cleaning", WorkoutType.CHORES),
-    ("public speaking", WorkoutType.LIFESTYLE),
-    ("musical performance", WorkoutType.LIFESTYLE),
-    ("dedicated parenting", WorkoutType.LIFESTYLE),
-    ("wheelchair pushing", WorkoutType.WALKING),
-    # Outdoor Activities
-    ("paintball", WorkoutType.SPORT),
-    # Generic/Other
-    ("activity", WorkoutType.GENERIC),
-    ("other", WorkoutType.GENERIC),
+    ("gymnastics", 51, WorkoutType.GYMNASTICS),
+    # Recovery & wellness
+    ("ice-bath", 88, WorkoutType.RECOVERY),
+    ("sauna", 233, WorkoutType.RECOVERY),
+    ("massage-therapy", 121, WorkoutType.RECOVERY),
+    ("air-compression", 236, WorkoutType.RECOVERY),
+    ("percussive-massage", 237, WorkoutType.RECOVERY),
+    # Military / operations
+    ("operations-tactical", 74, WorkoutType.OPERATIONS),
+    ("operations-medical", 75, WorkoutType.OPERATIONS),
+    ("operations-flying", 76, WorkoutType.OPERATIONS),
+    # Work & daily activities
+    ("manual-labor", 99, WorkoutType.WORK),
+    ("high-stress-work", 109, WorkoutType.WORK),
+    ("coaching", 87, WorkoutType.WORK),
+    ("watching-sports", 125, WorkoutType.LIFESTYLE),
+    ("commuting", 89, WorkoutType.LIFESTYLE),
+    ("gaming", 90, WorkoutType.GAMING),
+    ("yard-work", 235, WorkoutType.CHORES),
+    ("cooking", 269, WorkoutType.CHORES),
+    ("cleaning", 270, WorkoutType.CHORES),
+    ("public-speaking", 272, WorkoutType.LIFESTYLE),
+    ("musical-performance", 263, WorkoutType.LIFESTYLE),
+    ("dedicated-parenting", 251, WorkoutType.LIFESTYLE),
 ]
 
-# Create lookup dictionary (case-insensitive)
 WHOOP_TO_UNIFIED: dict[str, WorkoutType] = {
-    sport_name.lower(): unified_type for sport_name, unified_type in WHOOP_WORKOUT_TYPE_MAPPINGS
+    sport_name: unified_type for sport_name, _, unified_type in WHOOP_WORKOUT_TYPE_MAPPINGS
 }
 
+WHOOP_ID_TO_UNIFIED: dict[int, WorkoutType] = {
+    sport_id: unified_type for _, sport_id, unified_type in WHOOP_WORKOUT_TYPE_MAPPINGS
+}
 
-def get_unified_workout_type(whoop_sport_name: str | None) -> WorkoutType:
+# Alternate spellings for slugs where WHOOP's rendering of "&", "/" and "'" is unverified.
+# The sport_id fallback covers these too; these keep name-only lookups working.
+WHOOP_TO_UNIFIED.update(
+    {
+        "track-and-field": WorkoutType.RUNNING,  # 35
+        "barry-s": WorkoutType.GROUP_EXERCISE,  # 250
+        "hurling-and-camogie": WorkoutType.SPORT,  # 112
+    }
+)
+
+
+def get_unified_workout_type(whoop_sport_name: str | None, whoop_sport_id: int | None = None) -> WorkoutType:
     """
-    Convert Whoop sport name to unified WorkoutType.
+    Convert Whoop sport to unified WorkoutType.
+
+    Resolves by sport_name, then falls back to sport_id for sports whose slug is not
+    listed. An unrecognised sport is logged rather than silently collapsing to OTHER,
+    so a newly added Whoop sport is visible.
 
     Args:
-        whoop_sport_name: Whoop sport name string (e.g., "running", "cycling")
+        whoop_sport_name: Whoop sport_name slug (e.g. "running", "hiking-rucking")
+        whoop_sport_id: Whoop numeric sport id (e.g. 0, 52), deprecated but still sent
 
     Returns:
         Unified WorkoutType enum value
@@ -172,21 +193,31 @@ def get_unified_workout_type(whoop_sport_name: str | None) -> WorkoutType:
     Examples:
         >>> get_unified_workout_type("running")
         WorkoutType.RUNNING
-        >>> get_unified_workout_type("cycling")
-        WorkoutType.CYCLING
-        >>> get_unified_workout_type("yoga")
-        WorkoutType.YOGA
-        >>> get_unified_workout_type("unknown_sport")
-        WorkoutType.OTHER
-        >>> get_unified_workout_type(None)
+        >>> get_unified_workout_type("hiking-rucking")
+        WorkoutType.HIKING
+        >>> get_unified_workout_type(None, 52)
+        WorkoutType.HIKING
+        >>> get_unified_workout_type("unknown-sport")
         WorkoutType.OTHER
 
     Note:
-        - Whoop uses lowercase strings for sport names
-        - If sport_name is missing, defaults to WorkoutType.OTHER
+        - Whoop sends lowercase hyphenated slugs, not the display names in its docs
+        - If both fields are missing or unmapped, defaults to WorkoutType.OTHER
     """
-    if not whoop_sport_name:
-        return WorkoutType.OTHER
+    if whoop_sport_name:
+        unified_type = WHOOP_TO_UNIFIED.get(whoop_sport_name.lower().strip())
+        if unified_type is not None:
+            return unified_type
 
-    normalized = whoop_sport_name.lower().strip()
-    return WHOOP_TO_UNIFIED.get(normalized, WorkoutType.OTHER)
+    if whoop_sport_id is not None:
+        unified_type = WHOOP_ID_TO_UNIFIED.get(whoop_sport_id)
+        if unified_type is not None:
+            return unified_type
+
+    if whoop_sport_name or whoop_sport_id is not None:
+        logger.warning(
+            "Unmapped Whoop sport, falling back to OTHER",
+            extra={"provider": "whoop", "sport_name": whoop_sport_name, "sport_id": whoop_sport_id},
+        )
+
+    return WorkoutType.OTHER

--- a/backend/app/services/providers/whoop/workouts.py
+++ b/backend/app/services/providers/whoop/workouts.py
@@ -256,8 +256,7 @@ class WhoopWorkouts(BaseWorkoutsTemplate):
         """Normalize Whoop workout to EventRecordCreate, EventRecordDetailCreate, and strain HealthScoreCreate."""
         workout_id = uuid4()
 
-        # Get workout type from sport_name (sport_id deprecated after 09/01/2025)
-        workout_type = get_unified_workout_type(raw_workout.sport_name)
+        workout_type = get_unified_workout_type(raw_workout.sport_name, raw_workout.sport_id)
 
         # Extract dates
         start_date, end_date = self._extract_dates(raw_workout.start, raw_workout.end)

--- a/docs/providers/coverage.mdx
+++ b/docs/providers/coverage.mdx
@@ -356,7 +356,8 @@ Key differences and limitations to be aware of when working with each provider:
   **Integration Method:** OAuth 2.0 (pull + webhook)
 
   - Data synced via periodic polling (default: every hour) and real-time webhook notifications for `workout`, `sleep`, and `recovery` events
-  - Full workout support with 145+ workout type mappings to unified taxonomy
+  - Full workout support with 122 workout type mappings to unified taxonomy
+  - Workout types are matched on Whoop's lowercase hyphenated `sport_name` slug (e.g. `hiking-rucking`), falling back to the deprecated numeric `sport_id` for unlisted slugs
   - Workout metrics include: avg/max heart rate, calories, distance, elevation gain, moving time
   - Continuous heart rate data is **not available** via API (only during workouts)
   - Does not track steps (device limitation)


### PR DESCRIPTION
## Description

Our Whoop workouts were not assigned correctly and mostly fell back to `OTHER` due to the fact Whoop uses hyphens and not whitespace to separate workout names. Also, sport ids were supposed to be deprecated after 09/01/2025 - but they are still here, so adding them as a fallback as well.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved WHOOP workout recognition using sport names and numeric sport IDs.
  * Added support for 122 mapped workout types, including wheelchair pushing and handball.
  * Standardized activity mappings for more consistent classification.

* **Bug Fixes**
  * Improved fallback handling for unrecognized or incomplete sport information.
  * Corrected several existing activity mappings.

* **Documentation**
  * Updated WHOOP coverage documentation with supported workout types and matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->