### PR TITLE
fix(frontend): clear "Device info not available" label when a source has no device details

### DIFF
--- a/frontend/src/components/common/data-source-info.tsx
+++ b/frontend/src/components/common/data-source-info.tsx
@@ -11,7 +11,7 @@ import {
 import { cn } from '@/lib/utils';
 import type { SourceMetadata } from '@/lib/api/types';
 
-const UNKNOWN_DEVICE = '???';
+const NO_DEVICE_INFO = 'Device info not available';
 
 export function DataSourceInfo({
   source,
@@ -23,7 +23,7 @@ export function DataSourceInfo({
   if (!source) return null;
 
   const { label: deviceTypeLabel } = deviceTypeInfo(source.device_type);
-  const deviceName = source.device_name ?? UNKNOWN_DEVICE;
+  const deviceName = source.device_name ?? null;
   // Native API integrations store the provider key as the source ("garmin"/"garmin"),
   // so it only carries information for HealthKit / Health Connect writers.
   const showSource =
@@ -63,20 +63,24 @@ export function DataSourceInfo({
               deviceType={source.device_type}
               className="h-3 w-3 shrink-0"
             />
-            <span className="truncate">{deviceName}</span>
+            <span className="truncate">{deviceName ?? NO_DEVICE_INFO}</span>
           </span>
         </TooltipTrigger>
         <TooltipContent>
-          <div className="space-y-0.5">
-            <div>
-              {deviceTypeLabel}: {deviceName}
-            </div>
-            {source.device && source.device !== deviceName && (
-              <div className="text-muted-foreground">
-                Model: {source.device}
+          {deviceName ? (
+            <div className="space-y-0.5">
+              <div>
+                {deviceTypeLabel}: {deviceName}
               </div>
-            )}
-          </div>
+              {source.device && source.device !== deviceName && (
+                <div className="text-muted-foreground">
+                  Model: {source.device}
+                </div>
+              )}
+            </div>
+          ) : (
+            NO_DEVICE_INFO
+          )}
         </TooltipContent>
       </Tooltip>
     </div>

--- a/frontend/src/components/common/data-source-info.tsx
+++ b/frontend/src/components/common/data-source-info.tsx
@@ -23,7 +23,7 @@ export function DataSourceInfo({
   if (!source) return null;
 
   const { label: deviceTypeLabel } = deviceTypeInfo(source.device_type);
-  const deviceName = source.device_name ?? null;
+  const deviceName = source.device_name?.trim() || null;
   // Native API integrations store the provider key as the source ("garmin"/"garmin"),
   // so it only carries information for HealthKit / Health Connect writers.
   const showSource =

--- a/frontend/src/components/common/source-badge.tsx
+++ b/frontend/src/components/common/source-badge.tsx
@@ -39,14 +39,17 @@ const PROVIDER_STYLES: Record<
 
 const DEFAULT_STYLE = { bg: 'bg-muted/40', text: 'text-muted-foreground' };
 
-/** Human-readable label for a provider key (falls back to the raw key). */
+/** Human-readable label for a provider key (falls back to a capitalized key). */
 export function providerLabel(provider: string): string {
-  return PROVIDER_STYLES[provider]?.label ?? provider;
+  return (
+    PROVIDER_STYLES[provider]?.label ??
+    (provider ? provider.charAt(0).toUpperCase() + provider.slice(1) : provider)
+  );
 }
 
 export function SourceBadge({ provider, className = '' }: SourceBadgeProps) {
   const style = PROVIDER_STYLES[provider] ?? DEFAULT_STYLE;
-  const label = PROVIDER_STYLES[provider]?.label ?? provider;
+  const label = providerLabel(provider);
 
   return (
     <span

--- a/frontend/src/lib/utils/activity.ts
+++ b/frontend/src/lib/utils/activity.ts
@@ -1,4 +1,5 @@
 import type { ActivitySummary } from '@/lib/api/types';
+import { providerLabel } from '@/components/common/source-badge';
 import { formatDistance, formatMinutes, formatNumber } from './format';
 
 /**
@@ -195,7 +196,8 @@ const ACTIVITY_FIELD_DEFINITIONS: ActivityFieldDefinition[] = [
   {
     key: 'source',
     label: 'Source',
-    getValue: (s) => s.source?.provider || null,
+    getValue: (s) =>
+      s.source?.provider ? providerLabel(s.source.provider) : null,
   },
 ];
 

--- a/frontend/src/lib/utils/sleep.ts
+++ b/frontend/src/lib/utils/sleep.ts
@@ -3,6 +3,7 @@ import type {
   SleepSummary,
   SleepStagesSummary,
 } from '@/lib/api/types';
+import { providerLabel } from '@/components/common/source-badge';
 import { formatMinutes } from './format';
 
 /**
@@ -243,7 +244,8 @@ const SLEEP_FIELD_DEFINITIONS: SleepFieldDefinition[] = [
   {
     key: 'source',
     label: 'Source',
-    getValue: (s) => s.source?.provider || null,
+    getValue: (s) =>
+      s.source?.provider ? providerLabel(s.source.provider) : null,
   },
 ];
 

--- a/frontend/src/lib/utils/workout.ts
+++ b/frontend/src/lib/utils/workout.ts
@@ -1,5 +1,6 @@
 import { format } from 'date-fns';
 import type { EventRecordResponse } from '@/lib/api/types';
+import { providerLabel } from '@/components/common/source-badge';
 
 /**
  * Workout category types for field configuration
@@ -93,7 +94,7 @@ export const WORKOUT_FIELD_DEFINITIONS: Record<string, WorkoutFieldConfig> = {
     format: (v) => {
       if (!v) return '-';
       const source = v as { provider?: string; device?: string };
-      return source.provider || '-';
+      return source.provider ? providerLabel(source.provider) : '-';
     },
   },
 };


### PR DESCRIPTION
## Description

The data-source badge on dashboard records showed a confusing `???` label with an **"Unknown: ???"** tooltip when a source reports no device details (e.g. **Ultrahuman**).

This shows a clear **"Device info not available"** message (label + tooltip) instead. It also capitalizes unrecognized provider labels so they render as **"Unknown"** rather than **"unknown"**, on both the badge and the **Source** detail row. Known providers (Garmin, Oura, …) are unaffected.

Closes #1471 

**Key changes**
- `data-source-info.tsx`: drop the `???` fallback; show "Device info not available" when `device_name` is absent.
- `source-badge.tsx`: `providerLabel()` capitalizes its fallback; the badge uses it.
- `lib/utils/{sleep,activity,workout}.ts`: the **Source** row runs the provider through `providerLabel()`.

Screenshots:

<img width="2205" height="383" alt="Screenshot 2026-08-24 at 20 47 14" src="https://github.com/user-attachments/assets/82c4a314-10a0-4048-9775-3bb572641429" />
<img width="2201" height="411" alt="Screenshot 2026-08-24 at 20 46 56" src="https://github.com/user-attachments/assets/58cc83c3-dd80-447b-aac6-a5cfa9c7f857" />

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable) <!-- presentational-only change; no unit test added -->
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Frontend Changes

- [x] `pnpm run lint` passes <!-- oxlint: 0 warnings, 0 errors -->
- [x] `pnpm run format:check` passes <!-- prettier: all matched files formatted -->
- [x] `pnpm run build` succeeds <!-- vite production build built successfully -->

## Testing Instructions

**Steps to test:**
1. Open a user's dashboard and find a record from a source that reports no device details (e.g. an Ultrahuman sleep session).
2. Look at the data-source badge on the record card and hover the device segment.
3. Confirm it reads **"Device info not available"** (label + tooltip) instead of `???` / `Unknown: ???`.
4. Expand the record and check the **Source** row; a source with an unrecognized provider key should read **"Unknown"**, not "unknown".

**Expected behavior:**
Records without device info show a clear "Device info not available" message; records that *do* have a device name are unchanged. Unrecognized provider labels are capitalized everywhere they surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Provider names now appear in a clearer, consistently capitalized format across activity, sleep, workout, and source details.
  - Device information displays a descriptive fallback when details are unavailable.
  - Device labels and tooltips now show available device type, name, and model information more clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->