### PR TITLE
fix(api): handle missing SDK users and invalid webhook filters

### DIFF
--- a/backend/app/api/routes/v1/outgoing_webhooks.py
+++ b/backend/app/api/routes/v1/outgoing_webhooks.py
@@ -15,6 +15,7 @@ from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from svix.api import EndpointOut, MessageAttemptListByEndpointOptions, MessageListOptions, MessageStatus
+from svix.api.errors.http_validation_error import HTTPValidationError
 
 from app.schemas.webhooks.endpoints import (
     EndpointCreateRequest,
@@ -32,6 +33,11 @@ from app.services import DeveloperDep
 from app.services.outgoing_webhooks import svix as svix_service
 
 router = APIRouter()
+
+_ENDPOINT_VALIDATION_DETAIL = (
+    "Webhook endpoint configuration was rejected by Svix. "
+    "Check filter_types against /api/v1/webhooks/event-types and the Svix event registry."
+)
 
 
 def _ep_to_response(ep: EndpointOut) -> EndpointResponse:
@@ -59,13 +65,19 @@ SvixAppId = Annotated[str, Depends(_svix_app_id)]
 
 @router.post("/endpoints", status_code=status.HTTP_201_CREATED)
 def create_endpoint(body: EndpointCreateRequest, app_id: SvixAppId) -> EndpointResponse:
-    ep = svix_service.create_endpoint(
-        app_id,
-        url=body.url,
-        description=body.description,
-        filter_types=body.filter_types,
-        user_id=body.user_id,
-    )
+    try:
+        ep = svix_service.create_endpoint(
+            app_id,
+            url=body.url,
+            description=body.description,
+            filter_types=body.filter_types,
+            user_id=body.user_id,
+        )
+    except HTTPValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_ENDPOINT_VALIDATION_DETAIL,
+        ) from exc
     return _ep_to_response(ep)
 
 
@@ -84,15 +96,21 @@ def get_endpoint(endpoint_id: str, app_id: SvixAppId) -> EndpointResponse:
 @router.patch("/endpoints/{endpoint_id}")
 def update_endpoint(endpoint_id: str, body: EndpointUpdateRequest, app_id: SvixAppId) -> EndpointResponse:
     clear_user = "user_id" in body.model_fields_set and body.user_id is None
-    ep = svix_service.patch_endpoint(
-        app_id,
-        endpoint_id,
-        url=body.url,
-        description=body.description,
-        filter_types=body.filter_types,
-        user_id=body.user_id,
-        clear_user_id=clear_user,
-    )
+    try:
+        ep = svix_service.patch_endpoint(
+            app_id,
+            endpoint_id,
+            url=body.url,
+            description=body.description,
+            filter_types=body.filter_types,
+            user_id=body.user_id,
+            clear_user_id=clear_user,
+        )
+    except HTTPValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=_ENDPOINT_VALIDATION_DETAIL,
+        ) from exc
     return _ep_to_response(ep)
 
 

--- a/backend/app/api/routes/v1/sdk_token.py
+++ b/backend/app/api/routes/v1/sdk_token.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Body, HTTPException, status
 from app.config import settings
 from app.database import DbSession
 from app.schemas.auth import SDKTokenRequest, TokenResponse
-from app.services import application_service, create_sdk_user_token, refresh_token_service
+from app.services import application_service, create_sdk_user_token, refresh_token_service, user_service
 from app.utils.auth import DeveloperOptionalDep
 
 router = APIRouter()
@@ -43,6 +43,7 @@ def create_user_token(
     Raises:
         401: If app credentials are invalid or admin auth is missing
         400: If neither app credentials nor admin auth is provided
+        404: If the user does not exist (after authentication)
     """
     app_id: str
 
@@ -61,6 +62,9 @@ def create_user_token(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Either app credentials (app_id, app_secret) or admin authentication (Bearer token) is required",
         )
+
+    # Authenticate first, then reject absent users before signing or writing tokens.
+    user_service.get(db, user_id, raise_404=True)
 
     # Generate user-scoped SDK token
     access_token = create_sdk_user_token(

--- a/backend/tests/api/v1/test_outgoing_webhooks.py
+++ b/backend/tests/api/v1/test_outgoing_webhooks.py
@@ -18,6 +18,7 @@ from uuid import uuid4
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
+from svix.api.errors.http_validation_error import HTTPValidationError
 
 from app.integrations.celery.tasks.emit_webhook_event_task import emit_webhook_event
 from app.schemas.webhooks.event_types import EVENT_TYPE_DESCRIPTIONS, WebhookEventType
@@ -387,6 +388,68 @@ class TestOutgoingWebhooksAPI:
         data = resp.json()
         assert data["id"] == "ep_123"
         assert data["url"] == "https://example.com/wh"
+
+    @pytest.mark.parametrize("method", ["post", "patch"])
+    def test_invalid_svix_subscription_returns_422(
+        self,
+        client: TestClient,
+        mock_svix: MagicMock,
+        method: str,
+    ) -> None:
+        developer = DeveloperFactory()
+        token = create_access_token(developer.id)
+        operation = mock_svix.create_endpoint if method == "post" else mock_svix.patch_endpoint
+        operation.side_effect = HTTPValidationError(detail=[], status_code=422)
+        url = "/api/v1/webhooks/endpoints" + ("/ep_123" if method == "patch" else "")
+        response = client.request(
+            method,
+            url,
+            json={"url": "https://example.com/wh", "filter_types": ["sleep.batch_created"]},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 422
+        assert response.json()["detail"] == (
+            "Webhook endpoint configuration was rejected by Svix. "
+            "Check filter_types against /api/v1/webhooks/event-types and the Svix event registry."
+        )
+        operation.assert_called_once()
+
+    @pytest.mark.parametrize(("body", "clear_user"), [({}, False), ({"user_id": None}, True)])
+    def test_patch_preserves_omitted_vs_null_user_filter(
+        self,
+        client: TestClient,
+        mock_svix: MagicMock,
+        body: dict,
+        clear_user: bool,
+    ) -> None:
+        token = create_access_token(DeveloperFactory().id)
+        mock_svix.patch_endpoint.return_value = MagicMock(
+            id="ep_123",
+            url="https://example.com/wh",
+            description=None,
+            filter_types=None,
+        )
+        response = client.patch(
+            "/api/v1/webhooks/endpoints/ep_123",
+            json=body,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        assert mock_svix.patch_endpoint.call_args.kwargs["clear_user_id"] is clear_user
+
+    def test_svix_service_failure_is_not_reported_as_validation(
+        self,
+        client: TestClient,
+        mock_svix: MagicMock,
+    ) -> None:
+        token = create_access_token(DeveloperFactory().id)
+        mock_svix.patch_endpoint.side_effect = RuntimeError("test service unavailable")
+        with pytest.raises(RuntimeError, match="test service unavailable"):
+            client.patch(
+                "/api/v1/webhooks/endpoints/ep_123",
+                json={"filter_types": ["sleep.created"]},
+                headers={"Authorization": f"Bearer {token}"},
+            )
 
     def test_list_endpoints(
         self,

--- a/backend/tests/api/v1/test_sdk_token.py
+++ b/backend/tests/api/v1/test_sdk_token.py
@@ -1,11 +1,16 @@
 """Tests for SDK token exchange endpoint."""
 
+from uuid import uuid4
+
+import pytest
 from jose import jwt
 from sqlalchemy.orm import Session
 from starlette.testclient import TestClient
 
 from app.config import settings
+from app.models import RefreshToken
 from tests.factories import ApplicationFactory, DeveloperFactory, UserFactory
+from tests.utils import developer_auth_headers
 
 
 class TestCreateUserToken:
@@ -99,3 +104,38 @@ class TestCreateUserToken:
             json={},
         )
         assert response.status_code in [400, 422]
+
+    @pytest.mark.parametrize("auth_method", ["application", "admin"])
+    def test_missing_user_does_not_issue_tokens(
+        self,
+        client: TestClient,
+        db: Session,
+        api_v1_prefix: str,
+        auth_method: str,
+    ) -> None:
+        developer = DeveloperFactory()
+        application = ApplicationFactory(developer=developer, app_secret="test_secret")
+        missing_user = uuid4()
+        before = db.query(RefreshToken).count()
+        response = client.post(
+            f"{api_v1_prefix}/users/{missing_user}/token",
+            json={"app_id": application.app_id, "app_secret": "test_secret"} if auth_method == "application" else None,
+            headers=developer_auth_headers(developer.id) if auth_method == "admin" else {},
+        )
+        assert response.status_code == 404
+        assert "access_token" not in response.json()
+        assert db.query(RefreshToken).count() == before
+
+    def test_missing_user_with_invalid_credentials_still_returns_401(
+        self,
+        client: TestClient,
+        db: Session,
+        api_v1_prefix: str,
+    ) -> None:
+        application = ApplicationFactory(app_secret="real_secret")
+        response = client.post(
+            f"{api_v1_prefix}/users/{uuid4()}/token",
+            json={"app_id": application.app_id, "app_secret": "wrong_secret"},
+        )
+        assert response.status_code == 401
+        assert db.query(RefreshToken).count() == 0

--- a/docs/api-reference/guides/webhooks.mdx
+++ b/docs/api-reference/guides/webhooks.mdx
@@ -33,6 +33,15 @@ Webhooks are delivered via [Svix](https://svix.com/), which handles retries, sig
 
 ---
 
+## Endpoint validation errors
+
+Creating or updating an endpoint with a filter type that is not registered in
+Svix returns HTTP `422`, including when Open Wearables accepts the JSON shape.
+Use `GET /api/v1/webhooks/event-types` for the event names supported by this OW
+version and ensure they are seeded in your Svix instance. Do not retry the same
+invalid subscription unchanged; correct the filter or repair event registration.
+A rejected PATCH leaves the existing endpoint configuration intact.
+
 ## Quickstart
 
 <Steps>

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -82,6 +82,12 @@ With an invitation code, a single-use code is issued via [`POST /api/v1/users/{u
 
 ## Security Model
 
+`POST /api/v1/users/{user_id}/token` authenticates the application or administrator
+before checking the user. Valid authentication with an unknown user returns
+`404` without issuing or persisting tokens. Invalid app credentials return `401`,
+including for unknown users. Create the user before requesting tokens; server
+errors do not establish that application credentials are invalid.
+
 The SDK uses a secure token-based authentication flow that keeps your App credentials safe:
 
 1. **App credentials stay on your backend** - `app_id` and `app_secret` are never exposed to mobile apps


### PR DESCRIPTION
## What does this change?

SDK token exchange now returns 404 for an authenticated request targeting a missing user, before signing or persisting tokens. Endpoint creation/update maps Svix's `HTTPValidationError` to 422 with guidance to check event registration.

## Why?

A missing user currently causes a refresh-token foreign-key failure and HTTP 500. An unregistered event filter also becomes 500 because Svix's validation exception is not handled at the HTTP boundary. Clients cannot distinguish these invalid requests from a service outage.

This preserves the refresh-token rotation introduced in #431 and the endpoint management behavior from #821, including #923's omitted/null PATCH semantics. Authentication still precedes the user lookup; invalid credentials return 401. Other service exceptions are not reclassified as validation errors.

Downstream integration fix: [Dorsi #4576](https://github.com/xchasm-ai/dorsi/pull/4576).

## How did you test this?

- Regression tests first reproduced the missing-user FK error and uncaught Svix validation error.
- `pytest tests/api/v1/test_sdk_token.py tests/api/v1/test_outgoing_webhooks.py tests/services/test_refresh_token_service.py` against isolated PostgreSQL and Redis: 48 tests passed. Checks include no token rows after 404, app/admin authentication, normal issuance/rotation, invalid subscriptions and PATCH semantics.
- Real local Svix through the changed OW HTTP routes: 24 current events accepted; a downstream client's two startup reconciliations performed one PATCH and no duplicate create. Unregistered legacy events returned 422 on POST/PATCH, and endpoint filters/signing secret remained intact. Temporary Svix application deleted afterward.
- `ruff check .`, changed-file `ruff format --check`, and `ty check .` passed.
- Local diff review: one indexed user lookup, no schema changes, no new retries or external requests, no credentials in error responses.

## AI usage

Codex assisted with tracing the historical changes, implementing the boundary fixes, writing tests, and reviewing the local diff.
