### PR TITLE
feat(backend): offload SDK upload payload to S3, enqueue only a reference

### DIFF
--- a/backend/app/api/routes/v1/sdk_sync.py
+++ b/backend/app/api/routes/v1/sdk_sync.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, HTTPException, status
 from app.integrations.celery.tasks.process_sdk_upload_task import process_sdk_upload
 from app.schemas.providers.mobile_sdk import SyncRequest
 from app.schemas.responses.upload import UploadDataResponse
-from app.services.raw_payload_storage import store_raw_payload
+from app.services.raw_payload_storage import s3_enabled, store_raw_payload
 from app.utils.api_utils import inline_schema_defs
 from app.utils.auth import SDKAuthDep
 from app.utils.structured_logging import log_structured
@@ -107,7 +107,10 @@ def sync_sdk_data(
 
     content_str = json.dumps(body)
 
-    store_raw_payload(
+    # Persist the raw payload and pass only a reference to the worker so the (potentially
+    # multi-MB) body never travels through the Celery/Redis broker - that broker bloat is
+    # what drove Redis to maxmemory. When S3 storage is off (dev), fall back to inline content.
+    payload_ref = store_raw_payload(
         source="sdk",
         provider=provider,
         payload=content_str,
@@ -115,12 +118,31 @@ def sync_sdk_data(
         trace_id=batch_id,
     )
 
+    if s3_enabled() and payload_ref is None:
+        # S3 is the payload channel here; a missing key means the write failed or the payload
+        # exceeded the size limit. Fail loudly rather than silently falling back to inline
+        # content (which would re-introduce the broker bloat for exactly the large payloads).
+        log_structured(
+            logger,
+            "error",
+            "Failed to persist SDK payload to S3; rejecting batch",
+            action="sdk_payload_persist_failed",
+            batch_id=batch_id,
+            user_id=user_id,
+            provider=provider,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Failed to persist payload; please retry.",
+        )
+
     process_sdk_upload.delay(
-        content=content_str,
+        content=None if payload_ref else content_str,
         content_type="application/json",
         user_id=user_id,
         provider=provider,
         batch_id=batch_id,
+        payload_ref=payload_ref,
     )
 
     return UploadDataResponse(status_code=202, response="Import task queued successfully", user_id=user_id)

--- a/backend/app/api/routes/v1/sdk_sync.py
+++ b/backend/app/api/routes/v1/sdk_sync.py
@@ -4,6 +4,7 @@ from logging import getLogger
 
 from fastapi import APIRouter, HTTPException, status
 
+from app.config import settings
 from app.integrations.celery.tasks.process_sdk_upload_task import process_sdk_upload
 from app.schemas.providers.mobile_sdk import SyncRequest
 from app.schemas.responses.upload import UploadDataResponse
@@ -107,9 +108,6 @@ def sync_sdk_data(
 
     content_str = json.dumps(body)
 
-    # Persist the raw payload and pass only a reference to the worker so the (potentially
-    # multi-MB) body never travels through the Celery/Redis broker - that broker bloat is
-    # what drove Redis to maxmemory. When S3 storage is off (dev), fall back to inline content.
     payload_ref = store_raw_payload(
         source="sdk",
         provider=provider,
@@ -118,10 +116,12 @@ def sync_sdk_data(
         trace_id=batch_id,
     )
 
-    if s3_enabled() and payload_ref is None:
+    # Gated by SDK_PAYLOAD_S3_OFFLOAD so instances without S3 keep the legacy inline path.
+    offload_to_s3 = settings.sdk_payload_s3_offload and s3_enabled()
+
+    if offload_to_s3 and payload_ref is None:
         # S3 is the payload channel here; a missing key means the write failed or the payload
-        # exceeded the size limit. Fail loudly rather than silently falling back to inline
-        # content (which would re-introduce the broker bloat for exactly the large payloads).
+        # exceeded the size limit. Fail loudly rather than silently falling back to inline.
         log_structured(
             logger,
             "error",
@@ -137,12 +137,12 @@ def sync_sdk_data(
         )
 
     process_sdk_upload.delay(
-        content=None if payload_ref else content_str,
+        content=None if offload_to_s3 else content_str,
         content_type="application/json",
         user_id=user_id,
         provider=provider,
         batch_id=batch_id,
-        payload_ref=payload_ref,
+        payload_ref=payload_ref if offload_to_s3 else None,
     )
 
     return UploadDataResponse(status_code=202, response="Import task queued successfully", user_id=user_id)

--- a/backend/app/api/routes/v1/sdk_sync.py
+++ b/backend/app/api/routes/v1/sdk_sync.py
@@ -8,9 +8,10 @@ from app.config import settings
 from app.integrations.celery.tasks.process_sdk_upload_task import process_sdk_upload
 from app.schemas.providers.mobile_sdk import SyncRequest
 from app.schemas.responses.upload import UploadDataResponse
-from app.services.raw_payload_storage import s3_enabled, store_raw_payload
+from app.services.raw_payload_storage import put_payload_to_s3, store_raw_payload
 from app.utils.api_utils import inline_schema_defs
 from app.utils.auth import SDKAuthDep
+from app.utils.sentry_helpers import log_and_capture_error
 from app.utils.structured_logging import log_structured
 
 router = APIRouter()
@@ -108,20 +109,19 @@ def sync_sdk_data(
 
     content_str = json.dumps(body)
 
-    payload_ref = store_raw_payload(
-        source="sdk",
-        provider=provider,
-        payload=content_str,
-        user_id=user_id,
-        trace_id=batch_id,
-    )
+    offload = settings.sdk_payload_s3_offload
+    payload_ref: str | None = None
 
-    # Gated by SDK_PAYLOAD_S3_OFFLOAD so instances without S3 keep the legacy inline path.
-    offload_to_s3 = settings.sdk_payload_s3_offload and s3_enabled()
+    if offload:
+        payload_ref = put_payload_to_s3(
+            source="sdk", provider=provider, payload=content_str, user_id=user_id, trace_id=batch_id
+        )
+    else:
+        store_raw_payload(source="sdk", provider=provider, payload=content_str, user_id=user_id, trace_id=batch_id)
 
-    if offload_to_s3 and payload_ref is None:
-        # S3 is the payload channel here; a missing key means the write failed or the payload
-        # exceeded the size limit. Fail loudly rather than silently falling back to inline.
+    if offload and payload_ref is None:
+        # Fail loudly: falling back to an inline body is what fills the broker until Redis
+        # hits maxmemory, and the SDK can retry the upload.
         log_structured(
             logger,
             "error",
@@ -131,18 +131,25 @@ def sync_sdk_data(
             user_id=user_id,
             provider=provider,
         )
-        raise HTTPException(
+        exc = HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Failed to persist payload; please retry.",
         )
+        log_and_capture_error(
+            exc,
+            logger,
+            "Failed to persist SDK payload to S3; rejecting batch",
+            extra={"batch_id": batch_id, "user_id": user_id, "provider": provider},
+        )
+        raise exc
 
     process_sdk_upload.delay(
-        content=None if offload_to_s3 else content_str,
+        content=None if offload else content_str,
         content_type="application/json",
         user_id=user_id,
         provider=provider,
         batch_id=batch_id,
-        payload_ref=payload_ref if offload_to_s3 else None,
+        payload_ref=payload_ref,
     )
 
     return UploadDataResponse(status_code=202, response="Import task queued successfully", user_id=user_id)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -244,6 +244,11 @@ class Settings(BaseSettings):
     raw_payload_s3_prefix: str = "raw-payloads"
     raw_payload_s3_endpoint_url: str | None = None  # for S3-compatible storage (e.g. Railway Object Storage)
 
+    # When on (and raw_payload_storage=s3), the SDK sync endpoint enqueues an S3 reference to
+    # the payload instead of the inline body, keeping large uploads out of the Celery/Redis
+    # broker. Off by default so instances without S3 keep the legacy inline path (migration).
+    sdk_payload_s3_offload: bool = False
+
     # SVIX WEBHOOK SETTINGS
     # Master switch for outgoing webhooks. Off by default so deployments without Svix
     # (no svix-server container) never build a client, emit, or register event types.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -244,9 +244,9 @@ class Settings(BaseSettings):
     raw_payload_s3_prefix: str = "raw-payloads"
     raw_payload_s3_endpoint_url: str | None = None  # for S3-compatible storage (e.g. Railway Object Storage)
 
-    # When on (and raw_payload_storage=s3), the SDK sync endpoint enqueues an S3 reference to
-    # the payload instead of the inline body, keeping large uploads out of the Celery/Redis
-    # broker. Off by default so instances without S3 keep the legacy inline path (migration).
+    # SDK sync enqueues an S3 reference instead of the inline body, so a queued batch is
+    # ~1 KB rather than ~1.5x the payload and a backlog stops eating Redis. Needs a bucket,
+    # not raw_payload_storage=s3 — archival is a debug aid, not a reliability dependency.
     sdk_payload_s3_offload: bool = False
 
     # SVIX WEBHOOK SETTINGS
@@ -264,6 +264,16 @@ class Settings(BaseSettings):
         if self.access_log_level is None:
             self.access_log_level = (
                 AccessLogLevel.ERRORS if self.environment == EnvironmentType.PRODUCTION else AccessLogLevel.ALL
+            )
+        return self
+
+    @model_validator(mode="after")
+    def check_sdk_payload_s3_offload(self) -> "Settings":
+        """Fail at startup rather than degrading to inline payloads on the first request."""
+        if self.sdk_payload_s3_offload and not self.raw_payload_bucket:
+            raise ValueError(
+                "SDK_PAYLOAD_S3_OFFLOAD is on but no S3 bucket is configured - "
+                "set RAW_PAYLOAD_S3_BUCKET or AWS_BUCKET_NAME."
             )
         return self
 
@@ -336,6 +346,11 @@ class Settings(BaseSettings):
             )
             return legacy_value
         return f"{self.api_base_url}/api/v1/oauth/{provider.value}/callback"
+
+    @property
+    def raw_payload_bucket(self) -> str | None:
+        """Bucket for raw payload storage and SDK payload offload."""
+        return self.raw_payload_s3_bucket or self.aws_bucket_name
 
     @property
     def redis_url(self) -> str:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -244,9 +244,9 @@ class Settings(BaseSettings):
     raw_payload_s3_prefix: str = "raw-payloads"
     raw_payload_s3_endpoint_url: str | None = None  # for S3-compatible storage (e.g. Railway Object Storage)
 
-    # SDK sync enqueues an S3 reference instead of the inline body, so a queued batch is
-    # ~1 KB rather than ~1.5x the payload and a backlog stops eating Redis. Needs a bucket,
-    # not raw_payload_storage=s3 — archival is a debug aid, not a reliability dependency.
+    # SDK sync enqueues an S3 reference instead of the inline body, so a backlog stops eating
+    # broker memory. Needs a bucket, not raw_payload_storage=s3 — archival is a debug aid,
+    # not a reliability dependency.
     sdk_payload_s3_offload: bool = False
 
     # SVIX WEBHOOK SETTINGS

--- a/backend/app/integrations/celery/core.py
+++ b/backend/app/integrations/celery/core.py
@@ -69,10 +69,11 @@ def init_raw_payload_storage(**kwargs) -> None:
     raw_payload_storage.configure(
         settings.raw_payload_storage,
         settings.raw_payload_max_size_bytes,
-        s3_bucket=settings.raw_payload_s3_bucket or settings.aws_bucket_name,
+        s3_bucket=settings.raw_payload_bucket,
         s3_prefix=settings.raw_payload_s3_prefix,
         s3_endpoint_url=settings.raw_payload_s3_endpoint_url,
         fit_files_enabled=settings.store_fit_files,
+        transport_enabled=settings.sdk_payload_s3_offload,
     )
 
 

--- a/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
+++ b/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
@@ -16,6 +16,7 @@ from app.services.apple.healthkit.import_service import (
 from app.services.apple.healthkit.import_service import (
     import_service as sdk_import_service,
 )
+from app.services.raw_payload_storage import load_raw_payload
 from app.services.sync_status_service import completed, failed, started
 from app.utils.structured_logging import log_structured
 
@@ -30,21 +31,25 @@ def _get_import_service(provider: str) -> SDKImportService:
 
 @shared_task(queue="sdk_sync")
 def process_sdk_upload(
-    content: str,
+    content: str | None,
     content_type: str,
     user_id: str,
     provider: str,
     batch_id: str | None = None,
+    payload_ref: str | None = None,
 ) -> dict[str, Any]:
     """
     Process SDK data import asynchronously.
 
     Args:
-        content: The request content as string (JSON or multipart data)
+        content: The request content as string (JSON or multipart data). None when the
+            payload was offloaded to S3 - see ``payload_ref``.
         content_type: The content type header value
         user_id: User ID to associate with the data
         provider: Import provider - "apple", "samsung", "google"
         batch_id: Unique batch identifier for tracking (optional for backwards compatibility)
+        payload_ref: S3 key of the stored payload. When set (and ``content`` is None) the body
+            is loaded from S3 here, so the large payload never travels through the broker.
 
     Returns:
         Dictionary with status_code and response message
@@ -52,6 +57,23 @@ def process_sdk_upload(
     # Generate batch_id if not provided (backwards compatibility)
     if not batch_id:
         batch_id = str(uuid.uuid4())
+
+    # Load the payload from S3 when only a reference was enqueued. A read failure raises,
+    # letting Celery retry (the S3 object persists) rather than losing the batch.
+    if content is None and payload_ref:
+        content = load_raw_payload(payload_ref)
+
+    if content is None:
+        log_structured(
+            logger,
+            "warning",
+            "No payload content or reference provided",
+            provider=provider,
+            action="validate_payload_present",
+            batch_id=batch_id,
+            user_id=user_id,
+        )
+        return {"status": "error", "reason": "missing_payload", "batch_id": batch_id}
 
     # Validate user_id format
     try:

--- a/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
+++ b/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
@@ -48,8 +48,8 @@ def process_sdk_upload(
         user_id: User ID to associate with the data
         provider: Import provider - "apple", "samsung", "google"
         batch_id: Unique batch identifier for tracking (optional for backwards compatibility)
-        payload_ref: S3 key of the stored payload. When set (and ``content`` is None) the body
-            is loaded from S3 here, so the large payload never travels through the broker.
+        payload_ref: ``s3://bucket/key`` of the stored payload. When set (and ``content`` is
+            None) the body is loaded from S3 here, so it never travels through the broker.
 
     Returns:
         Dictionary with status_code and response message
@@ -58,10 +58,24 @@ def process_sdk_upload(
     if not batch_id:
         batch_id = str(uuid.uuid4())
 
-    # Load the payload from S3 when only a reference was enqueued. A read failure raises,
-    # letting Celery retry (the S3 object persists) rather than losing the batch.
+    # Payload was offloaded to S3, so the body never travelled through the broker. A read
+    # failure propagates: boto3 has already retried the transient cases, and CeleryIntegration
+    # reports the exception to Sentry.
     if content is None and payload_ref:
-        content = get_payload_from_s3(payload_ref)
+        try:
+            content = get_payload_from_s3(payload_ref)
+        except Exception:
+            log_structured(
+                logger,
+                "error",
+                "Failed to load SDK payload from S3",
+                provider=provider,
+                action="load_payload_ref",
+                batch_id=batch_id,
+                user_id=user_id,
+                payload_ref=payload_ref,
+            )
+            raise
 
     if content is None:
         log_structured(

--- a/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
+++ b/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from celery import shared_task
 
+from app.config import settings
 from app.database import SessionLocal
 from app.models import User
 from app.repositories.user_connection_repository import UserConnectionRepository
@@ -16,7 +17,7 @@ from app.services.apple.healthkit.import_service import (
 from app.services.apple.healthkit.import_service import (
     import_service as sdk_import_service,
 )
-from app.services.raw_payload_storage import get_payload_from_s3
+from app.services.raw_payload_storage import delete_payload_from_s3, get_payload_from_s3
 from app.services.sync_status_service import completed, failed, started
 from app.utils.structured_logging import log_structured
 
@@ -197,6 +198,10 @@ def process_sdk_upload(
                     "dropped_count": dropped_count,
                 },
             )
+            if payload_ref and settings.raw_payload_storage == "disabled":
+                # Transport-only copy and the data is committed, so drop it. A failed batch
+                # keeps its payload for diagnosis.
+                delete_payload_from_s3(payload_ref)
         else:
             failed(
                 user_uuid,

--- a/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
+++ b/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
@@ -16,7 +16,7 @@ from app.services.apple.healthkit.import_service import (
 from app.services.apple.healthkit.import_service import (
     import_service as sdk_import_service,
 )
-from app.services.raw_payload_storage import load_raw_payload
+from app.services.raw_payload_storage import get_payload_from_s3
 from app.services.sync_status_service import completed, failed, started
 from app.utils.structured_logging import log_structured
 
@@ -61,7 +61,7 @@ def process_sdk_upload(
     # Load the payload from S3 when only a reference was enqueued. A read failure raises,
     # letting Celery retry (the S3 object persists) rather than losing the batch.
     if content is None and payload_ref:
-        content = load_raw_payload(payload_ref)
+        content = get_payload_from_s3(payload_ref)
 
     if content is None:
         log_structured(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -59,10 +59,11 @@ init_sentry()
 raw_payload_storage.configure(
     settings.raw_payload_storage,
     settings.raw_payload_max_size_bytes,
-    s3_bucket=settings.raw_payload_s3_bucket or settings.aws_bucket_name,
+    s3_bucket=settings.raw_payload_bucket,
     s3_prefix=settings.raw_payload_s3_prefix,
     s3_endpoint_url=settings.raw_payload_s3_endpoint_url,
     fit_files_enabled=settings.store_fit_files,
+    transport_enabled=settings.sdk_payload_s3_offload,
 )
 
 add_cors_middleware(api)

--- a/backend/app/services/raw_payload_storage.py
+++ b/backend/app/services/raw_payload_storage.py
@@ -131,7 +131,7 @@ def store_raw_payload(
     if _storage_backend == "log":
         _store_to_log(source, provider, payload_str, size, user_id, trace_id)
         return None
-    elif _storage_backend == "s3":
+    if _storage_backend == "s3":
         return _store_to_s3(source, provider, payload_str, size, user_id, trace_id)
     return None
 

--- a/backend/app/services/raw_payload_storage.py
+++ b/backend/app/services/raw_payload_storage.py
@@ -84,6 +84,15 @@ def _create_s3_client(endpoint_url: str | None = None) -> Any:
         return None
 
 
+def s3_enabled() -> bool:
+    """True when the S3 backend is active and usable (client + bucket configured).
+
+    Callers that need a retrievable reference (e.g. async task payloads) check this to
+    decide between passing an S3 key or falling back to inline content.
+    """
+    return _storage_backend == "s3" and _s3_client is not None and _s3_bucket is not None
+
+
 def store_raw_payload(
     *,
     source: str,
@@ -91,7 +100,7 @@ def store_raw_payload(
     payload: Any,
     user_id: str | None = None,
     trace_id: str | None = None,
-) -> None:
+) -> str | None:
     """Store a raw payload. No-op when disabled.
 
     Args:
@@ -100,9 +109,12 @@ def store_raw_payload(
         payload: Raw data (dict, list, or pre-serialized string)
         user_id: Optional user identifier for correlation
         trace_id: Optional trace/batch ID for correlation with processed data
+
+    Returns:
+        The S3 object key when stored to S3, else None (disabled/log backend, or skipped).
     """
     if _storage_backend == "disabled":
-        return
+        return None
 
     payload_str = payload if isinstance(payload, str) else json.dumps(payload, default=json_serial)
 
@@ -114,12 +126,27 @@ def store_raw_payload(
             size,
             _max_size_bytes,
         )
-        return
+        return None
 
     if _storage_backend == "log":
         _store_to_log(source, provider, payload_str, size, user_id, trace_id)
+        return None
     elif _storage_backend == "s3":
-        _store_to_s3(source, provider, payload_str, size, user_id, trace_id)
+        return _store_to_s3(source, provider, payload_str, size, user_id, trace_id)
+    return None
+
+
+def load_raw_payload(key: str) -> str:
+    """Read a previously-stored payload back from S3 by key.
+
+    Used by async tasks that receive an S3 reference instead of the inline payload, so the
+    large body never travels through the Celery/Redis broker. Raises on any read failure;
+    the caller decides whether to retry the task.
+    """
+    if _s3_client is None or _s3_bucket is None:
+        raise RuntimeError("Cannot load raw payload: S3 client or bucket not configured")
+    obj = _s3_client.get_object(Bucket=_s3_bucket, Key=key)
+    return obj["Body"].read().decode("utf-8")
 
 
 def _store_to_log(
@@ -153,15 +180,17 @@ def _store_to_s3(
     size: int,
     user_id: str | None,
     trace_id: str | None,
-) -> None:
+) -> str | None:
     """Upload raw payload to S3.
 
     Key format: {prefix}/{provider}/{source}/{YYYY-MM-DD}/{uuid}.json
     Metadata includes user_id, trace_id, and size for easy filtering.
+
+    Returns the object key on success, or None on failure.
     """
     if _s3_client is None or _s3_bucket is None:
         logger.warning("S3 client or bucket not configured - skipping raw payload storage")
-        return
+        return None
 
     now = datetime.now(UTC)
     date_part = now.strftime("%Y-%m-%d")
@@ -194,8 +223,10 @@ def _store_to_s3(
             key,
             size,
         )
+        return key
     except Exception:
         logger.exception("Failed to store raw payload to S3: s3://%s/%s", _s3_bucket, key)
+        return None
 
 
 def store_fit_file(

--- a/backend/app/services/raw_payload_storage.py
+++ b/backend/app/services/raw_payload_storage.py
@@ -38,6 +38,7 @@ def configure(
     s3_prefix: str = "raw-payloads",
     s3_endpoint_url: str | None = None,
     fit_files_enabled: bool = False,
+    transport_enabled: bool = False,
 ) -> None:
     """Called once at startup from settings."""
     global _storage_backend, _max_size_bytes, _s3_bucket, _s3_prefix, _s3_client, _fit_files_enabled
@@ -46,7 +47,7 @@ def configure(
     _s3_prefix = s3_prefix
     _fit_files_enabled = False
 
-    if storage_backend == "s3" or fit_files_enabled:
+    if storage_backend == "s3" or fit_files_enabled or transport_enabled:
         _s3_bucket = s3_bucket
         if not _s3_bucket:
             logger.error("S3 storage requested but no S3 bucket configured")
@@ -58,7 +59,7 @@ def configure(
             _storage_backend = "disabled"
             return
         if storage_backend != "s3":
-            # Client created solely for FIT file storage
+            # Client created solely for FIT file storage / payload transport
             _storage_backend = "disabled"
         _fit_files_enabled = fit_files_enabled
 
@@ -84,15 +85,6 @@ def _create_s3_client(endpoint_url: str | None = None) -> Any:
         return None
 
 
-def s3_enabled() -> bool:
-    """True when the S3 backend is active and usable (client + bucket configured).
-
-    Callers that need a retrievable reference (e.g. async task payloads) check this to
-    decide between passing an S3 key or falling back to inline content.
-    """
-    return _storage_backend == "s3" and _s3_client is not None and _s3_bucket is not None
-
-
 def store_raw_payload(
     *,
     source: str,
@@ -100,8 +92,8 @@ def store_raw_payload(
     payload: Any,
     user_id: str | None = None,
     trace_id: str | None = None,
-) -> str | None:
-    """Store a raw payload. No-op when disabled.
+) -> None:
+    """Store a raw payload for debugging. No-op when disabled.
 
     Args:
         source: Origin type - "sdk", "webhook", or "api_response"
@@ -109,12 +101,9 @@ def store_raw_payload(
         payload: Raw data (dict, list, or pre-serialized string)
         user_id: Optional user identifier for correlation
         trace_id: Optional trace/batch ID for correlation with processed data
-
-    Returns:
-        The S3 object key when stored to S3, else None (disabled/log backend, or skipped).
     """
     if _storage_backend == "disabled":
-        return None
+        return
 
     payload_str = payload if isinstance(payload, str) else json.dumps(payload, default=json_serial)
 
@@ -126,26 +115,26 @@ def store_raw_payload(
             size,
             _max_size_bytes,
         )
-        return None
+        return
 
     if _storage_backend == "log":
         _store_to_log(source, provider, payload_str, size, user_id, trace_id)
-        return None
-    if _storage_backend == "s3":
-        return _store_to_s3(source, provider, payload_str, size, user_id, trace_id)
-    return None
+    elif _storage_backend == "s3":
+        put_payload_to_s3(source=source, provider=provider, payload=payload_str, user_id=user_id, trace_id=trace_id)
 
 
-def load_raw_payload(key: str) -> str:
-    """Read a previously-stored payload back from S3 by key.
+def get_payload_from_s3(ref: str) -> str:
+    """Read a payload back from an ``s3://bucket/key`` reference.
 
-    Used by async tasks that receive an S3 reference instead of the inline payload, so the
-    large body never travels through the Celery/Redis broker. Raises on any read failure;
-    the caller decides whether to retry the task.
+    Raises on any read failure; the caller decides whether to retry the task.
     """
-    if _s3_client is None or _s3_bucket is None:
-        raise RuntimeError("Cannot load raw payload: S3 client or bucket not configured")
-    obj = _s3_client.get_object(Bucket=_s3_bucket, Key=key)
+    if _s3_client is None:
+        raise RuntimeError("Cannot get payload: S3 client not configured")
+    # Bucket travels in the ref: app/worker config drift would otherwise be a silent 404.
+    bucket, _, key = ref.removeprefix("s3://").partition("/")
+    if not bucket or not key:
+        raise ValueError(f"Malformed S3 payload reference: {ref}")
+    obj = _s3_client.get_object(Bucket=bucket, Key=key)
     return obj["Body"].read().decode("utf-8")
 
 
@@ -173,25 +162,26 @@ def _store_to_log(
     print(json.dumps(entry), file=sys.stdout, flush=True)
 
 
-def _store_to_s3(
+def put_payload_to_s3(
+    *,
     source: str,
     provider: str,
-    payload_str: str,
-    size: int,
-    user_id: str | None,
-    trace_id: str | None,
+    payload: str,
+    user_id: str | None = None,
+    trace_id: str | None = None,
 ) -> str | None:
-    """Upload raw payload to S3.
+    """Upload a serialized payload to S3 and return its ``s3://bucket/key`` reference.
 
-    Key format: {prefix}/{provider}/{source}/{YYYY-MM-DD}/{uuid}.json
+    Key format: {prefix}/{provider}/{source}/{YYYY-MM-DD}/{user_id}/{uuid}.json
     Metadata includes user_id, trace_id, and size for easy filtering.
 
-    Returns the object key on success, or None on failure.
+    Returns None on failure - a caller that needs the reference has to handle that.
     """
     if _s3_client is None or _s3_bucket is None:
-        logger.warning("S3 client or bucket not configured - skipping raw payload storage")
+        logger.warning("S3 client or bucket not configured - skipping payload upload")
         return None
 
+    body = payload.encode("utf-8")
     now = datetime.now(UTC)
     date_part = now.strftime("%Y-%m-%d")
     file_id = uuid4().hex[:12]
@@ -201,7 +191,7 @@ def _store_to_s3(
     metadata: dict[str, str] = {
         "source": source,
         "provider": provider,
-        "size_bytes": str(size),
+        "size_bytes": str(len(body)),
         "timestamp": now.isoformat(),
     }
     if user_id:
@@ -213,19 +203,14 @@ def _store_to_s3(
         _s3_client.put_object(
             Bucket=_s3_bucket,
             Key=key,
-            Body=payload_str.encode("utf-8"),
+            Body=body,
             ContentType="application/json",
             Metadata=metadata,
         )
-        logger.debug(
-            "Stored raw payload to S3: s3://%s/%s (%d bytes)",
-            _s3_bucket,
-            key,
-            size,
-        )
-        return key
+        logger.debug("Stored payload to S3: s3://%s/%s (%d bytes)", _s3_bucket, key, len(body))
+        return f"s3://{_s3_bucket}/{key}"
     except Exception:
-        logger.exception("Failed to store raw payload to S3: s3://%s/%s", _s3_bucket, key)
+        logger.exception("Failed to store payload to S3: s3://%s/%s", _s3_bucket, key)
         return None
 
 

--- a/backend/app/services/raw_payload_storage.py
+++ b/backend/app/services/raw_payload_storage.py
@@ -156,7 +156,11 @@ def _split_ref(ref: str) -> tuple[str, str]:
     The bucket travels in the reference because app/worker config drift would otherwise
     turn into a silent 404 on a payload that was written just fine.
     """
-    bucket, _, key = ref.removeprefix("s3://").partition("/")
+    if not ref.startswith("s3://"):
+        # A bare key would split into a bucket named after our own prefix, reading from
+        # someone else's bucket without a word of complaint.
+        raise ValueError(f"Payload reference must be an s3:// URI: {ref}")
+    bucket, _, key = ref[len("s3://") :].partition("/")
     if not bucket or not key:
         raise ValueError(f"Malformed S3 payload reference: {ref}")
     return bucket, key

--- a/backend/app/services/raw_payload_storage.py
+++ b/backend/app/services/raw_payload_storage.py
@@ -130,12 +130,36 @@ def get_payload_from_s3(ref: str) -> str:
     """
     if _s3_client is None:
         raise RuntimeError("Cannot get payload: S3 client not configured")
-    # Bucket travels in the ref: app/worker config drift would otherwise be a silent 404.
+    bucket, key = _split_ref(ref)
+    obj = _s3_client.get_object(Bucket=bucket, Key=key)
+    return obj["Body"].read().decode("utf-8")
+
+
+def delete_payload_from_s3(ref: str) -> None:
+    """Delete a payload by ``s3://bucket/key`` reference. Best-effort - never raises.
+
+    Drops a transport-only copy once the data is persisted, so a deployment that opted out
+    of payload archival does not accumulate them. Needs ``s3:DeleteObject``.
+    """
+    if _s3_client is None:
+        return
+    try:
+        bucket, key = _split_ref(ref)
+        _s3_client.delete_object(Bucket=bucket, Key=key)
+    except Exception:
+        logger.exception("Failed to delete payload from S3: %s", ref)
+
+
+def _split_ref(ref: str) -> tuple[str, str]:
+    """Split ``s3://bucket/key``.
+
+    The bucket travels in the reference because app/worker config drift would otherwise
+    turn into a silent 404 on a payload that was written just fine.
+    """
     bucket, _, key = ref.removeprefix("s3://").partition("/")
     if not bucket or not key:
         raise ValueError(f"Malformed S3 payload reference: {ref}")
-    obj = _s3_client.get_object(Bucket=bucket, Key=key)
-    return obj["Body"].read().decode("utf-8")
+    return bucket, key
 
 
 def _store_to_log(

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -62,6 +62,10 @@ ADMIN_PASSWORD=your-secure-password
 # RAW_PAYLOAD_STORAGE=disabled
 # RAW_PAYLOAD_MAX_SIZE_BYTES=10485760  # Max stored payload size (10 MB)
 
+#--- SDK PAYLOAD OFFLOAD ---#
+# Queue an S3 reference to the SDK sync payload instead of the payload itself
+SDK_PAYLOAD_S3_OFFLOAD=false
+
 #--- REPLAY RAW PAYLOADS ---#
 # set -a && source config/.env && set +a
 # uv run --with boto3,httpx scripts/replay_raw_payloads.py --user-id <user UUID within s3 bucket> --target-user-id <your's OW instance user UUID>

--- a/backend/tests/api/v1/test_sdk_sync_offload.py
+++ b/backend/tests/api/v1/test_sdk_sync_offload.py
@@ -1,0 +1,84 @@
+"""Tests for SDK sync payload offload - the queue carries a reference, not the body."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from app.config import settings
+from tests.factories import ApiKeyFactory
+
+_USER_ID = "123e4567-e89b-12d3-a456-426614174000"
+_REF = "s3://bucket/raw-payloads/apple/sdk/2026-08-26/user/x.json"
+_BODY = {
+    "provider": "apple",
+    "sdkVersion": "1.0.0",
+    "syncTimestamp": "2021-01-01T00:00:00Z",
+    "data": {"records": [], "workouts": [], "sleep": []},
+}
+
+
+@pytest.fixture
+def mock_task() -> Generator[MagicMock, None, None]:
+    with patch("app.api.routes.v1.sdk_sync.process_sdk_upload") as mock:
+        mock.delay.return_value = None
+        yield mock
+
+
+def _sync(client: TestClient, api_v1_prefix: str) -> object:
+    api_key = ApiKeyFactory()
+    return client.post(
+        f"{api_v1_prefix}/sdk/users/{_USER_ID}/sync/",
+        headers={"X-Open-Wearables-API-Key": api_key.id},
+        json=_BODY,
+    )
+
+
+class TestOffloadDisabled:
+    def test_body_is_enqueued_inline(self, client: TestClient, api_v1_prefix: str, mock_task: MagicMock) -> None:
+        with (
+            patch.object(settings, "sdk_payload_s3_offload", False),
+            patch("app.api.routes.v1.sdk_sync.store_raw_payload") as mock_archive,
+            patch("app.api.routes.v1.sdk_sync.put_payload_to_s3") as mock_put,
+        ):
+            response = _sync(client, api_v1_prefix)
+
+        assert response.status_code == 202
+        mock_put.assert_not_called()
+        mock_archive.assert_called_once()
+
+        kwargs = mock_task.delay.call_args[1]
+        assert kwargs["payload_ref"] is None
+        assert '"provider": "apple"' in kwargs["content"]
+
+
+class TestOffloadEnabled:
+    def test_only_a_reference_is_enqueued(self, client: TestClient, api_v1_prefix: str, mock_task: MagicMock) -> None:
+        with (
+            patch.object(settings, "sdk_payload_s3_offload", True),
+            patch("app.api.routes.v1.sdk_sync.store_raw_payload") as mock_archive,
+            patch("app.api.routes.v1.sdk_sync.put_payload_to_s3", return_value=_REF),
+        ):
+            response = _sync(client, api_v1_prefix)
+
+        assert response.status_code == 202
+        # Transport owns the object, so the archival write is not called on top of it.
+        mock_archive.assert_not_called()
+
+        kwargs = mock_task.delay.call_args[1]
+        assert kwargs["content"] is None
+        assert kwargs["payload_ref"] == _REF
+
+    def test_upload_failure_rejects_the_batch(
+        self, client: TestClient, api_v1_prefix: str, mock_task: MagicMock
+    ) -> None:
+        """Falling back to an inline body is what fills the broker, so fail loudly instead."""
+        with (
+            patch.object(settings, "sdk_payload_s3_offload", True),
+            patch("app.api.routes.v1.sdk_sync.put_payload_to_s3", return_value=None),
+        ):
+            response = _sync(client, api_v1_prefix)
+
+        assert response.status_code == 503
+        mock_task.delay.assert_not_called()

--- a/backend/tests/services/test_raw_payload_storage.py
+++ b/backend/tests/services/test_raw_payload_storage.py
@@ -152,12 +152,22 @@ class TestStoreRawPayload:
         assert call_kwargs["Body"] == b'{"pre":"serialized"}'
 
 
-def _configure_s3(bucket: str = "test-bucket", **kwargs) -> MagicMock:
+def _configure_s3(
+    bucket: str = "test-bucket",
+    backend: str = "s3",
+    max_size: int = 1024,
+    s3_prefix: str = "raw-payloads",
+    transport_enabled: bool = False,
+) -> MagicMock:
     """Configure the module with a mocked S3 client and return it."""
     mock_client = MagicMock()
     with patch.object(raw_payload_storage, "_create_s3_client", return_value=mock_client):
         raw_payload_storage.configure(
-            kwargs.pop("backend", "s3"), kwargs.pop("max_size", 1024), s3_bucket=bucket, **kwargs
+            backend,
+            max_size,
+            s3_bucket=bucket,
+            s3_prefix=s3_prefix,
+            transport_enabled=transport_enabled,
         )
     return mock_client
 
@@ -229,12 +239,22 @@ class TestGetPayloadFromS3:
         with pytest.raises(RuntimeError, match="S3 client not configured"):
             raw_payload_storage.get_payload_from_s3("s3://bucket/key.json")
 
-    @pytest.mark.parametrize("ref", ["s3://bucket", "s3://", "", "bucket-only"])
+    @pytest.mark.parametrize("ref", ["s3://bucket", "s3://"])
     def test_raises_on_a_malformed_reference(self, ref: str) -> None:
         _configure_s3()
 
         with pytest.raises(ValueError, match="Malformed"):
             raw_payload_storage.get_payload_from_s3(ref)
+
+    @pytest.mark.parametrize("ref", ["raw-payloads/apple/sdk/x.json", "bucket-only", ""])
+    def test_rejects_a_reference_without_the_scheme(self, ref: str) -> None:
+        """A bare key would otherwise split into a bucket named after our own prefix."""
+        mock_client = _configure_s3()
+
+        with pytest.raises(ValueError, match="must be an s3:// URI"):
+            raw_payload_storage.get_payload_from_s3(ref)
+
+        mock_client.get_object.assert_not_called()
 
 
 class TestDeletePayloadFromS3:

--- a/backend/tests/services/test_raw_payload_storage.py
+++ b/backend/tests/services/test_raw_payload_storage.py
@@ -42,6 +42,16 @@ class TestConfigure:
         assert raw_payload_storage._s3_prefix == "payloads"
         assert raw_payload_storage._s3_client is mock_client
 
+    def test_configure_transport_creates_a_client_without_archival(self) -> None:
+        """Offload needs a usable bucket, not RAW_PAYLOAD_STORAGE=s3."""
+        mock_client = MagicMock()
+        with patch.object(raw_payload_storage, "_create_s3_client", return_value=mock_client):
+            raw_payload_storage.configure("disabled", 1024, s3_bucket="my-bucket", transport_enabled=True)
+
+        assert raw_payload_storage._storage_backend == "disabled"
+        assert raw_payload_storage._s3_client is mock_client
+        assert raw_payload_storage._s3_bucket == "my-bucket"
+
     def test_configure_s3_client_creation_fails(self) -> None:
         with patch.object(raw_payload_storage, "_create_s3_client", return_value=None):
             raw_payload_storage.configure("s3", 1024, s3_bucket="my-bucket")
@@ -140,3 +150,114 @@ class TestStoreRawPayload:
 
         call_kwargs = mock_client.put_object.call_args[1]
         assert call_kwargs["Body"] == b'{"pre":"serialized"}'
+
+
+def _configure_s3(bucket: str = "test-bucket", **kwargs) -> MagicMock:
+    """Configure the module with a mocked S3 client and return it."""
+    mock_client = MagicMock()
+    with patch.object(raw_payload_storage, "_create_s3_client", return_value=mock_client):
+        raw_payload_storage.configure(
+            kwargs.pop("backend", "s3"), kwargs.pop("max_size", 1024), s3_bucket=bucket, **kwargs
+        )
+    return mock_client
+
+
+class TestPutPayloadToS3:
+    """The transport write: no archival policy, always uploads, returns a reference."""
+
+    def test_returns_an_s3_reference(self) -> None:
+        mock_client = _configure_s3(s3_prefix="raw")
+
+        ref = raw_payload_storage.put_payload_to_s3(
+            source="sdk", provider="apple", payload='{"a":1}', user_id="user-1", trace_id="batch-1"
+        )
+
+        key = mock_client.put_object.call_args[1]["Key"]
+        assert ref == f"s3://test-bucket/{key}"
+        assert key.startswith("raw/apple/sdk/")
+        assert "/user-1/" in key
+
+    def test_ignores_the_archival_size_limit(self) -> None:
+        """The limit caps what is worth archiving, not what gets processed."""
+        mock_client = _configure_s3(max_size=10)
+
+        ref = raw_payload_storage.put_payload_to_s3(source="sdk", provider="apple", payload="x" * 500)
+
+        assert ref is not None
+        mock_client.put_object.assert_called_once()
+
+    def test_works_with_archival_disabled(self) -> None:
+        mock_client = _configure_s3(backend="disabled", transport_enabled=True)
+
+        ref = raw_payload_storage.put_payload_to_s3(source="sdk", provider="apple", payload='{"a":1}')
+
+        assert ref is not None
+        assert raw_payload_storage._storage_backend == "disabled"
+        mock_client.put_object.assert_called_once()
+
+    def test_size_metadata_counts_encoded_bytes(self) -> None:
+        mock_client = _configure_s3()
+
+        raw_payload_storage.put_payload_to_s3(source="sdk", provider="apple", payload="żółw")
+
+        call_kwargs = mock_client.put_object.call_args[1]
+        assert call_kwargs["Body"] == "żółw".encode()
+        assert call_kwargs["Metadata"]["size_bytes"] == "7"
+
+    def test_returns_none_without_a_client(self) -> None:
+        assert raw_payload_storage.put_payload_to_s3(source="sdk", provider="apple", payload="{}") is None
+
+    def test_returns_none_on_upload_failure(self) -> None:
+        mock_client = _configure_s3()
+        mock_client.put_object.side_effect = Exception("S3 error")
+
+        assert raw_payload_storage.put_payload_to_s3(source="sdk", provider="apple", payload="{}") is None
+
+
+class TestGetPayloadFromS3:
+    def test_takes_bucket_and_key_from_the_reference(self) -> None:
+        """The ref wins over local config, so app/worker drift is not a silent 404."""
+        mock_client = _configure_s3(bucket="configured-bucket")
+        mock_client.get_object.return_value = {"Body": MagicMock(read=lambda: b'{"a":1}')}
+
+        content = raw_payload_storage.get_payload_from_s3("s3://other-bucket/raw/apple/sdk/x.json")
+
+        assert content == '{"a":1}'
+        mock_client.get_object.assert_called_once_with(Bucket="other-bucket", Key="raw/apple/sdk/x.json")
+
+    def test_raises_without_a_client(self) -> None:
+        with pytest.raises(RuntimeError, match="S3 client not configured"):
+            raw_payload_storage.get_payload_from_s3("s3://bucket/key.json")
+
+    @pytest.mark.parametrize("ref", ["s3://bucket", "s3://", "", "bucket-only"])
+    def test_raises_on_a_malformed_reference(self, ref: str) -> None:
+        _configure_s3()
+
+        with pytest.raises(ValueError, match="Malformed"):
+            raw_payload_storage.get_payload_from_s3(ref)
+
+
+class TestDeletePayloadFromS3:
+    def test_deletes_using_the_reference(self) -> None:
+        mock_client = _configure_s3()
+
+        raw_payload_storage.delete_payload_from_s3("s3://other-bucket/raw/x.json")
+
+        mock_client.delete_object.assert_called_once_with(Bucket="other-bucket", Key="raw/x.json")
+
+    def test_is_a_noop_without_a_client(self) -> None:
+        raw_payload_storage.delete_payload_from_s3("s3://bucket/key.json")
+
+    def test_swallows_delete_failures(self) -> None:
+        """A bucket policy without s3:DeleteObject must never fail the batch."""
+        mock_client = _configure_s3()
+        mock_client.delete_object.side_effect = Exception("AccessDenied")
+
+        raw_payload_storage.delete_payload_from_s3("s3://test-bucket/raw/x.json")
+
+    def test_swallows_a_malformed_reference(self) -> None:
+        mock_client = _configure_s3()
+
+        raw_payload_storage.delete_payload_from_s3("nonsense")
+
+        mock_client.delete_object.assert_not_called()

--- a/backend/tests/tasks/test_process_sdk_upload_task.py
+++ b/backend/tests/tasks/test_process_sdk_upload_task.py
@@ -4,11 +4,14 @@ Tests for process_apple_upload Celery task.
 Tests Apple Health data import processing with user validation.
 """
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import pytest
 from sqlalchemy.orm import Session
 
+from app.config import settings
 from app.integrations.celery.tasks.process_sdk_upload_task import process_sdk_upload
 from tests.factories import UserFactory
 
@@ -131,3 +134,120 @@ class TestProcessSDKUploadTask:
         call_args = mock_user_repo.get.call_args
         assert call_args[0][0] == mock_db
         assert call_args[0][1] == UUID(user_id)
+
+
+_MODULE = "app.integrations.celery.tasks.process_sdk_upload_task"
+_PAYLOAD_REF = "s3://bucket/raw/apple/sdk/2026-08-26/user/x.json"
+
+
+class TestOffloadedPayload:
+    """The body is fetched in the worker, so the broker only ever carries a reference."""
+
+    @patch(f"{_MODULE}.get_payload_from_s3")
+    @patch(f"{_MODULE}.SessionLocal")
+    @patch(f"{_MODULE}.UserRepository")
+    def test_content_is_loaded_from_the_reference(
+        self,
+        mock_user_repo_class: MagicMock,
+        mock_session_local: MagicMock,
+        mock_get_payload: MagicMock,
+    ) -> None:
+        mock_get_payload.return_value = '{"data":{"records":[]}}'
+        mock_session_local.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_session_local.return_value.__exit__ = MagicMock(return_value=None)
+        mock_user_repo = MagicMock()
+        mock_user_repo.get.return_value = None
+        mock_user_repo_class.return_value = mock_user_repo
+
+        result = process_sdk_upload(
+            content=None,
+            content_type="application/json",
+            user_id=str(uuid4()),
+            provider="apple",
+            payload_ref=_PAYLOAD_REF,
+        )
+
+        mock_get_payload.assert_called_once_with(_PAYLOAD_REF)
+        assert result["reason"] == "user_not_found"
+
+    @patch(f"{_MODULE}.get_payload_from_s3")
+    def test_read_failure_propagates(self, mock_get_payload: MagicMock) -> None:
+        """Swallowing this would drop the batch silently; raising reports it to Sentry."""
+        mock_get_payload.side_effect = RuntimeError("S3 unavailable")
+
+        with pytest.raises(RuntimeError, match="S3 unavailable"):
+            process_sdk_upload(
+                content=None,
+                content_type="application/json",
+                user_id=str(uuid4()),
+                provider="apple",
+                payload_ref=_PAYLOAD_REF,
+            )
+
+    def test_neither_content_nor_reference_is_reported(self) -> None:
+        result = process_sdk_upload(
+            content=None,
+            content_type="application/json",
+            user_id=str(uuid4()),
+            provider="apple",
+        )
+
+        assert result["reason"] == "missing_payload"
+
+
+def _run_offloaded_batch(db: Session, user: Any, *, archival: str, status_code: int = 200) -> MagicMock:
+    """Process an offloaded batch; returns the delete_payload_from_s3 mock."""
+    response = MagicMock()
+    response.model_dump.return_value = {"status_code": status_code, "message": "done"}
+
+    with (
+        patch(f"{_MODULE}.delete_payload_from_s3") as mock_delete,
+        patch(f"{_MODULE}.get_payload_from_s3", return_value='{"data":{"records":[]}}'),
+        patch(f"{_MODULE}.sdk_import_service") as mock_import,
+        patch(f"{_MODULE}.SessionLocal") as mock_session_local,
+        patch(f"{_MODULE}.UserRepository") as mock_user_repo_class,
+        patch.object(settings, "raw_payload_storage", archival),
+    ):
+        mock_session_local.return_value.__enter__ = MagicMock(return_value=db)
+        mock_session_local.return_value.__exit__ = MagicMock(return_value=None)
+        mock_user_repo = MagicMock()
+        mock_user_repo.get.return_value = user
+        mock_user_repo_class.return_value = mock_user_repo
+        mock_import.import_data_from_request.return_value = response
+
+        process_sdk_upload(
+            content=None,
+            content_type="application/json",
+            user_id=str(user.id),
+            provider="apple",
+            payload_ref=_PAYLOAD_REF,
+        )
+
+    return mock_delete
+
+
+class TestTransportedPayloadCleanup:
+    """With archival off the S3 object only carries the payload, so it is dropped once saved."""
+
+    def test_deleted_when_archival_is_disabled(self, db: Session, mock_celery_app: MagicMock) -> None:
+        mock_delete = _run_offloaded_batch(db, UserFactory(), archival="disabled")
+
+        mock_delete.assert_called_once_with(_PAYLOAD_REF)
+
+    def test_kept_when_archival_uses_s3(self, db: Session, mock_celery_app: MagicMock) -> None:
+        """That same object is the archive, so deleting it would throw the archive away."""
+        mock_delete = _run_offloaded_batch(db, UserFactory(), archival="s3")
+
+        mock_delete.assert_not_called()
+
+    def test_kept_when_archival_uses_log(self, db: Session, mock_celery_app: MagicMock) -> None:
+        """The offload path skips the stdout write, so S3 holds the only copy."""
+        mock_delete = _run_offloaded_batch(db, UserFactory(), archival="log")
+
+        mock_delete.assert_not_called()
+
+    def test_kept_when_the_import_fails(self, db: Session, mock_celery_app: MagicMock) -> None:
+        """A failed batch keeps its payload so it can be diagnosed and replayed."""
+        mock_delete = _run_offloaded_batch(db, UserFactory(), archival="disabled", status_code=500)
+
+        mock_delete.assert_not_called()

--- a/backend/tests/utils_tests/test_sdk_payload_offload_settings.py
+++ b/backend/tests/utils_tests/test_sdk_payload_offload_settings.py
@@ -1,0 +1,42 @@
+"""Tests for the SDK_PAYLOAD_S3_OFFLOAD startup validation."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings
+
+
+class TestSdkPayloadOffloadValidation:
+    """Misconfiguration must fail at startup, not degrade to inline payloads at runtime."""
+
+    def test_offload_without_a_bucket_is_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="SDK_PAYLOAD_S3_OFFLOAD"):
+            Settings(sdk_payload_s3_offload=True, raw_payload_s3_bucket=None, aws_bucket_name=None)
+
+    def test_bucket_is_not_required_when_offload_is_off(self) -> None:
+        settings = Settings(sdk_payload_s3_offload=False, raw_payload_s3_bucket=None, aws_bucket_name=None)
+
+        assert settings.raw_payload_bucket is None
+
+    def test_offload_does_not_require_s3_archival(self) -> None:
+        """Archival is a debugging aid and must not gate queue reliability."""
+        settings = Settings(
+            sdk_payload_s3_offload=True,
+            raw_payload_storage="disabled",
+            raw_payload_s3_bucket=None,
+            aws_bucket_name="open-wearables",
+        )
+
+        assert settings.sdk_payload_s3_offload is True
+
+
+class TestRawPayloadBucket:
+    def test_prefers_the_dedicated_bucket(self) -> None:
+        settings = Settings(raw_payload_s3_bucket="payloads", aws_bucket_name="open-wearables")
+
+        assert settings.raw_payload_bucket == "payloads"
+
+    def test_falls_back_to_the_aws_bucket(self) -> None:
+        settings = Settings(raw_payload_s3_bucket=None, aws_bucket_name="open-wearables")
+
+        assert settings.raw_payload_bucket == "open-wearables"

--- a/docs/dev-guides/raw-payload-storage.mdx
+++ b/docs/dev-guides/raw-payload-storage.mdx
@@ -139,6 +139,8 @@ It needs a bucket (`RAW_PAYLOAD_S3_BUCKET`, or `AWS_BUCKET_NAME`) and startup fa
 
 With `RAW_PAYLOAD_STORAGE=s3` there is still one object, written to the same key with the same metadata, serving as both the queued payload and the archive.
 
+With `RAW_PAYLOAD_STORAGE=disabled` the object only exists to carry the payload, so the worker deletes it once the batch is committed — a failed batch keeps its payload for diagnosis. This needs `s3:DeleteObject` on the bucket, otherwise every batch logs a delete failure.
+
 <Warning>
   S3 is now on the critical path. Keep any lifecycle expiry above your worst queue lag, and expect `503` from the endpoint when the upload fails.
 </Warning>

--- a/docs/dev-guides/raw-payload-storage.mdx
+++ b/docs/dev-guides/raw-payload-storage.mdx
@@ -125,6 +125,24 @@ Raw payloads storage is currently enabled at two ingestion points:
 | `POST /api/v1/garmin/push` | `webhook` | `garmin` | 8-char request trace ID |
 | `POST /api/v1/sdk/users/{user_id}/sync` | `sdk` | `apple`, `samsung`, `google` | UUID4 batch ID |
 
+## SDK Payload Offload
+
+By default the SDK sync endpoint hands the whole payload to Celery, which keeps it in the Redis broker. A queued backlog then grows with payload size, and a large backfill can push Redis to `maxmemory`.
+
+`SDK_PAYLOAD_S3_OFFLOAD` uploads the payload to S3 instead and queues only its `s3://bucket/key` reference. The worker fetches the body when the task runs.
+
+```bash
+SDK_PAYLOAD_S3_OFFLOAD=false  # default
+```
+
+It needs a bucket (`RAW_PAYLOAD_S3_BUCKET`, or `AWS_BUCKET_NAME`) and startup fails without one. It does **not** need `RAW_PAYLOAD_STORAGE=s3` — archival is a debugging aid and must not gate queue reliability, so offload works with archival `disabled`. For the same reason `RAW_PAYLOAD_MAX_SIZE_BYTES` does not apply to it.
+
+With `RAW_PAYLOAD_STORAGE=s3` there is still one object, written to the same key with the same metadata, serving as both the queued payload and the archive.
+
+<Warning>
+  S3 is now on the critical path. Keep any lifecycle expiry above your worst queue lag, and expect `503` from the endpoint when the upload fails.
+</Warning>
+
 ## Error Handling
 
 Raw payloads storage is designed to never break your data ingestion pipeline:
@@ -133,6 +151,8 @@ Raw payloads storage is designed to never break your data ingestion pipeline:
 - **S3 upload failures** - Errors are logged but not propagated. The webhook or sync request continues processing.
 - **Missing S3 bucket** - If the S3 backend is configured but no bucket is available, it falls back to `disabled` with an error log.
 - **S3 client failure** - If the S3 client cannot be created (e.g., missing `boto3` or invalid credentials), it falls back to `disabled`.
+
+This covers archival only. Under `SDK_PAYLOAD_S3_OFFLOAD` the upload is the payload's only copy, so a failure returns `503` and the SDK retries, rather than a batch being queued without a body.
 
 ## Example Setup
 


### PR DESCRIPTION
Passing the full upload body as a Celery task argument serializes it into the Redis broker queue, so every queued message carries several MB. A backlog therefore grows in proportion to payload size and steadily eats broker memory. How quickly it reaches `maxmemory` - and whether the worker drops into an OOM crash-loop, as it did in production - depends not only on the Redis instance's RAM but on the load driving the queue: 
- how large a range of historical data is being backfilled, 
- for how many users at once. 

Enqueuing only an S3 reference keeps each broker message at ~1 KB, so a backlog no longer scales with payload size.

## What this changes

The SDK sync endpoint now enqueues an S3 reference to the payload instead of the payload itself, and the worker loads the body from S3 when the task runs. The payload was already being written to S3, so this removes a duplicate copy from the broker.

**This is just a draft for now, still needs some thinking.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional S3 offloading for SDK sync payloads.
  * Deferred processing can retrieve and clean up offloaded payloads.
  * Added dedicated bucket configuration with startup validation.
  * Added clearer handling for missing payloads and storage configuration issues.

* **Bug Fixes**
  * SDK sync requests now return a service-unavailable response when payload persistence fails.
  * Payload references are passed correctly for deferred processing.
  * Offloaded payloads are retained when processing fails.

* **Documentation**
  * Documented S3 offloading requirements, behavior, cleanup, and retry handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->