### PR TITLE
docs: document Samsung Health production requirements

### DIFF
--- a/docs/sdk/android/index.mdx
+++ b/docs/sdk/android/index.mdx
@@ -41,7 +41,7 @@ This is the **core native implementation** that powers health data sync on Andro
 | Compile SDK | 36 |
 | Java | 17 |
 | Kotlin | 2.1.0+ |
-| Samsung Health SDK | For Samsung Health provider |
+| Samsung Health SDK | For Samsung Health provider (requires Samsung Health app 6.30.2+) |
 | Health Connect | For Health Connect provider |
 
 ## Installation

--- a/docs/sdk/android/integration.mdx
+++ b/docs/sdk/android/integration.mdx
@@ -505,7 +505,7 @@ class MainActivity : AppCompatActivity() {
 
 ## Samsung Health Production Requirements
 
-Samsung Health works on your development build with Developer Mode - **for that you only need a Samsung account, no partnership request**. Production adds a requirement: the same code runs, but the permission flow aborts on release builds until **both** of these are true:
+Samsung Health works on your development build with Developer Mode - **for read access (what Open Wearables needs) you only need a Samsung account, no partnership request**. Production adds a requirement: the same code runs, but the permission flow aborts on release builds until **both** of these are true:
 
 1. **Your partnership request is approved by Samsung.** Submit it through Samsung's [app creation process](https://developer.samsung.com/health/data/process.html), providing your app's package name and release signing key signature.
 2. **Your release signing key is on Samsung's allowlist.** Samsung [matches package name + SHA-256 at runtime](https://developer.samsung.com/health/data/guide/app-verification.html). Get the fingerprint from your release keystore - and if you use Play App Signing, register the Play **app signing key** (Play Console → `Setup → App integrity → App signing`), not your upload key:
@@ -515,7 +515,7 @@ Samsung Health works on your development build with Developer Mode - **for that 
    ```
 
 <Note>
-  `IllegalStateException: Could not get policy for {package}` on a release build means your signing key is not yet allowlisted - the partnership is not approved, or the wrong certificate was registered (a common Play App Signing pitfall). Confirm both, then contact [Samsung Developer Support](https://developer.samsung.com/health/data).
+  `IllegalStateException: Could not get policy for {package}` on a release build means Samsung has not matched your app - the partnership is not approved, or the running build's **package name or signing certificate** does not match what Samsung registered (a common Play App Signing pitfall). Confirm all three, then contact [Samsung Developer Support](https://developer.samsung.com/health/data).
 </Note>
 
 <Tip>
@@ -524,13 +524,7 @@ Samsung Health works on your development build with Developer Mode - **for that 
 
 ### Background sync
 
-Samsung Health does **not** use the `android.permission.health.*` declarations Health Connect relies on. For reliable background sync, though, declare an exact-alarm permission in your `AndroidManifest.xml` - prefer `SCHEDULE_EXACT_ALARM`, since `USE_EXACT_ALARM` attracts extra Google Play review and needs justification:
-
-```xml
-<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
-```
-
-See [Troubleshooting](/sdk/android/troubleshooting) for the foreground-service and `POST_NOTIFICATIONS` requirements that also apply to background sync.
+Samsung Health does **not** use the `android.permission.health.*` declarations Health Connect relies on - permissions are granted through Samsung Health's own dialog, so no extra manifest permissions are needed for the Samsung provider. Background sync uses the same WorkManager and foreground-service mechanism as Health Connect; see [Troubleshooting](/sdk/android/troubleshooting) for the battery-optimization and `POST_NOTIFICATIONS` requirements that affect it.
 
 ## Complete Integration Example
 

--- a/docs/sdk/android/integration.mdx
+++ b/docs/sdk/android/integration.mdx
@@ -350,6 +350,26 @@ if (!success) {
   Health Connect is recommended as the default provider for the widest device and data type support.
 </Tip>
 
+### Samsung Health SDK dependency
+
+If you target Samsung Health, add Samsung's own **Health Data SDK** (distributed as an `.aar`) to your app module. This is required to use the `"samsung"` provider **at all** - including in Developer Mode - not just for production. Download it from the [Samsung Health Data SDK](https://developer.samsung.com/health/data) page:
+
+```kotlin
+// app/build.gradle.kts
+dependencies {
+    // Samsung Health Data SDK (downloaded from Samsung)
+    implementation(files("libs/samsung-health-data-api.aar"))
+}
+```
+
+<Warning>
+  **Shipping Samsung Health to production requires Samsung's approval.** The permission flow is blocked at runtime until Samsung approves your partnership request and allowlists your release signing key. See [Samsung Health Production Requirements](#samsung-health-production-requirements) before you plan a release.
+</Warning>
+
+<Note>
+  **Testing Samsung Health:** Samsung Health is not available in the Android emulator - test on a physical Samsung device with the Samsung Health app installed. Before Samsung approves your app for production, enable [**Developer Mode**](https://developer.samsung.com/health/data/guide/developer-mode.html) in the Samsung Health app so the permission flow works on your test build. If `setProvider("samsung")` returns `false`, the device, the Samsung Health app, or Developer Mode is not set up.
+</Note>
+
 ## Step 5: Request Permissions
 
 Request access to specific health data types. The type IDs are string-based:
@@ -482,6 +502,35 @@ class MainActivity : AppCompatActivity() {
     }
 }
 ```
+
+## Samsung Health Production Requirements
+
+Samsung Health works on your development build with Developer Mode - **for that you only need a Samsung account, no partnership request**. Production adds a requirement: the same code runs, but the permission flow aborts on release builds until **both** of these are true:
+
+1. **Your partnership request is approved by Samsung.** Submit it through Samsung's [app creation process](https://developer.samsung.com/health/data/process.html), providing your app's package name and release signing key signature.
+2. **Your release signing key is on Samsung's allowlist.** Samsung [matches package name + SHA-256 at runtime](https://developer.samsung.com/health/data/guide/app-verification.html). Get the fingerprint from your release keystore - and if you use Play App Signing, register the Play **app signing key** (Play Console → `Setup → App integrity → App signing`), not your upload key:
+
+   ```bash
+   keytool -list -v -keystore release.keystore -alias your_release_alias
+   ```
+
+<Note>
+  `IllegalStateException: Could not get policy for {package}` on a release build means your signing key is not yet allowlisted - the partnership is not approved, or the wrong certificate was registered (a common Play App Signing pitfall). Confirm both, then contact [Samsung Developer Support](https://developer.samsung.com/health/data).
+</Note>
+
+<Tip>
+  None of this applies to Health Connect (`"google"`), so you can ship with Health Connect first and add Samsung Health once approval lands.
+</Tip>
+
+### Background sync
+
+Samsung Health does **not** use the `android.permission.health.*` declarations Health Connect relies on. For reliable background sync, though, declare an exact-alarm permission in your `AndroidManifest.xml` - prefer `SCHEDULE_EXACT_ALARM`, since `USE_EXACT_ALARM` attracts extra Google Play review and needs justification:
+
+```xml
+<uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+```
+
+See [Troubleshooting](/sdk/android/troubleshooting) for the foreground-service and `POST_NOTIFICATIONS` requirements that also apply to background sync.
 
 ## Complete Integration Example
 

--- a/docs/sdk/android/troubleshooting.mdx
+++ b/docs/sdk/android/troubleshooting.mdx
@@ -72,6 +72,32 @@ keywords: ["android health connect troubleshooting", "health connect permissions
        ```
   </Accordion>
 
+  <Accordion title="Samsung Health permissions never appear on a release build (Could not get policy)">
+    **Symptoms:** The Samsung permission dialog shows in development but not on your production/release build. Logs contain:
+
+    ```text
+    java.lang.IllegalStateException: Could not get policy for {your.package.name}
+    ```
+
+    **Cause:** The signing key of the running build is not on Samsung's allowlist - either the partnership request is not yet approved, or the wrong certificate was registered.
+
+    **Solutions:**
+
+    1. **Confirm partnership status:**
+       Check your partnership request in the Samsung Developer dashboard. Production access requires explicit approval.
+
+    2. **Verify the signing certificate:**
+       The fingerprint you registered must match the certificate that **actually** signs the build. If you use Play App Signing, that is the Google-held app signing key (Play Console → `Setup → App integrity → App signing`), **not** your upload key.
+
+    3. **Check the package name:**
+       The `applicationId` you shipped must match the package name registered with Samsung exactly.
+
+    4. **Contact Samsung Developer Support:**
+       If everything looks correct, ask them to confirm the allowlist entry is active.
+
+    See [Samsung Health Production Requirements](/sdk/android/integration#samsung-health-production-requirements) for the full production flow.
+  </Accordion>
+
   <Accordion title="Background sync not working">
     **Symptoms:** Data only syncs when the app is in the foreground.
 

--- a/docs/sdk/android/troubleshooting.mdx
+++ b/docs/sdk/android/troubleshooting.mdx
@@ -79,7 +79,7 @@ keywords: ["android health connect troubleshooting", "health connect permissions
     java.lang.IllegalStateException: Could not get policy for {your.package.name}
     ```
 
-    **Cause:** The signing key of the running build is not on Samsung's allowlist - either the partnership request is not yet approved, or the wrong certificate was registered.
+    **Cause:** Samsung has not matched your app - either the partnership request is not yet approved, or the running build's package name or signing certificate does not match what Samsung registered.
 
     **Solutions:**
 


### PR DESCRIPTION
## Description

Adds a short section documenting the production flow for Samsung Health (partnership approval + signing-key allowlisting), which our Android docs were missing.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Samsung Health Developer Mode requirements, including Samsung account access for read-only integrations.
  * Updated background synchronization guidance to note that no additional manifest permissions are required and removed the exact-alarm recommendation.
  * Expanded release-build troubleshooting for missing permissions, including partnership approval, package name, and signing certificate checks.
  * Added the requirement for Samsung Health version 6.30.2 or later.
  * Clarified that Samsung-specific production requirements do not apply to Health Connect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->