### PR TITLE
chore: nightly Docker builds and release-driven tag scheme

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -4,7 +4,7 @@ name: Publish Docker images
 # (schedule), release (release published), and manual (workflow_dispatch).
 on:
   schedule:
-    - cron: "0 0 * * *" # 00:00 UTC daily; scheduled runs use the default branch (main)
+    - cron: "0 2 * * *" # 02:00 UTC daily; scheduled runs use the default branch (main)
   release:
     types: [published] # github.ref is then refs/tags/<version>, parsed by the semver tags below
   workflow_dispatch:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -2,8 +2,6 @@ name: Publish Docker images
 
 # Build & push the production images to Docker Hub on three triggers: nightly
 # (schedule), release (release published), and manual (workflow_dispatch).
-# What each trigger tags is the documentation's job, not this file's:
-# https://openwearables.io/docs/deployment/docker#image-tags
 on:
   schedule:
     - cron: "0 0 * * *" # 00:00 UTC daily; scheduled runs use the default branch (main)

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -10,9 +10,8 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Extra one-off image tag to push (in addition to `nightly` and `nightly-<sha>`). Reserved names (latest, nightly, nightly-<sha>, release versions) are rejected. Leave empty to skip."
-        required: false
-        default: ""
+        description: "Image tag to push. A manual run publishes this tag only - no nightly tags. Reserved names (latest, nightly, nightly-<sha>, release versions) are rejected."
+        required: true
 
 jobs:
   publish:
@@ -34,22 +33,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # A manual run pushes inputs.tag verbatim, so a reserved name would move
-      # `latest`/`nightly` to an unreleased build or overwrite an immutable
-      # release/nightly-<sha> tag. Restrict one-off tags to non-reserved names.
-      # (TAG via env, not inline ${{ }}, to avoid shell injection.)
-      - name: Reject reserved tag names
-        if: inputs.tag != ''
+      # A manual run publishes inputs.tag verbatim as its only tag. Require it,
+      # and reject reserved names so a manual run can't move `latest`/`nightly`
+      # to an unreleased build or overwrite an immutable release/nightly-<sha>
+      # tag. (TAG via env, not inline ${{ }}, to avoid shell injection.)
+      - name: Validate manual tag
+        if: github.event_name == 'workflow_dispatch'
         env:
           TAG: ${{ inputs.tag }}
         run: |
+          if [ -z "$TAG" ]; then
+            echo "::error::a manual run requires a tag"
+            exit 1
+          fi
           case "$TAG" in
             latest | nightly | nightly-*)
-              echo "::error::one-off tag '$TAG' is reserved (latest / nightly / nightly-<sha>)"
+              echo "::error::tag '$TAG' is reserved (latest / nightly / nightly-<sha>)"
               exit 1 ;;
           esac
           if printf '%s' "$TAG" | grep -Eq '^v?[0-9]+(\.[0-9]+){1,2}$'; then
-            echo "::error::one-off tag '$TAG' looks like a release version and is reserved"
+            echo "::error::tag '$TAG' looks like a release version and is reserved"
             exit 1
           fi
 
@@ -72,18 +75,17 @@ jobs:
           flavor: |
             latest=auto
           tags: |
-            type=raw,value=nightly,enable=${{ github.event_name != 'release' }}
-            type=sha,prefix=nightly-,enable=${{ github.event_name != 'release' }}
-            type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+            type=raw,value=nightly,enable=${{ github.event_name == 'schedule' }}
+            type=sha,prefix=nightly-,enable=${{ github.event_name == 'schedule' }}
+            type=raw,value=${{ inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
 
-      # A scheduled run rebuilds main's current HEAD unconditionally, so a day
-      # with no new commits would re-push nightly-<sha> for an unchanged SHA -
-      # overwriting (mutable registry) or rejecting (immutable registry) a tag
-      # docs promise is immutable. Keyed on the artifact, not the clock: if this
-      # exact nightly-<sha> already exists in the registry, skip the rebuild.
-      # Release/manual runs have no nightly-<sha> tag, so this never fires there.
+      # A scheduled run rebuilds main's current HEAD unconditionally, so an
+      # unchanged SHA would re-push nightly-<sha> - overwriting (mutable registry)
+      # or rejecting (immutable registry) a tag docs promise is immutable. Keyed
+      # on the artifact, not the clock: skip the rebuild if this exact
+      # nightly-<sha> already exists in the registry. Only schedule emits it.
       - name: Skip build if this nightly SHA is already published
         id: nightly_guard
         if: github.event_name == 'schedule'

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Extra one-off image tag to push (in addition to `nightly` and `nightly-<sha>`). Leave empty to skip."
+        description: "Extra one-off image tag to push (in addition to `nightly` and `nightly-<sha>`). Reserved names (latest, nightly, nightly-<sha>, release versions) are rejected. Leave empty to skip."
         required: false
         default: ""
 
@@ -33,6 +33,25 @@ jobs:
             image: themomentum/open-wearables-frontend
     steps:
       - uses: actions/checkout@v4
+
+      # A manual run pushes inputs.tag verbatim, so a reserved name would move
+      # `latest`/`nightly` to an unreleased build or overwrite an immutable
+      # release/nightly-<sha> tag. Restrict one-off tags to non-reserved names.
+      # (TAG via env, not inline ${{ }}, to avoid shell injection.)
+      - name: Reject reserved tag names
+        if: inputs.tag != ''
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          case "$TAG" in
+            latest | nightly | nightly-*)
+              echo "::error::one-off tag '$TAG' is reserved (latest / nightly / nightly-<sha>)"
+              exit 1 ;;
+          esac
+          if printf '%s' "$TAG" | grep -Eq '^v?[0-9]+(\.[0-9]+){1,2}$'; then
+            echo "::error::one-off tag '$TAG' looks like a release version and is reserved"
+            exit 1
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -52,8 +52,6 @@ jobs:
           # and skips it for pre-releases; nightly builds never touch it.
           flavor: |
             latest=auto
-          # Tag scheme (nightly / nightly-<sha> / release versions / latest) is
-          # documented at the URL in the header comment above.
           tags: |
             type=raw,value=nightly,enable=${{ github.event_name != 'release' }}
             type=sha,prefix=nightly-,enable=${{ github.event_name != 'release' }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,12 +1,18 @@
 name: Publish Docker images
 
-# Manually triggered build & push of the production images to Docker Hub.
-# Run it from the GitHub UI: Actions -> "Publish Docker images" -> Run workflow.
+# Build & push the production images to Docker Hub on three triggers: nightly
+# (schedule), release (release published), and manual (workflow_dispatch).
+# What each trigger tags is the documentation's job, not this file's:
+# https://openwearables.io/docs/deployment/docker#image-tags
 on:
+  schedule:
+    - cron: "0 0 * * *" # 00:00 UTC daily; scheduled runs use the default branch (main)
+  release:
+    types: [published] # github.ref is then refs/tags/<version>, parsed by the semver tags below
   workflow_dispatch:
     inputs:
       tag:
-        description: "Extra image tag to push (in addition to `latest` and the commit SHA). Leave empty to skip."
+        description: "Extra one-off image tag to push (in addition to `nightly` and `nightly-<sha>`). Leave empty to skip."
         required: false
         default: ""
 
@@ -44,10 +50,18 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ matrix.image }}
+          # latest=auto moves `latest` only for the release semver tags below,
+          # and skips it for pre-releases; nightly builds never touch it.
+          flavor: |
+            latest=auto
+          # Tag scheme (nightly / nightly-<sha> / release versions / latest) is
+          # documented at the URL in the header comment above.
           tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=sha
+            type=raw,value=nightly,enable=${{ github.event_name != 'release' }}
+            type=sha,prefix=nightly-,enable=${{ github.event_name != 'release' }}
             type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
 
       - name: Build and push ${{ matrix.name }}
         uses: docker/build-push-action@v6

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -59,7 +59,24 @@ jobs:
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
             type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'release' }}
 
+      # A scheduled run rebuilds main's current HEAD unconditionally, so a day
+      # with no new commits would re-push nightly-<sha> for an unchanged SHA -
+      # overwriting (mutable registry) or rejecting (immutable registry) a tag
+      # docs promise is immutable. Keyed on the artifact, not the clock: if this
+      # exact nightly-<sha> already exists in the registry, skip the rebuild.
+      # Release/manual runs have no nightly-<sha> tag, so this never fires there.
+      - name: Skip build if this nightly SHA is already published
+        id: nightly_guard
+        if: github.event_name == 'schedule'
+        run: |
+          sha_tag=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | grep -m1 ':nightly-' || true)
+          if [ -n "$sha_tag" ] && docker buildx imagetools inspect "$sha_tag" >/dev/null 2>&1; then
+            echo "$sha_tag already published; skipping rebuild"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push ${{ matrix.name }}
+        if: steps.nightly_guard.outputs.skip != 'true'
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.context }}

--- a/docs/deployment/docker.mdx
+++ b/docs/deployment/docker.mdx
@@ -35,7 +35,7 @@ Both images share the same tag scheme. Choose a tag based on how much stability 
 
 Tags are produced by [`.github/workflows/publish-images.yml`](https://github.com/the-momentum/open-wearables/blob/main/.github/workflows/publish-images.yml):
 
-- **Nightly** - a scheduled run at `00:00` UTC builds `main` and pushes `nightly` plus an immutable `nightly-<sha>`.
+- **Nightly** - a scheduled run at `02:00` UTC builds `main` and pushes `nightly` plus an immutable `nightly-<sha>`.
 - **Release** - publishing a [GitHub release](https://github.com/the-momentum/open-wearables/releases) builds its git tag, pushes the version tags (`0.7.0`, `0.7`), and moves `latest`. Pre-releases are published under their version tag but do not move `latest`.
 - **Manual** - the workflow can also be run by hand from the GitHub Actions UI. It behaves like a nightly (pushes `nightly` and `nightly-<sha>`) and takes an optional **one-off tag** input pushed as an extra label alongside them. Reserved names - `latest`, `nightly`, `nightly-<sha>`, and release versions like `0.7.0`/`0.7` - are rejected, so a manual run can never move or overwrite them.
 

--- a/docs/deployment/docker.mdx
+++ b/docs/deployment/docker.mdx
@@ -37,7 +37,7 @@ Tags are produced by [`.github/workflows/publish-images.yml`](https://github.com
 
 - **Nightly** - a scheduled run at `02:00` UTC builds `main` and pushes `nightly` plus an immutable `nightly-<sha>`.
 - **Release** - publishing a [GitHub release](https://github.com/the-momentum/open-wearables/releases) builds its git tag, pushes the version tags (`0.7.0`, `0.7`), and moves `latest`. Pre-releases are published under their version tag but do not move `latest`.
-- **Manual** - the workflow can also be run by hand from the GitHub Actions UI. It requires a **tag** input and publishes that tag only - no `nightly` tags. Reserved names - `latest`, `nightly`, `nightly-<sha>`, and release versions like `0.7.0`/`0.7` - are rejected, so a manual run can never move or overwrite them.
+- **Manual** - the workflow can also be run by hand from the GitHub Actions UI. It requires a **tag** input and publishes that tag only - no `nightly` tags. Reserved names - `latest`, `nightly`, the whole `nightly-*` namespace, and release versions like `0.7.0`/`0.7` - are rejected, so a manual run can never move or overwrite them.
 
 For production, pin an exact version tag (e.g. `0.7.0`) rather than `latest` or `nightly`, so deployments are reproducible and upgrades are intentional.
 

--- a/docs/deployment/docker.mdx
+++ b/docs/deployment/docker.mdx
@@ -12,8 +12,6 @@ Open Wearables publishes two production images to Docker Hub:
 | [`themomentum/open-wearables-backend`](https://hub.docker.com/r/themomentum/open-wearables-backend) | FastAPI API + Celery worker/beat/flower | `8000` |
 | [`themomentum/open-wearables-frontend`](https://hub.docker.com/r/themomentum/open-wearables-frontend) | React frontend (TanStack Start, served by Nitro) | `3000` |
 
-Images are published manually through a GitHub Actions workflow. Every publish pushes a short commit SHA tag (`sha-<commit>`); runs from `main` also update `latest`. Pin a SHA tag in deployments to get repeatable builds.
-
 The single backend image covers every backend role. The start command selects what the container runs:
 
 | Command | Role |
@@ -22,6 +20,26 @@ The single backend image covers every backend role. The start command selects wh
 | `scripts/start/worker.sh` | Celery worker (data syncs, background jobs) |
 | `scripts/start/beat.sh` | Celery beat (scheduler) |
 | `scripts/start/flower.sh` | Flower (Celery monitoring UI, port `5555`) |
+
+## Image tags
+
+Both images share the same tag scheme. Choose a tag based on how much stability you need:
+
+| Tag | Points to | Use for |
+|-----|-----------|---------|
+| `latest` | The newest stable [release](https://github.com/the-momentum/open-wearables/releases) | Quick trials, and deployments that always want the current stable version |
+| `0.7.0` (exact version) | That release, immutably | **Production** - pin an exact version for repeatable, deliberate upgrades |
+| `0.7` (major.minor) | The latest patch of that minor line | Following patch releases without manually bumping the version |
+| `nightly` | The most recent build of `main` | Testing unreleased changes; **not for production** |
+| `nightly-<sha>` | A specific nightly build, immutably | Reproducing or rolling back to an exact nightly, e.g. `nightly-a0b56b8` |
+
+Tags are produced by [`.github/workflows/publish-images.yml`](https://github.com/the-momentum/open-wearables/blob/main/.github/workflows/publish-images.yml):
+
+- **Nightly** - a scheduled run at `00:00` UTC builds `main` and pushes `nightly` plus an immutable `nightly-<sha>`.
+- **Release** - publishing a [GitHub release](https://github.com/the-momentum/open-wearables/releases) builds its git tag, pushes the version tags (`0.7.0`, `0.7`), and moves `latest`. Pre-releases are published under their version tag but do not move `latest`.
+- **Manual** - the workflow can also be run by hand from the GitHub Actions UI, which behaves like a nightly.
+
+For production, pin an exact version tag (e.g. `0.7.0`) rather than `latest` or `nightly`, so deployments are reproducible and upgrades are intentional.
 
 ## What a deployment runs
 
@@ -44,7 +62,7 @@ The backend reads all of its configuration from environment variables at runtime
 
 ## Example: Compose deployment
 
-A baseline Compose stack using the published images. It uses the `latest` tag to stay copy-pasteable; pin `sha-<commit>` tags for real deployments.
+A baseline Compose stack using the published images. It uses the `latest` tag to stay copy-pasteable; pin an exact version tag like `0.7.0` for real deployments (see [Image tags](#image-tags)).
 
 ```yaml docker-compose.yml
 services:

--- a/docs/deployment/docker.mdx
+++ b/docs/deployment/docker.mdx
@@ -37,7 +37,7 @@ Tags are produced by [`.github/workflows/publish-images.yml`](https://github.com
 
 - **Nightly** - a scheduled run at `02:00` UTC builds `main` and pushes `nightly` plus an immutable `nightly-<sha>`.
 - **Release** - publishing a [GitHub release](https://github.com/the-momentum/open-wearables/releases) builds its git tag, pushes the version tags (`0.7.0`, `0.7`), and moves `latest`. Pre-releases are published under their version tag but do not move `latest`.
-- **Manual** - the workflow can also be run by hand from the GitHub Actions UI. It behaves like a nightly (pushes `nightly` and `nightly-<sha>`) and takes an optional **one-off tag** input pushed as an extra label alongside them. Reserved names - `latest`, `nightly`, `nightly-<sha>`, and release versions like `0.7.0`/`0.7` - are rejected, so a manual run can never move or overwrite them.
+- **Manual** - the workflow can also be run by hand from the GitHub Actions UI. It requires a **tag** input and publishes that tag only - no `nightly` tags. Reserved names - `latest`, `nightly`, `nightly-<sha>`, and release versions like `0.7.0`/`0.7` - are rejected, so a manual run can never move or overwrite them.
 
 For production, pin an exact version tag (e.g. `0.7.0`) rather than `latest` or `nightly`, so deployments are reproducible and upgrades are intentional.
 

--- a/docs/deployment/docker.mdx
+++ b/docs/deployment/docker.mdx
@@ -37,7 +37,7 @@ Tags are produced by [`.github/workflows/publish-images.yml`](https://github.com
 
 - **Nightly** - a scheduled run at `00:00` UTC builds `main` and pushes `nightly` plus an immutable `nightly-<sha>`.
 - **Release** - publishing a [GitHub release](https://github.com/the-momentum/open-wearables/releases) builds its git tag, pushes the version tags (`0.7.0`, `0.7`), and moves `latest`. Pre-releases are published under their version tag but do not move `latest`.
-- **Manual** - the workflow can also be run by hand from the GitHub Actions UI, which behaves like a nightly.
+- **Manual** - the workflow can also be run by hand from the GitHub Actions UI. It behaves like a nightly (pushes `nightly` and `nightly-<sha>`) and takes an optional **one-off tag** input pushed as an extra label alongside them. Reserved names - `latest`, `nightly`, `nightly-<sha>`, and release versions like `0.7.0`/`0.7` - are rejected, so a manual run can never move or overwrite them.
 
 For production, pin an exact version tag (e.g. `0.7.0`) rather than `latest` or `nightly`, so deployments are reproducible and upgrades are intentional.
 


### PR DESCRIPTION
## What

Adds automated nightly Docker builds and a release-driven tag scheme to the `Publish Docker images` workflow, previously manual-only.

Both images (`open-wearables-backend`, `open-wearables-frontend`) get tags from three triggers:

| Trigger | When | Tags |
|---|---|---|
| `schedule` | daily at 02:00 UTC, off `main` | `nightly`, `nightly-<sha>` |
| `release` (published) | a GitHub release is published | `<version>`, `<major>.<minor>`, `latest` |
| `workflow_dispatch` | manual | required one-off tag only (non-reserved) |

## Why

- **Nightly** gives a predictable bleeding-edge image off `main` without a manual run.
- **`nightly-<sha>`** is immutable - a scheduled run skips the rebuild when that SHA tag already exists - so it can be pinned or rolled back to.
- **`latest` tracks the newest stable release** (Docker convention) instead of `main`; `latest=auto` keeps pre-releases from moving it.

## Notes

- `docker/metadata-action` with conditional `enable=` per `github.event_name`; no duplicated build logic.
- A manual run requires a tag and publishes only that tag (no nightly tags); reserved names (`latest`, `nightly`, `nightly-<sha>`, release versions) are rejected so it can't move or overwrite them.
- The schedule starts only once this lands on `main` (GitHub reads cron from the default branch).

## Docs

`docs/deployment/docker.mdx` gains an **Image tags** section as the source of truth for the scheme.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic nightly container image publishing at 02:00 UTC.
  * Added release image tags for exact versions and major/minor versions.
  * Ensured `latest` tracks stable releases only.
  * Added required manual image tags with validation against reserved or release-style names.
  * Prevented duplicate nightly images from being republished.

* **Documentation**
  * Updated Docker deployment guidance with release, nightly, immutable, and manual tag options.
  * Recommended exact version tags for Compose deployments and production use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
