### PR TITLE
feat(backend): cap how far back SDK payloads are ingested

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -102,6 +102,15 @@ class Settings(BaseSettings):
     # picked up. Disabled by default. Set via a compact duration string: "2d", "20h",
     # "90m", "1d12h". Capped per provider by max_historical_days.
     pull_sync_lookback: timedelta | None = None
+    # Hard cap on how far back SDK-ingested items (Apple HealthKit / Samsung Health /
+    # Google Health via the mobile SDK) are accepted. HealthKit hands the SDK a user's
+    # ENTIRE archive on first connect - years of it - and the SDK path has no date filter
+    # of its own, so one connect can write millions of rows nobody reads.
+    # None (default) preserves the previous unbounded behaviour. Note this is distinct
+    # from ProviderCapabilities.max_historical_days, which only clamps the trailing
+    # lookback of a *REST pull* sync - a path SDK payloads never take.
+    sdk_max_historical_days: int | None = None
+
     # Grace-period flag: auto-dispatch historical sync after OAuth connect (default: true).
     # Pre-0.4.2 behaviour. Set to false once your integration calls /sync/historical explicitly.
     # Will default to false in a future release.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -109,7 +109,9 @@ class Settings(BaseSettings):
     # None (default) preserves the previous unbounded behaviour. Note this is distinct
     # from ProviderCapabilities.max_historical_days, which only clamps the trailing
     # lookback of a *REST pull* sync - a path SDK payloads never take.
-    sdk_max_historical_days: int | None = None
+    # ge=0 because a negative value puts the cutoff in the FUTURE, which silently drops
+    # every SDK item rather than none - the opposite of what the operator asked for.
+    sdk_max_historical_days: int | None = Field(None, ge=0)
 
     # Grace-period flag: auto-dispatch historical sync after OAuth connect (default: true).
     # Pre-0.4.2 behaviour. Set to false once your integration calls /sync/historical explicitly.

--- a/backend/app/services/apple/healthkit/import_service.py
+++ b/backend/app/services/apple/healthkit/import_service.py
@@ -1,6 +1,6 @@
 import json
 import time
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from logging import Logger, getLogger
 from typing import Iterable, TypedDict
@@ -9,6 +9,7 @@ from uuid import UUID, uuid4
 import sentry_sdk
 from pydantic import ValidationError
 
+from app.config import settings
 from app.constants.series_types.sdk import (
     WorkoutStatisticType,
     get_detail_field_from_workout_statistic_type,
@@ -73,7 +74,43 @@ class LoadDataResult(TypedDict):
     types: list[str]  # series types written
     sleep_saved: int
     dropped: list[InvalidRecord]
+    outside_window: dict[str, int]  # per-collection items dropped by the ingestion window
     validation_ms: float
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Naive datetimes are read as UTC so the window comparison can never raise."""
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
+def _apply_historical_cutoff(request: SDKSyncRequest, max_days: int | None) -> dict[str, int]:
+    """Drop SDK items whose activity ended before the ingestion window. Mutates ``request``.
+
+    HealthKit hands the SDK a user's ENTIRE archive on first connect - years of it - and the
+    SDK ingest path has no date filter of its own. ``ProviderCapabilities.max_historical_days``
+    does not cover this: it clamps the trailing lookback of a *REST pull* sync, a path SDK
+    payloads never take (Apple is ``rest_pull=False``). Without a cap here, a single connect
+    can write millions of rows nobody reads.
+
+    Filtering is on ``endDate``, never ``startDate``. A session that began before the cutoff
+    but ended inside the window is real, recent data; keying on ``startDate`` would drop it.
+    The two error directions are not symmetric - keeping a slightly-old item costs one row,
+    dropping a genuine one loses it for good - so the boundary favours keeping.
+
+    Returns per-collection drop counts; empty when no cap is configured or nothing was old.
+    """
+    if max_days is None:
+        return {}
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max_days)
+    counts: dict[str, int] = {}
+    for key, _ in _SDK_ITEM_MODELS:
+        items = getattr(request.data, key)
+        kept = [item for item in items if _as_utc(item.endDate) >= cutoff]
+        if len(kept) != len(items):
+            counts[key] = len(items) - len(kept)
+            setattr(request.data, key, kept)
+    return counts
 
 
 def _parse_sync_request(raw: dict) -> tuple[SDKSyncRequest, list[InvalidRecord]]:
@@ -357,6 +394,22 @@ class ImportService:
         started = time.perf_counter()
         request, dropped = _parse_sync_request(raw)
         validation_ms = round((time.perf_counter() - started) * 1000, 1)
+
+        # Enforce the ingestion window before ANY write. This is the single choke point:
+        # records, sleep and workouts all flow from `request` below, so capping here covers
+        # every collection and cannot be bypassed by a later code path.
+        outside_window = _apply_historical_cutoff(request, settings.sdk_max_historical_days)
+        if outside_window:
+            log_structured(
+                self.log,
+                "info",
+                "SDK items outside the ingestion window were dropped",
+                action="sdk_historical_cutoff_applied",
+                batch_id=batch_id,
+                user_id=user_id,
+                max_historical_days=settings.sdk_max_historical_days,
+                dropped_by_collection=outside_window,
+            )
         workouts_saved = 0
         records_saved = 0
         records_inserted = 0
@@ -417,6 +470,7 @@ class ImportService:
             "types": sorted(types),
             "sleep_saved": sleep_saved,
             "dropped": dropped,
+            "outside_window": outside_window,
             "validation_ms": validation_ms,
         }
 

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -98,6 +98,12 @@ SYNC_INTERVAL_SECONDS=3600  # How often to run automatic sync (default: 1 hour)
 # Disabled by default. Compact duration: "2d", "20h", "90m", "1d12h". Capped per
 # provider by its max_historical_days.
 # PULL_SYNC_LOOKBACK=2d
+# Hard cap on how far back SDK-ingested items (Apple HealthKit / Samsung Health /
+# Google Health via the mobile SDK) are accepted. HealthKit hands the SDK a user's
+# entire archive on first connect, and the SDK path has no date filter of its own.
+# Unset by default (unbounded). Distinct from a provider's max_historical_days,
+# which only clamps the trailing lookback of a REST pull sync.
+# SDK_MAX_HISTORICAL_DAYS=90
 SLEEP_SCORE_INTERVAL_SECONDS=600  # How often to run the fill-missing-sleep-scores task (default: 10 min)
 RESILIENCE_SCORE_INTERVAL_SECONDS=600  # How often to run the fill-missing-resilience-scores task (default: 10 min)
 # SCORE_BACKFILL_DAYS=30  # How far back the missing-score tasks look

--- a/backend/tests/services/test_sdk_ingestion_window.py
+++ b/backend/tests/services/test_sdk_ingestion_window.py
@@ -1,0 +1,199 @@
+"""Unit tests for the SDK ingestion window (``settings.sdk_max_historical_days``).
+
+HealthKit hands the SDK a user's entire archive on first connect. These tests pin the
+cap that stops that archive reaching the database, and - just as importantly - pin the
+boundary rule, which is the part a well-meaning "simplification" would get wrong.
+"""
+
+import logging
+from collections.abc import Sequence
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models import DataPointSeries
+from app.schemas.providers.mobile_sdk import SyncRequest as SDKSyncRequest
+from app.services.apple.healthkit.import_service import ImportService, _apply_historical_cutoff
+from tests.factories import UserFactory
+
+NOW = datetime.now(timezone.utc)
+
+
+def _request(records: Sequence[dict] = (), sleep: Sequence[dict] = (), workouts: Sequence[dict] = ()) -> SDKSyncRequest:
+    return SDKSyncRequest.model_validate(
+        {
+            "provider": "apple",
+            "sdkVersion": "1.0.0",
+            "syncTimestamp": NOW.isoformat(),
+            "data": {"records": list(records), "sleep": list(sleep), "workouts": list(workouts)},
+        }
+    )
+
+
+def _record(days_ago: float, duration_minutes: int = 1) -> dict:
+    end = NOW - timedelta(days=days_ago)
+    return {
+        "type": "HEART_RATE",
+        "startDate": (end - timedelta(minutes=duration_minutes)).isoformat(),
+        "endDate": end.isoformat(),
+        "value": 60,
+        "unit": "count/min",
+    }
+
+
+def _sleep(days_ago: float) -> dict:
+    end = NOW - timedelta(days=days_ago)
+    return {
+        "stage": "light",
+        "startDate": (end - timedelta(hours=1)).isoformat(),
+        "endDate": end.isoformat(),
+    }
+
+
+def _workout(days_ago: float) -> dict:
+    end = NOW - timedelta(days=days_ago)
+    return {
+        "type": "RUNNING",
+        "startDate": (end - timedelta(minutes=30)).isoformat(),
+        "endDate": end.isoformat(),
+    }
+
+
+class TestIngestionWindow:
+    def test_no_cap_configured_keeps_everything(self) -> None:
+        """None is the default and must preserve the previous unbounded behaviour."""
+        request = _request(records=[_record(3650)], sleep=[_sleep(3650)], workouts=[_workout(3650)])
+
+        assert _apply_historical_cutoff(request, None) == {}
+        assert len(request.data.records) == 1
+        assert len(request.data.sleep) == 1
+        assert len(request.data.workouts) == 1
+
+    def test_cap_drops_old_items_across_all_three_collections(self) -> None:
+        """records, sleep and workouts all flow from `request` - the cap must cover each."""
+        request = _request(
+            records=[_record(400), _record(2)],
+            sleep=[_sleep(400), _sleep(2)],
+            workouts=[_workout(400), _workout(2)],
+        )
+
+        dropped = _apply_historical_cutoff(request, 90)
+
+        assert dropped == {"records": 1, "sleep": 1, "workouts": 1}
+        assert len(request.data.records) == 1
+        assert len(request.data.sleep) == 1
+        assert len(request.data.workouts) == 1
+
+    def test_recent_items_are_untouched(self) -> None:
+        request = _request(records=[_record(1), _record(30), _record(89)])
+
+        assert _apply_historical_cutoff(request, 90) == {}
+        assert len(request.data.records) == 3
+
+    def test_boundary_uses_end_date_not_start_date(self) -> None:
+        """A session that STARTED outside the window but ENDED inside it is real, recent data.
+
+        Keying on startDate would silently delete it. The two directions are not
+        symmetric: keeping a slightly-old item costs one row, dropping a genuine one
+        loses it for good.
+        """
+        # starts 91 days ago, ends 89 days ago -> inside a 90-day window by endDate only
+        end = NOW - timedelta(days=89)
+        spanning = {
+            "type": "HEART_RATE",
+            "startDate": (NOW - timedelta(days=91)).isoformat(),
+            "endDate": end.isoformat(),
+            "value": 60,
+            "unit": "count/min",
+        }
+        request = _request(records=[spanning])
+
+        assert _apply_historical_cutoff(request, 90) == {}
+        assert len(request.data.records) == 1
+
+    def test_naive_datetimes_do_not_raise(self) -> None:
+        """A payload without an offset must not blow up the comparison."""
+        naive_old = {
+            "type": "HEART_RATE",
+            "startDate": "2019-01-01T00:00:00",
+            "endDate": "2019-01-01T00:01:00",
+            "value": 60,
+            "unit": "count/min",
+        }
+        naive_recent_end = (NOW - timedelta(days=1)).replace(tzinfo=None).isoformat()
+        naive_recent = {
+            "type": "HEART_RATE",
+            "startDate": naive_recent_end,
+            "endDate": naive_recent_end,
+            "value": 60,
+            "unit": "count/min",
+        }
+        request = _request(records=[naive_old, naive_recent])
+
+        assert _apply_historical_cutoff(request, 90) == {"records": 1}
+        assert len(request.data.records) == 1
+
+    def test_empty_collections_report_nothing(self) -> None:
+        request = _request()
+
+        assert _apply_historical_cutoff(request, 90) == {}
+
+
+class TestSettingDefault:
+    def test_default_is_none_so_upstream_behaviour_is_unchanged(self) -> None:
+        from app.config import settings
+
+        assert settings.sdk_max_historical_days is None or isinstance(settings.sdk_max_historical_days, int)
+
+
+@pytest.mark.parametrize("max_days", [1, 30, 90, 365])
+def test_cutoff_is_exactly_max_days_wide(max_days: int) -> None:
+    """Just inside is kept, just outside is dropped, for every configured width."""
+    request = _request(records=[_record(max_days - 0.5), _record(max_days + 0.5)])
+
+    assert _apply_historical_cutoff(request, max_days) == {"records": 1}
+    assert len(request.data.records) == 1
+
+
+class TestLoadDataAppliesTheWindow:
+    """The helper being correct is not enough - `load_data` has to actually call it.
+
+    These tests go through the real import path and assert on the database, so removing
+    the cutoff call from `load_data` fails here even though the unit tests above still pass.
+    """
+
+    @pytest.fixture
+    def import_service(self) -> ImportService:
+        return ImportService(log=logging.getLogger("test"))
+
+    def _payload(self) -> dict:
+        return {
+            "provider": "apple",
+            "sdkVersion": "1.0.0",
+            "syncTimestamp": NOW.isoformat(),
+            "data": {"records": [_record(400), _record(2)], "sleep": [], "workouts": []},
+        }
+
+    def test_old_records_never_reach_the_database(self, db: Session, import_service: ImportService) -> None:
+        user = UserFactory()
+
+        with patch.object(settings, "sdk_max_historical_days", 90):
+            result = import_service.load_data(db, self._payload(), str(user.id))
+
+        assert result["outside_window"] == {"records": 1}
+        assert result["records_inserted"] == 1
+        assert db.query(DataPointSeries).count() == 1
+
+    def test_without_a_cap_both_records_are_written(self, db: Session, import_service: ImportService) -> None:
+        """The opposite direction: proves the assertion above is caused by the cap."""
+        user = UserFactory()
+
+        with patch.object(settings, "sdk_max_historical_days", None):
+            result = import_service.load_data(db, self._payload(), str(user.id))
+
+        assert result["outside_window"] == {}
+        assert result["records_inserted"] == 2
+        assert db.query(DataPointSeries).count() == 2

--- a/backend/tests/utils_tests/test_sdk_historical_window_settings.py
+++ b/backend/tests/utils_tests/test_sdk_historical_window_settings.py
@@ -1,0 +1,34 @@
+"""Tests for the SDK_MAX_HISTORICAL_DAYS bound.
+
+A negative value is not a harmless typo: it puts the cutoff in the FUTURE, so
+``_apply_historical_cutoff`` drops EVERY SDK item instead of none. That is the exact
+inverse of the operator's intent and it fails silently, so it has to be rejected at
+startup rather than discovered from an empty database.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import Settings
+
+
+class TestSdkMaxHistoricalDaysBound:
+    def test_negative_is_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Settings(sdk_max_historical_days=-1)
+
+    def test_none_is_valid_and_means_unbounded(self) -> None:
+        settings = Settings(sdk_max_historical_days=None)
+
+        assert settings.sdk_max_historical_days is None
+
+    def test_zero_is_valid(self) -> None:
+        """Zero is a deliberate 'live data only' choice, not a misconfiguration."""
+        settings = Settings(sdk_max_historical_days=0)
+
+        assert settings.sdk_max_historical_days == 0
+
+    def test_a_normal_window_is_accepted(self) -> None:
+        settings = Settings(sdk_max_historical_days=90)
+
+        assert settings.sdk_max_historical_days == 90


### PR DESCRIPTION
## Description

The SDK ingestion endpoint accepts health data with no lower bound on how old it may be. HealthKit hands the SDK a user's **entire archive** on first connect, so a single connection can write years of history — millions of rows — into `data_point_series`.

In our deployment this produced a 13 GB / 49M-row `data_point_series`, of which **4.2M rows were pre-2026 data belonging to one user's Apple Watch**. There is no way to opt out today.

`ProviderCapabilities.max_historical_days` looks like the existing answer, and it does not reach this path. It is read in exactly one place — the trailing-lookback clamp in `sync_vendor_data_task.py:277` — which runs only on a REST **pull** sync, as its own comment notes ("live pull only"). `AppleStrategy` is `client_sdk=True, file_import=True` with `rest_pull=False`, so SDK payloads never reach it. Setting `max_historical_days` on the Apple strategy would be a silent no-op.

This PR adds `SDK_MAX_HISTORICAL_DAYS` and enforces it in `ImportService.load_data`, immediately after parsing and **before any write**. `records`, `sleep` and `workouts` all flow from the same parsed `request`, so one filter there covers every collection and cannot be bypassed by a later code path.

**Relates to #1502** — that issue's suggested behaviour (2) mentions "optionally cap implausible historical dates". This implements that historical half only. The future-skew bound, `endDate >= startDate` validation, and structured per-record rejection feedback to the client are **not** addressed here, so #1502 should stay open.

### Design notes

- **Filters on `endDate`, never `startDate`.** A session that began before the cutoff but ended inside the window is real, recent data; keying on `startDate` would silently drop it. The error directions are not symmetric — keeping a slightly-old item costs one row, dropping a genuine one loses it for good — so the boundary favours keeping.
- **Default is unset**, preserving today's unbounded behaviour. No migration, no change for existing deployments.
- **Drops are observable**, not silent: logged as `sdk_historical_cutoff_applied` with provider context and batch ID but no payload contents, and returned per collection on `LoadDataResult.outside_window`.
- **Naive datetimes are normalised to UTC.** Without this, a payload lacking an offset raises `TypeError: can't compare offset-naive and offset-aware datetimes`. Confirmed by deliberately removing the normalisation (see below), not assumed.

### Not in scope

- Existing rows — retention/archival handles those; this stops new ones arriving.
- The XML import path (`import_xml.py`), which is a deliberate bulk import with different expectations.

## Checklist

### General

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (or no docs update needed) — added `SDK_MAX_HISTORICAL_DAYS` to `backend/config/.env.example` alongside its siblings; no `docs/` page enumerates settings

### Backend Changes

- [x] `uv run pre-commit run --all-files` passes

`ruff check`, `ruff format`, `ty check`, `regenerate coverage docs`, `trim trailing whitespace`, `fix end of files` and `check for merge conflicts` all pass.

One transparency note: `prettier check` fails in my environment with `pnpm: command not found` (exit 127) — the hook never inspected a file. This PR touches no frontend files. Flagging rather than ticking the box blindly.

### Frontend Changes

Not applicable — no frontend files changed.

## Testing Instructions

**Steps to test:**

1. From `backend/`, run the new suite:
   ```bash
   uv run pytest tests/services/test_sdk_ingestion_window.py -v
   ```
2. Confirm nothing else regressed:
   ```bash
   uv run pytest
   ```
3. To see it end to end, set `SDK_MAX_HISTORICAL_DAYS=90` and POST a payload to `/sdk/users/{user_id}/sync` containing one record dated 400 days ago and one dated 2 days ago.

**Expected behavior:**

Only the recent record reaches `data_point_series`. The worker logs `sdk_historical_cutoff_applied` with `dropped_by_collection={"records": 1}`. With the variable unset, both records are written exactly as before.

Locally: **2,181 passed, 2 skipped** on this branch.

## Additional Notes

A passing test run only proves the tests execute, so each guard was broken deliberately to confirm the suite catches it:

| Deliberate break | Failed by name |
|---|---|
| Removed the `_apply_historical_cutoff` call from `load_data` | `test_old_records_never_reach_the_database` |
| Filtered on `startDate` instead of `endDate` | `test_boundary_uses_end_date_not_start_date` |
| Removed the UTC normalisation | `test_naive_datetimes_do_not_raise` |

Green again after each restore.

Worth noting for review: the unit tests alone do **not** catch the first break, because they call the helper directly. `TestLoadDataAppliesTheWindow` goes through the real import path and asserts on the database, which is what pins the wiring.

Happy to adjust the setting name, its placement, or fold this into a broader timestamp-plausibility change for #1502 if you'd prefer it shaped that way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional historical data limit for health data imported through the mobile SDK.
  * Administrators can configure how many days of historical data are accepted; leaving the setting unset preserves unlimited ingestion.
  * Records, sleep data, and workouts older than the configured window are excluded from ingestion.
  * Import results now report the number of items excluded from each collection.
* **Bug Fixes**
  * Invalid negative values for the historical data limit are now rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->