### PR TITLE
fix: prevent duplicate sleep score calculation

### DIFF
--- a/backend/app/integrations/celery/tasks/fill_missing_sleep_scores_task.py
+++ b/backend/app/integrations/celery/tasks/fill_missing_sleep_scores_task.py
@@ -1,15 +1,13 @@
 from collections import defaultdict
 from datetime import date, datetime, timedelta, timezone
 from logging import getLogger
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from celery import shared_task
 from sqlalchemy import text
 
 from app.config import settings
 from app.database import SessionLocal
-from app.schemas.enums import HealthScoreCategory, ProviderName
-from app.schemas.model_crud.activities.health_score import HealthScoreCreate, ScoreComponent
 from app.services.health_score_service import health_score_service
 from app.services.scores.sleep_service import sleep_score_service
 from app.utils.sentry_helpers import log_and_capture_error
@@ -81,15 +79,11 @@ def fill_missing_sleep_scores() -> dict:
         total_skipped = 0
 
         for uid, record_wakes_extended in records_by_user.items():
-            record_wakes = [(rid, wd) for rid, _, wd, _ in record_wakes_extended]
-            # Map record_id → local end datetime so recorded_at is unique per
-            # session even when two sessions share the same local wake date.
-            local_end_by_id: dict[UUID, datetime] = {rid: le for rid, _, _, le in record_wakes_extended}
-            data_source_by_id: dict[UUID, UUID] = {rid: dsid for rid, dsid, _, _ in record_wakes_extended}
+            sessions = [(rid, dsid, local_end) for rid, dsid, _, local_end in record_wakes_extended]
             try:
-                scores_by_record = sleep_score_service.get_sleep_scores_for_records(db, uid, record_wakes)
+                scores_to_save = sleep_score_service.build_internal_sleep_scores(db, uid, sessions)
             except Exception as e:
-                total_skipped += len(record_wakes)
+                total_skipped += len(sessions)
                 log_and_capture_error(
                     e,
                     logger,
@@ -98,38 +92,18 @@ def fill_missing_sleep_scores() -> dict:
                 )
                 continue
 
-            if not scores_by_record:
-                total_skipped += len(record_wakes)
+            if not scores_to_save:
+                total_skipped += len(sessions)
                 continue
-
-            scores_to_save = [
-                HealthScoreCreate(
-                    id=uuid4(),
-                    user_id=uid,
-                    data_source_id=data_source_by_id[record_id],
-                    provider=ProviderName.INTERNAL,
-                    category=HealthScoreCategory.SLEEP,
-                    value=result.overall_score,
-                    event_record_id=record_id,
-                    recorded_at=local_end_by_id[record_id].replace(tzinfo=timezone.utc),
-                    components={
-                        "duration": ScoreComponent(value=result.breakdown.duration.score),
-                        "stages": ScoreComponent(value=result.breakdown.stages.score),
-                        "consistency": ScoreComponent(value=result.breakdown.consistency.score),
-                        "interruptions": ScoreComponent(value=result.breakdown.interruptions.score),
-                    },
-                )
-                for (record_id, _), result in scores_by_record.items()
-            ]
 
             try:
                 health_score_service.bulk_create(db, scores_to_save)
                 db.commit()
                 total_saved += len(scores_to_save)
-                total_skipped += len(record_wakes) - len(scores_to_save)
+                total_skipped += len(sessions) - len(scores_to_save)
             except Exception as e:
                 db.rollback()
-                total_skipped += len(record_wakes)
+                total_skipped += len(sessions)
                 log_and_capture_error(
                     e,
                     logger,

--- a/backend/app/repositories/health_score_repository.py
+++ b/backend/app/repositories/health_score_repository.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, cast
 from uuid import UUID
 
@@ -83,16 +83,18 @@ class HealthScoreRepository(CrudRepository[HealthScore, HealthScoreCreate, Healt
         """Delete health scores matching user/category/provider/date without loading objects.
 
         Caller is responsible for commit. Returns deleted row count.
-        Sleep scores are stored with recorded_at = midnight UTC of the local sleep date.
+        Matches the whole day rather than an exact timestamp: sleep scores are anchored to
+        the session's local wake time, and older rows sit at midnight of the same date.
         """
-        midnight = datetime(score_date.year, score_date.month, score_date.day, tzinfo=timezone.utc)
+        day_start = datetime(score_date.year, score_date.month, score_date.day, tzinfo=timezone.utc)
         return (
             db_session.query(HealthScore)
             .filter(
                 HealthScore.user_id == user_id,
                 HealthScore.provider == provider,
                 HealthScore.category == category,
-                HealthScore.recorded_at == midnight,
+                HealthScore.recorded_at >= day_start,
+                HealthScore.recorded_at < day_start + timedelta(days=1),
             )
             .delete(synchronize_session=False)
         )

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from logging import Logger, getLogger
 from uuid import UUID, uuid4
@@ -25,16 +25,14 @@ from app.repositories import (
     EventRecordRepository,
     HealthScoreRepository,
 )
-from app.schemas.enums import WORKOUTS_WITH_PACE, HealthScoreCategory, ProviderName
+from app.schemas.enums import WORKOUTS_WITH_PACE, HealthScoreCategory
 from app.schemas.model_crud.activities import (
     EventRecordCreate,
     EventRecordDetailCreate,
     EventRecordQueryParams,
     EventRecordResponse,
     EventRecordUpdate,
-    HealthScoreCreate,
     MenstrualCycleDetailCreate,
-    ScoreComponent,
 )
 from app.schemas.model_crud.activities.sleep import SleepStage
 from app.schemas.responses.activity import (
@@ -141,14 +139,19 @@ class EventRecordService(
         return result
 
     @staticmethod
-    def _local_sleep_date(start_datetime: datetime, zone_offset: str | None) -> date:
-        """Return the local calendar date of a sleep session start (mirrors SQL logic in fill task)."""
-        dt = start_datetime if start_datetime.tzinfo is not None else start_datetime.replace(tzinfo=timezone.utc)
+    def _to_local(dt: datetime, zone_offset: str | None) -> datetime:
+        """Shift a datetime into the session's local zone (mirrors SQL logic in fill task)."""
+        dt = dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
         if zone_offset is not None:
             sign = 1 if zone_offset[0] == "+" else -1
             hours, minutes = int(zone_offset[1:3]), int(zone_offset[4:6])
             dt = dt.astimezone(timezone(timedelta(hours=sign * hours, minutes=sign * minutes)))
-        return dt.date()
+        return dt
+
+    @classmethod
+    def _local_sleep_date(cls, start_datetime: datetime, zone_offset: str | None) -> date:
+        """Return the local calendar date of a sleep session start."""
+        return cls._to_local(start_datetime, zone_offset).date()
 
     def _recompute_sleep_scores(
         self,
@@ -162,31 +165,34 @@ class EventRecordService(
         date when a session shifts across midnight.  The session data has already
         been flushed, so sleep_score_service sees up-to-date rows within the
         same transaction.
+
+        Scores per session rather than per date, matching fill_missing_sleep_scores.
+        The two writers have to agree: recorded_at is what the unique constraint keys
+        on, so a second convention here produces a duplicate score instead of
+        replacing the existing one.
         """
         for d in sleep_dates:
             self.health_score_repo.delete_for_user_date(db_session, user_id, d, HealthScoreCategory.SLEEP)
-        scores = sleep_score_service.get_sleep_scores_for_date_range(db_session, user_id, list(sleep_dates))
-        if not scores:
-            return
-        creators = [
-            HealthScoreCreate(
-                id=uuid4(),
-                user_id=user_id,
-                data_source_id=None,
-                provider=ProviderName.INTERNAL,
-                category=HealthScoreCategory.SLEEP,
-                value=result.overall_score,
-                recorded_at=datetime(d.year, d.month, d.day, tzinfo=timezone.utc),
-                components={
-                    "duration": ScoreComponent(value=result.breakdown.duration.score),
-                    "stages": ScoreComponent(value=result.breakdown.stages.score),
-                    "consistency": ScoreComponent(value=result.breakdown.consistency.score),
-                    "interruptions": ScoreComponent(value=result.breakdown.interruptions.score),
-                },
+
+        # Widened by a day either side so a session whose local start lands on a target
+        # date is still inside the window whatever its zone offset.
+        window_start = datetime.combine(min(sleep_dates), time.min, tzinfo=timezone.utc) - timedelta(days=1)
+        window_end = datetime.combine(max(sleep_dates), time.min, tzinfo=timezone.utc) + timedelta(days=2)
+
+        sessions = [
+            (record.id, record.data_source_id, self._to_local(record.end_datetime, record.zone_offset))
+            for record, details in self.crud.get_sleep_records_with_details(
+                db_session, user_id, window_start, window_end
             )
-            for d, result in scores.items()
+            if details is not None
+            and not details.is_nap
+            and details.sleep_total_duration_minutes
+            and self._local_sleep_date(record.start_datetime, record.zone_offset) in sleep_dates
         ]
-        self.health_score_repo.bulk_create(db_session, creators)
+
+        creators = sleep_score_service.build_internal_sleep_scores(db_session, user_id, sessions)
+        if creators:
+            self.health_score_repo.bulk_create(db_session, creators)
 
     def find_adjacent_sleep_record(
         self,

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -176,21 +176,32 @@ class EventRecordService(
         window_start = datetime.combine(min(sleep_dates), time.min, tzinfo=timezone.utc) - timedelta(days=1)
         window_end = datetime.combine(max(sleep_dates), time.min, tzinfo=timezone.utc) + timedelta(days=2)
 
-        sessions = [
-            (record.id, record.data_source_id, self._to_local(record.end_datetime, record.zone_offset))
+        scorable = [
+            (record, self._to_local(record.end_datetime, record.zone_offset))
             for record, details in self.crud.get_sleep_records_with_details(
                 db_session, user_id, window_start, window_end
             )
-            if details is not None
-            and not details.is_nap
-            and details.sleep_total_duration_minutes
-            and self._local_sleep_date(record.start_datetime, record.zone_offset) in sleep_dates
+            if details is not None and not details.is_nap and details.sleep_total_duration_minutes
         ]
 
-        # A session running past midnight is scored on the day it ends, so the wake dates
-        # have to be cleared as well as the start dates the caller tracks.
-        wake_dates = {local_end.date() for _, _, local_end in sessions}
-        for d in sleep_dates | wake_dates:
+        # A session running past midnight is scored on the day it ends, so clear the wake
+        # dates of the sessions the caller named as well as the start dates themselves.
+        stale_dates = sleep_dates | {
+            local_end.date()
+            for record, local_end in scorable
+            if self._local_sleep_date(record.start_datetime, record.zone_offset) in sleep_dates
+        }
+
+        # Rebuild every session scored on a cleared date, not just the caller's — an
+        # earlier session ending that morning is scored there too and would otherwise
+        # be deleted without being rewritten.
+        sessions = [
+            (record.id, record.data_source_id, local_end)
+            for record, local_end in scorable
+            if local_end.date() in stale_dates
+        ]
+
+        for d in stale_dates:
             self.health_score_repo.delete_for_user_date(db_session, user_id, d, HealthScoreCategory.SLEEP)
 
         creators = sleep_score_service.build_internal_sleep_scores(db_session, user_id, sessions)

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -171,9 +171,6 @@ class EventRecordService(
         on, so a second convention here produces a duplicate score instead of
         replacing the existing one.
         """
-        for d in sleep_dates:
-            self.health_score_repo.delete_for_user_date(db_session, user_id, d, HealthScoreCategory.SLEEP)
-
         # Widened by a day either side so a session whose local start lands on a target
         # date is still inside the window whatever its zone offset.
         window_start = datetime.combine(min(sleep_dates), time.min, tzinfo=timezone.utc) - timedelta(days=1)
@@ -189,6 +186,12 @@ class EventRecordService(
             and details.sleep_total_duration_minutes
             and self._local_sleep_date(record.start_datetime, record.zone_offset) in sleep_dates
         ]
+
+        # A session running past midnight is scored on the day it ends, so the wake dates
+        # have to be cleared as well as the start dates the caller tracks.
+        wake_dates = {local_end.date() for _, _, local_end in sessions}
+        for d in sleep_dates | wake_dates:
+            self.health_score_repo.delete_for_user_date(db_session, user_id, d, HealthScoreCategory.SLEEP)
 
         creators = sleep_score_service.build_internal_sleep_scores(db_session, user_id, sessions)
         if creators:

--- a/backend/app/services/scores/sleep_service.py
+++ b/backend/app/services/scores/sleep_service.py
@@ -10,7 +10,7 @@ four-pillar algorithm (duration, stages, consistency, interruptions):
 
 from datetime import date, datetime, timedelta, timezone
 from logging import Logger, getLogger
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from pydantic import BaseModel
 
@@ -20,7 +20,8 @@ from app.constants.sleep import SleepStageType
 from app.database import DbSession
 from app.models import EventRecord, SleepDetails
 from app.repositories.event_record_repository import EventRecordRepository
-from app.schemas.model_crud.activities import EventRecordQueryParams
+from app.schemas.enums import HealthScoreCategory, ProviderName
+from app.schemas.model_crud.activities import EventRecordQueryParams, HealthScoreCreate, ScoreComponent
 from app.schemas.model_crud.activities.sleep import SleepStage
 from app.utils.exceptions import ResourceNotFoundError, handle_exceptions
 from app.utils.structured_logging import log_structured
@@ -225,6 +226,50 @@ class SleepScoreService:
             historical_bedtimes=historical_bedtimes,
             sleep_stages=sleep_stages,
         )
+
+    def build_internal_sleep_scores(
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        sessions: list[tuple[UUID, UUID, datetime]],
+    ) -> list[HealthScoreCreate]:
+        """Score sessions given as (record_id, data_source_id, local_end) and build the rows.
+
+        Shared by both writers — fill_missing_sleep_scores and the recompute after a
+        sleep merge — so they cannot drift apart again. recorded_at is the session's
+        local wake time, which is what the unique constraint keys on: a second
+        convention would add a duplicate score rather than replace the existing one.
+        """
+        if not sessions:
+            return []
+
+        session_by_record = {record_id: (ds_id, local_end) for record_id, ds_id, local_end in sessions}
+        scores = self.get_sleep_scores_for_records(
+            db_session, user_id, [(record_id, local_end.date()) for record_id, _, local_end in sessions]
+        )
+
+        creators = []
+        for (record_id, _), result in scores.items():
+            data_source_id, local_end = session_by_record[record_id]
+            creators.append(
+                HealthScoreCreate(
+                    id=uuid4(),
+                    user_id=user_id,
+                    data_source_id=data_source_id,
+                    provider=ProviderName.INTERNAL,
+                    category=HealthScoreCategory.SLEEP,
+                    value=result.overall_score,
+                    event_record_id=record_id,
+                    recorded_at=local_end.replace(tzinfo=timezone.utc),
+                    components={
+                        "duration": ScoreComponent(value=result.breakdown.duration.score),
+                        "stages": ScoreComponent(value=result.breakdown.stages.score),
+                        "consistency": ScoreComponent(value=result.breakdown.consistency.score),
+                        "interruptions": ScoreComponent(value=result.breakdown.interruptions.score),
+                    },
+                )
+            )
+        return creators
 
     def get_sleep_scores_for_records(
         self,

--- a/backend/tests/services/test_event_record_service.py
+++ b/backend/tests/services/test_event_record_service.py
@@ -8,14 +8,15 @@ Tests cover:
 - create_or_merge_sleep: adjacent session merging
 """
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from unittest.mock import patch
 from uuid import UUID, uuid4
 
 from sqlalchemy.orm import Session
 
-from app.models import DataSource, EventRecord
+from app.models import DataSource, EventRecord, HealthScore
+from app.schemas.enums import HealthScoreCategory, ProviderName
 from app.schemas.model_crud.activities import EventRecordCreate, EventRecordDetailCreate, EventRecordQueryParams
 from app.schemas.model_crud.activities.sleep import SleepStage
 from app.services.event_record_service import event_record_service
@@ -701,6 +702,79 @@ class TestCreateOrMergeSleep:
         # Stages should be sorted by start_time (early first)
         assert stages[0]["stage"] == "light"
         assert stages[1]["stage"] == "deep"
+
+
+class TestRecomputeSleepScores:
+    """Test the internal sleep score recompute triggered by create_or_merge_sleep."""
+
+    def _session(self, data_source: DataSource, start: datetime, end: datetime) -> EventRecord:
+        record = EventRecordFactory(
+            mapping=data_source,
+            category="sleep",
+            type_="sleep_session",
+            start_datetime=start,
+            end_datetime=end,
+        )
+        SleepDetailsFactory(event_record=record, sleep_total_duration_minutes=420, is_nap=False)
+        return record
+
+    def _internal_sleep_scores(self, db: Session, user_id: UUID) -> list[HealthScore]:
+        return (
+            db.query(HealthScore)
+            .filter(
+                HealthScore.user_id == user_id,
+                HealthScore.provider == ProviderName.INTERNAL,
+                HealthScore.category == HealthScoreCategory.SLEEP,
+            )
+            .all()
+        )
+
+    def test_earlier_midnight_spanning_session_keeps_its_score(self, db: Session) -> None:
+        """Recomputing one session must not drop the score of the one that woke that morning.
+
+        Both sessions are scored on the day they wake, so clearing the later session's
+        start date also clears the earlier session's score — it has to be rewritten too.
+        """
+        user = UserFactory()
+        data_source = DataSourceFactory(user=user)
+
+        # Wakes on the 21st, so it is scored on the 21st.
+        earlier = self._session(
+            data_source,
+            datetime(2026, 3, 20, 23, 0, tzinfo=timezone.utc),
+            datetime(2026, 3, 21, 7, 0, tzinfo=timezone.utc),
+        )
+        # Also starts on the 21st, so recomputing it clears the 21st.
+        later = self._session(
+            data_source,
+            datetime(2026, 3, 21, 23, 0, tzinfo=timezone.utc),
+            datetime(2026, 3, 22, 7, 0, tzinfo=timezone.utc),
+        )
+        db.commit()
+
+        event_record_service._recompute_sleep_scores(db, user.id, {date(2026, 3, 21)})
+        db.commit()
+
+        scored = {s.event_record_id for s in self._internal_sleep_scores(db, user.id)}
+        assert earlier.id in scored
+        assert later.id in scored
+
+    def test_repeated_recompute_does_not_duplicate(self, db: Session) -> None:
+        """Running the recompute twice replaces the score rather than adding a second."""
+        user = UserFactory()
+        data_source = DataSourceFactory(user=user)
+        self._session(
+            data_source,
+            datetime(2026, 3, 21, 23, 0, tzinfo=timezone.utc),
+            datetime(2026, 3, 22, 7, 0, tzinfo=timezone.utc),
+        )
+        db.commit()
+
+        for _ in range(2):
+            event_record_service._recompute_sleep_scores(db, user.id, {date(2026, 3, 21)})
+            db.commit()
+
+        assert len(self._internal_sleep_scores(db, user.id)) == 1
 
 
 class TestGetSleepSessions:


### PR DESCRIPTION
## Description

As in #1483:

> Related to PRs https://github.com/the-momentum/open-wearables/pull/884 and https://github.com/the-momentum/open-wearables/pull/900
> 
> We have two mechanisms for calculating sleep scores:
> 
> event_record_service._recompute_sleep_scores:168
> fill_missing_sleep_scores_task:105

This PR extracts the sleep score calculation into one helper method, and makes the two ways of calculation use it to prevent any duplication, and makes it so that both ways fill the `event_record_id` field (renamed in #1462)

To remove the previous duplicate scores - would need a data migration script, didn't add it here

Resolves #1009

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed)

### Backend Changes

<!-- If your PR includes backend changes, please verify: -->
You have to be in `backend` directory to make it work:
- [x] `uv run pre-commit run --all-files` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sleep-score generation by evaluating individual sleep sessions more accurately.
  - Corrected sleep-score date handling across time zones, including sessions that span calendar days.
  - Prevented naps and incomplete sleep records from producing inaccurate scores.
  - Fixed score cleanup so all scores recorded during a selected day are removed when recalculating.
- **Improvements**
  - Standardized sleep-score calculations and consistency across background processing and manual recalculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->