### PR TITLE
fix(backend): fix recovery endpoint and resolve cycle_id for recovery.updated

### DIFF
--- a/backend/app/services/providers/whoop/data_247.py
+++ b/backend/app/services/providers/whoop/data_247.py
@@ -858,14 +858,14 @@ class Whoop247Data(Base247DataTemplate):
         user_id: UUID,
         cycle_id: str,
     ) -> dict[str, Any]:
-        """Fetch a single recovery record by cycle_id from /v2/recovery/{cycle_id}."""
-        response = self._make_api_request(db, user_id, f"/v2/recovery/{cycle_id}")
+        """Fetch a single recovery record by cycle_id from /v2/cycle/{cycle_id}/recovery."""
+        response = self._make_api_request(db, user_id, f"/v2/cycle/{cycle_id}/recovery")
         store_raw_payload(
             source="api_response",
             provider="whoop",
             payload=response,
             user_id=str(user_id),
-            trace_id=f"/v2/recovery/{cycle_id}",
+            trace_id=f"/v2/cycle/{cycle_id}/recovery",
         )
         return response if isinstance(response, dict) else {}
 

--- a/backend/app/services/providers/whoop/webhook_handler.py
+++ b/backend/app/services/providers/whoop/webhook_handler.py
@@ -243,7 +243,8 @@ class WhoopWebhookHandler(BaseWebhookHandler):
             case WhoopWebhookNotificationType.SLEEP_UPDATED:
                 count = self.data_247.load_single_sleep(db, user_id, resource_id)
             case WhoopWebhookNotificationType.RECOVERY_UPDATED:
-                count = self.data_247.load_single_recovery(db, user_id, resource_id)
+                sleep = self.data_247.get_sleep_record(db, user_id, resource_id)
+                count = self.data_247.load_single_recovery(db, user_id, sleep['cycle_id'])
             case _:
                 return {"status": "ignored", "reason": f"unhandled_event_type: {event_type}"}
 

--- a/backend/app/services/providers/whoop/webhook_handler.py
+++ b/backend/app/services/providers/whoop/webhook_handler.py
@@ -244,7 +244,23 @@ class WhoopWebhookHandler(BaseWebhookHandler):
                 count = self.data_247.load_single_sleep(db, user_id, resource_id)
             case WhoopWebhookNotificationType.RECOVERY_UPDATED:
                 sleep = self.data_247.get_sleep_record(db, user_id, resource_id)
-                count = self.data_247.load_single_recovery(db, user_id, sleep['cycle_id'])
+                cycle_id = sleep.get("cycle_id") if isinstance(sleep, dict) else None
+                if not cycle_id:
+                    log_structured(
+                        logger,
+                        "warning",
+                        "No cycle_id found in sleep record for Whoop recovery.updated",
+                        provider="whoop",
+                        action="whoop_webhook_recovery_missing_cycle_id",
+                        user_id=str(user_id),
+                        resource_id=resource_id,
+                    )
+                    return {
+                        "status": "ignored",
+                        "reason": "missing_cycle_id",
+                        "resource_id": resource_id,
+                    }
+                count = self.data_247.load_single_recovery(db, user_id, str(cycle_id))
             case _:
                 return {"status": "ignored", "reason": f"unhandled_event_type: {event_type}"}
 


### PR DESCRIPTION
## Description

**Problem**
- Webhook Payload Identifier: According to Whoop's developer documentation, the recovery.updated webhook payload contains a sleep_id in its resource field rather than a direct recovery or cycle ID.
- Incorrect Recovery API Endpoint: Whoop does not expose a /v2/recovery/{id} endpoint for fetching a single recovery record. The correct API path is /v2/cycle/{cycle_id}/recovery.
- Previously, WhoopWebhookHandler attempted to call load_single_recovery directly with the webhook's resource_id against the non-existent /v2/recovery/{cycle_id} endpoint, resulting in failed webhook processing.

**Solution**
- Resolve cycle_id via Sleep Record: When handling WhoopWebhookNotificationType.RECOVERY_UPDATED, fetch the sleep record using the webhook's resource_id (sleep_id) first to obtain its associated cycle_id.
- Correct Recovery Endpoint: Updated Whoop data247.get_recovery_record to request /v2/cycle/{cycle_id}/recovery.

## Checklist

### General

- [X] My code follows the project's code style
- [X] I have performed a self-review of my code
- [X] I have added tests that prove my fix/feature works (if applicable)
- [X] New and existing tests pass locally
- [X] No Documentation Update Required 

### Backend Changes

- [X] `uv run pre-commit run --all-files` passes

## Testing Instructions

<!-- Describe how reviewers can test your changes -->

**Steps to test:**
1. Connect Whoop Provider
2. In Whoop App update your sleep or see when new sleep record is being added
3. in data_point_series table check any data_definition related to recovery e.g resting_heart_rate.

**Expected behavior:**
A record for that date for which you updated the sleep should exists in data_point_series table.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery updates from Whoop webhooks by associating recovery data with the correct sleep cycle.
  * Corrected recovery retrieval to use the appropriate cycle-based endpoint and matching trace information.
  * Added validation for missing or malformed sleep cycle information to prevent invalid recovery updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->