### PR TITLE
fix: split HRV into RMSSD/SDNN and deprecate recovery_score in recovery summaries endpoint

### DIFF
--- a/backend/app/api/routes/v1/summaries.py
+++ b/backend/app/api/routes/v1/summaries.py
@@ -67,7 +67,17 @@ def get_recovery_summary(
     cursor: str | None = None,
     limit: Annotated[int, Query(ge=1, le=100)] = 50,
 ) -> PaginatedResponse[RecoverySummary]:
-    """Returns daily recovery metrics (recovery score, HRV, resting HR, SpO2)."""
+    """Returns daily recovery metrics (recovery score, HRV, resting HR, SpO2).
+
+    **Warning - known limitation:** this endpoint currently returns data **only for WHOOP**.
+    Metrics are read from stored recovery-score records, which today are produced solely by
+    WHOOP, so users connected only to other providers (e.g. Apple Health) receive an empty
+    result even when the underlying resting HR, HRV and SpO2 are available. This is a bug.
+
+    These values will soon be computed from the timeseries we already store in the database
+    rather than from what a single provider reports, at which point recovery metrics will be
+    returned for all providers that supply the underlying data.
+    """
     start_datetime = parse_query_datetime(start_date)
     end_datetime = parse_query_datetime(end_date)
     return summaries_service.get_recovery_summaries(db, user_id, start_datetime, end_datetime, cursor, limit)

--- a/backend/app/schemas/responses/activity/summaries.py
+++ b/backend/app/schemas/responses/activity/summaries.py
@@ -178,5 +178,6 @@ class RecoverySummary(BaseModel):
     sleep_efficiency_percent: float | None = None
     resting_heart_rate_bpm: int | None = None
     avg_hrv_sdnn_ms: float | None = Field(None, description="Average HRV (SDNN)")
+    avg_hrv_rmssd_ms: float | None = Field(None, description="Average HRV (RMSSD)")
     avg_spo2_percent: float | None = None
     recovery_score: int | None = Field(None, ge=0, le=100, description="0-100 score")

--- a/backend/app/schemas/responses/activity/summaries.py
+++ b/backend/app/schemas/responses/activity/summaries.py
@@ -177,7 +177,30 @@ class RecoverySummary(BaseModel):
     sleep_duration_seconds: int | None = None
     sleep_efficiency_percent: float | None = None
     resting_heart_rate_bpm: int | None = None
-    avg_hrv_sdnn_ms: float | None = Field(None, description="Average HRV (SDNN)")
+    avg_hrv_sdnn_ms: float | None = Field(
+        None,
+        description=(
+            "Average HRV (SDNN). Currently always null: every record this endpoint returns "
+            "today comes from WHOOP - a recovery-score record is required for a row to be "
+            "returned, and only WHOOP produces one - and WHOOP reports HRV as RMSSD, which is "
+            "exposed in avg_hrv_rmssd_ms. Once recovery metrics are computed from stored "
+            "timeseries (and returned for all providers, not just WHOOP), this will carry SDNN "
+            "for providers that report it (e.g. Apple Health)."
+        ),
+    )
     avg_hrv_rmssd_ms: float | None = Field(None, description="Average HRV (RMSSD)")
     avg_spo2_percent: float | None = None
-    recovery_score: int | None = Field(None, ge=0, le=100, description="0-100 score")
+    recovery_score: int | None = Field(
+        None,
+        ge=0,
+        le=100,
+        deprecated=True,
+        description=(
+            "Deprecated and scheduled for removal in an upcoming release: 0-100 recovery "
+            "score. Among the supported providers only WHOOP reports a recovery score, and "
+            "Open Wearables does not compute its own, so this is null for every other "
+            "provider. Migrate to the health scores endpoint "
+            "(GET /api/v1/users/{user_id}/health-scores), whose `components` array exposes "
+            "the underlying metrics the score is derived from."
+        ),
+    )

--- a/backend/app/services/summaries_service.py
+++ b/backend/app/services/summaries_service.py
@@ -427,7 +427,7 @@ class SummariesService:
                 resting_heart_rate_bpm=int(r["resting_heart_rate"])
                 if r.get("resting_heart_rate") is not None
                 else None,
-                avg_hrv_sdnn_ms=float(r["hrv_rmssd_milli"]) if r.get("hrv_rmssd_milli") is not None else None,
+                avg_hrv_rmssd_ms=float(r["hrv_rmssd_milli"]) if r.get("hrv_rmssd_milli") is not None else None,
                 avg_spo2_percent=float(r["spo2_percentage"]) if r.get("spo2_percentage") is not None else None,
                 recovery_score=r.get("recovery_score"),
             )

--- a/backend/tests/api/v1/test_summaries.py
+++ b/backend/tests/api/v1/test_summaries.py
@@ -1514,7 +1514,8 @@ class TestRecoverySummaryEndpoint:
         assert response.status_code == 200
         item = response.json()["data"][0]
         assert item["resting_heart_rate_bpm"] == 58
-        assert item["avg_hrv_sdnn_ms"] == 45.5
+        assert item["avg_hrv_rmssd_ms"] == 45.5
+        assert item["avg_hrv_sdnn_ms"] is None
         assert item["avg_spo2_percent"] == 97.0
 
     def test_empty_range_returns_no_data(self, client: TestClient, db: Session) -> None:

--- a/backend/tests/services/test_summaries_service.py
+++ b/backend/tests/services/test_summaries_service.py
@@ -263,6 +263,43 @@ class TestGetSleepSummaries:
 
 
 # ---------------------------------------------------------------------------
+# get_recovery_summaries
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecoverySummaries:
+    def test_whoop_rmssd_is_not_exposed_as_sdnn(self, service: SummariesService, monkeypatch: pytest.MonkeyPatch) -> None:
+        row = {
+            "recovery_date": date(2026, 1, 2),
+            "provider": "whoop",
+            "source": "whoop",
+            "device_model": "WHOOP",
+            "device_type": "band",
+            "record_id": uuid4(),
+            "recorded_at": _dt("2026-01-02T00:00:00+00:00"),
+            "recovery_score": 74,
+            "resting_heart_rate": 51,
+            "hrv_rmssd_milli": 63.2,
+            "spo2_percentage": 98.4,
+        }
+        monkeypatch.setattr(service.health_score_repo, "get_recovery_summaries", lambda *_: [row])
+        monkeypatch.setattr(service, "_filter_by_priority", lambda *_args, **_kwargs: [row])
+
+        result = service.get_recovery_summaries(
+            db_session=None,
+            user_id=uuid4(),
+            start_date=_dt("2026-01-01T00:00:00+00:00"),
+            end_date=_dt("2026-01-03T00:00:00+00:00"),
+            cursor=None,
+            limit=10,
+        )
+
+        summary = result.data[0]
+        assert summary.avg_hrv_sdnn_ms is None
+        assert summary.avg_hrv_rmssd_ms == 63.2
+
+
+# ---------------------------------------------------------------------------
 # get_activity_summaries
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/services/test_summaries_service.py
+++ b/backend/tests/services/test_summaries_service.py
@@ -268,7 +268,9 @@ class TestGetSleepSummaries:
 
 
 class TestGetRecoverySummaries:
-    def test_whoop_rmssd_is_not_exposed_as_sdnn(self, service: SummariesService, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_rmssd_input_is_exposed_as_rmssd_not_sdnn(
+        self, service: SummariesService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         row = {
             "recovery_date": date(2026, 1, 2),
             "provider": "whoop",


### PR DESCRIPTION
## Description

Fixes a semantic mismatch in the recovery summaries API for WHOOP data.

WHOOP provides HRV as `hrv_rmssd_milli`, and Open Wearables already classifies this internally as `heart_rate_variability_rmssd`. However, the recovery-summary response exposed the same value through `avg_hrv_sdnn_ms`.

RMSSD and SDNN are distinct HRV measures. This change adds `avg_hrv_rmssd_ms` to the response and maps WHOOP RMSSD data to that field instead.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [x] No docs update needed

### Backend Changes

- [ ] `uv run pre-commit run --all-files` passes

### Frontend Changes

- [x] Not applicable

## Testing Instructions

**Steps to test:**

1. From the repository root, enter the backend directory:

   ```bash
   cd backend
   ```

2. Install the locked development environment:

   ```bash
   uv sync --group dev
   ```

3. Run the new regression test:

   ```bash
   uv run pytest tests/services/test_summaries_service.py -k whoop_rmssd
   ```

4. Run the full backend test suite:

   ```bash
   uv run pytest
   ```

5. Run project checks:

   ```bash
   uv run pre-commit run --all-files
   ```

**Expected behavior:**

- A WHOOP recovery summary with `hrv_rmssd_milli: 63.2` returns:

  ```json
  {
    "avg_hrv_sdnn_ms": null,
    "avg_hrv_rmssd_ms": 63.2
  }
  ```

- No WHOOP RMSSD value is exposed as SDNN.

## Screenshots

Not applicable; this is a backend API response correction.

## Additional Notes

This does not change WHOOP ingestion or stored source data. It corrects the recovery-summary API contract so that RMSSD and SDNN remain semantically distinct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery summaries now include average HRV RMSSD measurements.

* **Bug Fixes**
  * Corrected HRV data mapping so RMSSD values appear in the appropriate field instead of being reported as SDNN.

* **Documentation**
  * Clarified provider limitations and when SDNN may be unavailable.
  * Marked recovery scores as deprecated and directed users to the health scores endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->