### PR TITLE
feat: add metric descriptions with tooltip hints to coverage matrix

### DIFF
--- a/backend/app/api/routes/v1/meta.py
+++ b/backend/app/api/routes/v1/meta.py
@@ -6,7 +6,12 @@ from functools import lru_cache
 from fastapi import APIRouter
 
 from app.schemas.enums import ProviderName, SeriesType
-from app.schemas.enums.series_types import SERIES_TYPE_CATEGORY_BY_ENUM, SERIES_TYPE_UNIT_BY_ENUM
+from app.schemas.enums.health_score_category import HEALTH_SCORE_DESCRIPTION_BY_ENUM, HealthScoreCategory
+from app.schemas.enums.series_types import (
+    SERIES_TYPE_CATEGORY_BY_ENUM,
+    SERIES_TYPE_DESCRIPTION_BY_ENUM,
+    SERIES_TYPE_UNIT_BY_ENUM,
+)
 from app.schemas.model_crud.coverage import (
     CoverageResponse,
     HealthScore,
@@ -57,7 +62,10 @@ def _build_coverage() -> CoverageResponse:
     for st, prov_list in sorted(series_to_providers.items(), key=lambda x: x[0].value):
         cat = SERIES_TYPE_CATEGORY_BY_ENUM.get(st, "Other")
         unit = SERIES_TYPE_UNIT_BY_ENUM.get(st, "")
-        categories.setdefault(cat, []).append(TimeseriesMetric(code=st.value, unit=unit, providers=sorted(prov_list)))
+        description = SERIES_TYPE_DESCRIPTION_BY_ENUM.get(st, "")
+        categories.setdefault(cat, []).append(
+            TimeseriesMetric(code=st.value, unit=unit, description=description, providers=sorted(prov_list))
+        )
 
     timeseries = [TimeseriesCategory(name=cat, metrics=categories[cat]) for cat in _CATEGORY_ORDER if cat in categories]
 
@@ -99,7 +107,12 @@ def _build_coverage() -> CoverageResponse:
             score_to_providers.setdefault(score.value, []).append(provider)
 
     health_scores = [
-        HealthScore(code=score, providers=sorted(prov_list)) for score, prov_list in sorted(score_to_providers.items())
+        HealthScore(
+            code=score,
+            description=HEALTH_SCORE_DESCRIPTION_BY_ENUM.get(HealthScoreCategory(score), ""),
+            providers=sorted(prov_list),
+        )
+        for score, prov_list in sorted(score_to_providers.items())
     ]
 
     return CoverageResponse(

--- a/backend/app/schemas/enums/health_score_category.py
+++ b/backend/app/schemas/enums/health_score_category.py
@@ -10,3 +10,10 @@ class HealthScoreCategory(StrEnum):
     RESILIENCE = "resilience"
     BODY_BATTERY = "body_battery"
     STRAIN = "strain"
+
+
+# Optional human-readable descriptions surfaced in the coverage matrix (tooltips).
+# Only categories with a meaningful clarification need an entry; others default to "".
+HEALTH_SCORE_DESCRIPTION_BY_ENUM: dict[HealthScoreCategory, str] = {
+    HealthScoreCategory.BODY_BATTERY: "Daily peak body battery value",
+}

--- a/backend/app/schemas/enums/series_types.py
+++ b/backend/app/schemas/enums/series_types.py
@@ -319,6 +319,12 @@ SERIES_TYPE_ID_BY_ENUM: dict[SeriesType, int] = {enum: type_id for type_id, enum
 SERIES_TYPE_ENUM_BY_ID: dict[int, SeriesType] = {type_id: enum for type_id, enum, _ in SERIES_TYPE_DEFINITIONS}
 SERIES_TYPE_UNIT_BY_ENUM: dict[SeriesType, str] = {enum: unit for _, enum, unit in SERIES_TYPE_DEFINITIONS}
 
+# Optional human-readable descriptions surfaced in the coverage matrix (tooltips).
+# Only series types with a meaningful clarification need an entry; others default to "".
+SERIES_TYPE_DESCRIPTION_BY_ENUM: dict[SeriesType, str] = {
+    SeriesType.garmin_body_battery: "Intraday body battery readings (0-100), one sample per measurement",
+}
+
 
 # =============================================================================
 # HELPER FUNCTIONS

--- a/backend/app/schemas/enums/series_types.py
+++ b/backend/app/schemas/enums/series_types.py
@@ -320,7 +320,7 @@ SERIES_TYPE_ENUM_BY_ID: dict[int, SeriesType] = {type_id: enum for type_id, enum
 SERIES_TYPE_UNIT_BY_ENUM: dict[SeriesType, str] = {enum: unit for _, enum, unit in SERIES_TYPE_DEFINITIONS}
 
 # Optional human-readable descriptions surfaced in the coverage matrix (tooltips).
-# Only series types with a meaningful clarification need an entry; others default to "".
+# Only series types that need a meaningful clarification have an entry here;
 SERIES_TYPE_DESCRIPTION_BY_ENUM: dict[SeriesType, str] = {
     SeriesType.garmin_body_battery: "Intraday body battery readings (0-100), one sample per measurement",
 }

--- a/backend/app/schemas/model_crud/coverage.py
+++ b/backend/app/schemas/model_crud/coverage.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 class TimeseriesMetric(BaseModel):
     code: str
     unit: str
+    description: str = ""
     providers: list[str]
 
 
@@ -29,6 +30,7 @@ class MenstrualCycleField(BaseModel):
 
 class HealthScore(BaseModel):
     code: str
+    description: str = ""
     providers: list[str]
 
 

--- a/backend/app/schemas/model_crud/coverage.py
+++ b/backend/app/schemas/model_crud/coverage.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 
-_DESCRIPTION_DOC = (
+_DESCRIPTION_DOC: str = (
     "Optional human-readable clarification of what this data type represents. Empty when none is defined."
 )
 

--- a/backend/app/schemas/model_crud/coverage.py
+++ b/backend/app/schemas/model_crud/coverage.py
@@ -1,10 +1,12 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+_DESCRIPTION_DOC = "Optional human-readable clarification of what this data type represents. Empty when none is defined."
 
 
 class TimeseriesMetric(BaseModel):
     code: str
     unit: str
-    description: str = ""
+    description: str = Field(default="", description=_DESCRIPTION_DOC)
     providers: list[str]
 
 
@@ -30,7 +32,7 @@ class MenstrualCycleField(BaseModel):
 
 class HealthScore(BaseModel):
     code: str
-    description: str = ""
+    description: str = Field(default="", description=_DESCRIPTION_DOC)
     providers: list[str]
 
 

--- a/backend/app/schemas/model_crud/coverage.py
+++ b/backend/app/schemas/model_crud/coverage.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel, Field
 
-_DESCRIPTION_DOC = "Optional human-readable clarification of what this data type represents. Empty when none is defined."
+_DESCRIPTION_DOC = (
+    "Optional human-readable clarification of what this data type represents. Empty when none is defined."
+)
 
 
 class TimeseriesMetric(BaseModel):

--- a/frontend/src/components/pages/coverage/coverage-matrix.tsx
+++ b/frontend/src/components/pages/coverage/coverage-matrix.tsx
@@ -38,10 +38,13 @@ function Matrix({ providers, rows }: MatrixProps) {
                   {row.description ? (
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <span className="inline-flex items-center gap-1 cursor-help">
+                        <button
+                          type="button"
+                          className="inline-flex items-center gap-1 cursor-help"
+                        >
                           <code className="text-xs text-zinc-300 font-mono">{row.code}</code>
                           <Info aria-hidden="true" className="h-3 w-3 shrink-0 text-zinc-500" />
-                        </span>
+                        </button>
                       </TooltipTrigger>
                       <TooltipContent className="max-w-xs">{row.description}</TooltipContent>
                     </Tooltip>

--- a/frontend/src/components/pages/coverage/coverage-matrix.tsx
+++ b/frontend/src/components/pages/coverage/coverage-matrix.tsx
@@ -1,11 +1,13 @@
+import { Info } from 'lucide-react';
 import { useState } from 'react';
 import { SourceBadge } from '@/components/common/source-badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { CoverageResponse, TimeseriesCategory } from '@/lib/api';
 
 interface MatrixProps {
   providers: string[];
-  rows: { code: string; unit?: string; supportedBy: string[] }[];
+  rows: { code: string; unit?: string; description?: string; supportedBy: string[] }[];
 }
 
 function Matrix({ providers, rows }: MatrixProps) {
@@ -33,7 +35,19 @@ function Matrix({ providers, rows }: MatrixProps) {
             <tr key={row.code} className={i % 2 === 0 ? 'bg-zinc-900/20' : 'bg-transparent'}>
               <td className="sticky left-0 bg-inherit px-3 py-2 border-b border-zinc-800/40">
                 <div className="flex items-baseline gap-2">
-                  <code className="text-xs text-zinc-300 font-mono">{row.code}</code>
+                  {row.description ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex items-center gap-1 cursor-help">
+                          <code className="text-xs text-zinc-300 font-mono">{row.code}</code>
+                          <Info aria-hidden="true" className="h-3 w-3 shrink-0 text-zinc-500" />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-xs">{row.description}</TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    <code className="text-xs text-zinc-300 font-mono">{row.code}</code>
+                  )}
                   {row.unit && (
                     <span className="text-[10px] text-zinc-400 bg-zinc-800 px-1 py-0.5 rounded">
                       {row.unit}
@@ -101,6 +115,7 @@ function TimeseriesTab({
             rows={cat.metrics.map((m) => ({
               code: m.code,
               unit: m.unit,
+              description: m.description,
               supportedBy: m.providers,
             }))}
           />
@@ -157,7 +172,11 @@ export function CoverageMatrix({ data }: Props) {
       <TabsContent value="scores">
         <Matrix
           providers={providers}
-          rows={health_scores.map((s) => ({ code: s.code, supportedBy: s.providers }))}
+          rows={health_scores.map((s) => ({
+            code: s.code,
+            description: s.description,
+            supportedBy: s.providers,
+          }))}
         />
       </TabsContent>
     </Tabs>

--- a/frontend/src/components/pages/coverage/provider-detail.tsx
+++ b/frontend/src/components/pages/coverage/provider-detail.tsx
@@ -1,4 +1,6 @@
+import { Info } from 'lucide-react';
 import { SourceBadge } from '@/components/common/source-badge';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { CoverageResponse } from '@/lib/api';
 
 function Stat({ label, value }: { label: string; value: number }) {
@@ -23,6 +25,34 @@ function Stat({ label, value }: { label: string; value: number }) {
 interface Chip {
   code: string;
   unit?: string;
+  description?: string;
+}
+
+function ChipItem({ chip }: { chip: Chip }) {
+  const body = (
+    <span
+      className={`inline-flex items-baseline gap-1 rounded-md bg-zinc-800/70 px-2 py-1${
+        chip.description ? ' cursor-help' : ''
+      }`}
+    >
+      <code className="font-mono text-xs text-zinc-200">{chip.code}</code>
+      {chip.unit && <span className="text-[10px] text-zinc-500">{chip.unit}</span>}
+      {chip.description && (
+        <Info aria-hidden="true" className="h-3 w-3 shrink-0 self-center text-zinc-500" />
+      )}
+    </span>
+  );
+
+  if (!chip.description) {
+    return body;
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{body}</TooltipTrigger>
+      <TooltipContent className="max-w-xs">{chip.description}</TooltipContent>
+    </Tooltip>
+  );
 }
 
 function GroupCard({ title, chips }: { title: string; chips: Chip[] }) {
@@ -38,13 +68,7 @@ function GroupCard({ title, chips }: { title: string; chips: Chip[] }) {
       </div>
       <div className="flex flex-wrap gap-1.5">
         {chips.map((c) => (
-          <span
-            key={c.code}
-            className="inline-flex items-baseline gap-1 rounded-md bg-zinc-800/70 px-2 py-1"
-          >
-            <code className="font-mono text-xs text-zinc-200">{c.code}</code>
-            {c.unit && <span className="text-[10px] text-zinc-500">{c.unit}</span>}
-          </span>
+          <ChipItem key={c.code} chip={c} />
         ))}
       </div>
     </div>
@@ -76,13 +100,13 @@ export function ProviderDetail({ data, provider }: Props) {
     .map((f) => ({ code: f.code }));
   const scores = data.health_scores
     .filter((s) => s.providers.includes(provider))
-    .map((s) => ({ code: s.code }));
+    .map((s) => ({ code: s.code, description: s.description }));
 
   // One card per non-empty group, rendered in a uniform responsive grid.
   const cards: { title: string; chips: Chip[] }[] = [
     ...timeseries.map((cat) => ({
       title: cat.name,
-      chips: cat.metrics.map((m) => ({ code: m.code, unit: m.unit })),
+      chips: cat.metrics.map((m) => ({ code: m.code, unit: m.unit, description: m.description })),
     })),
     { title: 'Workout fields', chips: workout },
     { title: 'Sleep fields', chips: sleep },

--- a/frontend/src/components/pages/coverage/provider-detail.tsx
+++ b/frontend/src/components/pages/coverage/provider-detail.tsx
@@ -2,6 +2,7 @@ import { Info } from 'lucide-react';
 import { SourceBadge } from '@/components/common/source-badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { CoverageResponse } from '@/lib/api';
+import { cn } from '@/lib/utils';
 
 function Stat({ label, value }: { label: string; value: number }) {
   return (
@@ -31,9 +32,10 @@ interface Chip {
 function ChipItem({ chip }: { chip: Chip }) {
   const body = (
     <span
-      className={`inline-flex items-baseline gap-1 rounded-md bg-zinc-800/70 px-2 py-1${
-        chip.description ? ' cursor-help' : ''
-      }`}
+      className={cn(
+        'inline-flex items-baseline gap-1 rounded-md bg-zinc-800/70 px-2 py-1',
+        chip.description && 'cursor-help'
+      )}
     >
       <code className="font-mono text-xs text-zinc-200">{chip.code}</code>
       {chip.unit && <span className="text-[10px] text-zinc-500">{chip.unit}</span>}
@@ -49,7 +51,11 @@ function ChipItem({ chip }: { chip: Chip }) {
 
   return (
     <Tooltip>
-      <TooltipTrigger asChild>{body}</TooltipTrigger>
+      <TooltipTrigger asChild>
+        <button type="button" className="inline-flex text-left">
+          {body}
+        </button>
+      </TooltipTrigger>
       <TooltipContent className="max-w-xs">{chip.description}</TooltipContent>
     </Tooltip>
   );

--- a/frontend/src/lib/api/services/meta.service.ts
+++ b/frontend/src/lib/api/services/meta.service.ts
@@ -4,6 +4,7 @@ import { API_ENDPOINTS } from '../config';
 export interface TimeseriesMetric {
   code: string;
   unit: string;
+  description?: string;
   providers: string[];
 }
 
@@ -29,6 +30,7 @@ export interface MenstrualCycleField {
 
 export interface HealthScore {
   code: string;
+  description?: string;
   providers: string[];
 }
 


### PR DESCRIPTION
## Description

While debugging the issue described in #1227, I concluded it'd be useful to have a way to describe certain data types right in the coverage matrix - some codes look identical but mean different things (e.g. the `body_battery` series type vs the health score), and there was nowhere to explain that. So this adds optional per-metric descriptions surfaced as tooltips, with a small `Info` icon so the hint is discoverable instead of hidden behind a blind hover.

Motivated by the `body_battery` distinction, but generally useful going forward for clarifying any metric.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] New and existing tests pass locally

### Backend Changes

You have to be in `backend` directory to make it work:
- [ ] `uv run pre-commit run --all-files` passes

### Frontend Changes

- [ ] `pnpm run lint` passes
- [ ] `pnpm run format:check` passes
- [ ] `pnpm run build` succeeds

## Testing Instructions

**Steps to test:**
1. Open the coverage page, go to the Health Scores tab (or any provider detail view)
2. Look for the `Info` icon next to `body_battery`
3. Hover the chip/row

**Expected behavior:** Metrics with a description show an `Info` icon; hovering reveals the tooltip. Metrics without a description look unchanged.

## Screenshots

https://github.com/user-attachments/assets/ab151912-762d-4933-80a7-60aef598e04e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added human-readable descriptions for supported coverage metrics and health scores.
  * Coverage matrix entries now provide descriptions through accessible information tooltips.
  * Provider coverage chips display additional context with focusable info icons and tooltips.
  * Descriptions appear where available, while entries without supporting details retain their standard display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->