### PR TITLE
feat(backend): implement heart_rate_variability_rmssd_average

### DIFF
--- a/backend/app/schemas/enums/aggregation_method.py
+++ b/backend/app/schemas/enums/aggregation_method.py
@@ -27,6 +27,7 @@ AGGREGATION_METHOD_BY_TYPE: dict[SeriesType, AggregationMethod] = {
     SeriesType.heart_rate_recovery_one_minute: AggregationMethod.AVG,
     SeriesType.walking_heart_rate_average: AggregationMethod.AVG,
     SeriesType.heart_rate_variability_rmssd: AggregationMethod.AVG,
+    SeriesType.heart_rate_variability_rmssd_average: AggregationMethod.AVG,
     # ── Blood & Respiratory ──
     SeriesType.oxygen_saturation: AggregationMethod.AVG,
     SeriesType.blood_glucose: AggregationMethod.AVG,

--- a/backend/app/schemas/enums/series_types.py
+++ b/backend/app/schemas/enums/series_types.py
@@ -24,6 +24,7 @@ class SeriesType(str, Enum):
     heart_rate_recovery_one_minute = "heart_rate_recovery_one_minute"
     walking_heart_rate_average = "walking_heart_rate_average"
     heart_rate_variability_rmssd = "heart_rate_variability_rmssd"
+    heart_rate_variability_rmssd_average = "heart_rate_variability_rmssd_average"
 
     # =========================================================================
     # BIOMETRICS - Blood & Respiratory (IDs 20-39)
@@ -185,6 +186,7 @@ SERIES_TYPE_DEFINITIONS: list[tuple[int, SeriesType, str]] = [
     (4, SeriesType.heart_rate_recovery_one_minute, "bpm"),
     (5, SeriesType.walking_heart_rate_average, "bpm"),
     (7, SeriesType.heart_rate_variability_rmssd, "ms"),
+    (8, SeriesType.heart_rate_variability_rmssd_average, "ms"),
     # -------------------------------------------------------------------------
     # BIOMETRICS - Blood & Respiratory (IDs 20-39)
     # -------------------------------------------------------------------------
@@ -323,6 +325,9 @@ SERIES_TYPE_UNIT_BY_ENUM: dict[SeriesType, str] = {enum: unit for _, enum, unit 
 # Only series types that need a meaningful clarification have an entry here;
 SERIES_TYPE_DESCRIPTION_BY_ENUM: dict[SeriesType, str] = {
     SeriesType.garmin_body_battery: "Intraday body battery readings (0-100), one sample per measurement",
+    SeriesType.heart_rate_variability_rmssd_average: (
+        "Provider-reported nightly average HRV (RMSSD), one sample per sleep session"
+    ),
 }
 
 

--- a/backend/app/services/providers/oura/coverage.py
+++ b/backend/app/services/providers/oura/coverage.py
@@ -19,6 +19,7 @@ SLEEP_INTERVAL_SERIES: dict[str, SeriesType] = {
 SLEEP_SCALAR_SERIES: dict[str, SeriesType] = {
     "average_breath": SeriesType.respiratory_rate,
     "lowest_heart_rate": SeriesType.resting_heart_rate,
+    "average_hrv": SeriesType.heart_rate_variability_rmssd_average,
 }
 PERSONAL_INFO_SERIES: dict[str, SeriesType] = {
     "weight": SeriesType.weight,

--- a/backend/tests/providers/oura/test_oura_sleep_series_persistence.py
+++ b/backend/tests/providers/oura/test_oura_sleep_series_persistence.py
@@ -1,0 +1,123 @@
+"""Tests for Oura247Data.save_sleep_data — per-night scalar series persistence."""
+
+from collections.abc import Generator
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.schemas.enums import SeriesType
+from app.schemas.providers.oura.imports import OuraIntervalData
+from app.services.providers.oura.data_247 import Oura247Data
+from app.services.providers.oura.strategy import OuraStrategy
+
+
+@pytest.fixture
+def data_247() -> Oura247Data:
+    instance = OuraStrategy().data_247
+    assert isinstance(instance, Oura247Data)
+    return instance
+
+
+@pytest.fixture
+def timeseries_service_mock() -> Generator[MagicMock, None, None]:
+    with patch("app.services.providers.oura.data_247.timeseries_service") as mock:
+        yield mock
+
+
+@pytest.fixture(autouse=True)
+def event_record_service_mock() -> Generator[MagicMock, None, None]:
+    with patch("app.services.providers.oura.data_247.event_record_service") as mock:
+        yield mock
+
+
+def _normalized_sleep(user_id: object, **overrides: object) -> dict:
+    base = {
+        "id": uuid4(),
+        "user_id": user_id,
+        "provider": "oura",
+        "start_time": "2024-01-15T23:00:00+00:00",
+        "end_time": "2024-01-16T07:00:00+00:00",
+        "duration_seconds": 28800,
+        "efficiency_percent": 88.0,
+        "is_nap": False,
+        "stages": {"deep_seconds": 5400, "light_seconds": 14400, "rem_seconds": 7200, "awake_seconds": 1800},
+        "stage_timestamps": [],
+        "average_breath": 15.5,
+        "average_heart_rate": 55.0,
+        "average_hrv": 45,
+        "lowest_heart_rate": 48,
+        "heart_rate": None,
+        "hrv": None,
+        "oura_sleep_id": "sleep-abc123",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestOuraSleepScalarSeriesPersistence:
+    def test_persists_average_hrv_as_distinct_series_type(
+        self,
+        data_247: Oura247Data,
+        timeseries_service_mock: MagicMock,
+    ) -> None:
+        user_id = uuid4()
+        db = MagicMock()
+
+        data_247.save_sleep_data(db, user_id, [_normalized_sleep(user_id)])
+
+        samples = [
+            call.args[1][0]
+            for call in timeseries_service_mock.bulk_create_samples.call_args_list
+            if call.args[1][0].series_type
+            in {
+                SeriesType.respiratory_rate,
+                SeriesType.resting_heart_rate,
+                SeriesType.heart_rate_variability_rmssd_average,
+            }
+        ]
+        by_type = {s.series_type: s for s in samples}
+
+        assert by_type.keys() == {
+            SeriesType.respiratory_rate,
+            SeriesType.resting_heart_rate,
+            SeriesType.heart_rate_variability_rmssd_average,
+        }
+        hrv_sample = by_type[SeriesType.heart_rate_variability_rmssd_average]
+        assert hrv_sample.value == Decimal("45")
+        assert hrv_sample.recorded_at == datetime(2024, 1, 15, 23, 0, tzinfo=timezone.utc)
+        assert hrv_sample.user_id == user_id
+        assert hrv_sample.source == "oura"
+
+    def test_average_hrv_scalar_does_not_collide_with_interval_hrv_sample(
+        self,
+        data_247: Oura247Data,
+        timeseries_service_mock: MagicMock,
+    ) -> None:
+        """The nightly-average HRV write and the first 5-minute interval HRV sample share
+        the same recorded_at (sleep start); they must use different SeriesTypes or the
+        DB upsert on (data_source_id, series_type_definition_id, recorded_at) would let
+        one silently overwrite the other."""
+        user_id = uuid4()
+        db = MagicMock()
+        normalized = _normalized_sleep(
+            user_id,
+            hrv=OuraIntervalData(interval=300, items=[42.0, 43.0], timestamp="2024-01-15T23:00:00+00:00"),
+        )
+
+        data_247.save_sleep_data(db, user_id, [normalized])
+
+        all_samples = [
+            sample for call in timeseries_service_mock.bulk_create_samples.call_args_list for sample in call.args[1]
+        ]
+        same_timestamp_samples = [
+            s for s in all_samples if s.recorded_at == datetime(2024, 1, 15, 23, 0, tzinfo=timezone.utc)
+        ]
+        series_types_at_start = {s.series_type for s in same_timestamp_samples}
+
+        assert SeriesType.heart_rate_variability_rmssd in series_types_at_start
+        assert SeriesType.heart_rate_variability_rmssd_average in series_types_at_start
+        # Distinct series types at the same timestamp -> distinct DB rows, no upsert collision.
+        assert len(same_timestamp_samples) == len({id(s) for s in same_timestamp_samples})

--- a/docs/providers/coverage.mdx
+++ b/docs/providers/coverage.mdx
@@ -54,6 +54,7 @@ This guide gives an overview of data type support across the integrated wearable
 | `heart_rate` | bpm | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ |
 | `heart_rate_recovery_one_minute` | bpm | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `heart_rate_variability_rmssd` | ms | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
+| `heart_rate_variability_rmssd_average` | ms | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `heart_rate_variability_sdnn` | ms | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
 | `resting_heart_rate` | bpm | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
 | `walking_heart_rate_average` | bpm | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
@@ -342,7 +343,7 @@ Key differences and limitations to be aware of when working with each provider:
 
   - Webhooks push real-time notifications for: daily activity, daily readiness, daily sleep, daily SpO2, and workouts
   - Full sleep processing with stages (deep, light, REM, awake), duration, time in bed, efficiency score, stage timestamps, and nap detection
-  - Sleep biometrics: lowest heart rate persisted as a daily `resting_heart_rate` sample and average breathing rate persisted as `respiratory_rate`; average HR and average HRV are available from the API but not yet persisted per sleep record
+  - Sleep biometrics: lowest heart rate persisted as a daily `resting_heart_rate` sample, average breathing rate persisted as `respiratory_rate`, and nightly average HRV persisted as `heart_rate_variability_rmssd_average`; average HR is available from the API but not yet persisted per sleep record
   - Continuous 24/7 timeseries: heart rate (5-min intervals), HRV (RMSSD, 5-min intervals), daily SpO2, steps, active calories, walking distance
   - Recovery data from daily readiness: recovery score, skin temperature deviation, and skin temperature trend deviation
   - Fitness metrics: VO2 max (daily estimate) and cardiovascular age — both require the `heart_health` OAuth scope


### PR DESCRIPTION
## Description

Another support for Oura's nightly average HRV - `heart_rate_variability_rmssd_average`
Oura's average_hrv field from sleep records was previously fetched from the API but not persisted. So I added a new heart_rate_variability_rmssd_average series type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for persisting Oura nightly average heart rate variability (HRV) measurements.
  - Nightly average HRV is stored separately from interval HRV readings, preventing records from conflicting when timestamps match.
  - Added coverage and documentation for the new HRV measurement type.

- **Tests**
  - Added validation for nightly average HRV persistence and coexistence with interval HRV data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->