### PR TITLE
feat: parse Ultrahuman granular sleep stages from sleep_graph

### DIFF
--- a/backend/app/services/providers/ultrahuman/data_247.py
+++ b/backend/app/services/providers/ultrahuman/data_247.py
@@ -8,6 +8,7 @@ from uuid import UUID, uuid4
 from fastapi import HTTPException
 
 from app.config import settings
+from app.constants.sleep import SleepStageType
 from app.database import DbSession
 from app.models import EventRecord
 from app.repositories import EventRecordRepository, UserConnectionRepository
@@ -17,6 +18,7 @@ from app.schemas.enums.series_types import SeriesType
 from app.schemas.model_crud.activities.data_point_series import TimeSeriesSampleCreate
 from app.schemas.model_crud.activities.event_record import EventRecordCreate
 from app.schemas.model_crud.activities.event_record_detail import EventRecordDetailCreate
+from app.schemas.model_crud.activities.sleep import SleepStage
 from app.services.event_record_service import event_record_service
 from app.services.providers.api_client import make_authenticated_request
 from app.services.providers.templates.base_247_data import Base247DataTemplate
@@ -25,6 +27,14 @@ from app.services.providers.ultrahuman.coverage import ACTIVITY_SAMPLE_SERIES
 from app.services.raw_payload_storage import store_raw_payload
 from app.services.timeseries_service import timeseries_service
 from app.utils.structured_logging import log_structured
+
+# Ultrahuman sleep_graph.data stage names → our canonical SleepStageType.
+SLEEP_GRAPH_STAGE_MAP: dict[str, SleepStageType] = {
+    "deep_sleep": SleepStageType.DEEP,
+    "light_sleep": SleepStageType.LIGHT,
+    "rem_sleep": SleepStageType.REM,
+    "awake": SleepStageType.AWAKE,
+}
 
 
 class Ultrahuman247Data(Base247DataTemplate):
@@ -145,6 +155,34 @@ class Ultrahuman247Data(Base247DataTemplate):
     # Sleep Data
     # -------------------------------------------------------------------------
 
+    @staticmethod
+    def _normalize_sleep_stages(raw_sleep: dict[str, Any]) -> list[SleepStage]:
+        """Parse the ``sleep_graph.data`` interval timeline into canonical SleepStage objects.
+
+        Ultrahuman returns timestamped stage transitions as
+        ``{"start": <unix>, "end": <unix>, "type": "deep_sleep", ...}``. Unknown stage
+        names fall back to ``SleepStageType.UNKNOWN``; intervals missing start/end are skipped.
+        """
+        graph = raw_sleep.get("sleep_graph") or {}
+        intervals = graph.get("data", []) if isinstance(graph, dict) else []
+
+        stages: list[SleepStage] = []
+        for interval in intervals:
+            start_ts = interval.get("start")
+            end_ts = interval.get("end")
+            if start_ts is None or end_ts is None:
+                continue
+            stages.append(
+                SleepStage(
+                    stage=SLEEP_GRAPH_STAGE_MAP.get(interval.get("type"), SleepStageType.UNKNOWN),
+                    start_time=datetime.fromtimestamp(start_ts, tz=timezone.utc),
+                    end_time=datetime.fromtimestamp(end_ts, tz=timezone.utc),
+                )
+            )
+
+        stages.sort(key=lambda s: s.start_time)
+        return stages
+
     def normalize_sleep(
         self,
         raw_sleep: dict[str, Any],
@@ -201,6 +239,7 @@ class Ultrahuman247Data(Base247DataTemplate):
                 "rem_seconds": int(rem_seconds),
                 "awake_seconds": int(awake_seconds),
             },
+            "stage_timestamps": self._normalize_sleep_stages(raw_sleep),
             "ultrahuman_date": date_str,
             "raw": raw_sleep,
         }
@@ -269,6 +308,7 @@ class Ultrahuman247Data(Base247DataTemplate):
             sleep_rem_minutes=stages.get("rem_seconds", 0) // 60,
             sleep_awake_minutes=stages.get("awake_seconds", 0) // 60,
             is_nap=normalized_sleep.get("is_nap", False),
+            sleep_stages=normalized_sleep.get("stage_timestamps") or None,
         )
 
         try:

--- a/backend/tests/providers/conftest.py
+++ b/backend/tests/providers/conftest.py
@@ -491,7 +491,16 @@ def sample_ultrahuman_api_response() -> dict:
                                 "stage_time": 2100,
                             },
                         ],
-                        "sleep_graph": [],
+                        "sleep_graph": {
+                            "title": "Time In Bed",
+                            "data": [
+                                {"start": 1705287600, "end": 1705288200, "type": "awake"},
+                                {"start": 1705288200, "end": 1705291800, "type": "light_sleep"},
+                                {"start": 1705291800, "end": 1705295400, "type": "deep_sleep"},
+                                {"start": 1705295400, "end": 1705299000, "type": "rem_sleep"},
+                                {"start": 1705299000, "end": 1705314000, "type": "light_sleep"},
+                            ],
+                        },
                         "movement_graph": [],
                         "hr_graph": [],
                         "hrv_graph": [],

--- a/backend/tests/providers/ultrahuman/test_ultrahuman_data_247.py
+++ b/backend/tests/providers/ultrahuman/test_ultrahuman_data_247.py
@@ -136,6 +136,72 @@ class TestUltrahumanSleepData:
         assert normalized["duration_seconds"] == 0
         assert normalized["efficiency_percent"] is None
 
+    def test_normalize_sleep_parses_sleep_graph_stages(self, db: Session) -> None:
+        """sleep_graph.data intervals are parsed into canonical SleepStage objects."""
+        from app.constants.sleep import SleepStageType
+
+        user = UserFactory()
+        oauth = UltrahumanOAuth(
+            user_repo=UserRepository(User),
+            connection_repo=UserConnectionRepository(),
+            provider_name="ultrahuman",
+            api_base_url="https://partner.ultrahuman.com",
+        )
+        data_247 = Ultrahuman247Data(
+            provider_name="ultrahuman",
+            api_base_url="https://partner.ultrahuman.com",
+            oauth=oauth,
+        )
+
+        raw_sleep = {
+            "ultrahuman_date": "2025-01-14",
+            "bedtime_start": 1736816400,
+            "bedtime_end": 1736820000,
+            "sleep_graph": {
+                "data": [
+                    # deliberately out of order to verify sorting
+                    {"start": 1736817000, "end": 1736817600, "type": "deep_sleep"},
+                    {"start": 1736816400, "end": 1736817000, "type": "awake"},
+                    {"start": 1736817600, "end": 1736818200, "type": "rem_sleep"},
+                    {"start": 1736818200, "end": 1736818800, "type": "somethingelse"},  # unknown → UNKNOWN
+                    {"start": 1736818800, "type": "light_sleep"},  # missing end → skipped
+                ],
+            },
+        }
+
+        normalized = data_247.normalize_sleep(raw_sleep, user.id)
+        stages = normalized["stage_timestamps"]
+
+        # 4 valid intervals (the missing-end one is skipped), sorted by start_time
+        assert [s.stage for s in stages] == [
+            SleepStageType.AWAKE,
+            SleepStageType.DEEP,
+            SleepStageType.REM,
+            SleepStageType.UNKNOWN,
+        ]
+        assert stages[0].start_time.tzinfo is not None
+        assert stages[0].start_time < stages[1].start_time
+        assert stages[1].start_time == stages[0].end_time
+
+    def test_normalize_sleep_without_sleep_graph_yields_no_stages(self, db: Session) -> None:
+        """A payload with no sleep_graph produces an empty stage list, not an error."""
+        user = UserFactory()
+        oauth = UltrahumanOAuth(
+            user_repo=UserRepository(User),
+            connection_repo=UserConnectionRepository(),
+            provider_name="ultrahuman",
+            api_base_url="https://partner.ultrahuman.com",
+        )
+        data_247 = Ultrahuman247Data(
+            provider_name="ultrahuman",
+            api_base_url="https://partner.ultrahuman.com",
+            oauth=oauth,
+        )
+
+        normalized = data_247.normalize_sleep({"ultrahuman_date": "2025-01-14"}, user.id)
+
+        assert normalized["stage_timestamps"] == []
+
 
 class TestUltrahumanRecoveryData:
     """Tests for Ultrahuman recovery data handling."""

--- a/backend/tests/providers/ultrahuman/test_ultrahuman_integration.py
+++ b/backend/tests/providers/ultrahuman/test_ultrahuman_integration.py
@@ -202,6 +202,48 @@ class TestUltrahumanSleepDataIntegration:
 
             assert not all_zero, "All sleep stage values are zero - parsing may be broken"
 
+    def test_sleep_graph_stages_persisted_to_jsonb_with_mocked_api(
+        self, db: Session, sample_ultrahuman_api_response: dict
+    ) -> None:
+        """Verify sleep_graph.data intervals are normalized and stored in sleep_details.sleep_stages."""
+        user = UserFactory()
+        UserConnectionFactory(user=user, provider="ultrahuman", status="active", access_token="test_token")
+        DataSourceFactory(user_id=user.id, provider="ultrahuman")
+
+        factory = ProviderFactory()
+        strategy = factory.get_provider("ultrahuman")
+        provider_impl = strategy.data_247
+        assert isinstance(provider_impl, Ultrahuman247Data)
+
+        end_time = datetime(2024, 1, 16, tzinfo=timezone.utc)
+        start_time = datetime(2024, 1, 15, tzinfo=timezone.utc)
+
+        with patch.object(provider_impl, "_make_api_request", return_value=sample_ultrahuman_api_response):
+            provider_impl.load_and_save_all(db, user.id, start_time=start_time, end_time=end_time)
+            db.commit()
+
+        details = (
+            db.query(SleepDetails)
+            .join(EventRecord, SleepDetails.record_id == EventRecord.id)
+            .join(DataSource)
+            .filter(DataSource.user_id == user.id, EventRecord.category == "sleep")
+            .all()
+        )
+
+        with_stages = [d for d in details if d.sleep_stages]
+        assert with_stages, "Expected at least one sleep record with sleep_stages populated"
+
+        for detail in with_stages:
+            stages = detail.sleep_stages
+            # Stored as a JSONB list of {stage, start_time, end_time} with ISO 8601 strings.
+            assert isinstance(stages, list)
+            assert len(stages) > 0
+            for interval in stages:
+                assert set(interval) >= {"stage", "start_time", "end_time"}
+                assert isinstance(interval["start_time"], str)  # unix ts → ISO 8601 string
+                assert "T" in interval["start_time"]
+            assert {i["stage"] for i in stages} <= {"awake", "light", "deep", "rem", "unknown"}
+
 
 class TestUltrahumanActivitySamplesIntegration:
     """Integration tests for Ultrahuman activity samples synchronization."""


### PR DESCRIPTION
## Description

Parses Ultrahuman's timestamped `sleep_graph.data` timeline into canonical SleepStage intervals and persists them to the `sleep_details.sleep_stages` JSONB column, which was previously left empty. Stage names are mapped to our `SleepStageType` enum and unix timestamps are serialized to ISO 8601.

Closes #665

Confirmed:

<img width="822" height="220" alt="image" src="https://github.com/user-attachments/assets/54b3ef30-3ca3-4a25-bc34-d3f307ca9878" />


## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. Sync an Ultrahuman account whose sleep payload includes `sleep_graph.data` (or run the mocked integration tests).
2. Inspect the synced `sleep_details.sleep_stages` JSONB column.

**Expected behavior:**
The column holds an ordered list of `{stage, start_time, end_time}` intervals with ISO 8601 timestamps and stages mapped to `SleepStageType` (deep/light/rem/awake), instead of being empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing detailed sleep stages from Ultrahuman sleep data.
  * Sleep records now include timestamped awake, light, deep, and REM sleep intervals.
  * Unknown or incomplete sleep-stage entries are handled safely without disrupting data import.

* **Bug Fixes**
  * Sleep-stage details are now consistently normalized and saved with timezone-aware timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->