### PR TITLE
security: ignore host-only compose override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,5 @@ CLAUDE.local.md
 
 # Exception: AI tool configs that should be tracked
 !.gemini/settings.json
+# Host-only deployment files; credentials are sourced via 0600 protected paths (bead root-Secret-FleetCutover-001.22)
+/docker-compose.override.yml


### PR DESCRIPTION
ADR-003 root-Secret-FleetCutover-001.22. Reviewed integration SHA: 7d9644a7b76421cddd5238d8b449ebc60a08afea. Gate 3 PASS artifact is recorded in the Bead. This is a one-path .gitignore guard; no credential values, rotations, or service changes.