### PR TITLE
feat(summaries): all_sources returns every source's row for a day

### DIFF
--- a/backend/app/api/routes/v1/summaries.py
+++ b/backend/app/api/routes/v1/summaries.py
@@ -29,15 +29,31 @@ def get_activity_summary(
     cursor: str | None = None,
     limit: Annotated[int, Query(ge=1, le=400)] = 50,
     sort_order: Annotated[str, Query(pattern="^(asc|desc)$")] = "asc",
+    all_sources: Annotated[
+        bool,
+        Query(
+            description=(
+                "Return every source's row for each day instead of only the one the"
+                " global provider-priority table selects. Off by default. When on, a"
+                " day with two wearables yields TWO rows, so callers must resolve"
+                " which to use themselves."
+            )
+        ),
+    ] = False,
 ) -> PaginatedResponse[ActivitySummary]:
     """Returns daily aggregated activity metrics.
 
     Aggregates time-series data (steps, energy, heart rate, etc.) by day.
+
+    By default one row per day is returned, chosen by the GLOBAL provider
+    priority. `all_sources=true` returns every source's row for the day, for
+    callers that need to apply their own per-user preference — something the
+    priority table cannot express, since it has no `user_id` column.
     """
     start_datetime = parse_query_datetime(start_date)
     end_datetime = parse_query_datetime(end_date)
     return summaries_service.get_activity_summaries(
-        db, user_id, start_datetime, end_datetime, cursor, limit, sort_order
+        db, user_id, start_datetime, end_datetime, cursor, limit, sort_order, all_sources
     )
 
 

--- a/backend/app/services/summaries_service.py
+++ b/backend/app/services/summaries_service.py
@@ -85,6 +85,21 @@ DEFAULT_AVERAGE_PERIOD_DAYS = 7
 DEFAULT_LATEST_WINDOW_HOURS = 4
 
 
+def activity_sort_key(entry: dict) -> tuple:
+    """Compound ordering key for an activity row: (date, provider, device).
+
+    The cursor comparisons below and the ordering of `results` MUST agree, or
+    forward pagination silently skips rows. They share this one expression so
+    they cannot drift apart. `or ""` matches `decode_activity_cursor`, which
+    normalises a missing device to the empty string.
+    """
+    return (
+        entry["activity_date"],
+        entry.get("source") or "",
+        entry.get("device_model") or "",
+    )
+
+
 class SummariesService:
     """Service for aggregating daily health summaries."""
 
@@ -458,6 +473,7 @@ class SummariesService:
         cursor: str | None,
         limit: int,
         sort_order: str = "asc",
+        all_sources: bool = False,
     ) -> PaginatedResponse[ActivitySummary]:
         """Get daily activity summaries aggregated by date, provider, and device.
 
@@ -480,8 +496,22 @@ class SummariesService:
         # Merge archived data when archival is enabled
         results = self._merge_archive_activity(db_session, user_id, start_date, end_date, results)
 
-        # Filter by priority to get best source per date
-        results = self._filter_by_priority(db_session, user_id, results, date_key="activity_date")
+        # Filter by priority to get best source per date.
+        #
+        # `all_sources=True` skips this and returns every source's row, so a
+        # caller with its own per-user preference can choose. The global
+        # priority table cannot express that: it has no `user_id` column, and
+        # `ProviderPriority` documents itself as "not per-user".
+        if all_sources:
+            # Rows arrive ordered by date ONLY (`order_by(asc(local_date))` in
+            # `get_daily_activity_aggregates`). That was sufficient while this
+            # filter collapsed each date to a single row; with several rows per
+            # date the cursor comparisons below — which use the compound key —
+            # would operate on an unsorted list and skip records. Impose the
+            # same ordering the cursor assumes.
+            results = sorted(results, key=activity_sort_key)
+        else:
+            results = self._filter_by_priority(db_session, user_id, results, date_key="activity_date")
 
         # Get workout aggregates (elevation, distance, energy from workouts)
         workout_aggregates = self.event_record_repo.get_daily_workout_aggregates(
@@ -540,34 +570,18 @@ class SummariesService:
                 # Backward pagination: get items BEFORE cursor key (in current sort order)
                 if sort_order == "desc":
                     # In desc order, "before" means items with GREATER keys
-                    results = [
-                        r
-                        for r in results
-                        if (r["activity_date"], r["source"] or "", r.get("device_model") or "") > cursor_key
-                    ]
+                    results = [r for r in results if activity_sort_key(r) > cursor_key]
                 else:
-                    results = [
-                        r
-                        for r in results
-                        if (r["activity_date"], r["source"] or "", r.get("device_model") or "") < cursor_key
-                    ]
+                    results = [r for r in results if activity_sort_key(r) < cursor_key]
                 # Reverse to get correct order for backward pagination
                 results = list(reversed(results))
             else:
                 # Forward pagination: get items AFTER cursor key (in current sort order)
                 if sort_order == "desc":
                     # In desc order, "after" means items with SMALLER keys
-                    results = [
-                        r
-                        for r in results
-                        if (r["activity_date"], r["source"] or "", r.get("device_model") or "") < cursor_key
-                    ]
+                    results = [r for r in results if activity_sort_key(r) < cursor_key]
                 else:
-                    results = [
-                        r
-                        for r in results
-                        if (r["activity_date"], r["source"] or "", r.get("device_model") or "") > cursor_key
-                    ]
+                    results = [r for r in results if activity_sort_key(r) > cursor_key]
 
         # Check for more data
         has_more = len(results) > limit

--- a/backend/tests/services/test_all_sources_activity_summaries.py
+++ b/backend/tests/services/test_all_sources_activity_summaries.py
@@ -1,0 +1,221 @@
+"""`all_sources=True` returns every source's row instead of the priority winner.
+
+The global provider-priority table cannot express a per-user preference — it has
+no `user_id` column, and `ProviderPriority` documents itself as "not per-user".
+A caller that needs one has no way to reach the losing source's numbers today:
+the summaries endpoint returns only the row the global order picked.
+
+These tests pin both directions of the flag, and the ordering guarantee the
+cursor depends on once several rows can share a date.
+"""
+
+from datetime import date, datetime
+from logging import getLogger
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from app.schemas.responses.activity import ActivitySummary
+from app.schemas.utils import PaginatedResponse
+from app.services.summaries_service import SummariesService, activity_sort_key
+
+
+@pytest.fixture
+def service() -> SummariesService:
+    return SummariesService(log=getLogger(__name__))
+
+
+def _dt(iso: str) -> datetime:
+    return datetime.fromisoformat(iso)
+
+
+def _row(day: int, source: str, *, steps: int, device: str | None = None) -> dict[str, Any]:
+    """One aggregate row as `get_daily_activity_aggregates` returns it."""
+    return {
+        "activity_date": date(2026, 1, day),
+        "provider": source,
+        "source": source,
+        "device_model": device,
+        "device_type": None,
+        "steps_sum": steps,
+        "active_energy_sum": float(steps) / 10,
+        "basal_energy_sum": None,
+        "distance_sum": None,
+        "hr_avg": None,
+        "hr_max": None,
+        "hr_min": None,
+    }
+
+
+def _stub_reads(service: SummariesService, monkeypatch: pytest.MonkeyPatch, rows: list[dict]) -> None:
+    """Feed fixed aggregate rows in and stub every other read the builder makes."""
+    monkeypatch.setattr(service.data_point_repo, "get_daily_activity_aggregates", lambda *_a, **_k: list(rows))
+    monkeypatch.setattr(service, "_merge_archive_activity", lambda *_a, **_k: list(rows))
+    monkeypatch.setattr(service.event_record_repo, "get_daily_workout_aggregates", lambda *_a, **_k: [])
+    monkeypatch.setattr(service.data_point_repo, "get_daily_active_minutes", lambda *_a, **_k: [])
+    monkeypatch.setattr(service.data_point_repo, "get_daily_intensity_minutes", lambda *_a, **_k: [])
+    monkeypatch.setattr(service, "_get_user_max_hr", lambda *_a, **_k: 190)
+
+
+def _call(
+    service: SummariesService,
+    monkeypatch: pytest.MonkeyPatch,
+    rows: list[dict],
+    **kwargs: Any,
+) -> PaginatedResponse[ActivitySummary]:
+    _stub_reads(service, monkeypatch, rows)
+    return service.get_activity_summaries(
+        db_session=None,
+        user_id=uuid4(),
+        start_date=_dt("2026-01-01T00:00:00+00:00"),
+        end_date=_dt("2026-01-10T00:00:00+00:00"),
+        cursor=None,
+        limit=50,
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# The flag itself
+# ---------------------------------------------------------------------------
+
+
+class TestAllSourcesFlag:
+    def test_off_by_default_returns_one_row_per_day(
+        self, service: SummariesService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        rows = [_row(1, "garmin", steps=9000), _row(1, "apple", steps=40)]
+        # Priority is a DB read; with no session, stub it to the documented
+        # behaviour (one winner per date) rather than exercising the table.
+        monkeypatch.setattr(service, "_filter_by_priority", lambda _s, _u, r, **_k: [r[0]])
+
+        result = _call(service, monkeypatch, rows)
+
+        assert len(result.data) == 1, "default must stay one row per day"
+
+    def test_on_returns_every_source_for_the_day(
+        self, service: SummariesService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        rows = [_row(1, "garmin", steps=9000), _row(1, "apple", steps=40)]
+
+        result = _call(service, monkeypatch, rows, all_sources=True)
+
+        assert len(result.data) == 2, "both sources must survive"
+        assert {s.source.provider for s in result.data} == {"garmin", "apple"}
+
+    def test_on_does_not_consult_the_priority_table_at_all(
+        self, service: SummariesService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The whole point: the global order must not get a say."""
+        called = False
+
+        def _boom(*_a: Any, **_k: Any) -> list:
+            nonlocal called
+            called = True
+            return []
+
+        monkeypatch.setattr(service, "_filter_by_priority", _boom)
+        _call(service, monkeypatch, [_row(1, "garmin", steps=9000)], all_sources=True)
+
+        assert called is False, "all_sources must bypass the global priority filter"
+
+    def test_the_losing_source_keeps_its_own_numbers(
+        self, service: SummariesService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rows must not be merged or summed — each keeps its own values.
+
+        This is the failure that motivated the flag: an iPhone row with no
+        activity outranked a Garmin holding the real numbers.
+        """
+        rows = [_row(1, "apple", steps=40), _row(1, "garmin", steps=9000)]
+
+        result = _call(service, monkeypatch, rows, all_sources=True)
+
+        by_source = {s.source.provider: s for s in result.data}
+        assert by_source["garmin"].steps == 9000
+        assert by_source["apple"].steps == 40
+        assert sum(s.steps or 0 for s in result.data) == 9040, "no row may absorb another's steps"
+
+
+# ---------------------------------------------------------------------------
+# The ordering guarantee the cursor depends on
+# ---------------------------------------------------------------------------
+
+
+class TestCompoundOrdering:
+    def test_rows_sharing_a_date_come_back_in_compound_key_order(
+        self, service: SummariesService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`get_daily_activity_aggregates` orders by DATE ONLY.
+
+        That was sufficient while the priority filter collapsed each date to a
+        single row. With several rows per date the cursor comparisons use the
+        compound key, so an unsorted list makes forward pagination skip records.
+        """
+        rows = [
+            _row(2, "whoop", steps=3),
+            _row(1, "garmin", steps=2),
+            _row(1, "apple", steps=1),
+        ]
+
+        result = _call(service, monkeypatch, rows, all_sources=True)
+
+        keys = [(s.date, s.source.provider or "") for s in result.data]
+        assert keys == sorted(keys), "rows must be ordered by (date, source, device)"
+
+    def test_sort_key_matches_the_cursor_key_exactly(self) -> None:
+        """The sort and the cursor comparisons share one expression.
+
+        If they ever drift, pagination silently skips rows — so pin the
+        normalisation `decode_activity_cursor` applies: a missing device becomes
+        the empty string, never None (which would raise on comparison).
+        """
+        assert activity_sort_key({"activity_date": date(2026, 1, 1), "source": None, "device_model": None}) == (
+            date(2026, 1, 1),
+            "",
+            "",
+        )
+
+        assert activity_sort_key({"activity_date": date(2026, 1, 1), "source": "garmin", "device_model": "Fenix"}) == (
+            date(2026, 1, 1),
+            "garmin",
+            "Fenix",
+        )
+
+    def test_pagination_over_a_multi_source_day_loses_no_rows(
+        self, service: SummariesService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Page through a day with three sources and see all three, once each."""
+        rows = [
+            _row(1, "whoop", steps=3),
+            _row(1, "garmin", steps=2),
+            _row(1, "apple", steps=1),
+        ]
+
+        _stub_reads(service, monkeypatch, rows)
+        page1 = service.get_activity_summaries(
+            db_session=None,
+            user_id=uuid4(),
+            start_date=_dt("2026-01-01T00:00:00+00:00"),
+            end_date=_dt("2026-01-10T00:00:00+00:00"),
+            cursor=None,
+            limit=2,
+            all_sources=True,
+        )
+        assert len(page1.data) == 2
+        assert page1.pagination.has_more is True
+
+        _stub_reads(service, monkeypatch, rows)
+        page2 = service.get_activity_summaries(
+            db_session=None,
+            user_id=uuid4(),
+            start_date=_dt("2026-01-01T00:00:00+00:00"),
+            end_date=_dt("2026-01-10T00:00:00+00:00"),
+            cursor=page1.pagination.next_cursor,
+            limit=2,
+            all_sources=True,
+        )
+
+        seen = [s.source.provider for s in page1.data] + [s.source.provider for s in page2.data]
+        assert sorted(seen) == ["apple", "garmin", "whoop"], "every source must appear exactly once across the pages"


### PR DESCRIPTION
Adds an opt-in `all_sources` query parameter to the activity summaries endpoint. **Off by default**, so every existing caller is unchanged.

## Why

`ProviderPriority` states the constraint in its own docstring:

> This is a global configuration (not per-user or per-application).

`_filter_by_priority` resolves each day to one source using that global table. A caller that wants a **per-user** preference has no way to reach the losing source's numbers — they're computed, then discarded server-side.

Our concrete case: a user with a Garmin and an iPhone but no Apple Watch gets their iPhone's summary, which carries no active energy at all, while the Garmin's real figure sits unused. Reordering the global table fixes that user and demotes someone else's Apple Watch. There's no global order that's right for everyone, which is why this returns the rows and leaves the choice to the caller rather than trying to encode a better ordering.

```
GET /users/{id}/summaries/activity?all_sources=true
  -> a day with a Garmin and an Apple source yields TWO rows
```

## The non-obvious part

The priority filter was doing double duty. `get_daily_activity_aggregates` orders by **date only**:

```python
.order_by(asc(local_date))
```

That's sufficient while the filter collapses each date to a single row. With several rows per date, the cursor comparisons — which use the compound `(date, source, device)` key — operate on an unsorted list and **silently skip records** during forward pagination.

So the `all_sources` path imposes that ordering explicitly. And to stop the sort and the cursor drifting apart, both now call one `activity_sort_key()` helper instead of repeating the tuple in five places. It normalises a missing device to `""` exactly as `decode_activity_cursor` does — `None` raises on comparison.

If you'd rather see the ordering fixed at the query level (a secondary `order_by` in the repository) I'm happy to change it — it just seemed wrong to alter the default path's query for an opt-in feature.

## Tests

`tests/services/test_all_sources_activity_summaries.py`, 7 tests:

- flag off returns one row per day; flag on returns every source
- when on, `_filter_by_priority` is **not called at all**
- rows are never merged or summed — each source keeps its own numbers
- a multi-source day comes back in compound-key order
- paging across such a day yields every source exactly once
- `activity_sort_key` matches the cursor's normalisation

Verified in the failing direction, not just the passing one:

| Sabotage | Result |
|---|---|
| make the flag a no-op (always filter) | 5 failed, 2 passed |
| drop the explicit sort | 2 failed — including the pagination test |

That second row is why the sort is in there rather than being assumed unnecessary.

## What I verified, and what I didn't

Please read this precisely rather than as a blanket green.

**On our fork's base** (`4552b762`, the merge-base with this branch): `pytest` — 2188 passed, 2 skipped.

**On this branch, against your current `main`**: `ruff check`, `ruff format --check` (633 files) and `ty check` all pass. I could **not** re-run the pytest suite here, because the test harness starts a Postgres testcontainer and Docker isn't available on this machine right now — so I'm not claiming a green suite against your exact base.

What makes me reasonably confident anyway, and you can check it independently: `summaries.py`, `summaries_service.py` and `data_point_series_repository.py` are all **unchanged** upstream between that merge-base and current `main`, so the code under test is identical. Your CI will settle it properly.

**Production exposure is minimal so far.** This is deployed on our self-hosted instance, but the `all_sources` path has had essentially no traffic yet — the feature that consumes it hasn't shipped to users. I don't want to imply it's battle-tested.

## Related

We also have the SDK ingestion cap (#1537), which was closed. Happy to revisit that separately if it's useful — no expectation either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity summaries now support an `all_sources` option to display results from every source for each day.
  * Results preserve source-specific values and support consistent sorting and cursor-based pagination.

* **Documentation**
  * Updated endpoint documentation to explain the `all_sources` option and its response behavior.

* **Tests**
  * Added coverage for multi-source results, ordering, pagination, and source-specific values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->