### PR TITLE
fix(backend): send webhook after seeding the sleep data

### DIFF
--- a/backend/app/services/seed_data/service.py
+++ b/backend/app/services/seed_data/service.py
@@ -8,9 +8,8 @@ from datetime import date, datetime, timedelta, timezone
 from faker import Faker
 from sqlalchemy.orm import Session
 
-from app.models import EventRecordDetail, PersonalRecord, UserConnection
+from app.models import PersonalRecord, UserConnection
 from app.repositories import CrudRepository
-from app.repositories.event_record_detail_repository import EventRecordDetailRepository
 from app.schemas.enums import ProviderName, SeriesType, WorkoutType
 from app.schemas.model_crud.user_management import UserConnectionUpdate, UserCreate
 from app.schemas.utils.seed_data import SeedDataRequest
@@ -103,7 +102,6 @@ class SeedDataService:
         now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
         personal_record_repo = CrudRepository(PersonalRecord)
-        event_detail_repo = EventRecordDetailRepository(EventRecordDetail)
         connection_repo = CrudRepository(UserConnection)
 
         summary = {
@@ -187,7 +185,7 @@ class SeedDataService:
                         user.id, fake, prov, provider_sync_times[prov], profile.sleep_config
                     )
                     event_record_service.create(db, record)
-                    event_detail_repo.create(db, detail, detail_type="sleep")
+                    event_record_service.create_detail(db, detail, detail_type="sleep")
                     summary["sleeps"] += 1
 
             # Continuous time series (independent of workouts)


### PR DESCRIPTION
## Description

I discovered this problem because I needed to test webhooks for sleeping, and when I went to seed data generation (In UI it is: Settings → Seed Data → Generate users) and created sleep records to be send by webhook, they haven't been sent, altho the user had them.

If you look into the code you can find that the method which was used - `EventRecordDetailRepository.create()` didn't have any webhook logic, only db insert, but  `EventRecordService.create_detail()` has both (workout is using exactly that), so the fix is to use the `EventRecordService.create_detail()` and it works now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Sleep record details are now created through the same service workflow used for workout details, improving consistency in seed data generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->