### PR TITLE
feat(google): ingest daily sleep skin temperature from the Google Health API

### DIFF
--- a/backend/app/services/providers/google/health_api/metrics/vitals.py
+++ b/backend/app/services/providers/google/health_api/metrics/vitals.py
@@ -1,7 +1,13 @@
-"""Vitals metrics (respiratory rate, oxygen saturation) — list-only types.
+"""Vitals metrics (respiratory rate, oxygen saturation, sleep skin temperature) — list-only types.
 
-daily-respiratory-rate is a Daily type (date-stamped); oxygen-saturation is a Sample
-type (instantaneous). Neither supports rollUp. Units already match (brpm, percent).
+daily-respiratory-rate and daily-sleep-temperature-derivations are Daily types (date-stamped);
+oxygen-saturation is a Sample type (instantaneous). None supports rollUp. Units already match
+(brpm, percent, Celsius).
+
+daily-sleep-temperature-derivations carries the mean nightly skin temperature
+(``nightlyTemperatureCelsius``) plus a 30-day baseline median and stddev; only the nightly
+mean is a measurement, so it maps to ``skin_temperature`` and the deviation from baseline is
+left to consumers (the baseline fields have no unified series).
 """
 
 from app.schemas.enums import SeriesType
@@ -19,5 +25,11 @@ VITALS_METRICS: tuple[DataTypeMetric, ...] = (
         SeriesType.oxygen_saturation,
         value_key="oxygenSaturation",
         list_spec=ListSpec("percentage", TimeShape.SAMPLE),
+    ),
+    DataTypeMetric(
+        "daily-sleep-temperature-derivations",
+        SeriesType.skin_temperature,
+        value_key="dailySleepTemperatureDerivations",
+        list_spec=ListSpec("nightlyTemperatureCelsius", TimeShape.DATE, is_daily_total=True),
     ),
 )

--- a/backend/tests/providers/google/test_health_api_sleep_temperature.py
+++ b/backend/tests/providers/google/test_health_api_sleep_temperature.py
@@ -1,0 +1,128 @@
+"""Google Health API: daily-sleep-temperature-derivations → skin_temperature (daily total).
+
+Registry entry + list-path mapping. Payload field names follow the DataPoint reference
+(users.dataTypes.dataPoints#dailysleeptemperaturederivations).
+"""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.schemas.enums import DataGranularity, SeriesType
+from app.schemas.providers.google import TimeShape
+from app.services.providers.google.health_api.data_247 import GoogleHealth247Data
+from app.services.providers.google.health_api.metrics import METRICS
+
+DATA_TYPE = "daily-sleep-temperature-derivations"
+_BY_TYPE = {m.data_type: m for m in METRICS}
+
+
+@pytest.mark.parametrize(
+    ("data_type", "value_key", "field", "series_type"),
+    [
+        (DATA_TYPE, "dailySleepTemperatureDerivations", "nightlyTemperatureCelsius", SeriesType.skin_temperature),
+        ("daily-resting-heart-rate", "dailyRestingHeartRate", "beatsPerMinute", SeriesType.resting_heart_rate),
+    ],
+)
+def test_daily_metric_is_registered_as_list_only_daily_total(
+    data_type: str, value_key: str, field: str, series_type: SeriesType
+) -> None:
+    metric = _BY_TYPE[data_type]
+    assert metric.value_key == value_key
+    assert metric.series_type == series_type
+    assert metric.rollup_spec is None, "Daily types only support list/reconcile"
+    assert metric.list_spec is not None
+    assert metric.list_spec.field == field
+    assert metric.list_spec.time is TimeShape.DATE
+    assert metric.list_spec.is_daily_total is True
+    for granularity in DataGranularity:
+        assert metric.use_list(granularity)
+
+
+def test_registry_has_no_duplicate_data_types() -> None:
+    types = [m.data_type for m in METRICS]
+    assert len(types) == len(set(types))
+
+
+def _handler() -> GoogleHealth247Data:
+    return GoogleHealth247Data(
+        oauth=MagicMock(), connection_repo=MagicMock(), api_base_url="https://health.googleapis.com"
+    )
+
+
+def test_native_samples_map_daily_point_to_one_daily_total_sample() -> None:
+    handler = _handler()
+    metric = _BY_TYPE[DATA_TYPE]
+    user_id = uuid4()
+    start = datetime(2026, 9, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 9, 8, tzinfo=timezone.utc)
+    point = {
+        "name": f"users/me/dataTypes/{DATA_TYPE}/dataPoints/abc",
+        "dailySleepTemperatureDerivations": {
+            "date": {"year": 2026, "month": 9, "day": 5},
+            "nightlyTemperatureCelsius": 34.62,
+            "baselineTemperatureCelsius": 34.8,
+            "relativeNightlyStddev30dCelsius": 0.21,
+        },
+    }
+
+    with patch.object(GoogleHealth247Data, "_fetch_points", return_value=[point]) as fetch:
+        samples = handler._native_samples(MagicMock(), user_id, metric, start, end)
+
+    endpoint = fetch.call_args.args[2]
+    assert DATA_TYPE in endpoint
+    time_filter = fetch.call_args.args[3]
+    assert time_filter.startswith(f"{DATA_TYPE.replace('-', '_')}.date >= ")
+
+    assert len(samples) == 1, "only the nightly temperature is a measurement; baseline/stddev are not emitted"
+    sample = samples[0]
+    assert sample.series_type == SeriesType.skin_temperature
+    assert sample.value == Decimal("34.62")
+    assert sample.is_daily_total is True
+    assert sample.recorded_at == datetime(2026, 9, 5, tzinfo=timezone.utc)
+    assert sample.zone_offset is None
+    assert sample.user_id == user_id
+    assert sample.provider == "google"
+
+
+def test_native_samples_skip_points_outside_window_and_without_value() -> None:
+    handler = _handler()
+    metric = _BY_TYPE[DATA_TYPE]
+    points = [
+        {
+            "dailySleepTemperatureDerivations": {
+                "date": {"year": 2026, "month": 8, "day": 1},
+                "nightlyTemperatureCelsius": 34.0,
+            }
+        },
+        {"dailySleepTemperatureDerivations": {"date": {"year": 2026, "month": 9, "day": 5}}},
+        {
+            "dailySleepTemperatureDerivations": {
+                "date": {"year": 2026, "month": 9, "day": 6},
+                "nightlyTemperatureCelsius": 34.9,
+            }
+        },
+    ]
+    start = datetime(2026, 9, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 9, 8, tzinfo=timezone.utc)
+    with patch.object(GoogleHealth247Data, "_fetch_points", return_value=points):
+        samples = handler._native_samples(MagicMock(), uuid4(), metric, start, end)
+    assert [s.value for s in samples] == [Decimal("34.9")]
+
+
+def test_sync_data_type_routes_the_new_type() -> None:
+    """Webhook pings for the new type reach the registry (sync_data_type returns None only for unknown types)."""
+    handler = _handler()
+    with (
+        patch.object(GoogleHealth247Data, "_native_samples", return_value=[]) as native,
+        patch.object(handler.settings_repo, "get_data_granularity", return_value=DataGranularity.RAW),
+    ):
+        start = datetime(2026, 9, 1, tzinfo=timezone.utc)
+        end = datetime(2026, 9, 2, tzinfo=timezone.utc)
+        assert handler.sync_data_type(MagicMock(), uuid4(), DATA_TYPE, start, end) is None
+        assert native.call_count == 1
+        assert handler.sync_data_type(MagicMock(), uuid4(), "not-a-type", start, end) is None
+        assert native.call_count == 1

--- a/docs/providers/coverage.mdx
+++ b/docs/providers/coverage.mdx
@@ -86,7 +86,7 @@ This guide gives an overview of data type support across the integrated wearable
 | `height` | cm | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | `lean_body_mass` | kg | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `skeletal_muscle_mass` | kg | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `skin_temperature` | celsius | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
+| `skin_temperature` | celsius | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
 | `skin_temperature_deviation` | celsius | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `skin_temperature_trend_deviation` | celsius | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `waist_circumference` | cm | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |

--- a/docs/providers/google-api-integration.mdx
+++ b/docs/providers/google-api-integration.mdx
@@ -317,8 +317,8 @@ curl -X DELETE \
 <Note>
 `dataTypes` above is an abbreviated example — use the set the app supports for webhooks
 (steps, distance, hydration-log, heart-rate, run-vo2-max, daily-resting-heart-rate,
-heart-rate-variability, weight, body-fat, blood-glucose, daily-respiratory-rate, sleep,
-exercise). Registering a data type the app doesn't handle just means its notifications are ignored.
+heart-rate-variability, weight, body-fat, blood-glucose, daily-respiratory-rate,
+daily-sleep-temperature-derivations, sleep, exercise). Registering a data type the app doesn't handle just means its notifications are ignored.
 </Note>
 
 ## Next Steps


### PR DESCRIPTION
## Description

The Google Health API exposes the Daily type `daily-sleep-temperature-derivations` (mean nightly skin temperature
under the watch plus a 30-day baseline and stddev), which the `google` provider currently skips. This adds it to the
metrics registry mapped to the existing `skin_temperature` series as a daily total, taken from
`dailySleepTemperatureDerivations.nightlyTemperatureCelsius`.

- The baseline and stddev fields are not emitted: there is no unified series for them, and consumers can derive the
  deviation from their own baseline (that is how we use it: the absolute value is the sensor reading under the watch,
  only its deviation is meaningful).
- List/reconcile only with a `date` timestamp, so it follows the `daily-resting-heart-rate` pattern
  (`ListSpec(..., TimeShape.DATE, is_daily_total=True)`).
- Field names verified against the DataPoint reference
  (`/health/reference/rest/v4/users.dataTypes.dataPoints#dailysleeptemperaturederivations`).
- Coverage (`docs/providers/coverage.mdx`, regenerated with `scripts/generate_coverage_docs.py`) and webhook
  registration (`GOOGLE_WEBHOOK_DATA_TYPES`) pick the new type up from the registry automatically.

Verified on a live account after a 365-day historical sync: one sample per night with data, and webhook
notifications for the type are routed through `sync_data_type`.

## Checklist

- [x] My code follows the project's code style (`ruff check`, `ruff format --check`, `ty check` clean)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (`tests/providers/google/test_health_api_sleep_temperature.py`)
- [x] New and existing tests pass locally (`tests/providers/google tests/providers/test_provider_coverage.py`: 57 passed)
- [x] I have updated relevant documentation in `docs/` (coverage matrix, webhook data types in the Google guide)
- [x] `uv run pre-commit run --all-files` passes (backend hooks; this PR does not touch `frontend/`)

## Testing Instructions

**Steps to test:**
1. `cd backend && SECRET_KEY=test ENV=test uv run pytest tests/providers/google tests/providers/test_provider_coverage.py -q`
2. With a Google Health connection: `POST /api/v1/providers/google/users/{user_id}/sync/historical?days=90`, then
   `SELECT count(*) FROM data_point_series d JOIN series_type_definition t ON t.id = d.series_type_definition_id WHERE t.code = 'skin_temperature'`.

**Expected behavior:** one `skin_temperature` daily-total sample per night with data; the coverage guard test passes
with the regenerated matrix; no change for other providers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Health support for daily sleep temperature data.
  * Daily nightly temperature readings are now available as skin temperature measurements.

* **Documentation**
  * Updated provider coverage to show Google support for skin temperature.
  * Expanded Google Health webhook examples to include hydration and sleep temperature data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->