### PR TITLE
fix(backend): replace stages on same-window re-sync instead of concatenating (fixes #1539)

### DIFF
--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -455,6 +455,13 @@ class EventRecordService(
             )
 
             if same_window:
+                # Re-sync of the exact same window: replace sleep stages with the
+                # incoming detail's stages rather than concatenating them, which
+                # would duplicate every interval once per re-sync.
+                merged_detail_fields = {
+                    **merged_detail_fields,
+                    "sleep_stages": list(detail.sleep_stages or []),
+                }
                 self.event_record_detail_repo.delete_by_record_id(db_session, adjacent.id, "sleep")
                 self.event_record_detail_repo.create_and_flush(
                     db_session,

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -455,17 +455,24 @@ class EventRecordService(
             )
 
             if same_window:
-                # Re-sync of the exact same window: replace sleep stages with the
-                # incoming detail's stages rather than concatenating them, which
-                # would duplicate every interval once per re-sync.
-                merged_detail_fields = {
-                    **merged_detail_fields,
+                # Re-sync of the exact same window: replace the stored detail
+                # with the incoming detail's fields (minute-level aggregates and
+                # stages) instead of merging them with the existing session.
+                replacement_detail_fields = {
+                    "sleep_deep_minutes": detail.sleep_deep_minutes,
+                    "sleep_light_minutes": detail.sleep_light_minutes,
+                    "sleep_rem_minutes": detail.sleep_rem_minutes,
+                    "sleep_awake_minutes": detail.sleep_awake_minutes,
+                    "sleep_total_duration_minutes": detail.sleep_total_duration_minutes,
+                    "sleep_time_in_bed_minutes": detail.sleep_time_in_bed_minutes,
+                    "sleep_efficiency_score": detail.sleep_efficiency_score,
+                    "is_nap": detail.is_nap,
                     "sleep_stages": list(detail.sleep_stages or []),
                 }
                 self.event_record_detail_repo.delete_by_record_id(db_session, adjacent.id, "sleep")
                 self.event_record_detail_repo.create_and_flush(
                     db_session,
-                    detail.model_copy(update={"record_id": adjacent.id, **merged_detail_fields}),
+                    detail.model_copy(update={"record_id": adjacent.id, **replacement_detail_fields}),
                     detail_type="sleep",
                 )
                 self._recompute_sleep_scores(
@@ -492,7 +499,7 @@ class EventRecordService(
                 self.event_record_detail_repo.delete_by_record_id(db_session, adjacent.id, "sleep")
                 self.event_record_detail_repo.create_and_flush(
                     db_session,
-                    detail.model_copy(update={"record_id": adjacent.id, **merged_detail_fields}),
+                    detail.model_copy(update={"record_id": adjacent.id, **replacement_detail_fields}),
                     detail_type="sleep",
                 )
                 self._recompute_sleep_scores(

--- a/backend/app/services/event_record_service.py
+++ b/backend/app/services/event_record_service.py
@@ -443,6 +443,22 @@ class EventRecordService(
                 "sleep_stages": merged_stages,
             }
 
+            # Fields used when an incoming record exactly matches an existing window.
+            # Computed eagerly because the same-window path can be reached both by
+            # the explicit same_window check and by the unique-constraint fallback
+            # when data_source_id is resolved at insert time.
+            replacement_detail_fields = {
+                "sleep_deep_minutes": detail.sleep_deep_minutes,
+                "sleep_light_minutes": detail.sleep_light_minutes,
+                "sleep_rem_minutes": detail.sleep_rem_minutes,
+                "sleep_awake_minutes": detail.sleep_awake_minutes,
+                "sleep_total_duration_minutes": detail.sleep_total_duration_minutes,
+                "sleep_time_in_bed_minutes": detail.sleep_time_in_bed_minutes,
+                "sleep_efficiency_score": detail.sleep_efficiency_score,
+                "is_nap": detail.is_nap,
+                "sleep_stages": list(detail.sleep_stages or []),
+            }
+
             # When the merged window is identical to the existing record's window
             # (new session fully contained within adjacent), inserting a new record
             # would violate the unique constraint on (data_source_id, start, end).
@@ -458,17 +474,6 @@ class EventRecordService(
                 # Re-sync of the exact same window: replace the stored detail
                 # with the incoming detail's fields (minute-level aggregates and
                 # stages) instead of merging them with the existing session.
-                replacement_detail_fields = {
-                    "sleep_deep_minutes": detail.sleep_deep_minutes,
-                    "sleep_light_minutes": detail.sleep_light_minutes,
-                    "sleep_rem_minutes": detail.sleep_rem_minutes,
-                    "sleep_awake_minutes": detail.sleep_awake_minutes,
-                    "sleep_total_duration_minutes": detail.sleep_total_duration_minutes,
-                    "sleep_time_in_bed_minutes": detail.sleep_time_in_bed_minutes,
-                    "sleep_efficiency_score": detail.sleep_efficiency_score,
-                    "is_nap": detail.is_nap,
-                    "sleep_stages": list(detail.sleep_stages or []),
-                }
                 self.event_record_detail_repo.delete_by_record_id(db_session, adjacent.id, "sleep")
                 self.event_record_detail_repo.create_and_flush(
                     db_session,

--- a/backend/tests/services/test_event_record_service.py
+++ b/backend/tests/services/test_event_record_service.py
@@ -853,6 +853,59 @@ class TestCreateOrMergeSleep:
         assert result.sleep_detail.sleep_efficiency_score == detail.sleep_efficiency_score
 
 
+    def test_same_window_fallback_with_none_data_source_id(self, db: Session) -> None:
+        """When data_source_id is None on input, the unique-constraint fallback still
+        replaces the stored detail without raising UnboundLocalError.
+        """
+        user = UserFactory()
+        data_source = DataSourceFactory(user=user, provider=ProviderName.OURA, source="oura", device_type="ring")
+
+        existing_stage = {
+            "stage": "light",
+            "start_time": self._dt(22, 30).isoformat(),
+            "end_time": self._dt(22, 45).isoformat(),
+        }
+        existing = EventRecordFactory(
+            mapping=data_source,
+            category="sleep",
+            type_="sleep_session",
+            start_datetime=self._dt(22, 30),
+            end_datetime=self._dt(23, 30),
+        )
+        SleepDetailsFactory(event_record=existing, sleep_stages=[existing_stage])
+
+        incoming_stage = SleepStage(
+            stage="deep",
+            start_time=self._dt(22, 45),
+            end_time=self._dt(23, 30),
+        )
+
+        # Same window as existing, but data_source_id is resolved at insert time.
+        record = EventRecordCreate(
+            id=uuid4(),
+            category="sleep",
+            type="sleep_session",
+            source_name="Oura",
+            source="oura",
+            user_id=user.id,
+            start_datetime=self._dt(22, 30),
+            end_datetime=self._dt(23, 30),
+            duration_seconds=3600,
+        )
+        assert record.data_source_id is None
+        detail = self._detail(record.id, deep=90, light=30, rem=30, awake=0, in_bed=150, efficiency="95.00")
+        detail = detail.model_copy(update={"sleep_stages": [incoming_stage]})
+
+        result = event_record_service.create_or_merge_sleep(db, user.id, record, detail, self.THRESHOLD)
+
+        db.refresh(result)
+        stages = result.sleep_detail.sleep_stages
+        assert stages is not None
+        assert len(stages) == 1
+        assert stages[0]["stage"] == "deep"
+        assert result.sleep_detail.sleep_deep_minutes == detail.sleep_deep_minutes
+        assert result.data_source_id == data_source.id
+
 class TestRecomputeSleepScores:
     """Test the internal sleep score recompute triggered by create_or_merge_sleep."""
 

--- a/backend/tests/services/test_event_record_service.py
+++ b/backend/tests/services/test_event_record_service.py
@@ -809,8 +809,6 @@ class TestCreateOrMergeSleep:
         mock_sleep.assert_called_once()
         assert mock_sleep.call_args.kwargs["device_type"] == "ring"
 
-
-
     def test_same_window_re_sync_replaces_sleep_stages(self, db: Session) -> None:
         """Re-syncing the exact same window must replace stored detail with the incoming detail."""
         user = UserFactory()
@@ -841,19 +839,19 @@ class TestCreateOrMergeSleep:
         detail = self._detail(record.id, deep=90, light=30, rem=30, awake=0, in_bed=150, efficiency="95.00")
         detail = detail.model_copy(update={"sleep_stages": [incoming_stage]})
 
-        result = event_record_service.create_or_merge_sleep(
-            db, user.id, record, detail, self.THRESHOLD
-        )
+        result = event_record_service.create_or_merge_sleep(db, user.id, record, detail, self.THRESHOLD)
 
         db.refresh(result)
         stages = result.sleep_detail.sleep_stages
         assert stages is not None
         assert len(stages) == 1
         assert stages[0]["stage"] == "deep"
-        assert stages[0]["start_time"] == incoming_stage.start_time.isoformat()
-        assert stages[0]["end_time"] == incoming_stage.end_time.isoformat()
+        incoming_data = incoming_stage.model_dump(mode="json")
+        assert stages[0]["start_time"] == incoming_data["start_time"]
+        assert stages[0]["end_time"] == incoming_data["end_time"]
         assert result.sleep_detail.sleep_deep_minutes == detail.sleep_deep_minutes
         assert result.sleep_detail.sleep_efficiency_score == detail.sleep_efficiency_score
+
 
 class TestRecomputeSleepScores:
     """Test the internal sleep score recompute triggered by create_or_merge_sleep."""

--- a/backend/tests/services/test_event_record_service.py
+++ b/backend/tests/services/test_event_record_service.py
@@ -810,6 +810,40 @@ class TestCreateOrMergeSleep:
         assert mock_sleep.call_args.kwargs["device_type"] == "ring"
 
 
+
+    def test_same_window_re_sync_replaces_sleep_stages(self, db: Session) -> None:
+        """Re-syncing the exact same window must not duplicate stage intervals."""
+        user = UserFactory()
+        data_source = DataSourceFactory(user=user)
+
+        stage = {
+            "stage": "light",
+            "start_time": self._dt(22, 30).isoformat(),
+            "end_time": self._dt(23, 30).isoformat(),
+        }
+        existing = EventRecordFactory(
+            mapping=data_source,
+            category="sleep",
+            type_="sleep_session",
+            start_datetime=self._dt(22, 30),
+            end_datetime=self._dt(23, 30),
+        )
+        SleepDetailsFactory(event_record=existing, sleep_stages=[stage])
+
+        # Same window, same data_source_id -> should hit same_window branch
+        record = self._record(data_source, self._dt(22, 30), self._dt(23, 30))
+        detail = self._detail(record.id)
+        detail = detail.model_copy(update={"sleep_stages": [stage]})
+
+        result = event_record_service.create_or_merge_sleep(
+            db, user.id, record, detail, self.THRESHOLD
+        )
+
+        db.refresh(result)
+        stages = result.sleep_detail.sleep_stages
+        assert stages is not None
+        assert len(stages) == 1
+
 class TestRecomputeSleepScores:
     """Test the internal sleep score recompute triggered by create_or_merge_sleep."""
 

--- a/backend/tests/services/test_event_record_service.py
+++ b/backend/tests/services/test_event_record_service.py
@@ -812,14 +812,14 @@ class TestCreateOrMergeSleep:
 
 
     def test_same_window_re_sync_replaces_sleep_stages(self, db: Session) -> None:
-        """Re-syncing the exact same window must not duplicate stage intervals."""
+        """Re-syncing the exact same window must replace stored detail with the incoming detail."""
         user = UserFactory()
         data_source = DataSourceFactory(user=user)
 
-        stage = {
+        existing_stage = {
             "stage": "light",
             "start_time": self._dt(22, 30).isoformat(),
-            "end_time": self._dt(23, 30).isoformat(),
+            "end_time": self._dt(22, 45).isoformat(),
         }
         existing = EventRecordFactory(
             mapping=data_source,
@@ -828,12 +828,18 @@ class TestCreateOrMergeSleep:
             start_datetime=self._dt(22, 30),
             end_datetime=self._dt(23, 30),
         )
-        SleepDetailsFactory(event_record=existing, sleep_stages=[stage])
+        SleepDetailsFactory(event_record=existing, sleep_stages=[existing_stage])
+
+        incoming_stage = SleepStage(
+            stage="deep",
+            start_time=self._dt(22, 45),
+            end_time=self._dt(23, 30),
+        )
 
         # Same window, same data_source_id -> should hit same_window branch
         record = self._record(data_source, self._dt(22, 30), self._dt(23, 30))
-        detail = self._detail(record.id)
-        detail = detail.model_copy(update={"sleep_stages": [stage]})
+        detail = self._detail(record.id, deep=90, light=30, rem=30, awake=0, in_bed=150, efficiency="95.00")
+        detail = detail.model_copy(update={"sleep_stages": [incoming_stage]})
 
         result = event_record_service.create_or_merge_sleep(
             db, user.id, record, detail, self.THRESHOLD
@@ -843,6 +849,11 @@ class TestCreateOrMergeSleep:
         stages = result.sleep_detail.sleep_stages
         assert stages is not None
         assert len(stages) == 1
+        assert stages[0]["stage"] == "deep"
+        assert stages[0]["start_time"] == incoming_stage.start_time.isoformat()
+        assert stages[0]["end_time"] == incoming_stage.end_time.isoformat()
+        assert result.sleep_detail.sleep_deep_minutes == detail.sleep_deep_minutes
+        assert result.sleep_detail.sleep_efficiency_score == detail.sleep_efficiency_score
 
 class TestRecomputeSleepScores:
     """Test the internal sleep score recompute triggered by create_or_merge_sleep."""


### PR DESCRIPTION
"## Problem\n\nRe-syncing a Polar night whose window is identical to an existing sleep record currently appends the incoming stages to the stored stages via the adjacent-merge branch, duplicating every interval once per sync (#1539).\n\n## Root cause\n\ncreate_or_merge_sleep concatenates sleep stages for all adjacent merges. When same_window is true (identical start/end/data_source), the merged detail is written back with the concatenated list, so each re-sync adds another copy of the same stages.\n\n## Fix\n\nIn the same_window branch, replace the stored sleep detail with the incoming detail instead of merging. Minute-level aggregates and sleep stages now come from the latest incoming detail.\n\nThe conflict-handling path that catches the unique-constraint violation also uses the same replacement logic.\n\n## Tests\n\n- Added \test_same_window_re_sync_replaces_sleep_stages to verify that re-syncing the exact same window leaves exactly one copy of the incoming stages.\n- The existing \test_merge_concatenates_sleep_stages still validates that non-overlapping adjacent merges continue to concatenate correctly.\n\n## Notes\n\nI don't have a real Polar connection available, so end-to-end hardware validation hasn't been done. The targeted regression test plus the existing backend suite pass locally."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed sleep record synchronization when the data source is resolved during insertion.
  - Sleep stage details and deep-sleep duration are now correctly replaced during same-window updates.
  - Prevented failures when re-syncing records with missing data source information.

- **Tests**
  - Added coverage for same-window synchronization with unresolved data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->