### PR TITLE
feat(mcp): add get_menstrual_cycles tool

### DIFF
--- a/docs/mcp-server/index.mdx
+++ b/docs/mcp-server/index.mdx
@@ -51,6 +51,12 @@ The MCP server provides the following tools for AI assistants:
   <Card title="Workout Events" icon="dumbbell">
     Get workout and exercise sessions for a user within a date range.
   </Card>
+  <Card title="Time Series" icon="chart-line">
+    Get granular samples such as weight, SpO2, HRV, and intraday heart rate.
+  </Card>
+  <Card title="Menstrual Cycles" icon="calendar-days">
+    Get menstrual cycle records including cycle day, phase, and period length.
+  </Card>
 </CardGroup>
 
 ## Example Interactions

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -9,6 +9,7 @@ MCP (Model Context Protocol) server for Open Wearables, enabling AI assistants l
 - **get_sleep_summary**: Get sleep data for a user within a date range
 - **get_workout_events**: Get workout/exercise sessions for a user within a date range
 - **get_timeseries**: Get granular time-series samples (weight, SpO2, HRV, intraday heart rate, etc.)
+- **get_menstrual_cycles**: Get menstrual cycle records (cycle day, phase, period and cycle lengths)
 
 ## Prerequisites
 
@@ -188,7 +189,8 @@ mcp/
 │   │   ├── activity.py   # get_activity_summary tool
 │   │   ├── sleep.py      # get_sleep_summary tool
 │   │   ├── workouts.py   # get_workout_events tool
-│   │   └── timeseries.py # get_timeseries tool
+│   │   ├── timeseries.py # get_timeseries tool
+│   │   └── menstrual_cycles.py # get_menstrual_cycles tool
 │   └── services/
 │       └── api_client.py # HTTP client for backend API
 ├── config/

--- a/mcp/app/main.py
+++ b/mcp/app/main.py
@@ -8,6 +8,7 @@ from fastmcp import FastMCP
 from app.config import settings
 from app.prompts import prompts_router
 from app.tools.activity import activity_router
+from app.tools.menstrual_cycles import menstrual_cycles_router
 from app.tools.sleep import sleep_router
 from app.tools.timeseries import timeseries_router
 from app.tools.users import users_router
@@ -37,6 +38,7 @@ mcp = FastMCP(
     - get_sleep_summary: Get sleep data for a user over a specified time period
     - get_workout_events: Get workout/exercise data for a user over a specified time period
     - get_timeseries: Get granular time-series samples (e.g. weight, SpO2, HRV, intraday heart rate)
+    - get_menstrual_cycles: Get menstrual cycle records (cycle day, phase, period and cycle lengths)
 
     Available prompts:
     - present_health_data: Guidelines for formatting health data for human readability
@@ -118,6 +120,7 @@ mcp.mount(activity_router)
 mcp.mount(sleep_router)
 mcp.mount(workouts_router)
 mcp.mount(timeseries_router)
+mcp.mount(menstrual_cycles_router)
 
 # Mount prompts
 mcp.mount(prompts_router)

--- a/mcp/app/services/api_client.py
+++ b/mcp/app/services/api_client.py
@@ -204,6 +204,32 @@ class OpenWearablesClient:
             params["cursor"] = cursor
         return await self._request("GET", f"/api/v1/users/{user_id}/timeseries", params=params)
 
+    async def get_menstrual_cycles(
+        self,
+        user_id: str,
+        start_date: str,
+        end_date: str,
+        limit: int = 100,
+    ) -> dict[str, Any]:
+        """
+        Get menstrual cycle records for a user within a date range.
+
+        Args:
+            user_id: UUID of the user
+            start_date: Start date (YYYY-MM-DD format)
+            end_date: End date (YYYY-MM-DD format)
+            limit: Maximum number of records to return
+
+        Returns:
+            Paginated response with menstrual cycle records
+        """
+        params = {
+            "start_date": start_date,
+            "end_date": end_date,
+            "limit": limit,
+        }
+        return await self._request("GET", f"/api/v1/users/{user_id}/events/menstrual-cycles", params=params)
+
 
 # Singleton instance
 client = OpenWearablesClient()

--- a/mcp/app/services/api_client.py
+++ b/mcp/app/services/api_client.py
@@ -210,6 +210,7 @@ class OpenWearablesClient:
         start_date: str,
         end_date: str,
         limit: int = 100,
+        cursor: str | None = None,
     ) -> dict[str, Any]:
         """
         Get menstrual cycle records for a user within a date range.
@@ -218,16 +219,19 @@ class OpenWearablesClient:
             user_id: UUID of the user
             start_date: Start date (YYYY-MM-DD format)
             end_date: End date (YYYY-MM-DD format)
-            limit: Maximum number of records to return
+            limit: Page size (1-100)
+            cursor: Opaque pagination cursor returned by a previous call
 
         Returns:
             Paginated response with menstrual cycle records
         """
-        params = {
+        params: dict[str, Any] = {
             "start_date": start_date,
             "end_date": end_date,
             "limit": limit,
         }
+        if cursor:
+            params["cursor"] = cursor
         return await self._request("GET", f"/api/v1/users/{user_id}/events/menstrual-cycles", params=params)
 
 

--- a/mcp/app/tools/menstrual_cycles.py
+++ b/mcp/app/tools/menstrual_cycles.py
@@ -1,0 +1,229 @@
+"""MCP tools for querying menstrual cycle records."""
+
+import logging
+
+from fastmcp import FastMCP
+
+from app.services.api_client import client
+from app.services.exceptions import NotFoundError, OpenWearablesError
+from app.utils import normalize_datetime
+
+logger = logging.getLogger(__name__)
+
+# Create router for menstrual cycle tools
+menstrual_cycles_router = FastMCP(name="Menstrual Cycle Tools")
+
+
+@menstrual_cycles_router.tool
+async def get_menstrual_cycles(
+    user_id: str,
+    start_date: str,
+    end_date: str,
+) -> dict:
+    """
+    Get menstrual cycle records for a user within a date range.
+
+    This tool retrieves menstrual cycle tracking data including the current
+    cycle day, cycle phase, period length, cycle length, and predicted
+    fertile window from wearable devices.
+
+    Args:
+        user_id: UUID of the user. Use get_users to discover available users.
+        start_date: Start date in YYYY-MM-DD format.
+                    Example: "2026-01-01"
+        end_date: End date in YYYY-MM-DD format.
+                  Example: "2026-01-07"
+
+    Returns:
+        A dictionary containing:
+        - user: Information about the user (id, first_name, last_name)
+        - period: The date range queried (start, end)
+        - records: List of menstrual cycle records
+        - summary: Aggregate statistics (avg_cycle_length_days, phase_types, etc.)
+
+    Example response:
+        {
+            "user": {"id": "uuid-1", "first_name": "Jane", "last_name": "Doe"},
+            "period": {"start": "2026-01-01", "end": "2026-01-28"},
+            "records": [
+                {
+                    "id": "uuid-cycle-1",
+                    "start_datetime": "2026-01-05T00:00:00+00:00",
+                    "end_datetime": "2026-02-02T00:00:00+00:00",
+                    "day_in_cycle": 14,
+                    "cycle_length": 28,
+                    "period_length": 5,
+                    "current_phase": 2,
+                    "current_phase_type": "ovulation",
+                    "length_of_current_phase": 4,
+                    "days_until_next_phase": 2,
+                    "predicted_cycle_length": 28,
+                    "is_predicted_cycle": false,
+                    "fertile_window_start": 12,
+                    "length_of_fertile_window": 6,
+                    "has_specified_cycle_length": true,
+                    "has_specified_period_length": true,
+                    "pregnancy_snapshot": null,
+                    "last_updated_at": "2026-01-18T06:30:00+00:00",
+                    "source": "garmin"
+                }
+            ],
+            "summary": {
+                "total_records": 4,
+                "predicted_records": 1,
+                "avg_cycle_length_days": 28.5,
+                "avg_period_length_days": 5.0,
+                "phase_types": {"menstruation": 1, "follicular": 1, "ovulation": 1, "luteal": 1},
+                "has_pregnancy_data": false,
+                "latest": {
+                    "start_datetime": "2026-01-05T00:00:00+00:00",
+                    "day_in_cycle": 14,
+                    "current_phase_type": "ovulation",
+                    "days_until_next_phase": 2,
+                    "is_predicted_cycle": false
+                }
+            }
+        }
+
+    Notes for LLMs:
+        - Call get_users first to get the user_id.
+        - Calculate dates based on user queries:
+          "last month" -> start_date = 30 days ago, end_date = today
+          "this year" -> start_date = first of year, end_date = today
+        - Records are filtered by cycle start date only. The backend does not
+          apply end_date as an upper bound, so the cycle currently in progress
+          and predicted future cycles are always included. Filter records by
+          start_datetime yourself when the user asks about a strict window.
+        - summary.latest is the most recent logged cycle when one exists, and
+          falls back to the most recent predicted cycle otherwise.
+        - day_in_cycle counts from 1 on the first day of the menstrual period.
+        - current_phase_type is a lowercase string: "menstruation" (also reported
+          as "menstrual" by some providers), "follicular", "ovulation", "luteal",
+          or "pregnancy". Treat other values as unclassified.
+        - All length fields are in days. fertile_window_start is a day number
+          within the cycle, so the fertile window spans fertile_window_start to
+          fertile_window_start + length_of_fertile_window - 1.
+        - is_predicted_cycle true means the provider predicted this cycle instead
+          of the user logging it.
+        - The 'source' field indicates which provider supplied the data. Menstrual
+          cycle data is currently ingested from Garmin devices.
+        - This is sensitive health data. Present it factually and only to the
+          extent the user asked for.
+        - Use the present_health_data prompt for formatting guidelines when presenting to users.
+    """
+    try:
+        # Fetch user details
+        try:
+            user_data = await client.get_user(user_id)
+            user = {
+                "id": str(user_data.get("id")),
+                "first_name": user_data.get("first_name"),
+                "last_name": user_data.get("last_name"),
+            }
+        except NotFoundError as e:
+            return {"error": f"User not found: {user_id}", "details": str(e)}
+
+        # Fetch menstrual cycle data
+        cycles_response = await client.get_menstrual_cycles(
+            user_id=user_id,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        records_data = cycles_response.get("data", [])
+
+        # Transform records
+        records = []
+        cycle_lengths = []
+        period_lengths = []
+        phase_types: dict[str, int] = {}
+        predicted_count = 0
+        has_pregnancy_data = False
+        latest = None
+        latest_start = None
+        latest_predicted = False
+
+        for record in records_data:
+            cycle_length = record.get("cycle_length")
+            period_length = record.get("period_length")
+            phase_type = record.get("current_phase_type")
+            pregnancy_snapshot = record.get("pregnancy_snapshot")
+            start_time = record.get("start_time")
+
+            if cycle_length is not None:
+                cycle_lengths.append(cycle_length)
+            if period_length is not None:
+                period_lengths.append(period_length)
+            if phase_type:
+                phase_types[phase_type] = phase_types.get(phase_type, 0) + 1
+            if record.get("is_predicted_cycle"):
+                predicted_count += 1
+            if pregnancy_snapshot:
+                has_pregnancy_data = True
+
+            source = record.get("source", {})
+            transformed = {
+                "id": str(record.get("id")),
+                "start_datetime": normalize_datetime(start_time),
+                "end_datetime": normalize_datetime(record.get("end_time")),
+                "day_in_cycle": record.get("day_in_cycle"),
+                "cycle_length": cycle_length,
+                "period_length": period_length,
+                "current_phase": record.get("current_phase"),
+                "current_phase_type": phase_type,
+                "length_of_current_phase": record.get("length_of_current_phase"),
+                "days_until_next_phase": record.get("days_until_next_phase"),
+                "predicted_cycle_length": record.get("predicted_cycle_length"),
+                "is_predicted_cycle": record.get("is_predicted_cycle"),
+                "fertile_window_start": record.get("fertile_window_start"),
+                "length_of_fertile_window": record.get("length_of_fertile_window"),
+                "has_specified_cycle_length": record.get("has_specified_cycle_length"),
+                "has_specified_period_length": record.get("has_specified_period_length"),
+                "pregnancy_snapshot": pregnancy_snapshot,
+                "last_updated_at": normalize_datetime(record.get("last_updated_at")),
+                "source": source.get("provider") if isinstance(source, dict) else source,
+            }
+            records.append(transformed)
+
+            # Track the most recent logged cycle; a logged cycle always wins over
+            # a predicted one, which can start in the future.
+            is_predicted = bool(record.get("is_predicted_cycle"))
+            if start_time and (
+                latest_start is None
+                or (latest_predicted and not is_predicted)
+                or (latest_predicted == is_predicted and start_time > latest_start)
+            ):
+                latest_start = start_time
+                latest_predicted = is_predicted
+                latest = {
+                    "start_datetime": transformed["start_datetime"],
+                    "day_in_cycle": transformed["day_in_cycle"],
+                    "current_phase_type": transformed["current_phase_type"],
+                    "days_until_next_phase": transformed["days_until_next_phase"],
+                    "is_predicted_cycle": transformed["is_predicted_cycle"],
+                }
+
+        # Calculate summary statistics
+        summary = {
+            "total_records": len(records),
+            "predicted_records": predicted_count,
+            "avg_cycle_length_days": (round(sum(cycle_lengths) / len(cycle_lengths), 1) if cycle_lengths else None),
+            "avg_period_length_days": (round(sum(period_lengths) / len(period_lengths), 1) if period_lengths else None),
+            "phase_types": phase_types if phase_types else None,
+            "has_pregnancy_data": has_pregnancy_data,
+            "latest": latest,
+        }
+
+        return {
+            "user": user,
+            "period": {"start": start_date, "end": end_date},
+            "records": records,
+            "summary": summary,
+        }
+
+    except OpenWearablesError as e:
+        logger.error(f"API error in get_menstrual_cycles: {e}")
+        return {"error": str(e)}
+    except Exception as e:
+        logger.exception(f"Unexpected error in get_menstrual_cycles: {e}")
+        return {"error": f"Failed to fetch menstrual cycles: {e}"}

--- a/mcp/app/tools/menstrual_cycles.py
+++ b/mcp/app/tools/menstrual_cycles.py
@@ -1,6 +1,7 @@
 """MCP tools for querying menstrual cycle records."""
 
 import logging
+from datetime import date, datetime
 
 from fastmcp import FastMCP
 
@@ -10,8 +11,23 @@ from app.utils import normalize_datetime
 
 logger = logging.getLogger(__name__)
 
+# Safety ceiling for cursor pagination: 10 pages x 100 records covers decades of cycles.
+_MAX_PAGES = 10
+
 # Create router for menstrual cycle tools
 menstrual_cycles_router = FastMCP(name="Menstrual Cycle Tools")
+
+
+def _starts_after(start_time: str | None, end_date: str) -> bool:
+    """True when a record's cycle start date falls after the requested end date."""
+    if not start_time:
+        return False
+    try:
+        start = datetime.fromisoformat(start_time.replace("Z", "+00:00")).date()
+        end = date.fromisoformat(end_date)
+    except ValueError:
+        return False
+    return start > end
 
 
 @menstrual_cycles_router.tool
@@ -40,6 +56,8 @@ async def get_menstrual_cycles(
         - period: The date range queried (start, end)
         - records: List of menstrual cycle records
         - summary: Aggregate statistics (avg_cycle_length_days, phase_types, etc.)
+        - truncated: True when the pagination safety ceiling was hit and older
+          records were left out
 
     Example response:
         {
@@ -82,7 +100,8 @@ async def get_menstrual_cycles(
                     "days_until_next_phase": 2,
                     "is_predicted_cycle": false
                 }
-            }
+            },
+            "truncated": false
         }
 
     Notes for LLMs:
@@ -90,10 +109,11 @@ async def get_menstrual_cycles(
         - Calculate dates based on user queries:
           "last month" -> start_date = 30 days ago, end_date = today
           "this year" -> start_date = first of year, end_date = today
-        - Records are filtered by cycle start date only. The backend does not
-          apply end_date as an upper bound, so the cycle currently in progress
-          and predicted future cycles are always included. Filter records by
-          start_datetime yourself when the user asks about a strict window.
+        - Records are filtered by cycle start date. Cycles starting after
+          end_date are excluded, so a historical window does not pick up
+          predicted future cycles. The cycle currently in progress is included
+          when it started inside the window, even though it ends after
+          end_date.
         - summary.latest is the most recent logged cycle when one exists, and
           falls back to the most recent predicted cycle otherwise.
         - day_in_cycle counts from 1 on the first day of the menstrual period.
@@ -123,14 +143,23 @@ async def get_menstrual_cycles(
         except NotFoundError as e:
             return {"error": f"User not found: {user_id}", "details": str(e)}
 
-        # Fetch menstrual cycle data
-        cycles_response = await client.get_menstrual_cycles(
-            user_id=user_id,
-            start_date=start_date,
-            end_date=end_date,
-        )
-
-        records_data = cycles_response.get("data", [])
+        # Walk cursor pagination until exhausted or the safety ceiling is hit
+        records_data: list[dict] = []
+        cursor: str | None = None
+        truncated = False
+        for _ in range(_MAX_PAGES):
+            cycles_response = await client.get_menstrual_cycles(
+                user_id=user_id,
+                start_date=start_date,
+                end_date=end_date,
+                cursor=cursor,
+            )
+            records_data.extend(cycles_response.get("data", []))
+            cursor = (cycles_response.get("pagination") or {}).get("next_cursor")
+            if not cursor:
+                break
+        else:
+            truncated = True
 
         # Transform records
         records = []
@@ -144,11 +173,17 @@ async def get_menstrual_cycles(
         latest_predicted = False
 
         for record in records_data:
+            start_time = record.get("start_time")
+
+            # The backend leaves end_date unbounded so predicted cycles stay
+            # visible; apply the requested upper bound here.
+            if _starts_after(start_time, end_date):
+                continue
+
             cycle_length = record.get("cycle_length")
             period_length = record.get("period_length")
             phase_type = record.get("current_phase_type")
             pregnancy_snapshot = record.get("pregnancy_snapshot")
-            start_time = record.get("start_time")
 
             if cycle_length is not None:
                 cycle_lengths.append(cycle_length)
@@ -219,6 +254,7 @@ async def get_menstrual_cycles(
             "period": {"start": start_date, "end": end_date},
             "records": records,
             "summary": summary,
+            "truncated": truncated,
         }
 
     except OpenWearablesError as e:

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -166,6 +166,22 @@ async def test_get_menstrual_cycles_transforms_records_and_summary(httpx_mock: H
                     "period_length": 6,
                     "pregnancy_snapshot": None,
                 },
+                {
+                    # Predicted cycle starting after end_date: must be excluded
+                    "id": "33333333-3333-3333-3333-333333333333",
+                    "start_time": "2026-03-04T00:00:00Z",
+                    "end_time": "2026-04-03T00:00:00Z",
+                    "zone_offset": None,
+                    "source": {"provider": "garmin", "source": "Connect", "device": None, "device_type": None},
+                    "current_phase": None,
+                    "current_phase_type": None,
+                    "day_in_cycle": None,
+                    "cycle_length": None,
+                    "predicted_cycle_length": 30,
+                    "is_predicted_cycle": True,
+                    "period_length": 6,
+                    "pregnancy_snapshot": None,
+                },
             ],
             "pagination": {"next_cursor": None, "previous_cursor": None, "total_count": 2},
             "metadata": {},
@@ -179,9 +195,11 @@ async def test_get_menstrual_cycles_transforms_records_and_summary(httpx_mock: H
     )
 
     assert result["user"]["id"] == USER_ID
+    # The record starting after end_date is dropped
     assert len(result["records"]) == 2
     assert result["records"][0]["source"] == "garmin"
     assert result["records"][0]["start_datetime"] == "2026-01-05T00:00:00+00:00"
+    assert result["truncated"] is False
 
     summary = result["summary"]
     assert summary["total_records"] == 2
@@ -194,6 +212,58 @@ async def test_get_menstrual_cycles_transforms_records_and_summary(httpx_mock: H
     assert summary["latest"]["day_in_cycle"] == 14
     assert summary["latest"]["current_phase_type"] == "ovulation"
     assert summary["latest"]["is_predicted_cycle"] is False
+
+
+async def test_get_menstrual_cycles_walks_pagination(httpx_mock: HTTPXMock) -> None:
+    """`get_menstrual_cycles` follows next_cursor until the last page."""
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://api.test.com/api/v1/users/{USER_ID}",
+        json=USER_PAYLOAD,
+    )
+    record_template = {
+        "start_time": "2026-01-05T00:00:00Z",
+        "end_time": "2026-02-02T00:00:00Z",
+        "source": {"provider": "garmin"},
+        "cycle_length": 28,
+        "period_length": 5,
+        "current_phase_type": "luteal",
+        "is_predicted_cycle": False,
+    }
+    httpx_mock.add_response(
+        method="GET",
+        url=(
+            f"https://api.test.com/api/v1/users/{USER_ID}/events/menstrual-cycles"
+            "?start_date=2026-01-01&end_date=2026-02-28&limit=100"
+        ),
+        json={
+            "data": [{"id": "11111111-1111-1111-1111-111111111111", **record_template}],
+            "pagination": {"next_cursor": "page2", "previous_cursor": None, "total_count": 2},
+            "metadata": {},
+        },
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=(
+            f"https://api.test.com/api/v1/users/{USER_ID}/events/menstrual-cycles"
+            "?start_date=2026-01-01&end_date=2026-02-28&limit=100&cursor=page2"
+        ),
+        json={
+            "data": [{"id": "22222222-2222-2222-2222-222222222222", **record_template}],
+            "pagination": {"next_cursor": None, "previous_cursor": "prev_page1", "total_count": 2},
+            "metadata": {},
+        },
+    )
+
+    result = await get_menstrual_cycles.fn(
+        user_id=USER_ID,
+        start_date="2026-01-01",
+        end_date="2026-02-28",
+    )
+
+    assert len(result["records"]) == 2
+    assert result["summary"]["total_records"] == 2
+    assert result["truncated"] is False
 
 
 async def test_get_menstrual_cycles_handles_empty_data(httpx_mock: HTTPXMock) -> None:

--- a/mcp/tests/test_tools.py
+++ b/mcp/tests/test_tools.py
@@ -11,6 +11,7 @@ from fastmcp.tools import FunctionTool
 from pytest_httpx import HTTPXMock
 
 from app.tools.activity import get_activity_summary
+from app.tools.menstrual_cycles import get_menstrual_cycles
 from app.tools.sleep import get_sleep_summary
 from app.tools.timeseries import get_timeseries
 from app.tools.users import get_users
@@ -44,6 +45,7 @@ async def test_get_users_returns_empty_envelope_on_auth_error(httpx_mock: HTTPXM
     "tool",
     [
         pytest.param(get_activity_summary, id="activity"),
+        pytest.param(get_menstrual_cycles, id="menstrual_cycles"),
         pytest.param(get_sleep_summary, id="sleep"),
         pytest.param(get_workout_events, id="workouts"),
     ],
@@ -115,3 +117,113 @@ async def test_get_activity_summary_returns_generic_error_envelope_on_downstream
     assert "error" in result
     assert "Invalid API key" in result["error"]
     assert not result["error"].startswith("User not found")
+
+
+async def test_get_menstrual_cycles_transforms_records_and_summary(httpx_mock: HTTPXMock) -> None:
+    """`get_menstrual_cycles` maps backend records and aggregates cycle statistics."""
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://api.test.com/api/v1/users/{USER_ID}",
+        json=USER_PAYLOAD,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=(
+            f"https://api.test.com/api/v1/users/{USER_ID}/events/menstrual-cycles"
+            "?start_date=2026-01-01&end_date=2026-02-28&limit=100"
+        ),
+        json={
+            "data": [
+                {
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "start_time": "2026-01-05T00:00:00Z",
+                    "end_time": "2026-02-02T00:00:00Z",
+                    "zone_offset": None,
+                    "source": {"provider": "garmin", "source": "Connect", "device": None, "device_type": None},
+                    "current_phase": 2,
+                    "current_phase_type": "ovulation",
+                    "day_in_cycle": 14,
+                    "cycle_length": 28,
+                    "predicted_cycle_length": 28,
+                    "is_predicted_cycle": False,
+                    "period_length": 5,
+                    "fertile_window_start": 12,
+                    "length_of_fertile_window": 6,
+                    "pregnancy_snapshot": None,
+                },
+                {
+                    "id": "22222222-2222-2222-2222-222222222222",
+                    "start_time": "2026-02-02T00:00:00Z",
+                    "end_time": "2026-03-04T00:00:00Z",
+                    "zone_offset": None,
+                    "source": {"provider": "garmin", "source": "Connect", "device": None, "device_type": None},
+                    "current_phase": 1,
+                    "current_phase_type": "menstruation",
+                    "day_in_cycle": 3,
+                    "cycle_length": 30,
+                    "predicted_cycle_length": 30,
+                    "is_predicted_cycle": True,
+                    "period_length": 6,
+                    "pregnancy_snapshot": None,
+                },
+            ],
+            "pagination": {"next_cursor": None, "previous_cursor": None, "total_count": 2},
+            "metadata": {},
+        },
+    )
+
+    result = await get_menstrual_cycles.fn(
+        user_id=USER_ID,
+        start_date="2026-01-01",
+        end_date="2026-02-28",
+    )
+
+    assert result["user"]["id"] == USER_ID
+    assert len(result["records"]) == 2
+    assert result["records"][0]["source"] == "garmin"
+    assert result["records"][0]["start_datetime"] == "2026-01-05T00:00:00+00:00"
+
+    summary = result["summary"]
+    assert summary["total_records"] == 2
+    assert summary["predicted_records"] == 1
+    assert summary["avg_cycle_length_days"] == 29.0
+    assert summary["avg_period_length_days"] == 5.5
+    assert summary["phase_types"] == {"ovulation": 1, "menstruation": 1}
+    assert summary["has_pregnancy_data"] is False
+    # The most recent record is predicted, so latest falls back to the logged cycle
+    assert summary["latest"]["day_in_cycle"] == 14
+    assert summary["latest"]["current_phase_type"] == "ovulation"
+    assert summary["latest"]["is_predicted_cycle"] is False
+
+
+async def test_get_menstrual_cycles_handles_empty_data(httpx_mock: HTTPXMock) -> None:
+    """`get_menstrual_cycles` returns an empty records list and null aggregates when there is no data."""
+    httpx_mock.add_response(
+        method="GET",
+        url=f"https://api.test.com/api/v1/users/{USER_ID}",
+        json=USER_PAYLOAD,
+    )
+    httpx_mock.add_response(
+        method="GET",
+        url=(
+            f"https://api.test.com/api/v1/users/{USER_ID}/events/menstrual-cycles"
+            "?start_date=2026-01-01&end_date=2026-01-07&limit=100"
+        ),
+        json={
+            "data": [],
+            "pagination": {"next_cursor": None, "previous_cursor": None, "total_count": 0},
+            "metadata": {},
+        },
+    )
+
+    result = await get_menstrual_cycles.fn(
+        user_id=USER_ID,
+        start_date="2026-01-01",
+        end_date="2026-01-07",
+    )
+
+    assert result["records"] == []
+    assert result["summary"]["total_records"] == 0
+    assert result["summary"]["avg_cycle_length_days"] is None
+    assert result["summary"]["phase_types"] is None
+    assert result["summary"]["latest"] is None


### PR DESCRIPTION
## Description

Adds a `get_menstrual_cycles` MCP tool. The backend has stored menstrual cycle
records from Garmin since #1063 and the dashboard shows them in the women's
health tab, but there is no MCP path to them, so an AI client cannot answer
questions like "how long are my cycles on average" even when the data is
sitting in the database. Related to the wider women's health work in #991.

What this includes:

- `OpenWearablesClient.get_menstrual_cycles` in `mcp/app/services/api_client.py`,
  a thin wrapper for `GET /api/v1/users/{user_id}/events/menstrual-cycles`.
- The tool itself in `mcp/app/tools/menstrual_cycles.py`, built the same way as
  the existing tools: user lookup with the documented error envelopes, a record
  transform, and a summary block (record counts, average cycle and period
  length, phase distribution, and the most recent cycle).
- Router mount and instructions entry in `mcp/app/main.py`, README updates, and
  a docs update to the Available Tools cards on the MCP server page. That card
  list had stopped at four tools (`get_timeseries` was never added when it
  shipped), so it gains both missing cards.
- Tests: the tool joins the parametrized user-not-found envelope test and gets
  transform and empty-result cases.

Two backend behaviors came up while testing and are spelled out in the tool
docstring so LLM clients handle them correctly:

- The endpoint filters by cycle start date only. The upper bound is
  intentionally not applied server side (`event_record_service.get_menstrual_cycles`
  clears it so the in-progress cycle and predicted cycles stay visible). The
  docstring tells the model to filter by `start_datetime` itself when the user
  asks about a strict window.
- `summary.latest` prefers the most recent logged cycle over a predicted one. A
  predicted cycle can start in the future and carries mostly null fields, so it
  is a poor answer to "where am I in my cycle today".

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

No backend changes. For the `mcp` package:

- [x] `uv run --frozen pytest` passes (13 tests)
- [x] `uv run --frozen --group code-quality ruff check app/ tests/` passes
- [x] `uv run --frozen --group code-quality ruff format --check app/ tests/` passes
- [x] `uv run --frozen --group code-quality ty check app/` passes

### Frontend Changes

None.

## Testing Instructions

**Steps to test:**
1. Use an instance that has menstrual cycle records. If you need data, load
   Garmin MCT payloads through `Garmin247Data._build_mct_record` and
   `event_record_service.bulk_create` / `bulk_create_details`, which is what I
   did on a scratch instance (three completed cycles, one in progress, one
   predicted).
2. Point `mcp/config/.env` at the instance with a valid API key.
3. Connect with MCPJam or Claude Desktop and call `get_menstrual_cycles` with a
   user id and date range.

**Expected behavior:**
Records come back newest first with the same fields as the REST endpoint plus a
normalized `source` string, and the summary reports totals, averages, phase
distribution, and the most recent logged cycle.

## Screenshots

Not applicable, no UI changes.

## Additional Notes

Verified end to end through the MCP protocol (FastMCP client against the real
server, real HTTP to a scratch backend seeded as described above):

| Scenario | Result |
|---|---|
| 4 month window covering all 5 records | All 5 returned. `avg_cycle_length_days` 28.3, `avg_period_length_days` 5.2, `phase_types` `{"luteal": 4}`, `predicted_records` 1, `latest` is the in-progress cycle (day 27, luteal), not the predicted future one |
| Window starting after every cycle start | 0 records, null aggregates, `latest` null |
| Unknown user id | `{"error": "User not found: ...", "details": ...}` envelope, matching the other tools |

The MCP docs page fix (missing `get_timeseries` card) is a separate commit in
case you would rather take it separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a menstrual cycle data tool for retrieving records within a selected date range.
  * Added normalized cycle details, user information, summary statistics, and latest-cycle insights.
  * Added cursor-based pagination for retrieving larger result sets.
  * Added documentation covering menstrual cycle and time series tools.

* **Bug Fixes**
  * Improved handling for missing users, API errors, empty results, and records outside the requested date range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->