### PR TITLE
docs: broaden redaction guidance beyond tokens and health data

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ If your change touches a provider integration, we need to know it was tested aga
 a real account and real API responses.
 
 Paste the proof where you can - a log excerpt, a screenshot, a sample response - with
-tokens and anyone's health data removed.
+all secrets and sensitive personal data removed.
 -->
 
 ## AI usage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ See [Reporting Issues](./contributing/issues.md) and the [Pull Request Guideline
 
 > **Please run your change before you submit it.** Untested contributions are by far the most common reason we send a PR back. Code that has never actually been executed - not by the test suite, not by hand - isn't ready for review, however good it looks.
 
-- **Exercise the change by hand.** Call the endpoint, click through the flow, sync against a real provider account - whatever your change touches. A green test suite is not the same thing as a working feature. Where it makes sense, show the proof in the PR description or a comment - a log excerpt, a screenshot, a sample response - **with tokens and anyone's health data stripped out.**
+- **Exercise the change by hand.** Call the endpoint, click through the flow, sync against a real provider account - whatever your change touches. A green test suite is not the same thing as a working feature. Where it makes sense, show the proof in the PR description or a comment - a log excerpt, a screenshot, a sample response - **with all secrets and sensitive personal data stripped out.**
 - **Make sure the tests pass locally.** See the [Testing guide](./contributing/testing.md) for how to run them.
 - **Add tests for new behaviour.** If you're changing how something works, something should fail when you break it.
 


### PR DESCRIPTION
Secrets and personal data might come in more shapes than tokens and health records - this widens the wording to cover both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated pull request and contribution guidelines to require removing secrets and sensitive personal data from pasted proof or supporting artifacts.
  - Clarified and broadened the existing guidance beyond tokens and health data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->