### PR TITLE
fix(backend): unify sleep data delivered by api & webhook

### DIFF
--- a/backend/app/constants/webhooks/test_payloads.py
+++ b/backend/app/constants/webhooks/test_payloads.py
@@ -14,7 +14,13 @@ _RECORD_ID = "00000000-0000-0000-0000-000000000001"
 _CONNECTION_ID = "00000000-0000-0000-0000-000000000003"
 
 _SOURCE_GARMIN = {"provider": "garmin", "device": "Garmin Fenix 7"}
-_SOURCE_OURA = {"provider": "oura", "device": "Oura Ring Gen3"}
+_SOURCE_OURA = {
+    "provider": "oura",
+    "source": "oura",
+    "device": "Oura Ring Gen3",
+    "device_type": "ring",
+    "device_name": "Oura Ring Gen3",
+}
 _SOURCE_APPLE = {"provider": "apple", "device": "Apple Watch Series 9"}
 
 

--- a/backend/app/repositories/event_record_repository.py
+++ b/backend/app/repositories/event_record_repository.py
@@ -66,6 +66,7 @@ class EventRecordRepository(
                 device_model=creator.device_model,
                 source=creator.source,
                 software_version=creator.software_version,
+                original_source_name=creator.source,
             )
             data_source_id = data_source.id
 

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -254,6 +254,10 @@ class EventRecordService(
                     final_detail.sleep_rem_minutes,
                 ]
             )
+            device_type = None
+            if svix_service.is_enabled() and record.data_source_id is not None:
+                source_data_source = self.data_source_repo.get(db_session, record.data_source_id)
+                device_type = source_data_source.device_type if source_data_source else None
             on_sleep_created(
                 record_id=result.id,
                 user_id=user_id,
@@ -273,6 +277,18 @@ class EventRecordService(
                 if has_stages
                 else None,
                 is_nap=final_detail.is_nap,
+                source_app=record.source,
+                device_type=device_type,
+                sleep_duration_seconds=(
+                    final_detail.sleep_total_duration_minutes * 60
+                    if final_detail.sleep_total_duration_minutes is not None
+                    else None
+                ),
+                sleep_stage_intervals=(
+                    [stage.model_dump(mode="json") for stage in final_detail.sleep_stages]
+                    if final_detail.sleep_stages
+                    else None
+                ),
             )
         return result
 
@@ -550,6 +566,18 @@ class EventRecordService(
                     if has_stages
                     else None,
                     is_nap=detail.is_nap,
+                    source_app=data_source.source,
+                    device_type=data_source.device_type,
+                    sleep_duration_seconds=(
+                        detail.sleep_total_duration_minutes * 60
+                        if detail.sleep_total_duration_minutes is not None
+                        else None
+                    ),
+                    sleep_stage_intervals=(
+                        [stage.model_dump(mode="json") for stage in detail.sleep_stages]
+                        if detail.sleep_stages
+                        else None
+                    ),
                 )
             case "menstrual_cycle":
                 mcd = detail if isinstance(detail, MenstrualCycleDetailCreate) else None

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -255,8 +255,8 @@ class EventRecordService(
                 ]
             )
             device_type = None
-            if svix_service.is_enabled() and record.data_source_id is not None:
-                source_data_source = self.data_source_repo.get(db_session, record.data_source_id)
+            if svix_service.is_enabled() and result.data_source_id is not None:
+                source_data_source = self.data_source_repo.get(db_session, result.data_source_id)
                 device_type = source_data_source.device_type if source_data_source else None
             on_sleep_created(
                 record_id=result.id,

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -256,7 +256,8 @@ class EventRecordService(
             )
             device_type = None
             if svix_service.is_enabled() and result.data_source_id is not None:
-                if data_source := self.data_source_repo.get(db_session, result.data_source_id):
+                data_source = self.data_source_repo.get(db_session, result.data_source_id)
+                if data_source is not None:
                     device_type = data_source.device_type
 
             on_sleep_created(

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -256,8 +256,9 @@ class EventRecordService(
             )
             device_type = None
             if svix_service.is_enabled() and result.data_source_id is not None:
-                source_data_source = self.data_source_repo.get(db_session, result.data_source_id)
-                device_type = source_data_source.device_type if source_data_source else None
+                if data_source := self.data_source_repo.get(db_session, result.data_source_id):
+                    device_type = data_source.device_type
+
             on_sleep_created(
                 record_id=result.id,
                 user_id=user_id,

--- a/backend/app/services/outgoing_webhooks/events.py
+++ b/backend/app/services/outgoing_webhooks/events.py
@@ -12,6 +12,7 @@ import re
 from typing import Any
 from uuid import UUID
 
+from app.constants.devices_map import resolve_device_name
 from app.constants.webhooks.events import SERIES_TYPE_TO_GRANULAR_EVENT, SERIES_TYPE_TO_GROUP_EVENT
 from app.schemas.webhooks.event_types import WebhookEventType
 from app.services.outgoing_webhooks import svix as svix_service
@@ -153,6 +154,10 @@ def on_sleep_created(
     efficiency_percent: float | None = None,
     stages: dict[str, int | None] | None = None,
     is_nap: bool | None = None,
+    source_app: str | None = None,
+    device_type: str | None = None,
+    sleep_duration_seconds: float | None = None,
+    sleep_stage_intervals: list[dict[str, Any]] | None = None,
 ) -> None:
     _dispatch(
         WebhookEventType.SLEEP_CREATED,
@@ -165,9 +170,17 @@ def on_sleep_created(
                 "end_time": end_time,
                 "zone_offset": zone_offset,
                 "duration_seconds": duration_seconds,
-                "source": {"provider": provider, "device": device},
+                "sleep_duration_seconds": sleep_duration_seconds,
+                "source": {
+                    "provider": provider,
+                    "source": source_app,
+                    "device": device,
+                    "device_type": device_type,
+                    "device_name": resolve_device_name(device),
+                },
                 "efficiency_percent": efficiency_percent,
                 "stages": stages,
+                "sleep_stage_intervals": sleep_stage_intervals,
                 "is_nap": is_nap,
             },
         },

--- a/backend/tests/api/v1/test_outgoing_webhooks.py
+++ b/backend/tests/api/v1/test_outgoing_webhooks.py
@@ -108,12 +108,23 @@ class TestWebhookEmit:
             efficiency_percent=85.0,
             stages={"deep_minutes": 90, "rem_minutes": 60, "light_minutes": 120, "awake_minutes": 10},
             is_nap=False,
+            source_app="oura",
+            device_type="ring",
+            sleep_duration_seconds=27000,
+            sleep_stage_intervals=[
+                {"stage": "light", "start_time": "2026-01-01T22:00:00", "end_time": "2026-01-01T22:30:00"}
+            ],
         )
         mock_task.delay.assert_called_once()
         args = mock_task.delay.call_args
         assert args[0][0] == "sleep.created"
         assert args[0][1]["data"]["efficiency_percent"] == 85.0
         assert args[0][1]["data"]["stages"]["deep_minutes"] == 90
+        assert args[0][1]["data"]["sleep_duration_seconds"] == 27000
+        assert args[0][1]["data"]["sleep_stage_intervals"][0]["stage"] == "light"
+        assert args[0][1]["data"]["source"]["source"] == "oura"
+        assert args[0][1]["data"]["source"]["device_type"] == "ring"
+        assert args[0][1]["data"]["source"]["device_name"] == "Oura Ring Gen3"
 
     @patch("app.integrations.celery.tasks.emit_webhook_event_task.emit_webhook_event")
     def test_on_timeseries_batch_saved_dispatches(self, mock_task: MagicMock) -> None:

--- a/backend/tests/repositories/test_event_record_repository.py
+++ b/backend/tests/repositories/test_event_record_repository.py
@@ -102,6 +102,38 @@ class TestEventRecordRepository:
         assert data_source.source == "garmin"
         assert data_source.device_model == "device456"
 
+    def test_create_auto_creates_mapping_infers_device_type_from_source(
+        self, db: Session, event_repo: EventRecordRepository
+    ) -> None:
+        """Providers like Oura never report device_model for sleep — device_type must still
+        be inferred from the source string (e.g. "oura" -> ring) when auto-creating the mapping.
+        """
+        user = UserFactory()
+        now = datetime.now(timezone.utc)
+
+        event_data = EventRecordCreate(
+            id=uuid4(),
+            user_id=user.id,
+            source="oura",
+            device_model=None,
+            data_source_id=None,
+            category="sleep",
+            type="sleep_session",
+            source_name="Oura",
+            duration_seconds=25000,
+            start_datetime=now,
+            end_datetime=now + timedelta(seconds=25000),
+        )
+
+        result = event_repo.create(db, event_data)
+
+        from app.models import DataSource
+        from app.repositories.data_source_repository import DataSourceRepository
+
+        data_source = DataSourceRepository(DataSource).get(db, result.data_source_id)
+        assert data_source is not None
+        assert data_source.device_type == "ring"
+
     def test_get(self, db: Session, event_repo: EventRecordRepository) -> None:
         """Test retrieving an event record by ID."""
         # Arrange

--- a/backend/tests/services/test_event_record_service.py
+++ b/backend/tests/services/test_event_record_service.py
@@ -773,6 +773,42 @@ class TestCreateOrMergeSleep:
         mock_sleep.assert_called_once()
         assert mock_sleep.call_args.kwargs["device_type"] is None
 
+    def test_resolves_device_type_when_input_record_has_no_data_source_id(self, db: Session) -> None:
+        """Real provider ingestion (e.g. Oura's save_sleep_data) never sets data_source_id on
+        the input EventRecordCreate - it gets resolved/created by the repository during insert.
+        device_type must therefore be looked up from the *persisted* record, not the input.
+        """
+        user = UserFactory()
+        # Pre-existing DataSource matching the identity (user_id, provider, device_model, source)
+        # that the repository's get-or-create will resolve to - with a known device_type, so the
+        # assertion below actually distinguishes "looked up the resolved source" from "always None".
+        DataSourceFactory(user=user, provider=ProviderName.OURA, device_model=None, source="oura", device_type="ring")
+
+        start, end = self._dt(1, 35), self._dt(8, 51)
+        record = EventRecordCreate(
+            id=uuid4(),
+            category="sleep",
+            type="sleep_session",
+            source_name="Oura",
+            source="oura",
+            user_id=user.id,
+            start_datetime=start,
+            end_datetime=end,
+            duration_seconds=int((end - start).total_seconds()),
+        )
+        assert record.data_source_id is None
+        detail = self._detail(record.id)
+
+        with (
+            patch("app.services.event_record_service.svix_service.is_enabled", return_value=True),
+            patch("app.services.event_record_service.on_sleep_created") as mock_sleep,
+        ):
+            result = event_record_service.create_or_merge_sleep(db, user.id, record, detail, self.THRESHOLD)
+
+        assert result.data_source_id is not None
+        mock_sleep.assert_called_once()
+        assert mock_sleep.call_args.kwargs["device_type"] == "ring"
+
 
 class TestRecomputeSleepScores:
     """Test the internal sleep score recompute triggered by create_or_merge_sleep."""

--- a/backend/tests/services/test_event_record_service.py
+++ b/backend/tests/services/test_event_record_service.py
@@ -105,6 +105,35 @@ class TestEventRecordServiceCreateDetail:
         assert getattr(detail, "heart_rate_min", None) is None
         assert getattr(detail, "steps_count", None) is None
 
+    def test_create_detail_dispatches_sleep_webhook_with_source_and_stages(self, db: Session) -> None:
+        """_emit_event_record_webhook passes device_type, writer app, and stage intervals for sleep."""
+        data_source = DataSourceFactory(source="oura", device_type="ring")
+        event_record = EventRecordFactory(mapping=data_source, category="sleep", type_="sleep_session")
+        stage = SleepStage(
+            stage="light",
+            start_time=event_record.start_datetime,
+            end_time=event_record.end_datetime,
+        )
+        detail_payload = EventRecordDetailCreate(
+            record_id=event_record.id,
+            sleep_total_duration_minutes=90,
+            sleep_stages=[stage],
+        )
+
+        with (
+            patch("app.services.event_record_service.svix_service.is_enabled", return_value=True),
+            patch("app.services.event_record_service.on_sleep_created") as mock_sleep,
+        ):
+            event_record_service.create_detail(db, detail_payload, detail_type="sleep")
+
+        mock_sleep.assert_called_once()
+        kwargs = mock_sleep.call_args.kwargs
+        assert kwargs["record_id"] == event_record.id
+        assert kwargs["source_app"] == "oura"
+        assert kwargs["device_type"] == "ring"
+        assert kwargs["sleep_duration_seconds"] == 90 * 60
+        assert kwargs["sleep_stage_intervals"] == [stage.model_dump(mode="json")]
+
 
 class TestEventRecordServiceBulkCreateDetails:
     """bulk_create_details must dispatch a webhook per detail on commit.
@@ -702,6 +731,49 @@ class TestCreateOrMergeSleep:
         # Stages should be sorted by start_time (early first)
         assert stages[0]["stage"] == "light"
         assert stages[1]["stage"] == "deep"
+
+    def test_dispatches_webhook_with_source_and_stage_details(self, db: Session) -> None:
+        """create_or_merge_sleep passes device_type, writer app, and stage intervals to the webhook."""
+        data_source = DataSourceFactory(source="oura", device_type="ring")
+        start, end = self._dt(1, 35), self._dt(8, 51)
+        record = self._record(data_source, start, end)
+        detail = self._detail(record.id)
+        stage = SleepStage(stage="light", start_time=start, end_time=end)
+        detail = detail.model_copy(update={"sleep_stages": [stage]})
+
+        with (
+            patch("app.services.event_record_service.svix_service.is_enabled", return_value=True),
+            patch("app.services.event_record_service.on_sleep_created") as mock_sleep,
+        ):
+            result = event_record_service.create_or_merge_sleep(
+                db, data_source.user_id, record, detail, self.THRESHOLD
+            )
+
+        mock_sleep.assert_called_once()
+        kwargs = mock_sleep.call_args.kwargs
+        assert kwargs["record_id"] == result.id
+        assert kwargs["source_app"] == "oura"
+        assert kwargs["device_type"] == "ring"
+        assert kwargs["sleep_duration_seconds"] == detail.sleep_total_duration_minutes * 60
+        assert kwargs["sleep_stage_intervals"] == [stage.model_dump(mode="json")]
+
+    def test_skips_data_source_lookup_when_svix_disabled(self, db: Session) -> None:
+        """No device_type lookup (and no webhook) happens when Svix is not configured."""
+        data_source = DataSourceFactory(source="oura", device_type="ring")
+        start, end = self._dt(1, 35), self._dt(8, 51)
+        record = self._record(data_source, start, end)
+        detail = self._detail(record.id)
+
+        with (
+            patch("app.services.event_record_service.svix_service.is_enabled", return_value=False),
+            patch.object(event_record_service, "data_source_repo") as mock_repo,
+            patch("app.services.event_record_service.on_sleep_created") as mock_sleep,
+        ):
+            event_record_service.create_or_merge_sleep(db, data_source.user_id, record, detail, self.THRESHOLD)
+
+        mock_repo.get.assert_not_called()
+        mock_sleep.assert_called_once()
+        assert mock_sleep.call_args.kwargs["device_type"] is None
 
 
 class TestRecomputeSleepScores:

--- a/backend/tests/services/test_event_record_service.py
+++ b/backend/tests/services/test_event_record_service.py
@@ -745,9 +745,7 @@ class TestCreateOrMergeSleep:
             patch("app.services.event_record_service.svix_service.is_enabled", return_value=True),
             patch("app.services.event_record_service.on_sleep_created") as mock_sleep,
         ):
-            result = event_record_service.create_or_merge_sleep(
-                db, data_source.user_id, record, detail, self.THRESHOLD
-            )
+            result = event_record_service.create_or_merge_sleep(db, data_source.user_id, record, detail, self.THRESHOLD)
 
         mock_sleep.assert_called_once()
         kwargs = mock_sleep.call_args.kwargs

--- a/docs/api-reference/guides/webhooks.mdx
+++ b/docs/api-reference/guides/webhooks.mdx
@@ -318,9 +318,13 @@ Every payload envelope has `type` (the event name as a string) and `data`.
     "end_time": "2025-12-20T06:45:00+01:00",
     "zone_offset": "+01:00",
     "duration_seconds": 30600.0,
+    "sleep_duration_seconds": 29400.0,
     "source": {
       "provider": "oura",
-      "device": "Oura Ring Gen3"
+      "source": "oura",
+      "device": "Oura Ring Gen3",
+      "device_type": "ring",
+      "device_name": "Oura Ring Gen3"
     },
     "efficiency_percent": 87.0,
     "stages": {
@@ -329,10 +333,26 @@ Every payload envelope has `type` (the event name as a string) and `data`.
       "light_minutes": 215,
       "awake_minutes": 12
     },
+    "sleep_stage_intervals": [
+      {
+        "stage": "light",
+        "start_time": "2025-12-19T22:15:00+01:00",
+        "end_time": "2025-12-19T22:45:00+01:00"
+      },
+      {
+        "stage": "deep",
+        "start_time": "2025-12-19T22:45:00+01:00",
+        "end_time": "2025-12-19T23:30:00+01:00"
+      }
+    ],
     "is_nap": false
   }
 }
 ```
+
+<Note>
+  `sleep_duration_seconds` is the time actually asleep (excludes awake periods within the session); `duration_seconds` is the total time-in-bed span. Both `source.source` (the third-party writer app, e.g. HealthKit/Health Connect) and `sleep_stage_intervals` (the full per-interval stage timeline) are `null`/omitted when the provider or ingestion path did not report them.
+</Note>
 
 ### `menstrual_cycle.created`
 

--- a/docs/api-reference/guides/webhooks.mdx
+++ b/docs/api-reference/guides/webhooks.mdx
@@ -308,6 +308,8 @@ Every payload envelope has `type` (the event name as a string) and `data`.
 
 ### `sleep.created`
 
+`sleep_stage_intervals` below is shown **abbreviated** — three intervals out of a full night — to keep the example short. A real payload's array covers the entire session end-to-end (typically 15-60+ merged intervals, depending on how fragmented the sleep was).
+
 ```json
 {
   "type": "sleep.created",
@@ -343,6 +345,11 @@ Every payload envelope has `type` (the event name as a string) and `data`.
         "stage": "deep",
         "start_time": "2025-12-19T22:45:00+01:00",
         "end_time": "2025-12-19T23:30:00+01:00"
+      },
+      {
+        "stage": "rem",
+        "start_time": "2025-12-20T06:15:00+01:00",
+        "end_time": "2025-12-20T06:45:00+01:00"
       }
     ],
     "is_nap": false
@@ -351,7 +358,7 @@ Every payload envelope has `type` (the event name as a string) and `data`.
 ```
 
 <Note>
-  `sleep_duration_seconds` is the time actually asleep (excludes awake periods within the session); `duration_seconds` is the total time-in-bed span. Both `source.source` (the third-party writer app, e.g. HealthKit/Health Connect) and `sleep_stage_intervals` (the full per-interval stage timeline) are `null`/omitted when the provider or ingestion path did not report them.
+  `sleep_duration_seconds` is the time actually asleep (excludes awake periods within the session); `duration_seconds` is the total time-in-bed span. Both `source.source` (the third-party writer app, e.g. HealthKit/Health Connect) and `sleep_stage_intervals` are `null`/omitted when the provider or ingestion path did not report them. Unlike every other field in this example, `sleep_stage_intervals` above is **not** shown in full — see the note before the code block.
 </Note>
 
 ### `menstrual_cycle.created`


### PR DESCRIPTION
## Description

So the GET `/sleep-sessions` response included `sleep_duration_seconds`, `sleep_stage_intervals`, and additional source metadata (`source`, `device_type`, `device_name`) that the `sleep.created` webhook never sent, forcing consumers to make an extra API call after every webhook :/

Now `on_sleep_created` (events.py) accepts and emits these fields. Both call sites (`create_or_merge_sleep`, `_emit_event_record_webhook` in `event_record_service.py`) were updated to pass them through - the data was already loaded in memory (EventRecordDetailCreate.sleep_stages/sleep_total_duration_minutes, DataSource), so no new queries were needed except one DataSource lookup (only when Svix is enabled) for the merge path that didn't already have it.

---

This is a hot fix of the [1529](https://github.com/the-momentum/open-wearables/issues/1529) issue.
But we should try to unify webhooks and api responses with the same schema / response building functions. But because the issue was a bug, I decided to move forward with the simplest solution asap, and make a new task on our linear to not forget to continue the work on making sure the data is unified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sleep-created webhook events now include sleep duration, sleep-stage intervals, and richer source and device details.
  * Source information can include the originating app, device type, and device name.
  * Device metadata is automatically inferred when it is not explicitly provided, including from recognized source information.

* **Documentation**
  * Updated the webhook reference with the expanded payload format and clarified the difference between time asleep and total time in bed.
  * Documented when source and sleep-stage details may be unavailable or abbreviated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->