### PR TITLE
docs: rename "Sync SDK" to "Mobile SDK"

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -67,7 +67,7 @@
             ]
           },
           {
-            "group": "Sync SDK",
+            "group": "Mobile SDK",
             "pages": [
               "sdk/index",
               {

--- a/docs/providers/google-api-integration.mdx
+++ b/docs/providers/google-api-integration.mdx
@@ -19,7 +19,7 @@ keywords: ["google health api integration", "google health oauth", "google healt
 
 Google Health data reaches Open Wearables through two independent paths that share the single `google` provider identity:
 
-- **Health Connect (mobile SDK)** — data pushed from an Android device via the Sync SDK. See the [Android SDK guide](/sdk/android/integration).
+- **Health Connect (mobile SDK)** — data pushed from an Android device via the Mobile SDK. See the [Android SDK guide](/sdk/android/integration).
 - **Google Health API (cloud OAuth)** — this guide. A server-side OAuth 2.0 flow against the [Google Health API](https://developers.google.com/health) that lets you connect a user's Google account and pull their data over REST, plus receive notify-only webhooks.
 
 The Google Health API is an **aggregation layer**: it surfaces data from *every* source connected to the user's Google Health account — the phone's Health Connect store, Fitbit, Google Fit, and other apps — not just one device.

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -1,20 +1,20 @@
 ---
-title: "Wearable Sync SDK"
+title: "Open Wearables Mobile SDK"
 sidebarTitle: "Overview"
 description: "Native mobile SDKs for background sync from Apple HealthKit, Samsung Health, and Health Connect. iOS, Android, Flutter, and React Native supported."
-keywords: ["wearable sync sdk", "healthkit sdk", "health connect sdk", "mobile health data sdk"]
-"og:title": "Wearable Sync SDK | Open Wearables"
+keywords: ["mobile sdk", "healthkit sdk", "health connect sdk", "mobile health data sdk"]
+"og:title": "Mobile SDK | Open Wearables"
 "og:description": "Native mobile SDKs for Apple HealthKit, Samsung Health, and Health Connect. iOS, Android, Flutter, and React Native."
 "og:url": "https://docs.openwearables.io/sdk"
 "og:type": "article"
-"twitter:title": "Wearable Sync SDK | Open Wearables"
+"twitter:title": "Mobile SDK | Open Wearables"
 "twitter:description": "Native mobile SDKs for Apple HealthKit, Samsung Health, and Health Connect. iOS, Android, Flutter, and React Native."
 "twitter:card": "summary_large_image"
 ---
 
 ## Introduction
 
-Open Wearables Sync SDKs enable seamless background synchronization of health data directly from **Apple HealthKit** (iOS), **Samsung Health**, and **Health Connect** (Android) to the Open Wearables platform.
+Open Wearables Mobile SDKs enable seamless background synchronization of health data directly from **Apple HealthKit** (iOS), **Samsung Health**, and **Health Connect** (Android) to the Open Wearables platform.
 
 Unlike cloud-based providers (Garmin, Polar, Suunto) that use webhooks and OAuth, on-device health stores require a **push-based model** where data is sent from the user's device to your backend.
 
@@ -28,7 +28,7 @@ Unlike cloud-based providers (Garmin, Polar, Suunto) that use webhooks and OAuth
   <Step title="Health Data Store" icon="heart-pulse">
     Health data is stored locally on the user's device — in Apple Health (iOS), Samsung Health, or Health Connect (Android).
   </Step>
-  <Step title="Your App + Sync SDK" icon="mobile">
+  <Step title="Your App + Mobile SDK" icon="mobile">
     The SDK reads data from the health store and handles background synchronization automatically. Available as native iOS (Swift), native Android (Kotlin), or Flutter (cross-platform).
   </Step>
   <Step title="Open Wearables Platform" icon="cloud-arrow-up">


### PR DESCRIPTION
## Description

"Sync SDK" said little about what it actually is and could be confusing, so this renames the section to the clearer "Mobile SDK" across the nav group, page title, social/SEO metadata, and in-body references.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code

## Testing Instructions

**Steps to test:**
1. Build/preview the docs site.
2. Check the sidebar nav group, the SDK overview page title, and the Google API integration provider page.

**Expected behavior:**

Everywhere that previously read "Sync SDK" now reads "Mobile SDK" (page title: "Open Wearables Mobile SDK"). No remaining "Sync SDK" references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Renamed the “Sync SDK” navigation label to “Mobile SDK.”
  - Updated Google Health API integration guidance to reference the Mobile SDK.
  - Standardized product naming across SDK documentation, including page titles, metadata, introduction text, and architecture guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->