### PR TITLE
chore: cleanup app startup script

### DIFF
--- a/backend/scripts/start/app.sh
+++ b/backend/scripts/start/app.sh
@@ -26,13 +26,6 @@ echo 'Initializing series type definitions...'
 uv run python scripts/init/seed_series_types.py
 
 
-# TODO: Remove this after ~2026-09-01 once all deployments have migrated.
-# Relabels Oura HRV stored as SDNN (id=3) to RMSSD (id=7); scoped to provider='oura', no-op once corrected.
-echo 'Running Oura HRV SDNN->RMSSD relabel...'
-uv run python scripts/data_migrations/relabel_oura_hrv_sdnn_to_rmssd.py \
-    || echo "Warning: Oura HRV relabel failed — will retry on next startup."
-
-
 # TODO: Remove this after ~2026-11-01 once all deployments have migrated.
 # Relabels Ultrahuman temperature stored as body_temperature (id=45) to skin_temperature
 # (id=46); scoped to provider='ultrahuman', no-op once corrected.
@@ -40,13 +33,6 @@ echo 'Running Ultrahuman body_temperature->skin_temperature relabel...'
 uv run python scripts/data_migrations/relabel_ultrahuman_body_temp_to_skin_temp.py \
     || echo "Warning: Ultrahuman temperature relabel failed — will retry on next startup."
 
-
-# TODO: Remove this after ~2026-09-01 once all deployments have migrated.
-# Labels is_daily_total on archival data_point_series (daily totals → TRUE); idempotent,
-# only flips NULL rows, batched. After the first full pass, re-runs are no-ops.
-echo 'Running is_daily_total backfill...'
-uv run python scripts/data_migrations/backfill_is_daily_total.py \
-    || echo "Warning: is_daily_total backfill failed — will retry on next startup."
 
 # TODO: Remove this after ~2026-12-01 once all deployments have migrated.
 # Links legacy Whoop workout strain scores to their event records; without it they stay


### PR DESCRIPTION
Cleaning up `app.sh` startup 

Two data migration scripts:

- Oura SDNN -> RMSSD relabel - was merged June 13th, changing the series type definition id for Oura HRV
- daily total backfill: merged June 24th setting certain data types `is_daily_total` field to true (where we're certain that they actually are daily totals, e.g. Garmin steps total)

should be perfectly safe and most deploys will have already ran those

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated startup migration handling by removing two legacy data migrations.
  * Existing temperature relabeling and strain event backfill migrations continue to run unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->