### PR TITLE
feat(sdk): track whole-sync completion manifests

### DIFF
--- a/backend/app/api/routes/v1/sdk_sync.py
+++ b/backend/app/api/routes/v1/sdk_sync.py
@@ -1,14 +1,17 @@
 import json
 import uuid
 from logging import getLogger
+from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Header, HTTPException, status
 
 from app.config import settings
+from app.database import DbSession
 from app.integrations.celery.tasks.process_sdk_upload_task import process_sdk_upload
 from app.schemas.providers.mobile_sdk import SyncRequest
 from app.schemas.responses.upload import UploadDataResponse
 from app.services.raw_payload_storage import put_payload_to_s3, store_raw_payload
+from app.services.sdk_sync_run_service import sdk_sync_run_service
 from app.utils.api_utils import inline_schema_defs
 from app.utils.auth import SDKAuthDep
 from app.utils.sentry_helpers import log_and_capture_error
@@ -33,6 +36,11 @@ def sync_sdk_data(
     user_id: str,
     body: dict,
     auth: SDKAuthDep,
+    db: DbSession,
+    client_sync_id: Annotated[str | None, Header(alias="X-OW-Client-Sync-ID")] = None,
+    client_sync_chunk_index: Annotated[int | None, Header(alias="X-OW-Client-Sync-Chunk-Index")] = None,
+    client_sync_final: Annotated[bool | None, Header(alias="X-OW-Client-Sync-Final")] = None,
+    client_sync_total_items: Annotated[int | None, Header(alias="X-OW-Client-Sync-Total-Items")] = None,
 ) -> UploadDataResponse:
     """Import health data from SDK provider asynchronously via Celery.
 
@@ -79,7 +87,25 @@ def sync_sdk_data(
             detail=f"Unsupported provider: {provider}. Supported: apple, samsung, google",
         )
 
-    # Generate unique batch ID for tracking
+    manifest_header_present = any(
+        value is not None
+        for value in (
+            client_sync_id,
+            client_sync_chunk_index,
+            client_sync_final,
+            client_sync_total_items,
+        )
+    )
+    if manifest_header_present and (
+        client_sync_id is None or client_sync_chunk_index is None or client_sync_final is None
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Whole-sync uploads require sync id, chunk index, and final headers",
+        )
+
+    # Generate unique batch ID for tracking. Whole-sync retries recover the
+    # original batch ID from the durable manifest row below.
     batch_id = str(uuid.uuid4())
 
     # Extract and count data types from payload (best-effort; structure not yet validated)
@@ -91,6 +117,32 @@ def sync_sdk_data(
     records_count = len(records) if isinstance(records, list) else 0
     workouts_count = len(workouts) if isinstance(workouts, list) else 0
     sleep_count = len(sleep) if isinstance(sleep, list) else 0
+    total_items = records_count + workouts_count + sleep_count
+    content_str = json.dumps(body)
+
+    duplicate_processed = False
+    if client_sync_id is not None and client_sync_chunk_index is not None and client_sync_final is not None:
+        try:
+            accepted = sdk_sync_run_service.accept_chunk(
+                db,
+                user_id=user_id,
+                provider=provider,
+                client_sync_id=client_sync_id,
+                chunk_index=client_sync_chunk_index,
+                is_final=client_sync_final,
+                declared_total_items=client_sync_total_items,
+                item_count=total_items,
+                sleep_item_count=sleep_count,
+                payload=content_str.encode(),
+                batch_id=batch_id,
+            )
+        except (ValueError, TypeError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=str(exc),
+            ) from exc
+        batch_id = accepted.batch_id
+        duplicate_processed = accepted.duplicate and accepted.status == "processed"
 
     # Log initial batch receipt with counts
     log_structured(
@@ -104,10 +156,19 @@ def sync_sdk_data(
         records_count=records_count,
         workouts_count=workouts_count,
         sleep_count=sleep_count,
-        total_items=records_count + workouts_count + sleep_count,
+        total_items=total_items,
+        client_sync_id=client_sync_id,
+        client_sync_chunk_index=client_sync_chunk_index,
+        client_sync_final=client_sync_final,
+        client_sync_duplicate=duplicate_processed,
     )
 
-    content_str = json.dumps(body)
+    if duplicate_processed:
+        return UploadDataResponse(
+            status_code=202,
+            response="Import task was already processed",
+            user_id=user_id,
+        )
 
     offload = settings.sdk_payload_s3_offload
     payload_ref: str | None = None
@@ -150,6 +211,10 @@ def sync_sdk_data(
         provider=provider,
         batch_id=batch_id,
         payload_ref=payload_ref,
+        client_sync_id=client_sync_id,
+        client_sync_chunk_index=client_sync_chunk_index,
+        client_sync_final=client_sync_final,
+        client_sync_total_items=client_sync_total_items,
     )
 
     return UploadDataResponse(status_code=202, response="Import task queued successfully", user_id=user_id)

--- a/backend/app/api/routes/v1/sdk_token.py
+++ b/backend/app/api/routes/v1/sdk_token.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Body, HTTPException, status
 from app.config import settings
 from app.database import DbSession
 from app.schemas.auth import SDKTokenRequest, TokenResponse
-from app.services import application_service, create_sdk_user_token, refresh_token_service
+from app.services import application_service, create_sdk_user_token, refresh_token_service, user_service
 from app.utils.auth import DeveloperOptionalDep
 
 router = APIRouter()
@@ -61,6 +61,11 @@ def create_user_token(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Either app credentials (app_id, app_secret) or admin authentication (Bearer token) is required",
         )
+
+    # Validate the target before minting or persisting any token. Besides
+    # returning the documented 404, this prevents a missing user from leaking
+    # through as a refresh-token foreign-key 500.
+    user_service.get(db, user_id, raise_404=True)
 
     # Generate user-scoped SDK token
     access_token = create_sdk_user_token(

--- a/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
+++ b/backend/app/integrations/celery/tasks/process_sdk_upload_task.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from logging import getLogger
 from typing import Any
@@ -16,12 +17,26 @@ from app.services.apple.healthkit.import_service import (
 from app.services.apple.healthkit.import_service import (
     import_service as sdk_import_service,
 )
+from app.services.apple.healthkit.sleep_service import finalize_pending_sleep
 from app.services.raw_payload_storage import delete_payload_from_s3, get_payload_from_s3
+from app.services.sdk_ingestion_context import sdk_ingestion_context
+from app.services.sdk_sync_run_service import sdk_sync_run_service
 from app.services.sync_status_service import completed, failed, started
 from app.services.user_connection_service import user_connection_service
 from app.utils.structured_logging import log_structured
 
 logger = getLogger(__name__)
+
+
+def _submitted_item_count(content: str) -> int:
+    try:
+        body = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        return 0
+    data = body.get("data") if isinstance(body, dict) else None
+    if not isinstance(data, dict):
+        return 0
+    return sum(len(value) for key in ("records", "workouts", "sleep") if isinstance((value := data.get(key)), list))
 
 
 def _get_import_service(provider: str) -> SDKImportService:
@@ -30,7 +45,14 @@ def _get_import_service(provider: str) -> SDKImportService:
     raise ValueError(f"Unsupported provider: {provider}")
 
 
-@shared_task(queue="sdk_sync")
+@shared_task(
+    queue="sdk_sync",
+    autoretry_for=(Exception,),
+    retry_backoff=True,
+    retry_backoff_max=60,
+    retry_jitter=True,
+    max_retries=8,
+)
 def process_sdk_upload(
     content: str | None,
     content_type: str,
@@ -38,6 +60,10 @@ def process_sdk_upload(
     provider: str,
     batch_id: str | None = None,
     payload_ref: str | None = None,
+    client_sync_id: str | None = None,
+    client_sync_chunk_index: int | None = None,
+    client_sync_final: bool | None = None,
+    client_sync_total_items: int | None = None,
 ) -> dict[str, Any]:
     """
     Process SDK data import asynchronously.
@@ -131,14 +157,39 @@ def process_sdk_upload(
         provider=provider,
     )
 
-    started(
-        user_uuid,
-        provider,
-        SyncSource.SDK,
-        run_id=batch_id,
-        message=f"Processing {provider} SDK batch",
-        metadata={"batch_id": batch_id},
-    )
+    sdk_manifest = None
+    if client_sync_id is not None:
+        sdk_manifest = {
+            "client_sync_id": client_sync_id,
+            "batch_id": batch_id,
+            "chunk_index": client_sync_chunk_index,
+            "is_final": client_sync_final,
+            "declared_total_items": client_sync_total_items,
+        }
+        with SessionLocal() as db:
+            run, should_emit_started = sdk_sync_run_service.mark_started(db, batch_id=batch_id)
+        if should_emit_started:
+            started(
+                user_uuid,
+                provider,
+                SyncSource.SDK,
+                run_id=client_sync_id,
+                message=f"Processing {provider} SDK sync",
+                metadata={
+                    "client_sync_id": client_sync_id,
+                    "received_chunks": run.received_chunks,
+                    "received_items": run.received_items,
+                },
+            )
+    else:
+        started(
+            user_uuid,
+            provider,
+            SyncSource.SDK,
+            run_id=batch_id,
+            message=f"Processing {provider} SDK batch",
+            metadata={"batch_id": batch_id},
+        )
 
     with SessionLocal() as db:
         # Ensure SDK connection exists for this user (SDK-based, no OAuth tokens).
@@ -148,9 +199,10 @@ def process_sdk_upload(
         # Select the appropriate import service based on source
         import_service = _get_import_service(provider)
 
-        result = import_service.import_data_from_request(
-            db, content, content_type, user_id, batch_id=batch_id
-        ).model_dump()
+        with sdk_ingestion_context(sdk_manifest):
+            result = import_service.import_data_from_request(
+                db, content, content_type, user_id, batch_id=batch_id
+            ).model_dump()
 
         # Log processing completion with results
         log_structured(
@@ -178,44 +230,132 @@ def process_sdk_upload(
         dropped_count = int(result.get("dropped_count", 0) or 0)
         types = result.get("types") or []
         items_total = records_saved + workouts_saved + sleep_saved
+        submitted_items = _submitted_item_count(content)
 
         if isinstance(status_code, int) and 200 <= status_code < 300:
             # Same wording as webhook_push_task; records_saved counts samples submitted.
             message = f"{provider.capitalize()} batch saved: {records_inserted} new, {records_updated} updated"
             if dropped_count:
                 message += f" ({dropped_count} record(s) dropped by validation)"
-            completed(
-                user_uuid,
-                provider,
-                SyncSource.SDK,
-                run_id=batch_id,
-                status=SyncStatus.SUCCESS,
-                message=message,
-                items_processed=items_total,
-                metadata={
-                    "batch_id": batch_id,
-                    "records_saved": records_saved,
-                    "inserted": records_inserted,
-                    "updated": records_updated,
-                    "workouts_saved": workouts_saved,
-                    "sleep_saved": sleep_saved,
-                    "types": types,
-                    "dropped_count": dropped_count,
-                },
-            )
+            if client_sync_id is not None:
+                with SessionLocal() as manifest_db:
+                    run, is_terminal, count_mismatch = sdk_sync_run_service.mark_processed(
+                        manifest_db,
+                        batch_id=batch_id,
+                        processed_items=max(0, submitted_items - dropped_count),
+                    )
+                if is_terminal and count_mismatch:
+                    failed(
+                        user_uuid,
+                        provider,
+                        SyncSource.SDK,
+                        run_id=client_sync_id,
+                        error="whole-sync item count mismatch",
+                        message=f"{provider.capitalize()} SDK sync count mismatch",
+                        metadata={
+                            "client_sync_id": client_sync_id,
+                            "expected_chunks": run.expected_chunks,
+                            "received_chunks": run.received_chunks,
+                            "processed_chunks": run.processed_chunks,
+                            "declared_total_items": run.declared_total_items,
+                            "received_items": run.received_items,
+                            "processed_items": run.processed_items,
+                        },
+                    )
+                elif is_terminal:
+                    try:
+                        if provider == "apple" and run.received_sleep_items > 0:
+                            with sdk_ingestion_context(sdk_manifest):
+                                finalize_pending_sleep(db, user_id)
+                    except Exception as exc:
+                        with SessionLocal() as manifest_db:
+                            run, should_emit_failed = sdk_sync_run_service.mark_failed(
+                                manifest_db,
+                                batch_id=batch_id,
+                            )
+                        if should_emit_failed:
+                            failed(
+                                user_uuid,
+                                provider,
+                                SyncSource.SDK,
+                                run_id=client_sync_id,
+                                error=str(exc),
+                                message=f"{provider.capitalize()} SDK sleep finalization failed",
+                                metadata={
+                                    "client_sync_id": client_sync_id,
+                                    "received_sleep_items": run.received_sleep_items,
+                                },
+                            )
+                    else:
+                        completed(
+                            user_uuid,
+                            provider,
+                            SyncSource.SDK,
+                            run_id=client_sync_id,
+                            status=SyncStatus.SUCCESS,
+                            message=f"{provider.capitalize()} whole SDK sync completed",
+                            items_processed=run.processed_items,
+                            metadata={
+                                "client_sync_id": client_sync_id,
+                                "expected_chunks": run.expected_chunks,
+                                "received_chunks": run.received_chunks,
+                                "processed_chunks": run.processed_chunks,
+                                "declared_total_items": run.declared_total_items,
+                                "received_items": run.received_items,
+                                "processed_items": run.processed_items,
+                                "received_sleep_items": run.received_sleep_items,
+                            },
+                        )
+            else:
+                completed(
+                    user_uuid,
+                    provider,
+                    SyncSource.SDK,
+                    run_id=batch_id,
+                    status=SyncStatus.SUCCESS,
+                    message=message,
+                    items_processed=items_total,
+                    metadata={
+                        "batch_id": batch_id,
+                        "records_saved": records_saved,
+                        "inserted": records_inserted,
+                        "updated": records_updated,
+                        "workouts_saved": workouts_saved,
+                        "sleep_saved": sleep_saved,
+                        "types": types,
+                        "dropped_count": dropped_count,
+                    },
+                )
             if payload_ref and settings.raw_payload_storage == "disabled":
                 # Transport-only copy and the data is committed, so drop it. A failed batch
                 # keeps its payload for diagnosis.
                 delete_payload_from_s3(payload_ref)
         else:
-            failed(
-                user_uuid,
-                provider,
-                SyncSource.SDK,
-                run_id=batch_id,
-                error=str(result.get("response", "Unknown error")),
-                message=f"{provider.capitalize()} batch failed",
-                metadata={"batch_id": batch_id, "status_code": status_code},
-            )
+            terminal_run_id = batch_id
+            should_emit_failed = True
+            failure_metadata = {"batch_id": batch_id, "status_code": status_code}
+            if client_sync_id is not None:
+                terminal_run_id = client_sync_id
+                with SessionLocal() as manifest_db:
+                    run, should_emit_failed = sdk_sync_run_service.mark_failed(
+                        manifest_db,
+                        batch_id=batch_id,
+                    )
+                failure_metadata = {
+                    **failure_metadata,
+                    "client_sync_id": client_sync_id,
+                    "received_chunks": run.received_chunks,
+                    "processed_chunks": run.processed_chunks,
+                }
+            if should_emit_failed:
+                failed(
+                    user_uuid,
+                    provider,
+                    SyncSource.SDK,
+                    run_id=terminal_run_id,
+                    error=str(result.get("response", "Unknown error")),
+                    message=f"{provider.capitalize()} batch failed",
+                    metadata=failure_metadata,
+                )
 
-        return {**result, "batch_id": batch_id}
+        return {**result, "batch_id": batch_id, "client_sync_id": client_sync_id}

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -15,6 +15,7 @@ from .personal_record import PersonalRecord
 from .provider_priority import ProviderPriority
 from .provider_setting import ProviderSetting
 from .refresh_token import RefreshToken
+from .sdk_sync_run import SDKSyncChunk, SDKSyncRun
 from .series_type_definition import SeriesTypeDefinition
 from .sleep_details import SleepDetails
 from .user import User
@@ -52,6 +53,8 @@ __all__ = [
     "PersonalRecord",
     "DataPointSeries",
     "SeriesTypeDefinition",
+    "SDKSyncChunk",
+    "SDKSyncRun",
     "HealthScore",
     "DetailType",
     "DETAIL_MODELS",

--- a/backend/app/models/sdk_sync_run.py
+++ b/backend/app/models/sdk_sync_run.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import Index, String, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.database import BaseDbModel
+from app.mappings import PrimaryKey, str_32, str_50, str_64
+
+
+class SDKSyncRun(BaseDbModel):
+    """Durable whole-run manifest for a streaming mobile SDK sync."""
+
+    __tablename__ = "sdk_sync_run"
+    __table_args__ = (
+        UniqueConstraint("user_id", "provider", "client_sync_id", name="uq_sdk_sync_run_client"),
+        Index("ix_sdk_sync_run_status_updated", "status", "updated_at"),
+    )
+
+    id: Mapped[PrimaryKey[UUID]]
+    user_id: Mapped[UUID] = mapped_column(index=True)
+    provider: Mapped[str_50]
+    client_sync_id: Mapped[str_64]
+    status: Mapped[str_32]
+    expected_chunks: Mapped[int | None]
+    received_chunks: Mapped[int]
+    processed_chunks: Mapped[int]
+    received_items: Mapped[int]
+    processed_items: Mapped[int]
+    received_sleep_items: Mapped[int]
+    declared_total_items: Mapped[int | None]
+    started_at: Mapped[datetime | None]
+    completed_at: Mapped[datetime | None]
+    updated_at: Mapped[datetime] = mapped_column(server_default=func.now(), onupdate=func.now())
+
+
+class SDKSyncChunk(BaseDbModel):
+    """Idempotency and completion evidence for one SDK upload request."""
+
+    __tablename__ = "sdk_sync_chunk"
+    __table_args__ = (
+        UniqueConstraint("run_id", "chunk_index", name="uq_sdk_sync_chunk_index"),
+        Index("ix_sdk_sync_chunk_run_status", "run_id", "status"),
+    )
+
+    id: Mapped[PrimaryKey[UUID]]
+    run_id: Mapped[UUID] = mapped_column(index=True)
+    batch_id: Mapped[str_64] = mapped_column(unique=True)
+    chunk_index: Mapped[int]
+    payload_sha256: Mapped[str] = mapped_column(String(64))
+    item_count: Mapped[int]
+    processed_items: Mapped[int | None]
+    status: Mapped[str_32]
+    processed_at: Mapped[datetime | None]
+
+
+__all__ = ["SDKSyncChunk", "SDKSyncRun"]

--- a/backend/app/repositories/sdk_sync_run_repository.py
+++ b/backend/app/repositories/sdk_sync_run_repository.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+from sqlalchemy import func
+
+from app.database import DbSession
+from app.models.sdk_sync_run import SDKSyncChunk, SDKSyncRun
+
+
+class SDKSyncRunRepository:
+    """Atomic persistence operations for SDK whole-run manifests."""
+
+    def accept_chunk(
+        self,
+        db: DbSession,
+        *,
+        user_id: UUID,
+        provider: str,
+        client_sync_id: str,
+        chunk_index: int,
+        is_final: bool,
+        declared_total_items: int | None,
+        item_count: int,
+        sleep_item_count: int,
+        payload_sha256: str,
+        batch_id: str,
+    ) -> tuple[SDKSyncRun, SDKSyncChunk, bool]:
+        run = (
+            db.query(SDKSyncRun)
+            .filter(
+                SDKSyncRun.user_id == user_id,
+                SDKSyncRun.provider == provider,
+                SDKSyncRun.client_sync_id == client_sync_id,
+            )
+            .with_for_update()
+            .one_or_none()
+        )
+        if run is None:
+            run = SDKSyncRun(
+                id=uuid4(),
+                user_id=user_id,
+                provider=provider,
+                client_sync_id=client_sync_id,
+                status="accepting",
+                expected_chunks=None,
+                received_chunks=0,
+                processed_chunks=0,
+                received_items=0,
+                processed_items=0,
+                received_sleep_items=0,
+                declared_total_items=None,
+                started_at=None,
+                completed_at=None,
+            )
+            db.add(run)
+            db.flush()
+
+        existing = (
+            db.query(SDKSyncChunk)
+            .filter(
+                SDKSyncChunk.run_id == run.id,
+                SDKSyncChunk.chunk_index == chunk_index,
+            )
+            .one_or_none()
+        )
+        if existing is not None:
+            if existing.payload_sha256 != payload_sha256:
+                raise ValueError("sync chunk index was reused with different content")
+            return run, existing, True
+        if run.status in ("completed", "failed"):
+            raise ValueError(f"sync run is already {run.status}")
+        if run.expected_chunks is not None and chunk_index >= run.expected_chunks:
+            raise ValueError("sync chunk arrived after the final marker")
+        if is_final:
+            expected_chunks = chunk_index + 1
+            prior_after_final = (
+                db.query(func.count(SDKSyncChunk.id))
+                .filter(
+                    SDKSyncChunk.run_id == run.id,
+                    SDKSyncChunk.chunk_index >= expected_chunks,
+                )
+                .scalar()
+                or 0
+            )
+            if prior_after_final:
+                raise ValueError("final marker precedes an already accepted chunk")
+            if run.expected_chunks not in (None, expected_chunks):
+                raise ValueError("conflicting final marker")
+            run.expected_chunks = expected_chunks
+            run.declared_total_items = declared_total_items
+
+        chunk = SDKSyncChunk(
+            id=uuid4(),
+            run_id=run.id,
+            batch_id=batch_id,
+            chunk_index=chunk_index,
+            payload_sha256=payload_sha256,
+            item_count=item_count,
+            processed_items=None,
+            status="accepted",
+            processed_at=None,
+        )
+        db.add(chunk)
+        run.received_chunks += 1
+        run.received_items += item_count
+        run.received_sleep_items += sleep_item_count
+        run.updated_at = datetime.now(timezone.utc)
+        db.commit()
+        db.refresh(run)
+        db.refresh(chunk)
+        return run, chunk, False
+
+    def mark_started(self, db: DbSession, *, batch_id: str) -> tuple[SDKSyncRun, bool]:
+        run = self._run_for_batch(db, batch_id=batch_id, lock=True)
+        should_emit = run.started_at is None
+        if should_emit:
+            now = datetime.now(timezone.utc)
+            run.started_at = now
+            run.updated_at = now
+            db.commit()
+            db.refresh(run)
+        return run, should_emit
+
+    def mark_processed(
+        self,
+        db: DbSession,
+        *,
+        batch_id: str,
+        processed_items: int,
+    ) -> tuple[SDKSyncRun, bool, bool]:
+        chunk = db.query(SDKSyncChunk).filter(SDKSyncChunk.batch_id == batch_id).with_for_update().one()
+        run = db.query(SDKSyncRun).filter(SDKSyncRun.id == chunk.run_id).with_for_update().one()
+        if chunk.status == "processed":
+            return run, False, run.status == "failed"
+
+        now = datetime.now(timezone.utc)
+        chunk.status = "processed"
+        chunk.processed_items = processed_items
+        chunk.processed_at = now
+        run.processed_chunks += 1
+        run.processed_items += processed_items
+        run.updated_at = now
+
+        is_terminal = run.expected_chunks is not None and run.processed_chunks == run.expected_chunks
+        count_mismatch = False
+        if is_terminal:
+            count_mismatch = (
+                run.declared_total_items is None
+                or run.declared_total_items != run.received_items
+                or run.declared_total_items != run.processed_items
+            )
+            run.status = "failed" if count_mismatch else "completed"
+            run.completed_at = now
+        db.commit()
+        db.refresh(run)
+        return run, is_terminal, count_mismatch
+
+    def mark_failed(self, db: DbSession, *, batch_id: str) -> tuple[SDKSyncRun, bool]:
+        run = self._run_for_batch(db, batch_id=batch_id, lock=True)
+        should_emit = run.status != "failed"
+        if should_emit:
+            now = datetime.now(timezone.utc)
+            run.status = "failed"
+            run.completed_at = now
+            run.updated_at = now
+            db.commit()
+            db.refresh(run)
+        return run, should_emit
+
+    @staticmethod
+    def _run_for_batch(db: DbSession, *, batch_id: str, lock: bool) -> SDKSyncRun:
+        query = (
+            db.query(SDKSyncRun)
+            .join(SDKSyncChunk, SDKSyncChunk.run_id == SDKSyncRun.id)
+            .filter(SDKSyncChunk.batch_id == batch_id)
+        )
+        if lock:
+            query = query.with_for_update()
+        return query.one()
+
+
+sdk_sync_run_repository = SDKSyncRunRepository()
+
+__all__ = ["SDKSyncRunRepository", "sdk_sync_run_repository"]

--- a/backend/app/repositories/user_connection_repository.py
+++ b/backend/app/repositories/user_connection_repository.py
@@ -4,6 +4,7 @@ from typing import cast
 from uuid import UUID, uuid4
 
 from sqlalchemy import CursorResult, and_, func, select, tuple_, update
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Query
 from sqlalchemy.orm.exc import MultipleResultsFound
 
@@ -419,19 +420,45 @@ class UserConnectionRepository(CrudRepository[UserConnection, UserConnectionCrea
                 return existing, SdkConnectionOutcome.REACTIVATED
             return existing, SdkConnectionOutcome.EXISTING
 
-        # Create new SDK connection (no tokens needed)
+        # Create the SDK connection with a database-level conflict guard. SDK
+        # chunks are consumed concurrently, so a read-then-insert sequence can
+        # race even though both callers are implementing "ensure" semantics.
+        connection_id = uuid4()
+        now = datetime.now(timezone.utc)
+        created_id = db_session.execute(
+            insert(UserConnection)
+            .values(
+                id=connection_id,
+                user_id=user_id,
+                provider=provider,
+                access_token=None,
+                refresh_token=None,
+                token_expires_at=None,
+                status=ConnectionStatus.ACTIVE,
+                created_at=now,
+                updated_at=now,
+            )
+            .on_conflict_do_nothing(index_elements=[UserConnection.user_id, UserConnection.provider])
+            .returning(UserConnection.id)
+        ).scalar_one_or_none()
+        db_session.commit()
+
+        if created_id is None:
+            connection = self.get_by_user_and_provider(db_session, user_id, provider)
+            if connection is None:
+                raise RuntimeError("SDK connection conflict row is unavailable")
+            return connection, SdkConnectionOutcome.EXISTING
+
         connection = UserConnection(
-            id=uuid4(),
+            id=created_id,
             user_id=user_id,
             provider=provider,
             access_token=None,
             refresh_token=None,
             token_expires_at=None,
             status=ConnectionStatus.ACTIVE,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            created_at=now,
+            updated_at=now,
         )
-        db_session.add(connection)
-        db_session.commit()
-        db_session.refresh(connection)
+        connection = db_session.merge(connection)
         return connection, SdkConnectionOutcome.CREATED

--- a/backend/app/services/apple/healthkit/sleep_service.py
+++ b/backend/app/services/apple/healthkit/sleep_service.py
@@ -82,6 +82,33 @@ def delete_sleep_state(user_id: str) -> None:
     get_redis_client().srem(active_users_key(), user_id)
 
 
+def finalize_pending_sleep(db_session: DbSession, user_id: str) -> None:
+    """Persist a user's pending sleep state before whole-SDK completion.
+
+    The ordinary sleep path waits for a configurable quiet period so adjacent
+    HealthKit stages can be joined. A whole-SDK final marker is stronger evidence:
+    all chunks from this phone run have already been imported, so leaving its
+    pending state in Redis would make ``sync.completed`` claim data that is not yet
+    queryable. The same per-user lock prevents racing another chunk.
+    """
+    redis_client = get_redis_client()
+    lock = redis_client.lock(f"sleep:lock:{user_id}", timeout=30, blocking_timeout=15)
+
+    try:
+        if not lock.acquire():
+            raise TimeoutError(f"Could not acquire sleep finalization lock for user {user_id}")
+
+        state = load_sleep_state(user_id)
+        if state is None:
+            return
+        finish_sleep(db_session, user_id, state)
+        if load_sleep_state(user_id) is not None:
+            raise RuntimeError(f"Sleep state remained pending after finalization for user {user_id}")
+    finally:
+        with contextlib.suppress(Exception):
+            lock.release()
+
+
 def _create_new_sleep_state(
     start_time: datetime,
     end_time: datetime,

--- a/backend/app/services/outgoing_webhooks/events.py
+++ b/backend/app/services/outgoing_webhooks/events.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 
 import logging
 import re
+from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID
 
 from app.constants.webhooks.events import SERIES_TYPE_TO_GRANULAR_EVENT, SERIES_TYPE_TO_GROUP_EVENT
 from app.schemas.webhooks.event_types import WebhookEventType
 from app.services.outgoing_webhooks import svix as svix_service
+from app.services.sdk_ingestion_context import current_sdk_ingestion_manifest
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +37,16 @@ def _safe_key(raw: str) -> str:
     return _SVIX_ID_SAFE.sub("_", raw)
 
 
+def _sync_manifest_fields(manifest: dict[str, Any] | None = None) -> dict[str, Any]:
+    manifest = manifest or current_sdk_ingestion_manifest()
+    if not manifest:
+        return {}
+    fields = {key: manifest[key] for key in ("client_sync_id", "batch_id") if manifest.get(key) is not None}
+    if manifest.get("chunk_index") is not None:
+        fields["client_chunk_index"] = manifest["chunk_index"]
+    return fields
+
+
 def _dispatch(
     event_type: str,
     payload: dict[str, Any],
@@ -50,6 +62,7 @@ def _dispatch(
     """
     if not svix_service.is_enabled():
         return
+    payload.setdefault("event_created_at", datetime.now(timezone.utc).isoformat())
     try:
         from app.integrations.celery.tasks.emit_webhook_event_task import emit_webhook_event
 
@@ -95,6 +108,7 @@ def on_workout_created(
                 "max_heart_rate_bpm": max_heart_rate_bpm,
                 "avg_pace_sec_per_km": avg_pace_sec_per_km,
                 "elevation_gain_meters": elevation_gain_meters,
+                **_sync_manifest_fields(),
             },
         },
         idempotency_key=f"workout.created.{record_id}",
@@ -133,6 +147,7 @@ def on_menstrual_cycle_created(
                 "cycle_length": cycle_length,
                 "is_predicted_cycle": is_predicted_cycle,
                 "pregnancy_snapshot": pregnancy_snapshot,
+                **_sync_manifest_fields(),
             },
         },
         idempotency_key=f"menstrual_cycle.created.{record_id}",
@@ -169,6 +184,7 @@ def on_sleep_created(
                 "efficiency_percent": efficiency_percent,
                 "stages": stages,
                 "is_nap": is_nap,
+                **_sync_manifest_fields(),
             },
         },
         idempotency_key=f"sleep.created.{record_id}",
@@ -185,6 +201,7 @@ def on_timeseries_batch_saved(
     start_time: str | None = None,
     end_time: str | None = None,
     samples: list[dict[str, Any]] | None = None,
+    sync_manifest: dict[str, Any] | None = None,
 ) -> None:
     """Emit one webhook event per data-type per ingestion batch.
 
@@ -230,6 +247,7 @@ def on_timeseries_batch_saved(
             "start_time": start_time,
             "end_time": end_time,
             "samples": samples,
+            **_sync_manifest_fields(sync_manifest),
         }
         for event_type in event_types_to_emit:
             _emit(event_type, data, base_key)
@@ -254,6 +272,7 @@ def on_timeseries_batch_saved(
                 "samples": chunk,
                 "chunk_index": chunk_index,
                 "total_chunks": total_chunks,
+                **_sync_manifest_fields(sync_manifest),
             }
             for event_type in event_types_to_emit:
                 _emit(event_type, data, base_key)

--- a/backend/app/services/outgoing_webhooks/svix.py
+++ b/backend/app/services/outgoing_webhooks/svix.py
@@ -210,11 +210,11 @@ def send(
         )
     except httpx.ConnectError:
         logger.warning(
-            "Svix server unreachable — dropping event=%s for app=%s (no retry)",
+            "Svix server unreachable — retrying event=%s for app=%s",
             event_type,
             app_id,
         )
-        return True  # type: ignore[return-value]  # truthy = don't count as failure  # ty:ignore[invalid-return-type]
+        return None
     except HttpError as exc:
         if exc.status_code == 409:
             # Svix deduplication: the same event_id was already delivered.

--- a/backend/app/services/sdk_ingestion_context.py
+++ b/backend/app/services/sdk_ingestion_context.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any
+
+_sdk_manifest: ContextVar[dict[str, Any] | None] = ContextVar("sdk_manifest", default=None)
+
+
+@contextmanager
+def sdk_ingestion_context(manifest: dict[str, Any] | None) -> Iterator[None]:
+    """Expose non-sensitive SDK transport metadata during one import commit."""
+
+    token = _sdk_manifest.set(manifest)
+    try:
+        yield
+    finally:
+        _sdk_manifest.reset(token)
+
+
+def current_sdk_ingestion_manifest() -> dict[str, Any] | None:
+    manifest = _sdk_manifest.get()
+    return dict(manifest) if manifest is not None else None
+
+
+__all__ = ["current_sdk_ingestion_manifest", "sdk_ingestion_context"]

--- a/backend/app/services/sdk_sync_run_service.py
+++ b/backend/app/services/sdk_sync_run_service.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from uuid import UUID
+
+from app.database import DbSession
+from app.models.sdk_sync_run import SDKSyncRun
+from app.repositories.sdk_sync_run_repository import sdk_sync_run_repository
+
+
+@dataclass(frozen=True, slots=True)
+class AcceptedSDKSyncChunk:
+    batch_id: str
+    duplicate: bool
+    status: str
+
+
+class SDKSyncRunService:
+    """Validate and coordinate whole-run completion for streaming SDK uploads."""
+
+    def accept_chunk(
+        self,
+        db: DbSession,
+        *,
+        user_id: str,
+        provider: str,
+        client_sync_id: str,
+        chunk_index: int,
+        is_final: bool,
+        declared_total_items: int | None,
+        item_count: int,
+        sleep_item_count: int,
+        payload: bytes,
+        batch_id: str,
+    ) -> AcceptedSDKSyncChunk:
+        if not client_sync_id or len(client_sync_id) > 64:
+            raise ValueError("client sync id must contain 1-64 characters")
+        if chunk_index < 0:
+            raise ValueError("sync chunk index must be non-negative")
+        if is_final and declared_total_items is None:
+            raise ValueError("final sync marker requires total item count")
+        if declared_total_items is not None and declared_total_items < 0:
+            raise ValueError("total item count must be non-negative")
+        if sleep_item_count < 0 or sleep_item_count > item_count:
+            raise ValueError("sleep item count must be between zero and item count")
+        manifest_envelope = b"\0".join(
+            (
+                str(chunk_index).encode(),
+                str(is_final).encode(),
+                str(declared_total_items).encode(),
+                str(item_count).encode(),
+                payload,
+            )
+        )
+        _, chunk, duplicate = sdk_sync_run_repository.accept_chunk(
+            db,
+            user_id=UUID(user_id),
+            provider=provider,
+            client_sync_id=client_sync_id,
+            chunk_index=chunk_index,
+            is_final=is_final,
+            declared_total_items=declared_total_items,
+            item_count=item_count,
+            sleep_item_count=sleep_item_count,
+            payload_sha256=hashlib.sha256(manifest_envelope).hexdigest(),
+            batch_id=batch_id,
+        )
+        return AcceptedSDKSyncChunk(
+            batch_id=chunk.batch_id,
+            duplicate=duplicate,
+            status=chunk.status,
+        )
+
+    def mark_started(self, db: DbSession, *, batch_id: str) -> tuple[SDKSyncRun, bool]:
+        return sdk_sync_run_repository.mark_started(db, batch_id=batch_id)
+
+    def mark_processed(
+        self,
+        db: DbSession,
+        *,
+        batch_id: str,
+        processed_items: int,
+    ) -> tuple[SDKSyncRun, bool, bool]:
+        return sdk_sync_run_repository.mark_processed(
+            db,
+            batch_id=batch_id,
+            processed_items=processed_items,
+        )
+
+    def mark_failed(self, db: DbSession, *, batch_id: str) -> tuple[SDKSyncRun, bool]:
+        return sdk_sync_run_repository.mark_failed(db, batch_id=batch_id)
+
+
+sdk_sync_run_service = SDKSyncRunService()
+
+__all__ = ["AcceptedSDKSyncChunk", "SDKSyncRunService", "sdk_sync_run_service"]

--- a/backend/app/services/timeseries_service.py
+++ b/backend/app/services/timeseries_service.py
@@ -32,6 +32,7 @@ from app.schemas.utils import (
 )
 from app.services.outgoing_webhooks import svix as svix_service
 from app.services.outgoing_webhooks.events import on_timeseries_batch_saved
+from app.services.sdk_ingestion_context import current_sdk_ingestion_manifest
 from app.services.services import AppService
 from app.utils.exceptions import handle_exceptions
 from app.utils.pagination import encode_cursor
@@ -57,6 +58,7 @@ class TimeSeriesService(
     ) -> WriteCounts:
         counts = self.crud.bulk_create(db_session, samples)  # ty:ignore[invalid-argument-type]
         samples_copy = list(samples)
+        sync_manifest = current_sdk_ingestion_manifest()
 
         @sa_event.listens_for(db_session, "after_commit", once=True)
         def _start_webhook_thread(session: DbSession) -> None:  # noqa: ARG001
@@ -64,7 +66,7 @@ class TimeSeriesService(
                 return
             threading.Thread(
                 target=self._emit_timeseries_webhooks,
-                args=(samples_copy,),
+                args=(samples_copy, sync_manifest),
                 daemon=True,
             ).start()
 
@@ -73,6 +75,7 @@ class TimeSeriesService(
     @staticmethod
     def _emit_timeseries_webhooks(
         samples: list[TimeSeriesSampleCreate] | list[HeartRateSampleCreate] | list[StepSampleCreate],
+        sync_manifest: dict[str, Any] | None = None,
     ) -> None:
         """Emit one webhook event per (user, provider, series_type) batch."""
         if not samples:
@@ -106,6 +109,7 @@ class TimeSeriesService(
                     start_time=sorted_samples[0].recorded_at.isoformat(),
                     end_time=sorted_samples[-1].recorded_at.isoformat(),
                     samples=webhook_samples,
+                    sync_manifest=sync_manifest,
                 )
         except Exception:
             getLogger(__name__).warning("Failed to emit timeseries webhooks", exc_info=True)

--- a/backend/migrations/versions/2026_09_02_1300-a91c3f7e2b10_sdk_sync_manifest.py
+++ b/backend/migrations/versions/2026_09_02_1300-a91c3f7e2b10_sdk_sync_manifest.py
@@ -1,0 +1,64 @@
+"""Add durable whole-run manifests for streaming SDK uploads.
+
+Revision ID: a91c3f7e2b10
+Revises: dc5ac28c4b94
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a91c3f7e2b10"
+down_revision: Union[str, None] = "dc5ac28c4b94"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sdk_sync_run",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("user_id", sa.UUID(), nullable=False),
+        sa.Column("provider", sa.String(length=50), nullable=False),
+        sa.Column("client_sync_id", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("expected_chunks", sa.Integer(), nullable=True),
+        sa.Column("received_chunks", sa.Integer(), nullable=False),
+        sa.Column("processed_chunks", sa.Integer(), nullable=False),
+        sa.Column("received_items", sa.Integer(), nullable=False),
+        sa.Column("processed_items", sa.Integer(), nullable=False),
+        sa.Column("received_sleep_items", sa.Integer(), nullable=False),
+        sa.Column("declared_total_items", sa.Integer(), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "provider", "client_sync_id", name="uq_sdk_sync_run_client"),
+    )
+    op.create_index("ix_sdk_sync_run_user_id", "sdk_sync_run", ["user_id"])
+    op.create_index("ix_sdk_sync_run_status_updated", "sdk_sync_run", ["status", "updated_at"])
+    op.create_table(
+        "sdk_sync_chunk",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("run_id", sa.UUID(), nullable=False),
+        sa.Column("batch_id", sa.String(length=64), nullable=False),
+        sa.Column("chunk_index", sa.Integer(), nullable=False),
+        sa.Column("payload_sha256", sa.String(length=64), nullable=False),
+        sa.Column("item_count", sa.Integer(), nullable=False),
+        sa.Column("processed_items", sa.Integer(), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("processed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("batch_id"),
+        sa.UniqueConstraint("run_id", "chunk_index", name="uq_sdk_sync_chunk_index"),
+    )
+    op.create_index("ix_sdk_sync_chunk_run_id", "sdk_sync_chunk", ["run_id"])
+    op.create_index("ix_sdk_sync_chunk_run_status", "sdk_sync_chunk", ["run_id", "status"])
+
+
+def downgrade() -> None:
+    op.drop_table("sdk_sync_chunk")
+    op.drop_table("sdk_sync_run")

--- a/backend/tests/api/v1/test_sdk_sync_offload.py
+++ b/backend/tests/api/v1/test_sdk_sync_offload.py
@@ -35,6 +35,33 @@ def _sync(client: TestClient, api_v1_prefix: str) -> object:
     )
 
 
+def test_whole_sync_manifest_is_persisted_and_forwarded(
+    client: TestClient,
+    api_v1_prefix: str,
+    mock_task: MagicMock,
+) -> None:
+    api_key = ApiKeyFactory()
+    sync_id = "9d90ae59-9668-47b7-8704-b3aef12528e4"
+    with patch.object(settings, "sdk_payload_s3_offload", False):
+        response = client.post(
+            f"{api_v1_prefix}/sdk/users/{_USER_ID}/sync/",
+            headers={
+                "X-Open-Wearables-API-Key": api_key.id,
+                "X-OW-Client-Sync-ID": sync_id,
+                "X-OW-Client-Sync-Chunk-Index": "0",
+                "X-OW-Client-Sync-Final": "false",
+            },
+            json=_BODY,
+        )
+
+    assert response.status_code == 202
+    kwargs = mock_task.delay.call_args.kwargs
+    assert kwargs["client_sync_id"] == sync_id
+    assert kwargs["client_sync_chunk_index"] == 0
+    assert kwargs["client_sync_final"] is False
+    assert kwargs["client_sync_total_items"] is None
+
+
 class TestOffloadDisabled:
     def test_body_is_enqueued_inline(self, client: TestClient, api_v1_prefix: str, mock_task: MagicMock) -> None:
         with (

--- a/backend/tests/api/v1/test_token.py
+++ b/backend/tests/api/v1/test_token.py
@@ -6,6 +6,8 @@ Tests cover:
 - DELETE /api/v1/token/refresh - revoke refresh token
 """
 
+from uuid import uuid4
+
 from jose import jwt
 from sqlalchemy.orm import Session
 from starlette.testclient import TestClient
@@ -253,6 +255,17 @@ class TestSDKTokenReturnsRefreshToken:
         assert data["token_type"] == "bearer"
         assert data["expires_in"] == settings.access_token_expire_minutes * 60
         assert data["refresh_token"].startswith("rt-")
+
+    def test_sdk_token_returns_404_for_missing_user(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
+        developer = DeveloperFactory()
+        application = ApplicationFactory(developer=developer, app_secret="test_app_secret")
+
+        response = client.post(
+            f"{api_v1_prefix}/users/{uuid4()}/token",
+            json={"app_id": application.app_id, "app_secret": "test_app_secret"},
+        )
+
+        assert response.status_code == 404
 
     def test_admin_sdk_token_returns_refresh_token(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Admin-generated SDK token should return refresh token."""

--- a/backend/tests/services/test_sdk_sync_run_service.py
+++ b/backend/tests/services/test_sdk_sync_run_service.py
@@ -1,0 +1,212 @@
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.sdk_sync_run import SDKSyncChunk, SDKSyncRun
+from app.services.sdk_sync_run_service import AcceptedSDKSyncChunk, sdk_sync_run_service
+
+
+def test_manifest_models_match_migrated_table_names() -> None:
+    assert SDKSyncRun.__tablename__ == "sdk_sync_run"
+    assert SDKSyncChunk.__tablename__ == "sdk_sync_chunk"
+
+
+def _accept(
+    db: Session,
+    *,
+    user_id: str,
+    sync_id: str,
+    chunk_index: int,
+    item_count: int,
+    sleep_item_count: int = 0,
+    is_final: bool = False,
+    total_items: int | None = None,
+    payload: bytes | None = None,
+) -> AcceptedSDKSyncChunk:
+    return sdk_sync_run_service.accept_chunk(
+        db,
+        user_id=user_id,
+        provider="apple",
+        client_sync_id=sync_id,
+        chunk_index=chunk_index,
+        is_final=is_final,
+        declared_total_items=total_items,
+        item_count=item_count,
+        sleep_item_count=sleep_item_count,
+        payload=payload or f"chunk-{chunk_index}".encode(),
+        batch_id=str(uuid4()),
+    )
+
+
+def test_completion_requires_every_chunk_and_matching_item_count(db: Session) -> None:
+    user_id = str(uuid4())
+    sync_id = str(uuid4())
+    first = _accept(
+        db,
+        user_id=user_id,
+        sync_id=sync_id,
+        chunk_index=0,
+        item_count=2,
+    )
+    duplicate = _accept(
+        db,
+        user_id=user_id,
+        sync_id=sync_id,
+        chunk_index=0,
+        item_count=2,
+    )
+    assert duplicate.duplicate is True
+    assert duplicate.batch_id == first.batch_id
+
+    run, should_emit_started = sdk_sync_run_service.mark_started(db, batch_id=first.batch_id)
+    assert should_emit_started is True
+    _, should_emit_started_again = sdk_sync_run_service.mark_started(db, batch_id=first.batch_id)
+    assert should_emit_started_again is False
+    assert run.client_sync_id == sync_id
+
+    run, is_terminal, mismatch = sdk_sync_run_service.mark_processed(
+        db,
+        batch_id=first.batch_id,
+        processed_items=2,
+    )
+    assert is_terminal is False
+    assert mismatch is False
+    assert run.status == "accepting"
+
+    final = _accept(
+        db,
+        user_id=user_id,
+        sync_id=sync_id,
+        chunk_index=1,
+        item_count=0,
+        is_final=True,
+        total_items=2,
+    )
+    run, is_terminal, mismatch = sdk_sync_run_service.mark_processed(
+        db,
+        batch_id=final.batch_id,
+        processed_items=0,
+    )
+
+    assert is_terminal is True
+    assert mismatch is False
+    assert run.status == "completed"
+    assert run.expected_chunks == 2
+    assert run.received_chunks == 2
+    assert run.processed_chunks == 2
+    assert run.received_items == 2
+    assert run.processed_items == 2
+
+
+def test_manifest_tracks_sleep_items_across_chunks(db: Session) -> None:
+    user_id = str(uuid4())
+    sync_id = str(uuid4())
+    first = _accept(
+        db,
+        user_id=user_id,
+        sync_id=sync_id,
+        chunk_index=0,
+        item_count=3,
+        sleep_item_count=2,
+    )
+    final = _accept(
+        db,
+        user_id=user_id,
+        sync_id=sync_id,
+        chunk_index=1,
+        item_count=0,
+        is_final=True,
+        total_items=3,
+    )
+
+    sdk_sync_run_service.mark_processed(db, batch_id=first.batch_id, processed_items=3)
+    run, is_terminal, mismatch = sdk_sync_run_service.mark_processed(
+        db,
+        batch_id=final.batch_id,
+        processed_items=0,
+    )
+
+    assert is_terminal is True
+    assert mismatch is False
+    assert run.received_sleep_items == 2
+
+
+def test_final_marker_fails_closed_on_count_mismatch(db: Session) -> None:
+    user_id = str(uuid4())
+    sync_id = str(uuid4())
+    data = _accept(
+        db,
+        user_id=user_id,
+        sync_id=sync_id,
+        chunk_index=0,
+        item_count=3,
+    )
+    sdk_sync_run_service.mark_processed(db, batch_id=data.batch_id, processed_items=2)
+    final = _accept(
+        db,
+        user_id=user_id,
+        sync_id=sync_id,
+        chunk_index=1,
+        item_count=0,
+        is_final=True,
+        total_items=3,
+    )
+
+    run, is_terminal, mismatch = sdk_sync_run_service.mark_processed(
+        db,
+        batch_id=final.batch_id,
+        processed_items=0,
+    )
+
+    assert is_terminal is True
+    assert mismatch is True
+    assert run.status == "failed"
+
+
+def test_chunk_index_cannot_be_reused_with_different_payload(db: Session) -> None:
+    user_id = str(uuid4())
+    sync_id = str(uuid4())
+    _accept(
+        db,
+        user_id=user_id,
+        sync_id=sync_id,
+        chunk_index=0,
+        item_count=1,
+        payload=b"first",
+    )
+
+    with pytest.raises(ValueError, match="different content"):
+        _accept(
+            db,
+            user_id=user_id,
+            sync_id=sync_id,
+            chunk_index=0,
+            item_count=1,
+            payload=b"changed",
+        )
+
+
+def test_chunk_index_cannot_change_manifest_headers_on_retry(db: Session) -> None:
+    user_id = str(uuid4())
+    sync_id = str(uuid4())
+    _accept(
+        db,
+        user_id=user_id,
+        sync_id=sync_id,
+        chunk_index=0,
+        item_count=0,
+        payload=b"same-body",
+    )
+
+    with pytest.raises(ValueError, match="different content"):
+        _accept(
+            db,
+            user_id=user_id,
+            sync_id=sync_id,
+            chunk_index=0,
+            item_count=0,
+            is_final=True,
+            total_items=0,
+            payload=b"same-body",
+        )

--- a/backend/tests/services/test_sdk_webhook_manifest.py
+++ b/backend/tests/services/test_sdk_webhook_manifest.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+from app.services.outgoing_webhooks.events import on_sleep_created, on_timeseries_batch_saved
+from app.services.sdk_ingestion_context import sdk_ingestion_context
+
+
+def test_sdk_manifest_is_added_to_timeseries_and_event_webhooks() -> None:
+    manifest = {
+        "client_sync_id": "sync-123",
+        "batch_id": "batch-9",
+        "chunk_index": 4,
+    }
+    with patch("app.services.outgoing_webhooks.events._dispatch") as dispatch:
+        on_timeseries_batch_saved(
+            user_id=uuid4(),
+            provider="apple",
+            series_type="heart_rate",
+            sample_count=1,
+            samples=[{"timestamp": "2026-09-02T12:00:00Z", "value": 61}],
+            sync_manifest=manifest,
+        )
+        with sdk_ingestion_context(manifest):
+            on_sleep_created(
+                record_id=uuid4(),
+                user_id=uuid4(),
+                provider="apple",
+                device="iPhone",
+                start_time="2026-09-01T23:00:00Z",
+                end_time="2026-09-02T07:00:00Z",
+                zone_offset="+08:00",
+                duration_seconds=28_800,
+            )
+
+    assert dispatch.call_count >= 2
+    for call in dispatch.call_args_list:
+        payload_data = call.args[1]["data"]
+        assert payload_data["client_sync_id"] == "sync-123"
+        assert payload_data["batch_id"] == "batch-9"
+        assert payload_data["client_chunk_index"] == 4
+
+
+def test_dispatch_stamps_event_creation_time() -> None:
+    with (
+        patch("app.services.outgoing_webhooks.events.svix_service.is_enabled", return_value=True),
+        patch("app.integrations.celery.tasks.emit_webhook_event_task.emit_webhook_event.delay") as delay,
+    ):
+        on_sleep_created(
+            record_id=uuid4(),
+            user_id=uuid4(),
+            provider="apple",
+            device="iPhone",
+            start_time="2026-09-01T23:00:00Z",
+            end_time="2026-09-02T07:00:00Z",
+            zone_offset="+08:00",
+            duration_seconds=28_800,
+        )
+
+    payload = delay.call_args.args[1]
+    assert datetime.fromisoformat(payload["event_created_at"]).tzinfo is not None

--- a/backend/tests/services/test_sleep_service.py
+++ b/backend/tests/services/test_sleep_service.py
@@ -28,6 +28,7 @@ from app.schemas.providers.mobile_sdk import (
 )
 from app.services.apple.healthkit.sleep_service import (
     _calculate_final_metrics,
+    finalize_pending_sleep,
     finish_sleep,
     handle_sleep_data,
 )
@@ -524,6 +525,53 @@ class TestFinishSleep:
         assert detail.sleep_rem_minutes == 45
         assert detail.sleep_awake_minutes == 10
         assert detail.sleep_total_duration_minutes == 245  # light+deep+rem (no sleeping)
+
+
+class TestFinalizePendingSleep:
+    @patch("app.services.apple.healthkit.sleep_service.finish_sleep")
+    @patch("app.services.apple.healthkit.sleep_service.load_sleep_state")
+    @patch("app.services.apple.healthkit.sleep_service.get_redis_client")
+    def test_finalizes_under_the_user_lock(
+        self,
+        mock_redis_func: MagicMock,
+        mock_load_state: MagicMock,
+        mock_finish_sleep: MagicMock,
+        db: Session,
+    ) -> None:
+        user_id = str(uuid4())
+        state = MagicMock(spec=SleepState)
+        lock = MagicMock()
+        lock.acquire.return_value = True
+        mock_redis_func.return_value.lock.return_value = lock
+        mock_load_state.side_effect = [state, None]
+
+        finalize_pending_sleep(db, user_id)
+
+        mock_finish_sleep.assert_called_once_with(db, user_id, state)
+        lock.release.assert_called_once()
+
+    @patch("app.services.apple.healthkit.sleep_service.finish_sleep")
+    @patch("app.services.apple.healthkit.sleep_service.load_sleep_state")
+    @patch("app.services.apple.healthkit.sleep_service.get_redis_client")
+    def test_fails_closed_when_state_remains_pending(
+        self,
+        mock_redis_func: MagicMock,
+        mock_load_state: MagicMock,
+        mock_finish_sleep: MagicMock,
+        db: Session,
+    ) -> None:
+        user_id = str(uuid4())
+        state = MagicMock(spec=SleepState)
+        lock = MagicMock()
+        lock.acquire.return_value = True
+        mock_redis_func.return_value.lock.return_value = lock
+        mock_load_state.side_effect = [state, state]
+
+        with pytest.raises(RuntimeError, match="remained pending"):
+            finalize_pending_sleep(db, user_id)
+
+        mock_finish_sleep.assert_called_once_with(db, user_id, state)
+        lock.release.assert_called_once()
 
 
 class TestHandleSleepDataIntegration:

--- a/backend/tests/services/test_user_connection_service.py
+++ b/backend/tests/services/test_user_connection_service.py
@@ -482,3 +482,27 @@ class TestEnsureSdkConnection:
 
         assert emit.call_count == 1
         assert emit.call_args.kwargs["connected_at"] == first.created_at.isoformat()
+
+    def test_conflicting_create_recovers_existing_without_emitting(self, db: Session) -> None:
+        user = UserFactory()
+        existing = UserConnectionFactory(
+            user=user,
+            provider="apple",
+            status=ConnectionStatus.ACTIVE,
+        )
+        repository = user_connection_service.crud
+
+        with (
+            patch.object(
+                repository,
+                "get_by_user_and_provider",
+                side_effect=[None, existing],
+            ),
+            patch.object(db, "execute") as execute,
+            patch("app.services.user_connection_service.on_connection_created") as emit,
+        ):
+            execute.return_value.scalar_one_or_none.return_value = None
+            connection = user_connection_service.ensure_sdk_connection(db, user.id, "apple")
+
+        assert connection.id == existing.id
+        emit.assert_not_called()

--- a/backend/tests/tasks/test_process_sdk_upload_task.py
+++ b/backend/tests/tasks/test_process_sdk_upload_task.py
@@ -251,3 +251,61 @@ class TestTransportedPayloadCleanup:
         mock_delete = _run_offloaded_batch(db, UserFactory(), archival="disabled", status_code=500)
 
         mock_delete.assert_not_called()
+
+
+class TestWholeSyncSleepCompletion:
+    @patch(f"{_MODULE}.completed")
+    @patch(f"{_MODULE}.finalize_pending_sleep")
+    @patch(f"{_MODULE}.user_connection_service")
+    @patch(f"{_MODULE}.sdk_import_service")
+    @patch(f"{_MODULE}.sdk_sync_run_service")
+    @patch(f"{_MODULE}.SessionLocal")
+    @patch(f"{_MODULE}.UserRepository")
+    def test_terminal_run_finalizes_sleep_before_completed_event(
+        self,
+        mock_user_repo_class: MagicMock,
+        mock_session_local: MagicMock,
+        mock_run_service: MagicMock,
+        mock_import: MagicMock,
+        mock_connection_service: MagicMock,
+        mock_finalize_sleep: MagicMock,
+        mock_completed: MagicMock,
+    ) -> None:
+        user_id = str(uuid4())
+        db = MagicMock()
+        mock_session_local.return_value.__enter__ = MagicMock(return_value=db)
+        mock_session_local.return_value.__exit__ = MagicMock(return_value=None)
+        mock_user_repo_class.return_value.get.return_value = MagicMock()
+        response = MagicMock()
+        response.model_dump.return_value = {
+            "status_code": 200,
+            "records_saved": 0,
+            "workouts_saved": 0,
+            "sleep_saved": 2,
+        }
+        mock_import.import_data_from_request.return_value = response
+        run = MagicMock()
+        run.received_sleep_items = 2
+        run.processed_items = 2
+        mock_run_service.mark_started.return_value = (run, False)
+        mock_run_service.mark_processed.return_value = (run, True, False)
+        call_order: list[str] = []
+        mock_finalize_sleep.side_effect = lambda *_: call_order.append("sleep")
+        mock_completed.side_effect = lambda *_args, **_kwargs: call_order.append("completed")
+
+        process_sdk_upload(
+            content='{"provider":"apple","data":{"records":[],"workouts":[],"sleep":[{},{}]}}',
+            content_type="application/json",
+            user_id=user_id,
+            provider="apple",
+            batch_id=str(uuid4()),
+            client_sync_id=str(uuid4()),
+            client_sync_chunk_index=1,
+            client_sync_final=True,
+            client_sync_total_items=2,
+        )
+
+        mock_finalize_sleep.assert_called_once_with(db, user_id)
+        mock_completed.assert_called_once()
+        assert call_order == ["sleep", "completed"]
+        mock_connection_service.ensure_sdk_connection.assert_called_once()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,6 +172,9 @@ services:
       SVIX_QUEUE_TYPE: "redis"
       SVIX_REDIS_DSN: "redis://redis:6379/1"
       SVIX_CACHE_TYPE: "redis"
+      # Keep Svix's SSRF protection on by default. Local cross-stack acceptance
+      # can explicitly whitelist Docker Desktop's host bridge subnet.
+      SVIX_WHITELIST_SUBNETS: "${SVIX_WHITELIST_SUBNETS:-[]}"
     ports:
       - "${SVIX_PORT:-8071}:8071"
     depends_on:

--- a/docs/api-reference/guides/error-handling.mdx
+++ b/docs/api-reference/guides/error-handling.mdx
@@ -155,7 +155,7 @@ GET /api/v1/oauth/garmin/authorize?user_id={user_id}
 
 ### SDK Sync Payloads (Async Validation)
 
-`POST /api/v1/sdk/users/{user_id}/sync` returns **202 Accepted** immediately and validates/imports the payload in a background worker. A malformed record does **not** produce a synchronous `400`/`422` — validation failures are surfaced via the batch's sync status (and internal error reporting), not the HTTP response. The endpoint returns `400` only for an unsupported `provider`.
+`POST /api/v1/sdk/users/{user_id}/sync` returns **202 Accepted** immediately and validates/imports the payload in a background worker. A malformed record does **not** produce a synchronous `400`/`422` — validation failures are surfaced via the batch's sync status (and internal error reporting), not the HTTP response. The endpoint returns `400` for an unsupported `provider` or incomplete whole-sync headers, and `409` when a `(client_sync_id, chunk index)` is reused with different bytes or conflicts with a final marker.
 
 ---
 

--- a/docs/sdk/ios/integration.mdx
+++ b/docs/sdk/ios/integration.mdx
@@ -643,6 +643,18 @@ The SDK sends health data to:
 POST {host}/api/v1/sdk/users/{userId}/sync
 ```
 
+The iOS SDK automatically gives every full or incremental sync a durable
+`client_sync_id`, numbers each request, and sends a final empty marker with the
+exact submitted item total. The same ID and request index survive app restarts
+and network retries. Open Wearables emits one `sync.completed` event for that ID
+only after every numbered request has been processed and the submitted,
+received, and processed totals match.
+
+SDK data webhooks include `client_sync_id`, `batch_id`, and
+`client_chunk_index`, which lets consumers correlate individual sleep, workout,
+and timeseries events with the terminal whole-sync event. `chunk_index` and
+`total_chunks` remain reserved for splitting one large outgoing Svix event.
+
 Data is automatically normalized to the Open Wearables unified data model and can be accessed through the standard API endpoints.
 
 ## Internal Architecture


### PR DESCRIPTION
## Summary

- Persist a whole-sync manifest keyed by user, provider, and `client_sync_id`.
- Correlate chunk uploads and Svix events so `sync.completed` is emitted only after every declared chunk and item has been processed.
- Make retries idempotent, count sleep records correctly, and return 404 when the token user no longer exists.

## Why

Consumers currently receive per-resource events but have no durable way to know when an iPhone HealthKit upload is complete. The manifest adds an auditable completion boundary without weakening existing admission, retry, or webhook delivery behavior.

## Validation

- 79 targeted backend tests passed.
- Ruff passed on changed Python files.
- `ty check` passed.
- Alembic has one head: `a91c3f7e2b10`.
- Backend pre-commit hooks passed, including coverage-doc generation. The repository-wide frontend Prettier hook could not install unchanged frontend dependencies because the repository supply-chain policy blocks `esbuild@0.27.7`; this PR changes no frontend files.
- Physical iPhone acceptance: one run declared and completed 46/46 chunks and 84,762/84,762 items before emitting `sync.completed`.

## Compatibility

Existing SDK clients remain supported. Completion is emitted only for clients that send the new manifest metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable multi-part SDK sync processing with duplicate detection, progress tracking, and completion validation.
  * SDK data webhooks now include sync identifiers and chunk metadata for event correlation.
  * Pending Apple Health sleep data is finalized before a completed sync is reported.
  * SDK token requests now return 404 for nonexistent users.

* **Bug Fixes**
  * Webhook delivery failures now retry instead of being treated as successful sends.
  * Improved handling of concurrent SDK connection creation.

* **Documentation**
  * Documented sync consistency requirements and related error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->