### PR TITLE
docs: document structured logging as the default in backend/AGENTS.md

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -178,7 +178,7 @@ try:
     process_item(item)
 except Exception as e:
     log_and_capture_error(
-        e, logger, f"Failed to process item {item.id}: {e}", extra={"item_id": item.id, "user_id": user_id}
+        e, logger, "Failed to process item", extra={"item_id": item.id, "user_id": user_id, "error": str(e)}
     )
     continue
 ```
@@ -215,7 +215,7 @@ log_structured(
 
 - Pass the message as a stable, human-readable string and put the variable parts in `**attributes` (don't f-string them into the message).
 - `trace_id` is injected automatically from context when not supplied.
-- For handled exceptions in background tasks you still want in Sentry, use `log_and_capture_error` (see above) rather than plain `logger.error`.
+- For handled exceptions in background tasks you still want in Sentry, use `log_and_capture_error` (see above) rather than plain `logger.error`. Keep its `message` stable there too and pass variables via `extra` - note that `extra` becomes Sentry event context, not queryable log attributes.
 
 ### Provider Strategy Pattern
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -189,6 +189,34 @@ except Exception as e:
 - ✅ Multi-provider sync where one provider failure shouldn't stop others
 - ❌ Don't use if exception is re-raised or allowed to propagate naturally
 
+### Logging
+
+**Default rule:** Use `log_structured` instead of raw `logger.info/warning/error/...`. Structured logs are emitted as single-line JSON, making them queryable by attribute (`@user_id:...`, `@action:...`) in Railway, GCP, Vercel, etc. This is the established standard in the codebase - prefer it even when editing an existing file that still uses the raw logger.
+
+```python
+from app.utils.structured_logging import log_structured
+
+# DON'T - unstructured, not queryable by attribute
+self.logger.warning(f"Failed to save {key} sample for user {user_id} at {recorded_at}: {e}")
+
+# DO - structured, queryable
+log_structured(
+    self.logger,
+    "warning",
+    "Failed to save activity sample",
+    provider=self.provider_name,
+    action="save_activity_sample_failed",
+    user_id=str(user_id),
+    series=key,
+    recorded_at=recorded_at,
+    error=str(e),
+)
+```
+
+- Pass the message as a stable, human-readable string and put the variable parts in `**attributes` (don't f-string them into the message).
+- `trace_id` is injected automatically from context when not supplied.
+- For handled exceptions in background tasks you still want in Sentry, use `log_and_capture_error` (see above) rather than plain `logger.error`.
+
 ### Provider Strategy Pattern
 
 See `docs/dev-guides/how-to-add-new-provider.mdx` for the full guide.


### PR DESCRIPTION
Follow-up to the inconsistency @czajkub  pointed out regarding structured logging (https://github.com/the-momentum/open-wearables/pull/1469#discussion_r3842598363) - currently, especially in already-implemented files, agents don't pick up the right patterns and follow the old `self.logger`, and CodeRabbit also lacks an instruction that would let it catch this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the backend logging guide with guidance for stable messages, variable attributes, automatic trace ID inclusion, and Sentry error context.
  * Documented improved background-task error logging, including consistent messages and captured error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->