### PR TITLE
fix(google): acknowledge Health API webhook notifications with 204 No Content

### DIFF
--- a/backend/app/api/routes/v1/webhooks.py
+++ b/backend/app/api/routes/v1/webhooks.py
@@ -25,7 +25,7 @@ into its strategy, traffic can be cut over to this router.
 from logging import getLogger
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
 from app.database import DbSession
 from app.schemas.responses.incoming_webhooks import (
@@ -88,13 +88,13 @@ async def _read_body(request: Request) -> bytes:
     return await request.body()
 
 
-@router.post("")
+@router.post("", response_model=None)
 def handle_provider_webhook(
     provider: str,
     request: Request,
     db: DbSession,
     body: Annotated[bytes, Depends(_read_body)],
-) -> dict:
+) -> dict | Response:
     """Receive an incoming webhook event from a provider.
 
     Body bytes are pre-read by the async ``_read_body`` dependency so that
@@ -105,7 +105,13 @@ def handle_provider_webhook(
     Returns whatever dict the provider's ``dispatch()`` method returns.
     """
     handler = _get_webhook_handler(provider)
-    return handler.handle(request, body, db)
+    result = handler.handle(request, body, db)
+    # Providers whose notifications must be acknowledged with an empty 204 (Google Health API:
+    # any other status code is retried with exponential backoff for up to 7 days). The
+    # verification handshake keeps its 2xx JSON body ({"status": "verified"}).
+    if getattr(handler, "ack_no_content", False) and isinstance(result, dict) and result.get("status") == "accepted":
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    return result
 
 
 @router.get("")

--- a/backend/app/services/providers/google/health_api/webhook_handler.py
+++ b/backend/app/services/providers/google/health_api/webhook_handler.py
@@ -60,6 +60,13 @@ _SUPPORTED_OPERATIONS = ["UPSERT", "DELETE"]
 class GoogleWebhookHandler(BaseWebhookHandler):
     """Webhook handler for Google Health API notify-only events."""
 
+    # Google requires ``204 No Content`` as the acknowledgement of a notification batch
+    # (https://developers.google.com/health/webhooks: "Your server must respond to
+    # notifications with an HTTP 204 No Content status code immediately"; anything else is
+    # retried). The unified router honours this flag after ``dispatch()`` returns
+    # ``{"status": "accepted"}``; the verification handshake still answers 200 + JSON.
+    ack_no_content = True
+
     def __init__(self, data_247: GoogleHealth247Data, workouts: GoogleHealthApiWorkouts) -> None:
         super().__init__("google")
         self.data_247 = data_247

--- a/backend/tests/api/v1/test_provider_webhooks_ack.py
+++ b/backend/tests/api/v1/test_provider_webhooks_ack.py
@@ -1,0 +1,73 @@
+"""Acknowledgement status of the unified provider webhook endpoint.
+
+Google's webhook service requires an empty ``204 No Content`` in response to every
+notification batch and retries anything else (developers.google.com/health/webhooks). Other
+providers keep the JSON body their handlers return, and the Google endpoint-verification
+handshake keeps its 200 + JSON.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.routes.v1 import webhooks as webhooks_route
+from app.database import _get_db_dependency
+from app.services.providers.google.health_api.webhook_handler import GoogleWebhookHandler
+
+
+class _StubHandler:
+    def __init__(self, result: dict[str, Any], ack_no_content: bool) -> None:
+        self.result = result
+        self.ack_no_content = ack_no_content
+
+    def handle(self, request: Any, body: bytes, db: Any) -> dict[str, Any]:
+        return self.result
+
+
+def _client(handler: _StubHandler) -> TestClient:
+    app = FastAPI()
+    app.include_router(webhooks_route.router, prefix="/providers/{provider}/webhooks")
+    app.dependency_overrides[_get_db_dependency] = lambda: MagicMock()
+    strategy = MagicMock()
+    strategy.webhooks = handler
+    patcher = patch.object(webhooks_route._factory, "get_provider", return_value=strategy)
+    patcher.start()
+    client = TestClient(app)
+    client.__dict__["_patcher"] = patcher
+    return client
+
+
+def test_google_handler_requests_empty_204_acknowledgement() -> None:
+    assert GoogleWebhookHandler.ack_no_content is True
+
+
+def test_accepted_notification_is_acknowledged_with_204_when_handler_asks_for_it() -> None:
+    client = _client(_StubHandler({"status": "accepted"}, ack_no_content=True))
+    try:
+        response = client.post("/providers/google/webhooks", json=[{"data": {}}])
+    finally:
+        client.__dict__["_patcher"].stop()
+    assert response.status_code == 204
+    assert response.content == b""
+
+
+def test_verification_handshake_keeps_200_with_json_body() -> None:
+    client = _client(_StubHandler({"status": "verified"}, ack_no_content=True))
+    try:
+        response = client.post("/providers/google/webhooks", json={"type": "verification"})
+    finally:
+        client.__dict__["_patcher"].stop()
+    assert response.status_code == 200
+    assert response.json() == {"status": "verified"}
+
+
+def test_providers_without_the_flag_keep_their_json_body() -> None:
+    client = _client(_StubHandler({"status": "accepted"}, ack_no_content=False))
+    try:
+        response = client.post("/providers/polar/webhooks", json={"event": "PING"})
+    finally:
+        client.__dict__["_patcher"].stop()
+    assert response.status_code == 200
+    assert response.json() == {"status": "accepted"}

--- a/docs/providers/google-api-integration.mdx
+++ b/docs/providers/google-api-integration.mdx
@@ -195,6 +195,10 @@ Two distinct secrets are involved:
 - **`GOOGLE_WEBHOOK_SECRET`** — a bearer token you register with Google that it echoes back in the `Authorization` header of every notification, so Open Wearables can verify the ping is genuine. Defaults to `SECRET_KEY` if unset.
 - **Service-account credentials** — used only to *register* the subscriber (a project-level admin call). Not involved in receiving notifications.
 
+Notifications are acknowledged with an empty `204 No Content`, which is the only status Google accepts (any
+other status, or a timeout, makes Google retry the notification with exponential backoff for up to 7 days). The
+endpoint-verification handshake answers `200` with `{"status": "verified"}`.
+
 <Info>
 Receiving and processing webhooks needs only `GOOGLE_WEBHOOK_SECRET`. The service account is required only to register the subscriber programmatically — you can also register it manually via `gcloud`/the API console.
 </Info>


### PR DESCRIPTION
## Description

Google's webhook service requires an HTTP `204 No Content` in response to every notification batch and retries
anything else with exponential backoff for up to 7 days
(https://developers.google.com/health/webhooks — "Your server must respond to notifications with an HTTP 204 No
Content status code immediately"). The unified provider webhook router returns `200` + `{"status": "accepted"}`, so
each Google notification is enqueued correctly but then redelivered again and again.

- `GoogleWebhookHandler.ack_no_content = True` declares the contract; the router answers an empty `204` when a
  handler with that flag returns `{"status": "accepted"}`.
- The endpoint-verification handshake keeps `200` + `{"status": "verified"}` (Google accepts 200/201 there), and
  providers without the flag keep the JSON body their handlers return (Polar's PING, Oura, Strava…).
- Doc: the Google integration guide states the acknowledgement contract.

Observed in production: with the `200`, Google kept redelivering; with the `204` the first real batch (distance, sleep,
daily-resting-heart-rate, heart-rate, steps) was processed once and never redelivered.

## Checklist

- [x] My code follows the project's code style (`ruff`, `ty` clean)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works (`tests/api/v1/test_provider_webhooks_ack.py`: 204 for accepted
      notifications, 200 + JSON for the handshake, unchanged JSON for providers without the flag)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/`
- [x] `uv run pre-commit run --all-files` passes (backend hooks; this PR does not touch `frontend/`)

## Testing Instructions

**Steps to test:**
1. `cd backend && SECRET_KEY=test ENV=test uv run pytest tests/api/v1/test_provider_webhooks_ack.py tests/tasks/test_webhook_push_task.py -q`
2. Against a running instance with `GOOGLE_WEBHOOK_SECRET=<s>`:
   `curl -i -X POST -H "Authorization: Bearer <s>" -H "Content-Type: application/json" -d '[{"data":{"version":"1","healthUserId":"x","operation":"UPSERT","dataType":"steps","intervals":[]}}]' http://localhost:8000/api/v1/providers/google/webhooks`
   → `HTTP/1.1 204 No Content`, empty body. The same request with `{"type":"verification"}` → `200 {"status":"verified"}`; without the header → `401`.

**Expected behavior:** Google's verification handshake succeeds at subscriber creation and notifications are
delivered exactly once.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Google Health API webhook notifications now receive an empty `204 No Content` acknowledgement, reducing unnecessary retries.
  * Verification handshakes continue returning a `200` response with confirmation details.
  * Other providers retain their existing JSON acknowledgement behavior.

* **Documentation**
  * Updated Google Health API integration guidance to explain notification acknowledgements, verification responses, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->