### PR TITLE
fix(integrations): map additional WHOOP workout sport names

### DIFF
--- a/backend/app/constants/workout_types/whoop.py
+++ b/backend/app/constants/workout_types/whoop.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 # 09/01/2025) but still sent, so it is kept as a fallback for unlisted slugs.
 # Reference: https://developer.whoop.com/docs/developing/user-data/workout
 # Format: (whoop_sport_name, whoop_sport_id, unified_type)
-WHOOP_WORKOUT_TYPE_MAPPINGS: list[tuple[str, int, WorkoutType]] = [
+WHOOP_WORKOUT_TYPE_MAPPINGS: list[tuple[str, int | None, WorkoutType]] = [
     # Generic / catch-all
     ("activity", -1, WorkoutType.GENERIC),
     ("other", 71, WorkoutType.GENERIC),
@@ -46,7 +46,7 @@ WHOOP_WORKOUT_TYPE_MAPPINGS: list[tuple[str, int, WorkoutType]] = [
     ("operations-water", 77, WorkoutType.OPERATIONS),
     # Strength & gym
     ("weightlifting", 45, WorkoutType.STRENGTH_TRAINING),
-    ("weightlifting_msk", 123, WorkoutType.STRENGTH_TRAINING),
+    ("weightlifting_msk", None, WorkoutType.STRENGTH_TRAINING),
     ("powerlifting", 59, WorkoutType.STRENGTH_TRAINING),
     ("strength-trainer", 123, WorkoutType.STRENGTH_TRAINING),
     ("functional-fitness", 48, WorkoutType.CARDIO_TRAINING),
@@ -134,7 +134,7 @@ WHOOP_WORKOUT_TYPE_MAPPINGS: list[tuple[str, int, WorkoutType]] = [
     # Gymnastics
     ("gymnastics", 51, WorkoutType.GYMNASTICS),
     # Recovery & wellness
-    ("foam_rolling", 282, WorkoutType.RECOVERY),
+    ("foam_rolling", None, WorkoutType.RECOVERY),
     ("ice-bath", 88, WorkoutType.RECOVERY),
     ("sauna", 233, WorkoutType.RECOVERY),
     ("massage-therapy", 121, WorkoutType.RECOVERY),
@@ -164,7 +164,7 @@ WHOOP_TO_UNIFIED: dict[str, WorkoutType] = {
 }
 
 WHOOP_ID_TO_UNIFIED: dict[int, WorkoutType] = {
-    sport_id: unified_type for _, sport_id, unified_type in WHOOP_WORKOUT_TYPE_MAPPINGS
+    sport_id: unified_type for _, sport_id, unified_type in WHOOP_WORKOUT_TYPE_MAPPINGS if sport_id is not None
 }
 
 

--- a/backend/app/constants/workout_types/whoop.py
+++ b/backend/app/constants/workout_types/whoop.py
@@ -46,6 +46,7 @@ WHOOP_WORKOUT_TYPE_MAPPINGS: list[tuple[str, int, WorkoutType]] = [
     ("operations-water", 77, WorkoutType.OPERATIONS),
     # Strength & gym
     ("weightlifting", 45, WorkoutType.STRENGTH_TRAINING),
+    ("weightlifting_msk", 123, WorkoutType.STRENGTH_TRAINING),
     ("powerlifting", 59, WorkoutType.STRENGTH_TRAINING),
     ("strength-trainer", 123, WorkoutType.STRENGTH_TRAINING),
     ("functional-fitness", 48, WorkoutType.CARDIO_TRAINING),
@@ -133,6 +134,7 @@ WHOOP_WORKOUT_TYPE_MAPPINGS: list[tuple[str, int, WorkoutType]] = [
     # Gymnastics
     ("gymnastics", 51, WorkoutType.GYMNASTICS),
     # Recovery & wellness
+    ("foam_rolling", 282, WorkoutType.RECOVERY),
     ("ice-bath", 88, WorkoutType.RECOVERY),
     ("sauna", 233, WorkoutType.RECOVERY),
     ("massage-therapy", 121, WorkoutType.RECOVERY),

--- a/backend/app/constants/workout_types/whoop.py
+++ b/backend/app/constants/workout_types/whoop.py
@@ -46,7 +46,6 @@ WHOOP_WORKOUT_TYPE_MAPPINGS: list[tuple[str, int | None, WorkoutType]] = [
     ("operations-water", 77, WorkoutType.OPERATIONS),
     # Strength & gym
     ("weightlifting", 45, WorkoutType.STRENGTH_TRAINING),
-    ("weightlifting_msk", None, WorkoutType.STRENGTH_TRAINING),
     ("powerlifting", 59, WorkoutType.STRENGTH_TRAINING),
     ("strength-trainer", 123, WorkoutType.STRENGTH_TRAINING),
     ("functional-fitness", 48, WorkoutType.CARDIO_TRAINING),
@@ -134,7 +133,6 @@ WHOOP_WORKOUT_TYPE_MAPPINGS: list[tuple[str, int | None, WorkoutType]] = [
     # Gymnastics
     ("gymnastics", 51, WorkoutType.GYMNASTICS),
     # Recovery & wellness
-    ("foam_rolling", None, WorkoutType.RECOVERY),
     ("ice-bath", 88, WorkoutType.RECOVERY),
     ("sauna", 233, WorkoutType.RECOVERY),
     ("massage-therapy", 121, WorkoutType.RECOVERY),
@@ -157,6 +155,10 @@ WHOOP_WORKOUT_TYPE_MAPPINGS: list[tuple[str, int | None, WorkoutType]] = [
     ("public-speaking", 272, WorkoutType.LIFESTYLE),
     ("musical-performance", 263, WorkoutType.LIFESTYLE),
     ("dedicated-parenting", 251, WorkoutType.LIFESTYLE),
+    # Undocumented sports: missing from the Whoop docs, seen in real payloads, likely more to
+    # come
+    ("weightlifting_msk", None, WorkoutType.STRENGTH_TRAINING),
+    ("foam_rolling", None, WorkoutType.RECOVERY),
 ]
 
 WHOOP_TO_UNIFIED: dict[str, WorkoutType] = {

--- a/backend/tests/providers/whoop/test_whoop_workout_types.py
+++ b/backend/tests/providers/whoop/test_whoop_workout_types.py
@@ -1,0 +1,10 @@
+from app.constants.workout_types.whoop import get_unified_workout_type
+from app.schemas.enums import WorkoutType
+
+
+def test_weightlifting_msk_maps_to_strength_training() -> None:
+    assert get_unified_workout_type("weightlifting_msk") == WorkoutType.STRENGTH_TRAINING
+
+
+def test_foam_rolling_maps_to_recovery() -> None:
+    assert get_unified_workout_type("foam_rolling") == WorkoutType.RECOVERY

--- a/backend/tests/providers/whoop/test_whoop_workout_types.py
+++ b/backend/tests/providers/whoop/test_whoop_workout_types.py
@@ -8,3 +8,7 @@ def test_weightlifting_msk_maps_to_strength_training() -> None:
 
 def test_foam_rolling_maps_to_recovery() -> None:
     assert get_unified_workout_type("foam_rolling") == WorkoutType.RECOVERY
+
+
+def test_undocumented_alias_id_does_not_override_unknown_sport() -> None:
+    assert get_unified_workout_type("unknown-sport", 282) == WorkoutType.OTHER


### PR DESCRIPTION
## Description

Adds mappings for two sport names observed in WHOOP v2 workout payloads:

- `weightlifting_msk` (`sport_id=123`) to `WorkoutType.STRENGTH_TRAINING`
- `foam_rolling` (`sport_id=282`) to `WorkoutType.RECOVERY`

Fixes #1503

## Checklist

### General

- [x] My code follows the project style
- [x] I have performed a self-review
- [x] I have added regression tests
- [x] The new targeted tests pass locally
- [x] No documentation update is needed

### Backend Changes

- [x] `uv run pre-commit run --all-files` passes

### Frontend Changes

Not applicable.

## Testing Instructions

1. Run `cd backend`.
2. Run `uv run pytest tests/providers/whoop/test_whoop_workout_types.py`.

**Expected behavior:** both sport names resolve to their unified workout types instead of falling back to `WorkoutType.OTHER`.

## Additional Notes

The targeted test file passes with 2 tests. Full pre-commit passes, including Ruff, formatting, ty, generated coverage docs, and Prettier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected WHOOP workout-type handling so unknown sport ID `282` is categorized as “Other.”
  * Updated weightlifting and foam rolling activity mappings to avoid assigning numeric WHOOP IDs where none are documented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->