### PR TITLE
docs: point Getting Help at the published docs and community channels

### DIFF
--- a/contributing/issues.md
+++ b/contributing/issues.md
@@ -100,6 +100,7 @@ Common labels you may see:
 
 If you need help but it's not a bug or feature request:
 
-- Check the [documentation](../README.md)
-- Review the [API docs](http://localhost:8000/docs) when running locally
-- Ask in discussions or community channels
+- Check the [documentation](https://openwearables.io/docs)
+- Review the [API reference](https://openwearables.io/docs/api-reference/introduction)
+- Browse the live API docs at `http://localhost:8000/docs` when running the stack locally
+- Ask in [GitHub Discussions](https://github.com/the-momentum/open-wearables/discussions) or on [Discord](https://discord.gg/qrcfFnNE6H)


### PR DESCRIPTION
The Getting Help links pointed at a README and a localhost URL - they now point at the published docs, GitHub Discussions and Discord.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated issue-reporting guidance with links to the external documentation and API reference.
  - Added instructions for viewing live API documentation when running the stack locally.
  - Replaced generic community-support references with direct links to GitHub Discussions and Discord.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->