### PR TITLE
chore: add SECURITY.md vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**PLEASE DON'T DISCLOSE SECURITY-RELATED ISSUES PUBLICLY**
+
+If you discover a security vulnerability within Open Wearables, please send an
+email to **security@openwearables.io**. All security vulnerabilities will be
+promptly addressed.


### PR DESCRIPTION
## Description

Adds a SECURITY.md with a private vulnerability reporting policy, so security issues go to the security team instead of public issues. GitHub surfaces it automatically in the Security tab and when opening issues/PRs.

## Checklist

- [x] I have performed a self-review of my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a security policy with guidance for privately reporting potential vulnerabilities.
  - Provided a dedicated security contact channel and commitment to promptly address reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->