### PR TITLE
fix(frontend): fetch every item the profile summary widgets aggregate

### DIFF
--- a/backend/app/api/routes/v1/summaries.py
+++ b/backend/app/api/routes/v1/summaries.py
@@ -49,7 +49,7 @@ def get_sleep_summary(
     db: DbSession,
     _api_key: ApiKeyDep,
     cursor: str | None = None,
-    limit: Annotated[int, Query(ge=1, le=100)] = 50,
+    limit: Annotated[int, Query(ge=1, le=400)] = 50,
 ) -> PaginatedResponse[SleepSummary]:
     """Returns daily sleep metrics."""
     start_datetime = parse_query_datetime(start_date)

--- a/frontend/src/components/user/scores-section.tsx
+++ b/frontend/src/components/user/scores-section.tsx
@@ -14,7 +14,7 @@ import {
   ChevronUp,
   type LucideIcon,
 } from 'lucide-react';
-import { useAllHealthScores } from '@/hooks/api/use-health';
+import { useHealthScores } from '@/hooks/api/use-health';
 import { useDateRange } from '@/hooks/use-date-range';
 import type { DateRangeValue } from '@/components/ui/date-range-selector';
 import { SourceBadge } from '@/components/common/source-badge';
@@ -425,12 +425,13 @@ export function ScoresSection({
   const { startDate, endDate } = useDateRange(dateRange);
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
 
-  const { data: scoresData, isLoading } = useAllHealthScores(userId, {
+  const { data: scoresData, isLoading } = useHealthScores(userId, {
     start_date: startDate,
     end_date: endDate,
+    limit: 1000,
   });
 
-  const scores = useMemo(() => scoresData ?? [], [scoresData]);
+  const scores = useMemo(() => scoresData?.data ?? [], [scoresData?.data]);
 
   // Categories that have data, in defined order
   const availableCategories = useMemo(() => {

--- a/frontend/src/components/user/scores-section.tsx
+++ b/frontend/src/components/user/scores-section.tsx
@@ -14,7 +14,7 @@ import {
   ChevronUp,
   type LucideIcon,
 } from 'lucide-react';
-import { useHealthScores } from '@/hooks/api/use-health';
+import { useAllHealthScores } from '@/hooks/api/use-health';
 import { useDateRange } from '@/hooks/use-date-range';
 import type { DateRangeValue } from '@/components/ui/date-range-selector';
 import { SourceBadge } from '@/components/common/source-badge';
@@ -425,13 +425,14 @@ export function ScoresSection({
   const { startDate, endDate } = useDateRange(dateRange);
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
 
-  const { data: scoresData, isLoading } = useHealthScores(userId, {
+  // Follows pagination cursors so ranges with more than one API page of
+  // scores are fully covered
+  const { data: scoresData, isLoading } = useAllHealthScores(userId, {
     start_date: startDate,
     end_date: endDate,
-    limit: 1000,
   });
 
-  const scores = useMemo(() => scoresData?.data ?? [], [scoresData?.data]);
+  const scores = useMemo(() => scoresData ?? [], [scoresData]);
 
   // Categories that have data, in defined order
   const availableCategories = useMemo(() => {

--- a/frontend/src/components/user/scores-section.tsx
+++ b/frontend/src/components/user/scores-section.tsx
@@ -425,8 +425,6 @@ export function ScoresSection({
   const { startDate, endDate } = useDateRange(dateRange);
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
 
-  // Follows pagination cursors so ranges with more than one API page of
-  // scores are fully covered
   const { data: scoresData, isLoading } = useAllHealthScores(userId, {
     start_date: startDate,
     end_date: endDate,

--- a/frontend/src/components/user/sleep-section.tsx
+++ b/frontend/src/components/user/sleep-section.tsx
@@ -20,7 +20,7 @@ import {
 } from 'lucide-react';
 import {
   useSleepSessions,
-  useSleepSummaries,
+  useAllSleepSummaries,
   useTimeSeries,
   useDeleteSleepSession,
 } from '@/hooks/api/use-health';
@@ -518,15 +518,14 @@ export function SleepSection({
   const { startDate, endDate } = useDateRange(dateRange);
   const allTimeRange = useAllTimeRange();
 
-  // Fetch sleep summaries for summary stats (date range filtered)
-  const { data: sleepSummaries, isLoading: summaryLoading } = useSleepSummaries(
-    userId,
-    {
+  // Fetch sleep summaries for summary stats (date range filtered).
+  // Follows pagination cursors so ranges wider than one API page (100 days)
+  // are fully covered.
+  const { data: sleepSummaries, isLoading: summaryLoading } =
+    useAllSleepSummaries(userId, {
       start_date: startDate,
       end_date: endDate,
-      limit: 100,
-    }
-  );
+    });
 
   // Fetch sleep sessions with cursor-based pagination
   const {
@@ -555,7 +554,7 @@ export function SleepSection({
 
   // Calculate aggregate statistics from date-range filtered summaries
   const stats = useMemo(
-    () => calculateSleepStats(sleepSummaries?.data || []),
+    () => calculateSleepStats(sleepSummaries || []),
     [sleepSummaries]
   );
 
@@ -573,7 +572,7 @@ export function SleepSection({
 
   // Prepare chart data from summary data (sorted by date ascending)
   const chartData = useMemo(() => {
-    const summaries = sleepSummaries?.data || [];
+    const summaries = sleepSummaries || [];
     if (summaries.length === 0) return [];
 
     return [...summaries]

--- a/frontend/src/components/user/sleep-section.tsx
+++ b/frontend/src/components/user/sleep-section.tsx
@@ -518,9 +518,7 @@ export function SleepSection({
   const { startDate, endDate } = useDateRange(dateRange);
   const allTimeRange = useAllTimeRange();
 
-  // Fetch sleep summaries for summary stats (date range filtered).
-  // Follows pagination cursors so ranges wider than one API page (100 days)
-  // are fully covered.
+  // Fetch sleep summaries for summary stats (date range filtered)
   const { data: sleepSummaries, isLoading: summaryLoading } =
     useAllSleepSummaries(userId, {
       start_date: startDate,

--- a/frontend/src/components/user/workout-section.tsx
+++ b/frontend/src/components/user/workout-section.tsx
@@ -12,6 +12,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import {
+  useAllWorkouts,
   useWorkouts,
   useTimeSeries,
   useDeleteWorkout,
@@ -372,20 +373,20 @@ export function WorkoutSection({
   const handleNextPage = () => pagination.goToNextPage(nextCursor);
   const handlePrevPage = pagination.goToPrevPage;
 
-  // Fetch workouts for summary (with date filter, larger limit)
-  const { data: summaryWorkouts, isLoading: summaryLoading } = useWorkouts(
+  // Fetch workouts for summary (date filtered, following pagination cursors
+  // so ranges with more than one API page of workouts are fully covered)
+  const { data: summaryWorkouts, isLoading: summaryLoading } = useAllWorkouts(
     userId,
     {
       start_date: dateToTimestamp(startDate),
       end_date: dateToTimestamp(endDate),
-      limit: 100,
       sort_order: 'desc',
     }
   );
 
   // Calculate summary stats from date-filtered workouts
   const stats = useMemo(
-    () => calculateWorkoutStats(summaryWorkouts?.data || []),
+    () => calculateWorkoutStats(summaryWorkouts || []),
     [summaryWorkouts]
   );
 

--- a/frontend/src/components/user/workout-section.tsx
+++ b/frontend/src/components/user/workout-section.tsx
@@ -373,8 +373,7 @@ export function WorkoutSection({
   const handleNextPage = () => pagination.goToNextPage(nextCursor);
   const handlePrevPage = pagination.goToPrevPage;
 
-  // Fetch workouts for summary (date filtered, following pagination cursors
-  // so ranges with more than one API page of workouts are fully covered)
+  // Fetch workouts for summary (date range filtered)
   const { data: summaryWorkouts, isLoading: summaryLoading } = useAllWorkouts(
     userId,
     {

--- a/frontend/src/hooks/api/use-health.ts
+++ b/frontend/src/hooks/api/use-health.ts
@@ -123,8 +123,8 @@ export function useSleepSummaries(userId: string, params: SummaryParams) {
 }
 
 /**
- * Get all sleep summaries for a date range, following pagination cursors
- * so ranges wider than one API page (100 days) are fully covered.
+ * Get all pages of sleep summaries for a date range
+ * Uses GET /api/v1/users/{user_id}/summaries/sleep
  */
 export function useAllSleepSummaries(userId: string, params: SummaryParams) {
   return useQuery({
@@ -135,8 +135,8 @@ export function useAllSleepSummaries(userId: string, params: SummaryParams) {
 }
 
 /**
- * Get all workouts for a date range, following pagination cursors
- * so ranges with more than one API page (100 workouts) are fully covered.
+ * Get all pages of workouts for a date range
+ * Uses GET /api/v1/users/{user_id}/events/workouts
  */
 export function useAllWorkouts(userId: string, params?: WorkoutsParams) {
   return useQuery({
@@ -147,8 +147,8 @@ export function useAllWorkouts(userId: string, params?: WorkoutsParams) {
 }
 
 /**
- * Get all health scores for a date range, following pagination cursors
- * so ranges with more than one API page of scores are fully covered.
+ * Get all pages of health scores for a date range
+ * Uses GET /api/v1/users/{user_id}/health-scores
  */
 export function useAllHealthScores(userId: string, params: HealthScoreParams) {
   return useQuery({

--- a/frontend/src/hooks/api/use-health.ts
+++ b/frontend/src/hooks/api/use-health.ts
@@ -147,18 +147,6 @@ export function useAllWorkouts(userId: string, params?: WorkoutsParams) {
 }
 
 /**
- * Get all pages of health scores for a date range
- * Uses GET /api/v1/users/{user_id}/health-scores
- */
-export function useAllHealthScores(userId: string, params: HealthScoreParams) {
-  return useQuery({
-    queryKey: [...queryKeys.health.healthScores(userId, params), 'all-pages'],
-    queryFn: () => healthService.getAllHealthScores(userId, params),
-    enabled: !!userId && !!params.start_date && !!params.end_date,
-  });
-}
-
-/**
  * Delete a workout event
  */
 export function useDeleteWorkout(userId: string) {

--- a/frontend/src/hooks/api/use-health.ts
+++ b/frontend/src/hooks/api/use-health.ts
@@ -123,6 +123,42 @@ export function useSleepSummaries(userId: string, params: SummaryParams) {
 }
 
 /**
+ * Get all sleep summaries for a date range, following pagination cursors
+ * so ranges wider than one API page (100 days) are fully covered.
+ */
+export function useAllSleepSummaries(userId: string, params: SummaryParams) {
+  return useQuery({
+    queryKey: [...queryKeys.health.sleepSummaries(userId, params), 'all-pages'],
+    queryFn: () => healthService.getAllSleepSummaries(userId, params),
+    enabled: !!userId && !!params.start_date && !!params.end_date,
+  });
+}
+
+/**
+ * Get all workouts for a date range, following pagination cursors
+ * so ranges with more than one API page (100 workouts) are fully covered.
+ */
+export function useAllWorkouts(userId: string, params?: WorkoutsParams) {
+  return useQuery({
+    queryKey: [...queryKeys.health.workouts(userId, params), 'all-pages'],
+    queryFn: () => healthService.getAllWorkouts(userId, params),
+    enabled: !!userId,
+  });
+}
+
+/**
+ * Get all health scores for a date range, following pagination cursors
+ * so ranges with more than one API page of scores are fully covered.
+ */
+export function useAllHealthScores(userId: string, params: HealthScoreParams) {
+  return useQuery({
+    queryKey: [...queryKeys.health.healthScores(userId, params), 'all-pages'],
+    queryFn: () => healthService.getAllHealthScores(userId, params),
+    enabled: !!userId && !!params.start_date && !!params.end_date,
+  });
+}
+
+/**
  * Delete a workout event
  */
 export function useDeleteWorkout(userId: string) {

--- a/frontend/src/lib/api/services/health.service.ts
+++ b/frontend/src/lib/api/services/health.service.ts
@@ -53,9 +53,8 @@ export interface SummaryParams {
 }
 
 /**
- * Fetch every page of a cursor-paginated endpoint.
- * The API caps a single page (100 items on most endpoints), so date ranges
- * wider than one page need cursor traversal to be fully covered.
+ * Fetch every page of a cursor-paginated endpoint. Single pages cap at
+ * 100 items on most endpoints, so wide date ranges span several pages.
  */
 async function fetchAllPages<T>(
   endpoint: string,
@@ -216,7 +215,7 @@ export const healthService = {
   },
 
   /**
-   * Get all sleep summaries for a date range, following pagination cursors
+   * Get all pages of sleep summaries for a date range
    */
   async getAllSleepSummaries(
     userId: string,
@@ -229,7 +228,7 @@ export const healthService = {
   },
 
   /**
-   * Get all workouts for a date range, following pagination cursors
+   * Get all pages of workouts for a date range
    */
   async getAllWorkouts(
     userId: string,
@@ -242,7 +241,7 @@ export const healthService = {
   },
 
   /**
-   * Get all health scores for a date range, following pagination cursors
+   * Get all pages of health scores for a date range
    */
   async getAllHealthScores(
     userId: string,

--- a/frontend/src/lib/api/services/health.service.ts
+++ b/frontend/src/lib/api/services/health.service.ts
@@ -62,18 +62,19 @@ async function fetchAllPages<T>(
 ): Promise<T[]> {
   const items: T[] = [];
   let cursor: string | undefined;
-  // Safety cap to avoid an unbounded loop on a misbehaving cursor
+  // Page cap so a misbehaving cursor cannot loop forever
   for (let page = 0; page < 50; page++) {
     const response = await apiClient.get<PaginatedResponse<T>>(endpoint, {
       params: { ...params, limit: 100, cursor },
     });
     items.push(...response.data);
     if (!response.pagination.has_more || !response.pagination.next_cursor) {
-      break;
+      return items;
     }
     cursor = response.pagination.next_cursor;
   }
-  return items;
+  // Failing beats silently rendering partial history as complete
+  throw new Error(`Pagination for ${endpoint} exceeded 50 pages`);
 }
 
 export const healthService = {

--- a/frontend/src/lib/api/services/health.service.ts
+++ b/frontend/src/lib/api/services/health.service.ts
@@ -53,23 +53,27 @@ export interface SummaryParams {
 }
 
 /**
- * Fetch every page of a cursor-paginated endpoint. Single pages cap at
- * 100 items on most endpoints, so wide date ranges span several pages.
+ * Fetch every page of a cursor-paginated endpoint. Callers pass the
+ * endpoint's maximum page size so most date ranges resolve in one request.
  */
 async function fetchAllPages<T>(
   endpoint: string,
-  params: SummaryParams | WorkoutsParams | HealthScoreParams
+  params: SummaryParams | WorkoutsParams,
+  pageSize: number
 ): Promise<T[]> {
   const items: T[] = [];
   let cursor: string | undefined;
   // Page cap so a misbehaving cursor cannot loop forever
   for (let page = 0; page < 50; page++) {
     const response = await apiClient.get<PaginatedResponse<T>>(endpoint, {
-      params: { ...params, limit: 100, cursor },
+      params: { ...params, limit: pageSize, cursor },
     });
     items.push(...response.data);
-    if (!response.pagination.has_more || !response.pagination.next_cursor) {
+    if (!response.pagination.has_more) {
       return items;
+    }
+    if (!response.pagination.next_cursor) {
+      throw new Error(`${endpoint} reported more data without a cursor`);
     }
     cursor = response.pagination.next_cursor;
   }
@@ -224,7 +228,8 @@ export const healthService = {
   ): Promise<SleepSummary[]> {
     return fetchAllPages<SleepSummary>(
       API_ENDPOINTS.userSleepSummary(userId),
-      params
+      params,
+      400
     );
   },
 
@@ -237,20 +242,8 @@ export const healthService = {
   ): Promise<EventRecordResponse[]> {
     return fetchAllPages<EventRecordResponse>(
       API_ENDPOINTS.userWorkouts(userId),
-      params ?? {}
-    );
-  },
-
-  /**
-   * Get all pages of health scores for a date range
-   */
-  async getAllHealthScores(
-    userId: string,
-    params?: HealthScoreParams
-  ): Promise<HealthScoreResponse[]> {
-    return fetchAllPages<HealthScoreResponse>(
-      API_ENDPOINTS.userHealthScores(userId),
-      params ?? {}
+      params ?? {},
+      100
     );
   },
 

--- a/frontend/src/lib/api/services/health.service.ts
+++ b/frontend/src/lib/api/services/health.service.ts
@@ -52,6 +52,31 @@ export interface SummaryParams {
   [key: string]: string | number | undefined;
 }
 
+/**
+ * Fetch every page of a cursor-paginated endpoint.
+ * The API caps a single page (100 items on most endpoints), so date ranges
+ * wider than one page need cursor traversal to be fully covered.
+ */
+async function fetchAllPages<T>(
+  endpoint: string,
+  params: SummaryParams | WorkoutsParams | HealthScoreParams
+): Promise<T[]> {
+  const items: T[] = [];
+  let cursor: string | undefined;
+  // Safety cap to avoid an unbounded loop on a misbehaving cursor
+  for (let page = 0; page < 50; page++) {
+    const response = await apiClient.get<PaginatedResponse<T>>(endpoint, {
+      params: { ...params, limit: 100, cursor },
+    });
+    items.push(...response.data);
+    if (!response.pagination.has_more || !response.pagination.next_cursor) {
+      break;
+    }
+    cursor = response.pagination.next_cursor;
+  }
+  return items;
+}
+
 export const healthService = {
   /**
    * Synchronize workouts/exercises/activities from fitness provider API for a specific user
@@ -187,6 +212,45 @@ export const healthService = {
     return apiClient.get<PaginatedResponse<SleepSummary>>(
       API_ENDPOINTS.userSleepSummary(userId),
       { params }
+    );
+  },
+
+  /**
+   * Get all sleep summaries for a date range, following pagination cursors
+   */
+  async getAllSleepSummaries(
+    userId: string,
+    params: SummaryParams
+  ): Promise<SleepSummary[]> {
+    return fetchAllPages<SleepSummary>(
+      API_ENDPOINTS.userSleepSummary(userId),
+      params
+    );
+  },
+
+  /**
+   * Get all workouts for a date range, following pagination cursors
+   */
+  async getAllWorkouts(
+    userId: string,
+    params?: WorkoutsParams
+  ): Promise<EventRecordResponse[]> {
+    return fetchAllPages<EventRecordResponse>(
+      API_ENDPOINTS.userWorkouts(userId),
+      params ?? {}
+    );
+  },
+
+  /**
+   * Get all health scores for a date range, following pagination cursors
+   */
+  async getAllHealthScores(
+    userId: string,
+    params?: HealthScoreParams
+  ): Promise<HealthScoreResponse[]> {
+    return fetchAllPages<HealthScoreResponse>(
+      API_ENDPOINTS.userHealthScores(userId),
+      params ?? {}
     );
   },
 


### PR DESCRIPTION
## Description

The sleep and workout summary widgets on the dashboard user profile read one page from their paginated endpoints and ignore `next_cursor`. Pages cap at 100 items, so any date range holding more history than one page shows wrong totals with no truncation hint. With the 365 day range selected, "Nights Tracked" reads 100 for a window that holds 353 tracked nights, and workout stats aggregate the newest 100 of 926 workouts.

Fixes #1465.

Changes:

- `summaries/sleep` accepts `limit` up to 400, the same cap `summaries/activity` already has. The sleep aggregate runs over the whole requested range on every page, so walking pages at 100 repeats that work. The sleep widget now fetches its range with `limit=400`, one request for a year.
- The workout widget follows `next_cursor` through `events/workouts` with a `fetchAllPages` helper in `health.service.ts` (50 page safety cap). That endpoint is a plain indexed listing, so extra pages are cheap.
- The health scores widget is back to what main does. `health-scores` paginates by offset and already accepted `limit=1000` in one request. An earlier revision of this PR routed it through the cursor helper by mistake, which cut it to 100 items.
- `fetchAllPages` throws when a response reports `has_more` without a `next_cursor` instead of returning a partial list.

The cursor paginated lists below the widgets already handled pagination and are unchanged.

While testing I found that `summaries/sleep` computes `has_more` after the source priority filter, so a user with several sources can get a short page with `has_more: false` while more nights exist (`limit=200` returned 142 of 236 nights with `has_more: false`). The 400 cap avoids this for the widget's ranges. The underlying issue is out of scope here and I can open a separate issue for it.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

- [x] `ruff check` and `ruff format --check` pass on `summaries.py`
- [x] `pytest tests/api/v1/test_summaries.py` passes (39 tests)
- [x] No migration or schema change, only the `limit` validation bound

### Frontend Changes

- [x] `pnpm run lint` passes
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` succeeds

## Testing Instructions

**Steps to test:**
1. Seed a user with more than 100 nights and more than 100 workouts inside a 12 month window (Settings > Seed Data, or an Apple Health export through `POST /api/v1/users/{user_id}/import/apple/xml/direct`).
2. Open the user profile, pick the Sleep tab and the 365d range, then the Workouts tab and 365d.
3. Compare "Nights Tracked" and the workout count with what the API returns for the same window.

**Expected behavior:**
The sleep widget makes one `summaries/sleep` request with `limit=400` and Nights Tracked matches the API count. The workout widget walks every page and counts every workout in the range.

What I saw on a local stack with seeded data (365 nights and 500 workouts over 12 months across two providers, plus a second user with 362 WHOOP and Suunto scores in the window): sleep widget one request, 235 nights shown, matching the API; workout widget 5 pages, 496 shown; scores widget one request with `limit=1000`, all 362 listed.

## Screenshots

None, the change only affects the numbers the existing widgets compute.

## Additional Notes

No unit tests added: the widgets and the service layer have no existing test coverage to extend. Ranges that fit one page behave as before, one request, same parameters.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sleep and workout summaries now include all available records across the selected date range.
  * Summary statistics and charts no longer omit data beyond the previous page limit.
  * Sleep summary requests can now retrieve larger result sets for more complete reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->