### PR TITLE
fix(backend): report real synced item counts for Ultrahuman

### DIFF
--- a/backend/app/services/providers/ultrahuman/data_247.py
+++ b/backend/app/services/providers/ultrahuman/data_247.py
@@ -9,9 +9,9 @@ from fastapi import HTTPException
 
 from app.config import settings
 from app.database import DbSession
-from app.models import DataPointSeries, EventRecord
+from app.models import EventRecord
 from app.repositories import EventRecordRepository, UserConnectionRepository
-from app.repositories.data_point_series_repository import DataPointSeriesRepository
+from app.repositories.data_point_series_repository import WriteCounts
 from app.schemas.enums import daily_total_flag
 from app.schemas.enums.series_types import SeriesType
 from app.schemas.model_crud.activities.data_point_series import TimeSeriesSampleCreate
@@ -23,6 +23,7 @@ from app.services.providers.templates.base_247_data import Base247DataTemplate
 from app.services.providers.templates.base_oauth import BaseOAuthTemplate
 from app.services.providers.ultrahuman.coverage import ACTIVITY_SAMPLE_SERIES
 from app.services.raw_payload_storage import store_raw_payload
+from app.services.timeseries_service import timeseries_service
 
 
 class Ultrahuman247Data(Base247DataTemplate):
@@ -37,7 +38,6 @@ class Ultrahuman247Data(Base247DataTemplate):
         super().__init__(provider_name, api_base_url, oauth)
         self.event_record_repo = EventRecordRepository(EventRecord)
         self.connection_repo = UserConnectionRepository()
-        self.data_point_repo = DataPointSeriesRepository(DataPointSeries)
 
     def _make_api_request(
         self,
@@ -374,50 +374,46 @@ class Ultrahuman247Data(Base247DataTemplate):
 
         return result
 
-    def save_activity_samples(
+    def _build_activity_samples(
         self,
-        db: DbSession,
         user_id: UUID,
         normalized_samples: dict[str, list[dict[str, Any]]],
-    ) -> int:
-        """Save normalized activity samples (HR, HRV, etc.) to DataPointSeries."""
-        count = 0
+    ) -> list[TimeSeriesSampleCreate]:
+        """Build TimeSeriesSampleCreate rows from normalized activity samples (HR, HRV, etc.).
 
-        for key, samples in normalized_samples.items():
+        The rows are persisted in bulk by the caller via
+        ``timeseries_service.bulk_create_samples`` (upsert), not written here.
+        """
+        samples: list[TimeSeriesSampleCreate] = []
+
+        for key, entries in normalized_samples.items():
             series_type = ACTIVITY_SAMPLE_SERIES.get(key)
             if not series_type:
                 continue
 
-            for sample in samples:
+            for sample in entries:
                 recorded_at_str = sample.get("recorded_at")
+                if not recorded_at_str:
+                    continue
                 try:
-                    # Parse timestamp
-                    if not recorded_at_str:
-                        continue
-
                     recorded_at = datetime.fromisoformat(recorded_at_str.replace("Z", "+00:00"))
-
-                    # Create sample
-                    ts_sample = TimeSeriesSampleCreate(
-                        id=uuid4(),
-                        user_id=user_id,
-                        provider=self.provider_name,
-                        recorded_at=recorded_at,
-                        value=Decimal(str(sample.get("value"))),
-                        series_type=series_type,
-                        is_daily_total=daily_total_flag(series_type, is_daily=False),
+                    samples.append(
+                        TimeSeriesSampleCreate(
+                            id=uuid4(),
+                            user_id=user_id,
+                            provider=self.provider_name,
+                            recorded_at=recorded_at,
+                            value=Decimal(str(sample.get("value"))),
+                            series_type=series_type,
+                            is_daily_total=daily_total_flag(series_type, is_daily=False),
+                        )
                     )
-
-                    self.data_point_repo.create(db, ts_sample)
-                    count += 1
                 except Exception as e:
-                    # Log but continue for other samples
-                    # Use warning level for first few errors to help debug issues
                     self.logger.warning(
-                        f"Failed to save {key} sample for user {user_id} at {recorded_at_str or 'unknown time'}: {e}"
+                        f"Failed to build {key} sample for user {user_id} at {recorded_at_str or 'unknown time'}: {e}"
                     )
 
-        return count
+        return samples
 
     # -------------------------------------------------------------------------
     # Combined Load (Main Entry Point)
@@ -435,11 +431,14 @@ class Ultrahuman247Data(Base247DataTemplate):
 
         Returns:
             dict[str, Any]: Results containing:
-                - sleep_sessions_synced: int - Number of sleep sessions saved
-                - activity_samples: int - Number of activity samples saved
+                - sleep_sessions_synced: WriteCounts - Sleep sessions saved (all inserts)
+                - activity_samples: WriteCounts - Activity samples upserted (inserted + updated)
                 - recovery_days_synced: int - Number of recovery days processed
                 - failed_days: int - Number of days that failed to process
                 - errors: list[dict[str, str]] - List of errors with date and message
+
+            The two saved-row counts are WriteCounts (int subclass) so the sync
+            orchestrator can accumulate them via ``.inserted``/``.updated``.
         """
 
         # TODO: Extract default backfill days (30) to an env var / settings constant.
@@ -465,6 +464,9 @@ class Ultrahuman247Data(Base247DataTemplate):
             "failed_days": 0,
             "errors": [],
         }
+
+        activity_inserted = 0
+        activity_updated = 0
 
         current_date = datetime.combine(start_time.date(), datetime.min.time(), tzinfo=timezone.utc)
         end_date = datetime.combine(end_time.date(), datetime.min.time(), tzinfo=timezone.utc)
@@ -498,7 +500,8 @@ class Ultrahuman247Data(Base247DataTemplate):
 
                 # 3. Process Activity Samples
                 try:
-                    # Prepare list for normalization
+                    daily_samples: list[TimeSeriesSampleCreate] = []
+
                     sample_inputs = []
                     for t in ["hr", "hrv", "temp", "steps"]:
                         if t in items_by_type:
@@ -506,26 +509,23 @@ class Ultrahuman247Data(Base247DataTemplate):
 
                     if sample_inputs:
                         normalized_samples = self.normalize_activity_samples(sample_inputs, user_id)
-                        saved_count = self.save_activity_samples(db, user_id, normalized_samples)
-                        results["activity_samples"] += saved_count
+                        daily_samples.extend(self._build_activity_samples(user_id, normalized_samples))
 
-                    # VO2 max (single daily value, not a time series)
                     if "vo2_max" in items_by_type:
                         vo2_obj = items_by_type["vo2_max"]
                         vo2_value = vo2_obj.get("value")
                         vo2_ts = vo2_obj.get("day_start_timestamp")
                         if vo2_value and vo2_ts:
-                            recorded_at = datetime.fromtimestamp(vo2_ts, tz=timezone.utc)
-                            ts_sample = TimeSeriesSampleCreate(
-                                id=uuid4(),
-                                user_id=user_id,
-                                provider=self.provider_name,
-                                recorded_at=recorded_at,
-                                value=Decimal(str(vo2_value)),
-                                series_type=SeriesType.vo2_max,
+                            daily_samples.append(
+                                TimeSeriesSampleCreate(
+                                    id=uuid4(),
+                                    user_id=user_id,
+                                    provider=self.provider_name,
+                                    recorded_at=datetime.fromtimestamp(vo2_ts, tz=timezone.utc),
+                                    value=Decimal(str(vo2_value)),
+                                    series_type=SeriesType.vo2_max,
+                                )
                             )
-                            self.data_point_repo.create(db, ts_sample)
-                            results["activity_samples"] += 1
 
                     # Active time (single daily value in minutes, like vo2_max)
                     if "active_minutes" in items_by_type:
@@ -533,20 +533,22 @@ class Ultrahuman247Data(Base247DataTemplate):
                         active_value = active_obj.get("value")
                         active_ts = active_obj.get("day_start_timestamp")
                         if active_value is not None and active_ts:
-                            recorded_at = datetime.fromtimestamp(active_ts, tz=timezone.utc)
-                            self.data_point_repo.create(
-                                db,
+                            daily_samples.append(
                                 TimeSeriesSampleCreate(
                                     id=uuid4(),
                                     user_id=user_id,
                                     provider=self.provider_name,
-                                    recorded_at=recorded_at,
+                                    recorded_at=datetime.fromtimestamp(active_ts, tz=timezone.utc),
                                     value=Decimal(str(active_value)),
                                     series_type=SeriesType.active_time,
                                     is_daily_total=True,
-                                ),
+                                )
                             )
-                            results["activity_samples"] += 1
+
+                    if daily_samples:
+                        counts = timeseries_service.bulk_create_samples(db, daily_samples)
+                        activity_inserted += counts.inserted
+                        activity_updated += counts.updated
                 except Exception as e:
                     day_error = f"Activity samples processing failed: {e}"
 
@@ -564,6 +566,9 @@ class Ultrahuman247Data(Base247DataTemplate):
                 results["errors"].append({"date": date_str, "error": day_error})
 
             current_date += timedelta(days=1)
+
+        results["sleep_sessions_synced"] = WriteCounts(results["sleep_sessions_synced"], 0)
+        results["activity_samples"] = WriteCounts(activity_inserted, activity_updated)
 
         return results
 

--- a/backend/app/services/providers/ultrahuman/data_247.py
+++ b/backend/app/services/providers/ultrahuman/data_247.py
@@ -24,6 +24,7 @@ from app.services.providers.templates.base_oauth import BaseOAuthTemplate
 from app.services.providers.ultrahuman.coverage import ACTIVITY_SAMPLE_SERIES
 from app.services.raw_payload_storage import store_raw_payload
 from app.services.timeseries_service import timeseries_service
+from app.utils.structured_logging import log_structured
 
 
 class Ultrahuman247Data(Base247DataTemplate):
@@ -102,14 +103,40 @@ class Ultrahuman247Data(Base247DataTemplate):
         except HTTPException as e:
             # Fatal errors - should be raised to trigger token refresh or invalidate connection
             if e.status_code in (401, 403):
-                self.logger.error(f"Authorization failed for {date_str}: {e.detail}")
+                log_structured(
+                    self.logger,
+                    "error",
+                    "Authorization failed while fetching daily metrics",
+                    provider="ultrahuman",
+                    task="fetch_daily_metrics",
+                    date=date_str,
+                    status_code=e.status_code,
+                    error=e.detail,
+                )
                 raise
             # Recoverable errors - log and continue with next day
-            self.logger.warning(f"API error for {date_str}: {e.detail}")
+            log_structured(
+                self.logger,
+                "warning",
+                "API error while fetching daily metrics",
+                provider="ultrahuman",
+                task="fetch_daily_metrics",
+                date=date_str,
+                status_code=e.status_code,
+                error=e.detail,
+            )
             return []
         except Exception as e:
             # Network errors and other unexpected errors - log and continue
-            self.logger.warning(f"Failed to fetch metrics for {date_str}: {e}")
+            log_structured(
+                self.logger,
+                "warning",
+                "Failed to fetch daily metrics",
+                provider="ultrahuman",
+                task="fetch_daily_metrics",
+                date=date_str,
+                error=str(e),
+            )
             return []
 
         return []
@@ -193,7 +220,15 @@ class Ultrahuman247Data(Base247DataTemplate):
         end_dt = normalized_sleep.get("end_time")
 
         if not start_dt or not end_dt:
-            self.logger.warning(f"Skipping sleep record {sleep_id}: missing start/end time")
+            log_structured(
+                self.logger,
+                "warning",
+                "Skipping sleep record: missing start/end time",
+                provider="ultrahuman",
+                task="save_sleep_data",
+                sleep_id=str(sleep_id),
+                user_id=str(user_id),
+            )
             return False
 
         # Create EventRecord for sleep
@@ -240,7 +275,16 @@ class Ultrahuman247Data(Base247DataTemplate):
             event_record_service.create_or_merge_sleep(db, user_id, record, detail, settings.sleep_end_gap_minutes)
             return True
         except Exception as e:
-            self.logger.error(f"Error saving sleep record {sleep_id}: {e}")
+            log_structured(
+                self.logger,
+                "error",
+                "Error saving sleep record",
+                provider="ultrahuman",
+                task="save_sleep_data",
+                sleep_id=str(sleep_id),
+                user_id=str(user_id),
+                error=str(e),
+            )
             return False
 
     # -------------------------------------------------------------------------
@@ -409,8 +453,16 @@ class Ultrahuman247Data(Base247DataTemplate):
                         )
                     )
                 except Exception as e:
-                    self.logger.warning(
-                        f"Failed to build {key} sample for user {user_id} at {recorded_at_str or 'unknown time'}: {e}"
+                    log_structured(
+                        self.logger,
+                        "warning",
+                        "Failed to build activity sample",
+                        provider="ultrahuman",
+                        task="build_activity_samples",
+                        series=key,
+                        user_id=str(user_id),
+                        recorded_at=recorded_at_str or "unknown time",
+                        error=str(e),
                     )
 
         return samples

--- a/backend/tests/providers/ultrahuman/test_ultrahuman_integration.py
+++ b/backend/tests/providers/ultrahuman/test_ultrahuman_integration.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 from sqlalchemy.orm import Session
 
 from app.models import DataPointSeries, DataSource, EventRecord, SeriesTypeDefinition, SleepDetails
+from app.repositories.data_point_series_repository import WriteCounts
 from app.schemas.enums.series_types import SeriesType
 from app.services.providers.factory import ProviderFactory
 from app.services.providers.ultrahuman.data_247 import Ultrahuman247Data
@@ -584,3 +585,97 @@ class TestUltrahumanErrorHandling:
                 assert record.start_datetime <= end_time, (
                     f"Sleep record {record.start_datetime} is after end time {end_time}"
                 )
+
+
+class TestUltrahumanSyncCountContract:
+    """Guards the fix for the "Success but 0 items" sync report.
+
+    The sync orchestrator sums saved rows via ``getattr(_count, "inserted", 0)``
+    over the values of ``load_and_save_all``'s result. Plain ints resolve to 0
+    there, so the saved-row counters must be returned as ``WriteCounts``.
+    """
+
+    def test_saved_counts_are_writecounts_the_orchestrator_can_sum(
+        self, db: Session, sample_ultrahuman_api_response: dict
+    ) -> None:
+        user = UserFactory()
+        UserConnectionFactory(user=user, provider="ultrahuman", status="active", access_token="test_token")
+        DataSourceFactory(user_id=user.id, provider="ultrahuman")
+
+        factory = ProviderFactory()
+        strategy = factory.get_provider("ultrahuman")
+        provider_impl = strategy.data_247
+        assert isinstance(provider_impl, Ultrahuman247Data)
+
+        # Single-day range: the mock returns the same payload for every day in
+        # the range, so a multi-day range would upsert-update the same rows and
+        # produce updates. One day keeps the first sync deterministically all
+        # inserts.
+        start_time = datetime(2024, 1, 15, tzinfo=timezone.utc)
+        end_time = datetime(2024, 1, 15, tzinfo=timezone.utc)
+
+        with patch.object(provider_impl, "_make_api_request", return_value=sample_ultrahuman_api_response):
+            results = provider_impl.load_and_save_all(db, user.id, start_time=start_time, end_time=end_time)
+            db.commit()
+
+        # Fixture carries both sleep and activity data.
+        assert results["sleep_sessions_synced"] > 0
+        assert results["activity_samples"] > 0
+
+        # Saved-row counters must carry .inserted so the orchestrator counts them.
+        for key in ("sleep_sessions_synced", "activity_samples"):
+            count = results[key]
+            assert isinstance(count, WriteCounts), f"{key} must be WriteCounts, got {type(count)}"
+            assert count.inserted == int(count)
+            assert count.updated == 0
+
+        # Mirror the orchestrator's accumulation: it must no longer report 0.
+        pull_inserted = sum(getattr(v, "inserted", 0) for v in results.values())
+        pull_updated = sum(getattr(v, "updated", 0) for v in results.values())
+        assert pull_inserted == results["sleep_sessions_synced"] + results["activity_samples"]
+        assert pull_updated == 0
+        assert pull_inserted + pull_updated > 0
+
+        # failed_days / errors must not be mistaken for written rows.
+        assert getattr(results["failed_days"], "inserted", 0) == 0
+        assert getattr(results["errors"], "inserted", 0) == 0
+
+    def test_resync_upserts_instead_of_duplicating(self, db: Session, sample_ultrahuman_api_response: dict) -> None:
+        """Re-syncing the same day must upsert (dedupe), not insert duplicate rows."""
+        user = UserFactory()
+        UserConnectionFactory(user=user, provider="ultrahuman", status="active", access_token="test_token")
+        DataSourceFactory(user_id=user.id, provider="ultrahuman")
+
+        factory = ProviderFactory()
+        strategy = factory.get_provider("ultrahuman")
+        provider_impl = strategy.data_247
+        assert isinstance(provider_impl, Ultrahuman247Data)
+
+        # Single-day range so the first sync is deterministically all inserts;
+        # the re-sync then exercises the upsert/update path on the same rows.
+        start_time = datetime(2024, 1, 15, tzinfo=timezone.utc)
+        end_time = datetime(2024, 1, 15, tzinfo=timezone.utc)
+
+        def _sample_rows() -> int:
+            return (
+                db.query(DataPointSeries)
+                .join(DataSource)
+                .filter(DataSource.user_id == user.id, DataSource.provider == "ultrahuman")
+                .count()
+            )
+
+        with patch.object(provider_impl, "_make_api_request", return_value=sample_ultrahuman_api_response):
+            first = provider_impl.load_and_save_all(db, user.id, start_time=start_time, end_time=end_time)
+            db.commit()
+            rows_after_first = _sample_rows()
+
+            second = provider_impl.load_and_save_all(db, user.id, start_time=start_time, end_time=end_time)
+            db.commit()
+            rows_after_second = _sample_rows()
+
+        # First sync inserts; second sync updates the same rows in place.
+        assert first["activity_samples"].inserted > 0
+        assert first["activity_samples"].updated == 0
+        assert second["activity_samples"].inserted == 0
+        assert second["activity_samples"].updated == first["activity_samples"].inserted
+        assert rows_after_second == rows_after_first, "Re-sync must not duplicate timeseries rows"


### PR DESCRIPTION
## Description

Ultrahuman syncs were reporting "0 items" even when data was saved, because the implementation returned a different structure than the sync orchestrator expects to count (`WriteCounts`). Now, the Ultrahuman implementation follows the same shared `bulk_create_samples` upsert path as the other providers, which gives us real insert/update counts and deduplication on re-sync for free.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. Run `tests/providers/ultrahuman/test_ultrahuman_integration.py::TestUltrahumanSyncCountContract`
2. Or trigger a live Ultrahuman sync and check the reported item count

**Expected behavior:**
A successful sync reports the actual number of saved records instead of `0 items`, and re-syncing the same day upserts in place rather than duplicating rows.

**Verified, and what's more, it's now way faster!** 

<img width="1120" height="599" alt="image" src="https://github.com/user-attachments/assets/0fe7b186-16a8-485d-bad6-8a0e38ea0b7a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity and sleep data synchronization to update existing records instead of creating duplicates.
  * Sync results now accurately distinguish inserted and updated records.
  * Failed days and errors are excluded from saved-record totals.
  * Malformed activity entries are safely skipped, improving synchronization reliability.

* **Tests**
  * Added coverage for synchronization counts and repeated activity imports.
  * Verified that resynchronizing data does not create duplicate records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->