### PR TITLE
fix(backend): verify webhook garmin-client-id against configured value

### DIFF
--- a/backend/app/services/providers/garmin/webhook_handler.py
+++ b/backend/app/services/providers/garmin/webhook_handler.py
@@ -18,6 +18,7 @@ from uuid import UUID, uuid4
 from celery import current_app as celery_app
 from fastapi import HTTPException, Request
 
+from app.config import settings
 from app.database import DbSession
 from app.repositories import UserConnectionRepository
 from app.services.providers.garmin.backfill_state import (
@@ -68,7 +69,8 @@ class GarminWebhookHandler(BaseWebhookHandler):
 
     Garmin does not sign request bodies with HMAC; it identifies itself via the
     ``garmin-client-id`` request header.  ``verify_signature`` checks that this
-    header is present.
+    header matches the configured ``settings.garmin_client_id`` (constant-time),
+    failing closed when the value is not configured.
     """
 
     def __init__(self, garmin_workouts: GarminWorkouts, garmin_247: Garmin247Data) -> None:
@@ -93,8 +95,19 @@ class GarminWebhookHandler(BaseWebhookHandler):
     # ------------------------------------------------------------------
 
     def verify_signature(self, request: Request, body: bytes) -> bool:
-        client_id = request.headers.get("garmin-client-id")
-        if not client_id:
+        expected = settings.garmin_client_id
+        if not expected:
+            log_structured(
+                logger,
+                "error",
+                "GARMIN_CLIENT_ID not configured; rejecting webhook",
+                provider="garmin",
+                action="webhook_signature_missing_secret",
+            )
+            return False
+
+        provided = request.headers.get("garmin-client-id", "")
+        if not provided:
             log_structured(
                 logger,
                 "warning",
@@ -103,6 +116,17 @@ class GarminWebhookHandler(BaseWebhookHandler):
                 action="webhook_signature_invalid",
             )
             return False
+
+        if not self._verify_token(expected, provided):
+            log_structured(
+                logger,
+                "warning",
+                "garmin-client-id header does not match configured value",
+                provider="garmin",
+                action="webhook_signature_invalid",
+            )
+            return False
+
         return True
 
     def parse_payload(self, body: bytes) -> dict[str, Any]:

--- a/backend/tests/api/v1/test_garmin_webhooks.py
+++ b/backend/tests/api/v1/test_garmin_webhooks.py
@@ -5,16 +5,29 @@ The /api/v1/providers/garmin/webhooks endpoint immediately returns
 Celery task. Processing logic is tested in tests/tasks/test_garmin_webhook_task.py.
 """
 
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
+
+from app.config import settings
 
 PUSH_ENDPOINT = "/api/v1/providers/garmin/webhooks"
 LEGACY_PUSH_ENDPOINT = "/api/v1/garmin/webhooks/push"
 LEGACY_PING_ENDPOINT = "/api/v1/garmin/webhooks/ping"
 WEBHOOK_HANDLER = "app.services.providers.garmin.webhook_handler"
 PROCESS_PUSH_TASK = "app.integrations.celery.tasks.webhook_push_task.process_webhook_push"
+
+VALID_CLIENT_ID = "test-client-id"
+
+
+@pytest.fixture(autouse=True)
+def _configure_garmin_client_id() -> Generator[None, None, None]:
+    """Pin the configured Garmin client id so header comparisons are deterministic."""
+    with patch.object(settings, "garmin_client_id", VALID_CLIENT_ID):
+        yield
 
 
 class TestGarminWebhookAuth:
@@ -25,6 +38,25 @@ class TestGarminWebhookAuth:
         response = client.post(PUSH_ENDPOINT, json={"activities": []})
         assert response.status_code == 401
 
+    def test_wrong_client_id_returns_401(self, client: TestClient, db: Session) -> None:
+        """A garmin-client-id that doesn't match the configured value is rejected."""
+        response = client.post(
+            PUSH_ENDPOINT,
+            headers={"garmin-client-id": "attacker-invented"},
+            json={"activities": []},
+        )
+        assert response.status_code == 401
+
+    def test_unconfigured_client_id_rejects_any_request(self, client: TestClient, db: Session) -> None:
+        """When GARMIN_CLIENT_ID is unset the handler fails closed, even with a header."""
+        with patch.object(settings, "garmin_client_id", None):
+            response = client.post(
+                PUSH_ENDPOINT,
+                headers={"garmin-client-id": VALID_CLIENT_ID},
+                json={"activities": []},
+            )
+        assert response.status_code == 401
+
     def test_valid_client_id_returns_accepted(
         self,
         client: TestClient,
@@ -32,7 +64,7 @@ class TestGarminWebhookAuth:
         mock_external_apis: dict[str, MagicMock],
     ) -> None:
         """Valid request returns 200 with {"status": "accepted"} immediately."""
-        headers = {"garmin-client-id": "test-client-id"}
+        headers = {"garmin-client-id": VALID_CLIENT_ID}
         response = client.post(PUSH_ENDPOINT, headers=headers, json={"activities": []})
 
         assert response.status_code == 200
@@ -43,7 +75,7 @@ class TestGarminWebhookAuth:
         response = client.post(
             PUSH_ENDPOINT,
             content=b"not json",
-            headers={"garmin-client-id": "test-client-id", "Content-Type": "application/json"},
+            headers={"garmin-client-id": VALID_CLIENT_ID, "Content-Type": "application/json"},
         )
         assert response.status_code == 400
 
@@ -68,7 +100,7 @@ class TestGarminWebhookTaskEnqueue:
                 },
             ],
         }
-        headers = {"garmin-client-id": "test-client-id"}
+        headers = {"garmin-client-id": VALID_CLIENT_ID}
 
         with patch(f"{WEBHOOK_HANDLER}.celery_app") as mock_celery:
             mock_celery.send_task.return_value = MagicMock(id="test-task-id")
@@ -87,7 +119,7 @@ class TestGarminWebhookTaskEnqueue:
     ) -> None:
         """The payload passed to send_task matches the incoming webhook body."""
         payload = {"hrv": [{"userId": "u1", "summaryId": "s1"}]}
-        headers = {"garmin-client-id": "test-client-id"}
+        headers = {"garmin-client-id": VALID_CLIENT_ID}
 
         with patch(f"{WEBHOOK_HANDLER}.celery_app") as mock_celery:
             mock_celery.send_task.return_value = MagicMock(id="task-xyz")
@@ -127,7 +159,7 @@ class TestGarminDeprecatedRoutes:
         mock_external_apis: dict[str, MagicMock],
     ) -> None:
         """Deprecated /api/v1/garmin/webhooks/push delegates to the same handler."""
-        headers = {"garmin-client-id": "test-client-id"}
+        headers = {"garmin-client-id": VALID_CLIENT_ID}
         response = client.post(LEGACY_PUSH_ENDPOINT, headers=headers, json={"activities": []})
 
         assert response.status_code == 200
@@ -140,7 +172,7 @@ class TestGarminDeprecatedRoutes:
         mock_external_apis: dict[str, MagicMock],
     ) -> None:
         """Deprecated /api/v1/garmin/webhooks/ping also delegates to the handler."""
-        headers = {"garmin-client-id": "test-client-id"}
+        headers = {"garmin-client-id": VALID_CLIENT_ID}
         response = client.post(LEGACY_PING_ENDPOINT, headers=headers, json={"activities": []})
 
         assert response.status_code == 200


### PR DESCRIPTION
## Description

`GarminWebhookHandler.verify_signature` only checked that the `garmin-client-id` header was *present* - any non-empty string passed. This compares it against the configured `settings.garmin_client_id` in constant time and fails closed when the value is not configured.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [ ] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes

## Testing Instructions

**Steps to test:**
1. Set `GARMIN_CLIENT_ID` in the backend env.
2. `POST /api/v1/providers/garmin/webhooks` with a `garmin-client-id` header equal to that value -> `200 {"status": "accepted"}`.
3. Repeat with a wrong/absent header, or with `GARMIN_CLIENT_ID` unset -> `401`.

**Expected behavior:**
Only requests carrying the configured `garmin-client-id` are accepted; everything else is rejected, and the endpoint fails closed when the id is not configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Garmin webhook requests are now validated against the configured client ID.
  * Requests with missing, incorrect, or unconfigured client IDs are rejected.
  * Improved protection against unauthorized webhook requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->