### PR TITLE
feat(backend): add parsed Oura met data to the workouts API

### DIFF
--- a/backend/app/schemas/providers/oura/imports.py
+++ b/backend/app/schemas/providers/oura/imports.py
@@ -110,6 +110,14 @@ class OuraReadinessCollectionJSON(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class OuraMetJSON(BaseModel):
+    """Intraday MET series embedded in a daily activity record."""
+
+    interval: float | None = None  # seconds between items
+    items: list[float | None] = []
+    timestamp: str | None = None  # ISO 8601, start of the series
+
+
 class OuraDailyActivityJSON(BaseModel):
     """Single daily activity record from Oura API v2 /usercollection/daily_activity."""
 
@@ -136,6 +144,7 @@ class OuraDailyActivityJSON(BaseModel):
     total_calories: int | None = None
     timestamp: str | None = None
     contributors: dict | None = None
+    met: OuraMetJSON | None = None
 
 
 class OuraActivityCollectionJSON(BaseModel):

--- a/backend/app/schemas/providers/oura/imports.py
+++ b/backend/app/schemas/providers/oura/imports.py
@@ -145,6 +145,7 @@ class OuraDailyActivityJSON(BaseModel):
     timestamp: str | None = None
     contributors: dict | None = None
     met: OuraMetJSON | None = None
+    class_5_min: str | None = None
 
 
 class OuraActivityCollectionJSON(BaseModel):

--- a/backend/app/services/providers/oura/coverage.py
+++ b/backend/app/services/providers/oura/coverage.py
@@ -7,7 +7,11 @@ ACTIVITY_SERIES: dict[str, SeriesType] = {
     "energy": SeriesType.energy,
     "distance": SeriesType.distance_walking_running,
     "active_time": SeriesType.active_time,
+    "met": SeriesType.average_met,
 }
+# Keys in ACTIVITY_SERIES that carry intraday samples rather than one value per day —
+# these must not be flagged is_daily_total, unlike the rest of ACTIVITY_SERIES.
+INTRADAY_ACTIVITY_KEYS: frozenset[str] = frozenset({"met"})
 READINESS_SERIES: dict[str, SeriesType] = {
     "temperature_deviation": SeriesType.skin_temperature_deviation,
     "temperature_trend_deviation": SeriesType.skin_temperature_trend_deviation,

--- a/backend/app/services/providers/oura/coverage.py
+++ b/backend/app/services/providers/oura/coverage.py
@@ -7,11 +7,8 @@ ACTIVITY_SERIES: dict[str, SeriesType] = {
     "energy": SeriesType.energy,
     "distance": SeriesType.distance_walking_running,
     "active_time": SeriesType.active_time,
-    "met": SeriesType.average_met,
+    "met": SeriesType.physical_effort,
 }
-# Keys in ACTIVITY_SERIES that carry intraday samples rather than one value per day —
-# these must not be flagged is_daily_total, unlike the rest of ACTIVITY_SERIES.
-INTRADAY_ACTIVITY_KEYS: frozenset[str] = frozenset({"met"})
 READINESS_SERIES: dict[str, SeriesType] = {
     "temperature_deviation": SeriesType.skin_temperature_deviation,
     "temperature_trend_deviation": SeriesType.skin_temperature_trend_deviation,

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -30,12 +30,13 @@ from app.schemas.providers.oura import (
     OuraDailySleepJSON,
     OuraSleepJSON,
 )
-from app.schemas.providers.oura.imports import OuraIntervalData, OuraPersonalInfoJSON
+from app.schemas.providers.oura.imports import OuraIntervalData, OuraMetJSON, OuraPersonalInfoJSON
 from app.services.event_record_service import event_record_service
 from app.services.health_score_service import health_score_service
 from app.services.providers.api_client import make_authenticated_request
 from app.services.providers.oura.coverage import (
     ACTIVITY_SERIES,
+    INTRADAY_ACTIVITY_KEYS,
     PERSONAL_INFO_SERIES,
     READINESS_SERIES,
     SLEEP_INTERVAL_SERIES,
@@ -199,6 +200,22 @@ class Oura247Data(Base247DataTemplate):
             )
         return result
 
+    @staticmethod
+    def _expand_met_series(met: OuraMetJSON | None, zone_offset: str | None = None) -> list[dict[str, Any]]:
+        """Expand an Oura intraday MET series into individual timestamped samples."""
+        if met is None or not met.items or not met.interval or met.interval < 0:
+            return []
+
+        start = parse_iso_datetime(met.timestamp)
+        if start is None:
+            return []
+
+        return [
+            {"recorded_at": start + timedelta(seconds=met.interval * i), "value": value, "zone_offset": zone_offset}
+            for i, value in enumerate(met.items)
+            if value is not None
+        ]
+
     def normalize_activity_samples(
         self,
         raw_samples: list[dict[str, Any]],
@@ -213,6 +230,7 @@ class Oura247Data(Base247DataTemplate):
             "energy": [],
             "distance": [],
             "active_time": [],
+            "met": [],
         }
 
         for activity in activity_items:
@@ -260,6 +278,7 @@ class Oura247Data(Base247DataTemplate):
                         "zone_offset": activity_zone_offset,
                     }
                 )
+            result["met"].extend(self._expand_met_series(activity.met, activity_zone_offset))
 
         return result, activity_scores
 
@@ -286,7 +305,7 @@ class Oura247Data(Base247DataTemplate):
                             zone_offset=item.get("zone_offset"),
                             value=Decimal(str(item["value"])),
                             series_type=series_type,
-                            is_daily_total=True,
+                            is_daily_total=key not in INTRADAY_ACTIVITY_KEYS,
                         )
                     )
                 except Exception as e:

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -201,7 +201,7 @@ class Oura247Data(Base247DataTemplate):
         return result
 
     @staticmethod
-    def _expand_met_series(met: OuraMetJSON | None, zone_offset: str | None = None) -> list[dict[str, Any]]:
+    def _expand_met_series(met: OuraMetJSON | None) -> list[dict[str, Any]]:
         """Expand an Oura intraday MET series into individual timestamped samples."""
         if met is None or not met.items or not met.interval or met.interval < 0:
             return []
@@ -209,6 +209,11 @@ class Oura247Data(Base247DataTemplate):
         start = parse_iso_datetime(met.timestamp)
         if start is None:
             return []
+
+        zone_offset = None
+        utcoff = start.utcoffset()
+        if utcoff is not None:
+            zone_offset = offset_to_iso(int(utcoff.total_seconds()))
 
         return [
             {"recorded_at": start + timedelta(seconds=met.interval * i), "value": value, "zone_offset": zone_offset}
@@ -278,7 +283,7 @@ class Oura247Data(Base247DataTemplate):
                         "zone_offset": activity_zone_offset,
                     }
                 )
-            result["met"].extend(self._expand_met_series(activity.met, activity_zone_offset))
+            result["met"].extend(self._expand_met_series(activity.met))
 
         return result, activity_scores
 

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -1,5 +1,6 @@
 """Oura Ring 247 Data implementation for sleep, readiness, heart rate, activity, and SpO2."""
 
+import math
 from collections.abc import Callable
 from contextlib import suppress
 from datetime import datetime, timedelta, timezone
@@ -202,7 +203,7 @@ class Oura247Data(Base247DataTemplate):
     @staticmethod
     def _expand_met_series(met: OuraMetJSON | None, class_5_min: str | None) -> list[dict[str, Any]]:
         """Expand an Oura intraday MET series into individual timestamped samples."""
-        if met is None or not met.items or not met.interval or met.interval < 0:
+        if met is None or not met.items or not met.interval or met.interval < 0 or not math.isfinite(met.interval):
             return []
 
         start = parse_iso_datetime(met.timestamp)
@@ -224,7 +225,12 @@ class Oura247Data(Base247DataTemplate):
                 continue
 
             elapsed_seconds = met.interval * i
-            recorded_at = start + timedelta(seconds=elapsed_seconds)
+            try:
+                recorded_at = start + timedelta(seconds=elapsed_seconds)
+            except OverflowError:
+                # interval is finite but too large for timestamp arithmetic to represent
+                # (e.g. a corrupt payload) — the whole series is untrustworthy at that point.
+                return []
 
             if measured_seconds is not None and class_5_min is not None:
                 if elapsed_seconds >= measured_seconds:

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -207,7 +207,7 @@ class Oura247Data(Base247DataTemplate):
             return []
 
         start = parse_iso_datetime(met.timestamp)
-        if start is None:
+        if start is None or start.tzinfo is None:
             return []
 
         zone_offset = None

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -15,7 +15,7 @@ from app.database import DbSession
 from app.models import EventRecord
 from app.repositories import EventRecordRepository, UserConnectionRepository
 from app.repositories.data_point_series_repository import WriteCounts
-from app.schemas.enums import HealthScoreCategory, ProviderName, SeriesType
+from app.schemas.enums import HealthScoreCategory, ProviderName, SeriesType, daily_total_flag
 from app.schemas.model_crud.activities import (
     EventRecordCreate,
     EventRecordDetailCreate,
@@ -36,7 +36,6 @@ from app.services.health_score_service import health_score_service
 from app.services.providers.api_client import make_authenticated_request
 from app.services.providers.oura.coverage import (
     ACTIVITY_SERIES,
-    INTRADAY_ACTIVITY_KEYS,
     PERSONAL_INFO_SERIES,
     READINESS_SERIES,
     SLEEP_INTERVAL_SERIES,
@@ -201,7 +200,7 @@ class Oura247Data(Base247DataTemplate):
         return result
 
     @staticmethod
-    def _expand_met_series(met: OuraMetJSON | None) -> list[dict[str, Any]]:
+    def _expand_met_series(met: OuraMetJSON | None, class_5_min: str | None) -> list[dict[str, Any]]:
         """Expand an Oura intraday MET series into individual timestamped samples."""
         if met is None or not met.items or not met.interval or met.interval < 0:
             return []
@@ -215,11 +214,29 @@ class Oura247Data(Base247DataTemplate):
         if utcoff is not None:
             zone_offset = offset_to_iso(int(utcoff.total_seconds()))
 
-        return [
-            {"recorded_at": start + timedelta(seconds=met.interval * i), "value": value, "zone_offset": zone_offset}
-            for i, value in enumerate(met.items)
-            if value is not None
-        ]
+        measured_seconds = len(class_5_min) * 300 if class_5_min else None
+        now = datetime.now(timezone.utc)
+        non_wear_value = "0"  # 0=non-wear 1=rest 2=inactive 3=low 4=medium 5=high activity.
+
+        samples = []
+        for i, value in enumerate(met.items):
+            if value is None:
+                continue
+
+            elapsed_seconds = met.interval * i
+            recorded_at = start + timedelta(seconds=elapsed_seconds)
+
+            if measured_seconds is not None and class_5_min is not None:
+                if elapsed_seconds >= measured_seconds:
+                    continue
+                if class_5_min[int(elapsed_seconds // 300)] == non_wear_value:
+                    continue
+            elif recorded_at > now:
+                continue
+
+            samples.append({"recorded_at": recorded_at, "value": value, "zone_offset": zone_offset})
+
+        return samples
 
     def normalize_activity_samples(
         self,
@@ -283,7 +300,7 @@ class Oura247Data(Base247DataTemplate):
                         "zone_offset": activity_zone_offset,
                     }
                 )
-            result["met"].extend(self._expand_met_series(activity.met))
+            result["met"].extend(self._expand_met_series(activity.met, activity.class_5_min))
 
         return result, activity_scores
 
@@ -310,7 +327,7 @@ class Oura247Data(Base247DataTemplate):
                             zone_offset=item.get("zone_offset"),
                             value=Decimal(str(item["value"])),
                             series_type=series_type,
-                            is_daily_total=key not in INTRADAY_ACTIVITY_KEYS,
+                            is_daily_total=daily_total_flag(series_type, is_daily=True),
                         )
                     )
                 except Exception as e:

--- a/backend/app/services/providers/oura/data_247.py
+++ b/backend/app/services/providers/oura/data_247.py
@@ -1,6 +1,5 @@
 """Oura Ring 247 Data implementation for sleep, readiness, heart rate, activity, and SpO2."""
 
-import math
 from collections.abc import Callable
 from contextlib import suppress
 from datetime import datetime, timedelta, timezone
@@ -203,7 +202,7 @@ class Oura247Data(Base247DataTemplate):
     @staticmethod
     def _expand_met_series(met: OuraMetJSON | None, class_5_min: str | None) -> list[dict[str, Any]]:
         """Expand an Oura intraday MET series into individual timestamped samples."""
-        if met is None or not met.items or not met.interval or met.interval < 0 or not math.isfinite(met.interval):
+        if met is None or not met.items or not met.interval or met.interval < 0 or class_5_min is None:
             return []
 
         start = parse_iso_datetime(met.timestamp)
@@ -211,34 +210,23 @@ class Oura247Data(Base247DataTemplate):
             return []
 
         zone_offset = None
-        utcoff = start.utcoffset()
-        if utcoff is not None:
+        if (utcoff := start.utcoffset()) is not None:
             zone_offset = offset_to_iso(int(utcoff.total_seconds()))
 
-        measured_seconds = len(class_5_min) * 300 if class_5_min else None
-        now = datetime.now(timezone.utc)
-        non_wear_value = "0"  # 0=non-wear 1=rest 2=inactive 3=low 4=medium 5=high activity.
+        measured_seconds = len(class_5_min) * 300
+        measured_items = len(met.items) if measured_seconds == 86_400 else measured_seconds // int(met.interval)
+        non_wear_value = 0.1
 
         samples = []
-        for i, value in enumerate(met.items):
-            if value is None:
+        for i, value in enumerate(met.items[:measured_items]):
+            if value is None or value == non_wear_value:
                 continue
 
             elapsed_seconds = met.interval * i
             try:
                 recorded_at = start + timedelta(seconds=elapsed_seconds)
             except OverflowError:
-                # interval is finite but too large for timestamp arithmetic to represent
-                # (e.g. a corrupt payload) — the whole series is untrustworthy at that point.
                 return []
-
-            if measured_seconds is not None and class_5_min is not None:
-                if elapsed_seconds >= measured_seconds:
-                    continue
-                if class_5_min[int(elapsed_seconds // 300)] == non_wear_value:
-                    continue
-            elif recorded_at > now:
-                continue
 
             samples.append({"recorded_at": recorded_at, "value": value, "zone_offset": zone_offset})
 

--- a/backend/tests/providers/oura/test_oura_247.py
+++ b/backend/tests/providers/oura/test_oura_247.py
@@ -6,6 +6,8 @@ from uuid import uuid4
 import pytest
 
 from app.constants.sleep import SleepStageType
+from app.schemas.providers.oura.imports import OuraMetJSON
+from app.services.providers.oura.coverage import INTRADAY_ACTIVITY_KEYS
 from app.services.providers.oura.data_247 import Oura247Data
 from app.services.providers.oura.strategy import OuraStrategy
 
@@ -287,3 +289,105 @@ class TestOura247ActivityNormalization:
         assert samples["steps"] == []
         assert samples["energy"] == []
         assert samples["distance"] == []
+
+    def test_normalize_activity_samples_includes_met(self, data_247: Oura247Data) -> None:
+        user_id = uuid4()
+        raw = [
+            {
+                "id": "activity-met",
+                "day": "2024-01-15",
+                "timestamp": "2024-01-15T00:00:00+00:00",
+                "met": {
+                    "interval": 60,
+                    "items": [1.0, 1.2, None, 1.5],
+                    "timestamp": "2024-01-15T00:00:00+00:00",
+                },
+            },
+        ]
+        samples, _ = data_247.normalize_activity_samples(raw, user_id)
+
+        assert len(samples["met"]) == 3
+        assert [s["value"] for s in samples["met"]] == [1.0, 1.2, 1.5]
+
+    def test_normalize_activity_samples_met_absent(self, data_247: Oura247Data) -> None:
+        user_id = uuid4()
+        raw = [{"id": "activity-no-met", "day": "2024-01-15", "timestamp": "2024-01-15T00:00:00+00:00"}]
+        samples, _ = data_247.normalize_activity_samples(raw, user_id)
+
+        assert samples["met"] == []
+
+
+class TestOura247MetSeriesExpansion:
+    """Test expansion of the intraday MET series embedded in daily activity records."""
+
+    @pytest.fixture
+    def data_247(self) -> Oura247Data:
+        strategy = OuraStrategy()
+        return strategy.data_247
+
+    def test_expand_met_series_basic(self, data_247: Oura247Data) -> None:
+        met = OuraMetJSON(interval=60, items=[1.0, 1.1, 1.2], timestamp="2024-01-15T00:00:00+00:00")
+        samples = data_247._expand_met_series(met)
+
+        assert [s["value"] for s in samples] == [1.0, 1.1, 1.2]
+        assert samples[0]["recorded_at"] == datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc)
+        assert samples[1]["recorded_at"] == datetime(2024, 1, 15, 0, 1, 0, tzinfo=timezone.utc)
+        assert samples[2]["recorded_at"] == datetime(2024, 1, 15, 0, 2, 0, tzinfo=timezone.utc)
+
+    def test_expand_met_series_skips_null_items(self, data_247: Oura247Data) -> None:
+        met = OuraMetJSON(interval=60, items=[1.0, None, 1.2], timestamp="2024-01-15T00:00:00+00:00")
+        samples = data_247._expand_met_series(met)
+
+        # A null (unworn/unmeasured) sample must be dropped, never coerced to 0.0.
+        assert [s["value"] for s in samples] == [1.0, 1.2]
+
+    def test_expand_met_series_all_null(self, data_247: Oura247Data) -> None:
+        met = OuraMetJSON(interval=60, items=[None, None], timestamp="2024-01-15T00:00:00+00:00")
+        assert data_247._expand_met_series(met) == []
+
+    def test_expand_met_series_missing_met(self, data_247: Oura247Data) -> None:
+        assert data_247._expand_met_series(None) == []
+
+    def test_expand_met_series_empty_items(self, data_247: Oura247Data) -> None:
+        met = OuraMetJSON(interval=60, items=[], timestamp="2024-01-15T00:00:00+00:00")
+        assert data_247._expand_met_series(met) == []
+
+    def test_expand_met_series_missing_interval_is_dropped(self, data_247: Oura247Data) -> None:
+        # Oura's schema documents `interval` as a plain float, not a fixed 60s cadence —
+        # a missing value must not be guessed.
+        met = OuraMetJSON(interval=None, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
+        assert data_247._expand_met_series(met) == []
+
+    def test_expand_met_series_zero_interval_is_dropped(self, data_247: Oura247Data) -> None:
+        met = OuraMetJSON(interval=0, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
+        assert data_247._expand_met_series(met) == []
+
+    def test_expand_met_series_negative_interval_is_dropped(self, data_247: Oura247Data) -> None:
+        met = OuraMetJSON(interval=-60, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
+        assert data_247._expand_met_series(met) == []
+
+    def test_expand_met_series_unparseable_timestamp_is_dropped(self, data_247: Oura247Data) -> None:
+        # No fallback to the daily activity's own timestamp — it can anchor the whole
+        # series to the wrong point in the day (mirrors the sleep HR/HRV interval handling).
+        met = OuraMetJSON(interval=60, items=[1.0], timestamp="not-a-timestamp")
+        assert data_247._expand_met_series(met) == []
+
+    def test_expand_met_series_missing_timestamp_is_dropped(self, data_247: Oura247Data) -> None:
+        met = OuraMetJSON(interval=60, items=[1.0], timestamp=None)
+        assert data_247._expand_met_series(met) == []
+
+    def test_expand_met_series_full_day(self, data_247: Oura247Data) -> None:
+        met = OuraMetJSON(interval=60, items=[1.0] * 1440, timestamp="2024-01-15T00:00:00+00:00")
+        samples = data_247._expand_met_series(met)
+
+        assert len(samples) == 1440
+        assert samples[-1]["recorded_at"] == datetime(2024, 1, 15, 23, 59, 0, tzinfo=timezone.utc)
+
+    def test_expand_met_series_carries_zone_offset(self, data_247: Oura247Data) -> None:
+        met = OuraMetJSON(interval=60, items=[1.0], timestamp="2024-01-15T00:00:00+00:00")
+        samples = data_247._expand_met_series(met, zone_offset="+02:00")
+
+        assert samples[0]["zone_offset"] == "+02:00"
+
+    def test_met_is_flagged_as_intraday(self) -> None:
+        assert "met" in INTRADAY_ACTIVITY_KEYS

--- a/backend/tests/providers/oura/test_oura_247.py
+++ b/backend/tests/providers/oura/test_oura_247.py
@@ -384,8 +384,8 @@ class TestOura247MetSeriesExpansion:
         assert samples[-1]["recorded_at"] == datetime(2024, 1, 15, 23, 59, 0, tzinfo=timezone.utc)
 
     def test_expand_met_series_carries_zone_offset(self, data_247: Oura247Data) -> None:
-        met = OuraMetJSON(interval=60, items=[1.0], timestamp="2024-01-15T00:00:00+00:00")
-        samples = data_247._expand_met_series(met, zone_offset="+02:00")
+        met = OuraMetJSON(interval=60, items=[1.0], timestamp="2024-01-15T00:00:00+02:00")
+        samples = data_247._expand_met_series(met)
 
         assert samples[0]["zone_offset"] == "+02:00"
 

--- a/backend/tests/providers/oura/test_oura_247.py
+++ b/backend/tests/providers/oura/test_oura_247.py
@@ -367,6 +367,18 @@ class TestOura247MetSeriesExpansion:
         met = OuraMetJSON(interval=-60, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
         assert data_247._expand_met_series(met, None) == []
 
+    def test_expand_met_series_non_finite_interval_is_dropped(self, data_247: Oura247Data) -> None:
+        # interval is a plain float per Oura's schema — inf/nan must not reach timedelta math.
+        for bad_interval in (float("inf"), float("nan")):
+            met = OuraMetJSON(interval=bad_interval, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
+            assert data_247._expand_met_series(met, None) == []
+
+    def test_expand_met_series_unrepresentable_interval_returns_empty(self, data_247: Oura247Data) -> None:
+        # A finite but huge interval overflows `timedelta` once multiplied by the item
+        # index, instead of raising and failing the whole activity import.
+        met = OuraMetJSON(interval=1e20, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
+        assert data_247._expand_met_series(met, None) == []
+
     def test_expand_met_series_unparseable_timestamp_is_dropped(self, data_247: Oura247Data) -> None:
         # No fallback to the daily activity's own timestamp — it can anchor the whole
         # series to the wrong point in the day (mirrors the sleep HR/HRV interval handling).

--- a/backend/tests/providers/oura/test_oura_247.py
+++ b/backend/tests/providers/oura/test_oura_247.py
@@ -389,6 +389,12 @@ class TestOura247MetSeriesExpansion:
         met = OuraMetJSON(interval=60, items=[1.0], timestamp=None)
         assert data_247._expand_met_series(met, None) == []
 
+    def test_expand_met_series_offset_less_timestamp_is_dropped(self, data_247: Oura247Data) -> None:
+        # A timestamp with no UTC offset parses to a naive datetime, which would raise
+        # TypeError when compared against the aware `now` in the no-class_5_min fallback.
+        met = OuraMetJSON(interval=60, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00")
+        assert data_247._expand_met_series(met, None) == []
+
     def test_expand_met_series_full_day(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[1.0] * 1440, timestamp="2024-01-15T00:00:00+00:00")
         samples = data_247._expand_met_series(met, None)

--- a/backend/tests/providers/oura/test_oura_247.py
+++ b/backend/tests/providers/oura/test_oura_247.py
@@ -1,6 +1,6 @@
 """Tests for Oura247Data normalization."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
@@ -303,6 +303,7 @@ class TestOura247ActivityNormalization:
                     "items": [1.0, 1.2, None, 1.5],
                     "timestamp": "2024-01-15T00:00:00+00:00",
                 },
+                "class_5_min": "2",
             },
         ]
         samples, _ = data_247.normalize_activity_samples(raw, user_id)
@@ -328,7 +329,7 @@ class TestOura247MetSeriesExpansion:
 
     def test_expand_met_series_basic(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[1.0, 1.1, 1.2], timestamp="2024-01-15T00:00:00+00:00")
-        samples = data_247._expand_met_series(met, None)
+        samples = data_247._expand_met_series(met, "2")
 
         assert [s["value"] for s in samples] == [1.0, 1.1, 1.2]
         assert samples[0]["recorded_at"] == datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc)
@@ -337,74 +338,72 @@ class TestOura247MetSeriesExpansion:
 
     def test_expand_met_series_skips_null_items(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[1.0, None, 1.2], timestamp="2024-01-15T00:00:00+00:00")
-        samples = data_247._expand_met_series(met, None)
+        samples = data_247._expand_met_series(met, "2")
 
         # A null (unworn/unmeasured) sample must be dropped, never coerced to 0.0.
         assert [s["value"] for s in samples] == [1.0, 1.2]
 
+    def test_expand_met_series_skips_not_worn_sentinel(self, data_247: Oura247Data) -> None:
+        met = OuraMetJSON(interval=60, items=[1.0, 0.1, 1.2], timestamp="2024-01-15T00:00:00+00:00")
+        samples = data_247._expand_met_series(met, "2")
+
+        assert [s["value"] for s in samples] == [1.0, 1.2]
+
     def test_expand_met_series_all_null(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[None, None], timestamp="2024-01-15T00:00:00+00:00")
-        assert data_247._expand_met_series(met, None) == []
+        assert data_247._expand_met_series(met, "2") == []
 
     def test_expand_met_series_missing_met(self, data_247: Oura247Data) -> None:
-        assert data_247._expand_met_series(None, None) == []
+        assert data_247._expand_met_series(None, "2") == []
 
     def test_expand_met_series_empty_items(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[], timestamp="2024-01-15T00:00:00+00:00")
-        assert data_247._expand_met_series(met, None) == []
+        assert data_247._expand_met_series(met, "2") == []
 
     def test_expand_met_series_missing_interval_is_dropped(self, data_247: Oura247Data) -> None:
         # Oura's schema documents `interval` as a plain float, not a fixed 60s cadence —
         # a missing value must not be guessed.
         met = OuraMetJSON(interval=None, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
-        assert data_247._expand_met_series(met, None) == []
+        assert data_247._expand_met_series(met, "2") == []
 
     def test_expand_met_series_zero_interval_is_dropped(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=0, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
-        assert data_247._expand_met_series(met, None) == []
+        assert data_247._expand_met_series(met, "2") == []
 
     def test_expand_met_series_negative_interval_is_dropped(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=-60, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
-        assert data_247._expand_met_series(met, None) == []
-
-    def test_expand_met_series_non_finite_interval_is_dropped(self, data_247: Oura247Data) -> None:
-        # interval is a plain float per Oura's schema — inf/nan must not reach timedelta math.
-        for bad_interval in (float("inf"), float("nan")):
-            met = OuraMetJSON(interval=bad_interval, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
-            assert data_247._expand_met_series(met, None) == []
+        assert data_247._expand_met_series(met, "2") == []
 
     def test_expand_met_series_unrepresentable_interval_returns_empty(self, data_247: Oura247Data) -> None:
         # A finite but huge interval overflows `timedelta` once multiplied by the item
         # index, instead of raising and failing the whole activity import.
         met = OuraMetJSON(interval=1e20, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
-        assert data_247._expand_met_series(met, None) == []
+        assert data_247._expand_met_series(met, "2") == []
 
     def test_expand_met_series_unparseable_timestamp_is_dropped(self, data_247: Oura247Data) -> None:
         # No fallback to the daily activity's own timestamp — it can anchor the whole
         # series to the wrong point in the day (mirrors the sleep HR/HRV interval handling).
         met = OuraMetJSON(interval=60, items=[1.0], timestamp="not-a-timestamp")
-        assert data_247._expand_met_series(met, None) == []
+        assert data_247._expand_met_series(met, "2") == []
 
     def test_expand_met_series_missing_timestamp_is_dropped(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[1.0], timestamp=None)
-        assert data_247._expand_met_series(met, None) == []
+        assert data_247._expand_met_series(met, "2") == []
 
     def test_expand_met_series_offset_less_timestamp_is_dropped(self, data_247: Oura247Data) -> None:
-        # A timestamp with no UTC offset parses to a naive datetime, which would raise
-        # TypeError when compared against the aware `now` in the no-class_5_min fallback.
         met = OuraMetJSON(interval=60, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00")
-        assert data_247._expand_met_series(met, None) == []
+        assert data_247._expand_met_series(met, "2") == []
 
     def test_expand_met_series_full_day(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[1.0] * 1440, timestamp="2024-01-15T00:00:00+00:00")
-        samples = data_247._expand_met_series(met, None)
+        samples = data_247._expand_met_series(met, "2" * 288)
 
         assert len(samples) == 1440
         assert samples[-1]["recorded_at"] == datetime(2024, 1, 15, 23, 59, 0, tzinfo=timezone.utc)
 
     def test_expand_met_series_carries_zone_offset(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[1.0], timestamp="2024-01-15T00:00:00+02:00")
-        samples = data_247._expand_met_series(met, None)
+        samples = data_247._expand_met_series(met, "2")
 
         assert samples[0]["zone_offset"] == "+02:00"
 
@@ -415,9 +414,6 @@ class TestOura247MetSeriesExpansion:
 
     def test_expand_met_series_drops_unmeasured_tail_using_class_5_min_length(self, data_247: Oura247Data) -> None:
         # Reproduces real Oura behavior: `met.items` is pre-allocated for the full
-        # 1440-minute day and the not-yet-elapsed tail is padded with 0.9 (a value
-        # that is also a genuine reading elsewhere), not null. `class_5_min` only
-        # covers minutes actually measured so far — its length is the real boundary.
         items = [1.2] * 10 + [0.9] * 1430
         class_5_min = "22"  # only the first 10 minutes (2 * 5 min) have been measured
         met = OuraMetJSON(interval=60, items=items, timestamp="2024-01-15T04:00:00+00:00")
@@ -428,21 +424,18 @@ class TestOura247MetSeriesExpansion:
         assert all(s["value"] == 1.2 for s in samples)
 
     def test_expand_met_series_keeps_genuine_low_value_within_measured_window(self, data_247: Oura247Data) -> None:
-        # 0.9 within the already-measured window is a real reading and must be kept —
-        # only class_5_min length/classification decides validity, never the value.
         items = [0.9] * 5
-        class_5_min = "1"  # measured, classified as "rest"
         met = OuraMetJSON(interval=60, items=items, timestamp="2024-01-15T04:00:00+00:00")
 
-        samples = data_247._expand_met_series(met, class_5_min)
+        samples = data_247._expand_met_series(met, "1")
 
         assert [s["value"] for s in samples] == [0.9] * 5
 
-    def test_expand_met_series_drops_non_wear_bucket(self, data_247: Oura247Data) -> None:
-        # A '0' (non-wear) bucket means the ring wasn't recording, even mid-day —
-        # its minutes must be dropped regardless of whatever value items holds there.
+    def test_expand_met_series_drops_not_worn_values_regardless_of_class_5_min_content(
+        self, data_247: Oura247Data
+    ) -> None:
         items = [1.2, 1.2, 1.2, 1.2, 1.2, 0.1, 0.1, 0.1, 0.1, 0.1]
-        class_5_min = "20"  # minutes 0-4 = inactive, minutes 5-9 = non-wear
+        class_5_min = "22"
         met = OuraMetJSON(interval=60, items=items, timestamp="2024-01-15T04:00:00+00:00")
 
         samples = data_247._expand_met_series(met, class_5_min)
@@ -450,10 +443,7 @@ class TestOura247MetSeriesExpansion:
         assert len(samples) == 5
         assert all(s["value"] == 1.2 for s in samples)
 
-    def test_expand_met_series_without_class_5_min_falls_back_to_future_cutoff(self, data_247: Oura247Data) -> None:
-        # No class_5_min available (e.g. older payload shape) — fall back to dropping
-        # samples timestamped in the future, since those can never be real readings.
-        far_future_start = datetime.now(timezone.utc) + timedelta(days=1)
-        met = OuraMetJSON(interval=60, items=[1.0, 1.1], timestamp=far_future_start.isoformat())
+    def test_expand_met_series_without_class_5_min_is_dropped(self, data_247: Oura247Data) -> None:
+        met = OuraMetJSON(interval=60, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
 
         assert data_247._expand_met_series(met, None) == []

--- a/backend/tests/providers/oura/test_oura_247.py
+++ b/backend/tests/providers/oura/test_oura_247.py
@@ -1,13 +1,14 @@
 """Tests for Oura247Data normalization."""
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import pytest
 
 from app.constants.sleep import SleepStageType
+from app.schemas.enums import SeriesType
 from app.schemas.providers.oura.imports import OuraMetJSON
-from app.services.providers.oura.coverage import INTRADAY_ACTIVITY_KEYS
+from app.services.providers.oura.coverage import ACTIVITY_SERIES
 from app.services.providers.oura.data_247 import Oura247Data
 from app.services.providers.oura.strategy import OuraStrategy
 
@@ -327,7 +328,7 @@ class TestOura247MetSeriesExpansion:
 
     def test_expand_met_series_basic(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[1.0, 1.1, 1.2], timestamp="2024-01-15T00:00:00+00:00")
-        samples = data_247._expand_met_series(met)
+        samples = data_247._expand_met_series(met, None)
 
         assert [s["value"] for s in samples] == [1.0, 1.1, 1.2]
         assert samples[0]["recorded_at"] == datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc)
@@ -336,58 +337,105 @@ class TestOura247MetSeriesExpansion:
 
     def test_expand_met_series_skips_null_items(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[1.0, None, 1.2], timestamp="2024-01-15T00:00:00+00:00")
-        samples = data_247._expand_met_series(met)
+        samples = data_247._expand_met_series(met, None)
 
         # A null (unworn/unmeasured) sample must be dropped, never coerced to 0.0.
         assert [s["value"] for s in samples] == [1.0, 1.2]
 
     def test_expand_met_series_all_null(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[None, None], timestamp="2024-01-15T00:00:00+00:00")
-        assert data_247._expand_met_series(met) == []
+        assert data_247._expand_met_series(met, None) == []
 
     def test_expand_met_series_missing_met(self, data_247: Oura247Data) -> None:
-        assert data_247._expand_met_series(None) == []
+        assert data_247._expand_met_series(None, None) == []
 
     def test_expand_met_series_empty_items(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[], timestamp="2024-01-15T00:00:00+00:00")
-        assert data_247._expand_met_series(met) == []
+        assert data_247._expand_met_series(met, None) == []
 
     def test_expand_met_series_missing_interval_is_dropped(self, data_247: Oura247Data) -> None:
         # Oura's schema documents `interval` as a plain float, not a fixed 60s cadence —
         # a missing value must not be guessed.
         met = OuraMetJSON(interval=None, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
-        assert data_247._expand_met_series(met) == []
+        assert data_247._expand_met_series(met, None) == []
 
     def test_expand_met_series_zero_interval_is_dropped(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=0, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
-        assert data_247._expand_met_series(met) == []
+        assert data_247._expand_met_series(met, None) == []
 
     def test_expand_met_series_negative_interval_is_dropped(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=-60, items=[1.0, 1.1], timestamp="2024-01-15T00:00:00+00:00")
-        assert data_247._expand_met_series(met) == []
+        assert data_247._expand_met_series(met, None) == []
 
     def test_expand_met_series_unparseable_timestamp_is_dropped(self, data_247: Oura247Data) -> None:
         # No fallback to the daily activity's own timestamp — it can anchor the whole
         # series to the wrong point in the day (mirrors the sleep HR/HRV interval handling).
         met = OuraMetJSON(interval=60, items=[1.0], timestamp="not-a-timestamp")
-        assert data_247._expand_met_series(met) == []
+        assert data_247._expand_met_series(met, None) == []
 
     def test_expand_met_series_missing_timestamp_is_dropped(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[1.0], timestamp=None)
-        assert data_247._expand_met_series(met) == []
+        assert data_247._expand_met_series(met, None) == []
 
     def test_expand_met_series_full_day(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[1.0] * 1440, timestamp="2024-01-15T00:00:00+00:00")
-        samples = data_247._expand_met_series(met)
+        samples = data_247._expand_met_series(met, None)
 
         assert len(samples) == 1440
         assert samples[-1]["recorded_at"] == datetime(2024, 1, 15, 23, 59, 0, tzinfo=timezone.utc)
 
     def test_expand_met_series_carries_zone_offset(self, data_247: Oura247Data) -> None:
         met = OuraMetJSON(interval=60, items=[1.0], timestamp="2024-01-15T00:00:00+02:00")
-        samples = data_247._expand_met_series(met)
+        samples = data_247._expand_met_series(met, None)
 
         assert samples[0]["zone_offset"] == "+02:00"
 
-    def test_met_is_flagged_as_intraday(self) -> None:
-        assert "met" in INTRADAY_ACTIVITY_KEYS
+    def test_met_maps_to_physical_effort(self) -> None:
+        # average_met means one scalar per workout everywhere else (Apple/Google/Samsung);
+        # Oura's series is continuous per-minute data, so it must not share that series type.
+        assert ACTIVITY_SERIES["met"] == SeriesType.physical_effort
+
+    def test_expand_met_series_drops_unmeasured_tail_using_class_5_min_length(self, data_247: Oura247Data) -> None:
+        # Reproduces real Oura behavior: `met.items` is pre-allocated for the full
+        # 1440-minute day and the not-yet-elapsed tail is padded with 0.9 (a value
+        # that is also a genuine reading elsewhere), not null. `class_5_min` only
+        # covers minutes actually measured so far — its length is the real boundary.
+        items = [1.2] * 10 + [0.9] * 1430
+        class_5_min = "22"  # only the first 10 minutes (2 * 5 min) have been measured
+        met = OuraMetJSON(interval=60, items=items, timestamp="2024-01-15T04:00:00+00:00")
+
+        samples = data_247._expand_met_series(met, class_5_min)
+
+        assert len(samples) == 10
+        assert all(s["value"] == 1.2 for s in samples)
+
+    def test_expand_met_series_keeps_genuine_low_value_within_measured_window(self, data_247: Oura247Data) -> None:
+        # 0.9 within the already-measured window is a real reading and must be kept —
+        # only class_5_min length/classification decides validity, never the value.
+        items = [0.9] * 5
+        class_5_min = "1"  # measured, classified as "rest"
+        met = OuraMetJSON(interval=60, items=items, timestamp="2024-01-15T04:00:00+00:00")
+
+        samples = data_247._expand_met_series(met, class_5_min)
+
+        assert [s["value"] for s in samples] == [0.9] * 5
+
+    def test_expand_met_series_drops_non_wear_bucket(self, data_247: Oura247Data) -> None:
+        # A '0' (non-wear) bucket means the ring wasn't recording, even mid-day —
+        # its minutes must be dropped regardless of whatever value items holds there.
+        items = [1.2, 1.2, 1.2, 1.2, 1.2, 0.1, 0.1, 0.1, 0.1, 0.1]
+        class_5_min = "20"  # minutes 0-4 = inactive, minutes 5-9 = non-wear
+        met = OuraMetJSON(interval=60, items=items, timestamp="2024-01-15T04:00:00+00:00")
+
+        samples = data_247._expand_met_series(met, class_5_min)
+
+        assert len(samples) == 5
+        assert all(s["value"] == 1.2 for s in samples)
+
+    def test_expand_met_series_without_class_5_min_falls_back_to_future_cutoff(self, data_247: Oura247Data) -> None:
+        # No class_5_min available (e.g. older payload shape) — fall back to dropping
+        # samples timestamped in the future, since those can never be real readings.
+        far_future_start = datetime.now(timezone.utc) + timedelta(days=1)
+        met = OuraMetJSON(interval=60, items=[1.0, 1.1], timestamp=far_future_start.isoformat())
+
+        assert data_247._expand_met_series(met, None) == []

--- a/docs/providers/coverage.mdx
+++ b/docs/providers/coverage.mdx
@@ -105,7 +105,7 @@ This guide gives an overview of data type support across the integrated wearable
 | Metric | Unit | Apple | Fitbit | Garmin | Google | Oura | Polar | Samsung | Sensorbio | Strava | Suunto | Ultrahuman | Whoop |
 |------|------|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|
 | `active_time` | minutes | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| `average_met` | met | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `average_met` | met | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `basal_energy` | kcal | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `energy` | kcal | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
 | `exercise_time` | minutes | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |

--- a/docs/providers/coverage.mdx
+++ b/docs/providers/coverage.mdx
@@ -105,12 +105,12 @@ This guide gives an overview of data type support across the integrated wearable
 | Metric | Unit | Apple | Fitbit | Garmin | Google | Oura | Polar | Samsung | Sensorbio | Strava | Suunto | Ultrahuman | Whoop |
 |------|------|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|:----:|
 | `active_time` | minutes | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
-| `average_met` | met | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `average_met` | met | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `basal_energy` | kcal | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `energy` | kcal | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
 | `exercise_time` | minutes | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `flights_climbed` | count | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `physical_effort` | score | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `physical_effort` | score | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `stand_time` | minutes | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `steps` | count | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
 


### PR DESCRIPTION
## Description

We are including intraday data provided by `oura`.

raw payload looks like this
```
"met": {"interval": 60.0, "items": [0.9, 0.9, 0.9, ... (a lot of floats)], "timestamp": "2024-01-15T04:00:00.000+02:00"}
```

we parse it and make it look like this
```
[
    {"recorded_at": datetime(2024, 1, 15, 4, 0, tzinfo=utc), "value": 1.2, "zone_offset": "+00:00"},
    {"recorded_at": datetime(2024, 1, 15, 4, 1, tzinfo=utc), "value": 1.2, "zone_offset": "+00:00"},
    {"recorded_at": datetime(2024, 1, 15, 4, 2, tzinfo=utc), "value": 1.3, "zone_offset": "+00:00"},
    {"recorded_at": datetime(2024, 1, 15, 4, 4, tzinfo=utc), "value": 0.9, "zone_offset": "+00:00"},
    {"recorded_at": datetime(2024, 1, 15, 4, 5, tzinfo=utc), "value": 5.4, "zone_offset": "+00:00"},
]
```

Parsing convention is mirrored from sleep HR/HRV, but I'm afraid that our new `met` field is being provided much to often - every 60 seconds. Not fully sure this is the right tradeoff and would like reviewer input, because it is much denser than the densest existing Oura series which is mentioned before, which is sleep HR/HRV provided every 5 minutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Oura activity imports now include MET data when available.
  - Intraday MET readings are converted into timestamped physical-effort samples, including timezone support and full-day series handling.

- **Bug Fixes**
  - Improved filtering of padded, non-wear, invalid, and future-dated MET samples.
  - Missing or null MET data is handled without generating incorrect readings.
  - Unusable or excessively large intervals no longer cause import failures.

- **Documentation**
  - Updated coverage information to identify Oura support for physical-effort data instead of average MET data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->