### PR TITLE
fix(sync): steal a shared pull lock whose holder died mid-run

### DIFF
--- a/backend/app/integrations/celery/tasks/sync_vendor_data_task.py
+++ b/backend/app/integrations/celery/tasks/sync_vendor_data_task.py
@@ -14,7 +14,7 @@ from app.schemas.auth import LiveSyncMode
 from app.schemas.responses.upload import ProviderSyncResult, SyncVendorDataResult
 from app.schemas.sync_status import SyncSource, SyncStage, SyncStatus
 from app.services.providers.factory import ProviderFactory
-from app.services.sync_coordination import release_primary, release_stale_primary, try_become_primary
+from app.services.sync_coordination import primary_is_idle, release_primary, release_stale_primary, try_become_primary
 from app.services.sync_status_service import completed, failed, new_run_id, progress, started
 from app.utils.config_utils import format_duration
 from app.utils.context import trace_id_var
@@ -190,15 +190,22 @@ def sync_vendor_data(
                         provider_name, connection.provider_user_id, user_uuid, scope="pull"
                     )
                     if not is_pull_primary and existing_primary:
-                        # If the lock holder no longer has an active connection (e.g. user
-                        # deleted), the lock is stale and will never be released naturally.
-                        # Steal it so this profile can become primary.
+                        # The lock is stale — it will never be released naturally — when the
+                        # holder no longer has an active connection (e.g. user deleted) or when
+                        # the holder's run died with its worker (no live in-progress run for
+                        # this provider within PRIMARY_IDLE_SECONDS). Steal it so this profile
+                        # can become primary instead of skipping every pull until the TTL.
                         active = user_connection_repo.get_active_connection(db, existing_primary, provider_name)
+                        stale_reason: str | None = None
                         if not active:
+                            stale_reason = "holder has no active connection"
+                        elif primary_is_idle(provider_name, existing_primary):
+                            stale_reason = "holder has no live sync run (worker died mid-run?)"
+                        if stale_reason:
                             log_structured(
                                 logger,
                                 "info",
-                                f"Stealing stale {provider_name} primary lock — holder has no active connection",
+                                f"Stealing stale {provider_name} primary lock — {stale_reason}",
                                 provider=provider_name,
                                 task="sync_vendor_data",
                                 user_id=user_id,

--- a/backend/app/services/sync_coordination.py
+++ b/backend/app/services/sync_coordination.py
@@ -18,15 +18,25 @@ Redis keys (scoped to provider + provider_user_id + scope):
 """
 
 import logging
+from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
 from app.integrations.redis_client import get_redis_client
+from app.schemas.sync_status import SyncStatus
+from app.services import sync_status_service
 
 logger = logging.getLogger(__name__)
 
 _PREFIX = "linked_sync"
 _PRIMARY_TTL = 4 * 60 * 60  # 4 h — covers longest Garmin backfill
 _SECONDARY_TTL = 4 * 60 * 60
+
+# A pull primary that has reported no sync activity for this long is treated as orphaned:
+# its worker died mid-run (SIGKILL after the container stop grace period, OOM, host reboot)
+# and never reached release_primary, so the lock would block every periodic pull for the
+# account until the 4 h TTL. Must exceed the longest gap between progress events of a
+# legitimate run.
+PRIMARY_IDLE_SECONDS = 30 * 60
 
 # Atomically delete a key only if its current value matches ARGV[1].
 # Prevents releasing a lock that was already expired and re-acquired by
@@ -199,3 +209,31 @@ def release_stale_primary(
     Returns True when the key was deleted.
     """
     return bool(get_redis_client().delete(_primary_key(provider, provider_user_id, scope)))
+
+
+def primary_is_idle(
+    provider: str,
+    primary_user_id: UUID,
+    *,
+    idle_seconds: int = PRIMARY_IDLE_SECONDS,
+    now: datetime | None = None,
+) -> bool:
+    """Return True when the lock holder shows no live sync run for *provider*.
+
+    The sync-status stream (:mod:`app.services.sync_status_service`, Redis, 24 h TTL) is the
+    only trace of activity a running task leaves. The holder is considered alive when it has
+    an ``in_progress`` run for *provider* whose latest event is younger than *idle_seconds*;
+    anything else — no run recorded at all, only terminal runs, or an in-progress run that
+    stopped reporting — means the primary lock is orphaned and can be stolen.
+
+    Meant for the periodic pull scope; Garmin backfills track their own progress keys and
+    are garbage-collected separately (``garmin/gc_task.py``).
+    """
+    now = now or datetime.now(timezone.utc)
+    for run in sync_status_service.get_run_summaries(primary_user_id, limit=50):
+        if run.provider != provider or run.status != SyncStatus.IN_PROGRESS:
+            continue
+        last = run.last_update if run.last_update.tzinfo else run.last_update.replace(tzinfo=timezone.utc)
+        if (now - last).total_seconds() < idle_seconds:
+            return False
+    return True

--- a/backend/tests/services/test_sync_coordination.py
+++ b/backend/tests/services/test_sync_coordination.py
@@ -1,0 +1,44 @@
+"""primary_is_idle: an orphaned pull lock is one whose holder shows no live sync run.
+
+Uses the session Redis container (autouse fixtures in tests/conftest.py); runs are recorded
+through the real sync-status service so the check reads exactly what production reads.
+"""
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+from app.schemas.sync_status import SyncSource
+from app.services import sync_status_service
+from app.services.sync_coordination import PRIMARY_IDLE_SECONDS, primary_is_idle
+
+
+def test_holder_without_any_recorded_run_is_idle() -> None:
+    assert primary_is_idle("google", uuid4()) is True
+
+
+def test_holder_with_fresh_in_progress_run_is_alive() -> None:
+    holder = uuid4()
+    sync_status_service.started(holder, "google", SyncSource.PULL, run_id="pull_fresh")
+    assert primary_is_idle("google", holder) is False
+
+
+def test_in_progress_run_that_stopped_reporting_is_idle() -> None:
+    holder = uuid4()
+    sync_status_service.started(holder, "google", SyncSource.PULL, run_id="pull_dead")
+    later = datetime.now(timezone.utc) + timedelta(seconds=PRIMARY_IDLE_SECONDS + 1)
+    assert primary_is_idle("google", holder, now=later) is True
+    assert primary_is_idle("google", holder, now=later, idle_seconds=PRIMARY_IDLE_SECONDS + 60) is False
+
+
+def test_only_terminal_runs_means_idle() -> None:
+    holder = uuid4()
+    sync_status_service.started(holder, "google", SyncSource.PULL, run_id="pull_done")
+    sync_status_service.completed(holder, "google", SyncSource.PULL, run_id="pull_done", items_processed=3)
+    assert primary_is_idle("google", holder) is True
+
+
+def test_live_run_for_another_provider_does_not_count() -> None:
+    holder = uuid4()
+    sync_status_service.started(holder, "polar", SyncSource.PULL, run_id="pull_polar")
+    assert primary_is_idle("google", holder) is True
+    assert primary_is_idle("polar", holder) is False

--- a/backend/tests/tasks/test_sync_vendor_data_idle_lock.py
+++ b/backend/tests/tasks/test_sync_vendor_data_idle_lock.py
@@ -1,0 +1,100 @@
+"""sync_vendor_data steals a shared pull lock whose holder has no live run (worker died mid-run).
+
+Regression for the orphaned-lock failure mode: a periodic pull killed with its worker never
+releases ``linked_sync:{provider}:{provider_user_id}:pull:primary``; with a 4 h TTL every
+following pull logged "Skipping … — another linked profile is syncing" for hours.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy.orm import Session
+
+from app.integrations.celery.tasks.sync_vendor_data_task import sync_vendor_data
+from app.schemas.auth import ConnectionStatus
+from tests.factories import UserConnectionFactory, UserFactory
+
+TASK = "app.integrations.celery.tasks.sync_vendor_data_task"
+
+
+def _strategy() -> tuple[MagicMock, MagicMock]:
+    workouts = MagicMock()
+    workouts.load_data.return_value = True
+    strategy = MagicMock()
+    strategy.capabilities.rest_pull = True
+    strategy.capabilities.webhook_stream = False
+    strategy.workouts = workouts
+    return strategy, workouts
+
+
+@patch(f"{TASK}.SessionLocal")
+@patch("app.services.providers.factory.ProviderFactory.get_provider")
+@patch(f"{TASK}.release_stale_primary")
+@patch(f"{TASK}.primary_is_idle", return_value=True)
+@patch(f"{TASK}.try_become_primary")
+def test_idle_holder_lock_is_stolen_and_pull_proceeds(
+    mock_try_become_primary: MagicMock,
+    mock_primary_is_idle: MagicMock,
+    mock_release_stale: MagicMock,
+    mock_get_provider: MagicMock,
+    mock_session_local: MagicMock,
+    db: Session,
+    mock_celery_app: MagicMock,
+) -> None:
+    user = UserFactory()
+    holder = UserFactory()
+    UserConnectionFactory(
+        user=user, provider="garmin", status=ConnectionStatus.ACTIVE, provider_user_id="shared-account"
+    )
+    UserConnectionFactory(
+        user=holder, provider="garmin", status=ConnectionStatus.ACTIVE, provider_user_id="shared-account"
+    )
+    mock_session_local.return_value.__enter__.return_value = db
+    mock_session_local.return_value.__exit__.return_value = None
+    strategy, workouts = _strategy()
+    mock_get_provider.return_value = strategy
+    # first election lost to the (dead) holder, second one won after the steal
+    mock_try_become_primary.side_effect = [(False, "", holder.id), (True, "token", user.id)]
+
+    result = sync_vendor_data(str(user.id))
+
+    mock_primary_is_idle.assert_called_once_with("garmin", holder.id)
+    mock_release_stale.assert_called_once_with("garmin", "shared-account", scope="pull")
+    assert mock_try_become_primary.call_count == 2
+    workouts.load_data.assert_called_once()
+    assert result["providers_synced"]["garmin"]["success"] is True
+    assert result["providers_synced"]["garmin"]["params"].get("linked_account") is None
+
+
+@patch(f"{TASK}.SessionLocal")
+@patch("app.services.providers.factory.ProviderFactory.get_provider")
+@patch(f"{TASK}.release_stale_primary")
+@patch(f"{TASK}.primary_is_idle", return_value=False)
+@patch(f"{TASK}.try_become_primary")
+def test_live_holder_keeps_the_lock_and_pull_is_skipped(
+    mock_try_become_primary: MagicMock,
+    mock_primary_is_idle: MagicMock,
+    mock_release_stale: MagicMock,
+    mock_get_provider: MagicMock,
+    mock_session_local: MagicMock,
+    db: Session,
+    mock_celery_app: MagicMock,
+) -> None:
+    user = UserFactory()
+    holder = UserFactory()
+    UserConnectionFactory(
+        user=user, provider="garmin", status=ConnectionStatus.ACTIVE, provider_user_id="shared-account"
+    )
+    UserConnectionFactory(
+        user=holder, provider="garmin", status=ConnectionStatus.ACTIVE, provider_user_id="shared-account"
+    )
+    mock_session_local.return_value.__enter__.return_value = db
+    mock_session_local.return_value.__exit__.return_value = None
+    strategy, workouts = _strategy()
+    mock_get_provider.return_value = strategy
+    mock_try_become_primary.return_value = (False, "", holder.id)
+
+    result = sync_vendor_data(str(user.id))
+
+    mock_release_stale.assert_not_called()
+    workouts.load_data.assert_not_called()
+    assert result["providers_synced"]["garmin"]["params"] == {"linked_account": True}

--- a/docs/architecture/multi-account-sync.mdx
+++ b/docs/architecture/multi-account-sync.mdx
@@ -80,6 +80,8 @@ For providers polled periodically (Whoop, Oura, Suunto — those in `PULL` live 
 
 The lock TTL is 4 hours. Because `sync_vendor_data` tasks for different profiles may run in any order, the "primary" role is simply the first task to acquire the lock in a given polling cycle. If the primary completes before a competing task runs, that task acquires a fresh lock and does its own pull — which is acceptable (one extra API call per cycle, no data corruption).
 
+A lock whose holder died mid-run (worker killed after the container stop grace period, OOM, host reboot) is never released by `release_primary`, and without help every periodic pull for that account would be skipped until the TTL. `primary_is_idle` closes that gap: when a task loses the election it checks the holder's sync-status stream, and if the holder has no `in_progress` run for the provider updated within `PRIMARY_IDLE_SECONDS` (30 min) — or no run recorded at all — the lock is treated as orphaned and stolen, exactly like the existing "holder has no active connection" case.
+
 ---
 
 ## Redis Keys
@@ -116,7 +118,7 @@ primary_user_id: <uuid of the profile that ran the sync>
 
 | File | Role |
 |------|------|
-| `app/services/sync_coordination.py` | Redis lock primitives: `try_become_primary`, `release_primary`, `store_primary_token`, `release_primary_for_user`, `register_secondary`, `get_secondary_user_ids`, `clear_secondaries` |
+| `app/services/sync_coordination.py` | Redis lock primitives: `try_become_primary`, `release_primary`, `release_stale_primary`, `primary_is_idle`, `store_primary_token`, `release_primary_for_user`, `register_secondary`, `get_secondary_user_ids`, `clear_secondaries` |
 | `app/schemas/sync_status.py` | `SyncSource.LINKED_ACCOUNT` enum value; `primary_user_id` field on `SyncStatusEvent` and `SyncRunSummary` |
 | `app/repositories/user_connection_repository.py` | `get_all_by_provider_user_id()` — returns all active connections for a (provider, provider_user_id) pair; partial index `ix_user_connection_provider_external_id` |
 | `app/services/providers/garmin/handlers/activities.py` | Webhook fan-out for activity notifications |


### PR DESCRIPTION
## Description

A periodic pull that is killed together with its Celery worker — `docker compose up --force-recreate`, SIGKILL after
the container stop grace period, OOM, host reboot — never reaches `release_primary`. Its
`linked_sync:{provider}:{provider_user_id}:pull:primary` key then survives until the 4 h TTL and every following
`sync_vendor_data` run for that account logs `Skipping … pull — another linked profile is syncing`. We hit this with a
single Google Health connection: no new data for hours until the key was deleted by hand.

`sync_vendor_data` already steals the lock when the holder has no active connection. This adds the second stale case:

- `sync_coordination.primary_is_idle(provider, holder_user_id)` reads the holder's sync-status stream (Redis, 24 h
  TTL — the only trace a running task leaves) and reports the lock as orphaned when the holder has no `in_progress`
  run for the provider updated within `PRIMARY_IDLE_SECONDS` (30 min), or no run recorded at all.
- The pull task steals in that case through the existing path (`release_stale_primary` + a second election) and logs
  the reason.
- Garmin backfills keep their own progress keys and GC (`garmin/gc_task.py`) and are not touched.

30 min is well above the longest gap between progress events of a legitimate pull (a 2-day-lookback Google pull
reports every few minutes) and short enough that a dead worker costs at most one polling cycle.

## Checklist

- [x] My code follows the project's code style (`ruff`, `ty` clean)
- [x] I have performed a self-review of my code
- [x] I have added tests (`tests/services/test_sync_coordination.py` against the real sync-status service;
      `tests/tasks/test_sync_vendor_data_idle_lock.py` for stealing vs. skipping in the task)
- [x] New and existing tests pass locally
- [x] I have updated relevant documentation in `docs/` (`docs/architecture/multi-account-sync.mdx`)
- [x] `uv run pre-commit run --all-files` passes (backend hooks; this PR does not touch `frontend/`)

## Testing Instructions

**Steps to test:**
1. `cd backend && SECRET_KEY=test ENV=test uv run pytest tests/services/test_sync_coordination.py tests/tasks/test_sync_vendor_data_idle_lock.py tests/tasks/test_sync_vendor_data_task.py -q`
2. Manual: start a pull, `docker kill` the worker mid-run, restart it and wait one polling cycle.

**Expected behavior:** the next cycle logs `Stealing stale google primary lock — holder has no live sync run (worker
died mid-run?)` and syncs normally, instead of skipping until the 4 h TTL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Synchronization can now recover from orphaned or inactive provider locks, preventing stalled sync operations.
  * Active lock holders continue to retain their locks, avoiding unnecessary duplicate synchronization.
  * Logs now identify why a lock was considered stale.

* **Documentation**
  * Updated multi-account synchronization documentation to explain stale-lock recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->