### PR TITLE
feat(google): ingest daily HRV (RMSSD average) from the Google Health API

### DIFF
--- a/backend/app/services/providers/google/health_api/metrics/heart.py
+++ b/backend/app/services/providers/google/health_api/metrics/heart.py
@@ -1,8 +1,10 @@
 """Heart-family metrics.
 
-heart-rate / run-vo2-max support rollUp + list; daily-resting-heart-rate (Daily) and
-heart-rate-variability (Sample) are list only. The HRV sample emits both RMSSD (primary)
-and SDNN (extra) into their own series.
+heart-rate / run-vo2-max support rollUp + list; daily-resting-heart-rate (Daily),
+heart-rate-variability (Sample) and daily-heart-rate-variability (Daily) are list only. The
+HRV sample emits both RMSSD (primary) and SDNN (extra) into their own series; the daily HRV
+summary emits its RMSSD-based average into the RMSSD series as a daily total (the deep-sleep
+RMSSD, non-REM heart rate and entropy fields have no unified series yet).
 
 heart-rate and run-vo2-max rollUp values also carry Min/Max alongside the Avg we take;
 capturing those would use the same `extra` mechanism once dedicated SeriesTypes exist.
@@ -41,5 +43,11 @@ HEART_METRICS: tuple[DataTypeMetric, ...] = (
             TimeShape.SAMPLE,
             extra=(SeriesField(SeriesType.heart_rate_variability_sdnn, "standardDeviationMilliseconds"),),
         ),
+    ),
+    DataTypeMetric(
+        "daily-heart-rate-variability",
+        SeriesType.heart_rate_variability_rmssd,
+        value_key="dailyHeartRateVariability",
+        list_spec=ListSpec("averageHeartRateVariabilityMilliseconds", TimeShape.DATE, is_daily_total=True),
     ),
 )

--- a/backend/tests/providers/google/test_health_api_daily_hrv.py
+++ b/backend/tests/providers/google/test_health_api_daily_hrv.py
@@ -1,0 +1,92 @@
+"""Google Health API: daily-heart-rate-variability → heart_rate_variability_rmssd (daily total).
+
+Registry entry + list-path mapping. Payload field names follow the DataPoint reference
+(users.dataTypes.dataPoints#dailyheartratevariability).
+"""
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from app.schemas.enums import DataGranularity, SeriesType
+from app.schemas.providers.google import TimeShape
+from app.services.providers.google.health_api.data_247 import GoogleHealth247Data
+from app.services.providers.google.health_api.metrics import METRICS
+
+DATA_TYPE = "daily-heart-rate-variability"
+_BY_TYPE = {m.data_type: m for m in METRICS}
+
+
+def test_daily_hrv_is_registered_as_list_only_daily_total() -> None:
+    metric = _BY_TYPE[DATA_TYPE]
+    assert metric.value_key == "dailyHeartRateVariability"
+    assert metric.series_type == SeriesType.heart_rate_variability_rmssd
+    assert metric.rollup_spec is None, "Daily types only support list/reconcile"
+    assert metric.list_spec is not None
+    assert metric.list_spec.field == "averageHeartRateVariabilityMilliseconds"
+    assert metric.list_spec.time is TimeShape.DATE
+    assert metric.list_spec.is_daily_total is True
+    for granularity in DataGranularity:
+        assert metric.use_list(granularity)
+
+
+def test_registry_has_no_duplicate_data_types() -> None:
+    types = [m.data_type for m in METRICS]
+    assert len(types) == len(set(types))
+
+
+def _handler() -> GoogleHealth247Data:
+    return GoogleHealth247Data(
+        oauth=MagicMock(), connection_repo=MagicMock(), api_base_url="https://health.googleapis.com"
+    )
+
+
+def test_native_samples_map_daily_point_to_one_daily_total_sample() -> None:
+    handler = _handler()
+    metric = _BY_TYPE[DATA_TYPE]
+    user_id = uuid4()
+    start = datetime(2026, 9, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 9, 8, tzinfo=timezone.utc)
+    point = {
+        "name": f"users/me/dataTypes/{DATA_TYPE}/dataPoints/def",
+        "dailyHeartRateVariability": {
+            "date": {"year": 2026, "month": 9, "day": 5},
+            "averageHeartRateVariabilityMilliseconds": 41.3,
+            "nonRemHeartRateBeatsPerMinute": "52",
+            "entropy": 2.7,
+            "deepSleepRootMeanSquareOfSuccessiveDifferencesMilliseconds": 45.1,
+        },
+    }
+
+    with patch.object(GoogleHealth247Data, "_fetch_points", return_value=[point]) as fetch:
+        samples = handler._native_samples(MagicMock(), user_id, metric, start, end)
+
+    endpoint = fetch.call_args.args[2]
+    assert DATA_TYPE in endpoint
+    time_filter = fetch.call_args.args[3]
+    assert time_filter.startswith(f"{DATA_TYPE.replace('-', '_')}.date >= ")
+
+    assert len(samples) == 1, "only the RMSSD average is emitted; deep-sleep RMSSD, non-REM HR and entropy are not"
+    sample = samples[0]
+    assert sample.series_type == SeriesType.heart_rate_variability_rmssd
+    assert sample.value == Decimal("41.3")
+    assert sample.is_daily_total is True
+    assert sample.recorded_at == datetime(2026, 9, 5, tzinfo=timezone.utc)
+    assert sample.zone_offset is None
+    assert sample.user_id == user_id
+    assert sample.provider == "google"
+
+
+def test_sync_data_type_routes_the_new_type() -> None:
+    handler = _handler()
+    with (
+        patch.object(GoogleHealth247Data, "_native_samples", return_value=[]) as native,
+        patch.object(handler.settings_repo, "get_data_granularity", return_value=DataGranularity.RAW),
+    ):
+        start = datetime(2026, 9, 1, tzinfo=timezone.utc)
+        end = datetime(2026, 9, 2, tzinfo=timezone.utc)
+        assert handler.sync_data_type(MagicMock(), uuid4(), DATA_TYPE, start, end) is None
+        assert native.call_count == 1
+        assert handler.sync_data_type(MagicMock(), uuid4(), "not-a-type", start, end) is None
+        assert native.call_count == 1

--- a/docs/providers/google-api-integration.mdx
+++ b/docs/providers/google-api-integration.mdx
@@ -317,8 +317,8 @@ curl -X DELETE \
 <Note>
 `dataTypes` above is an abbreviated example — use the set the app supports for webhooks
 (steps, distance, hydration-log, heart-rate, run-vo2-max, daily-resting-heart-rate,
-heart-rate-variability, weight, body-fat, blood-glucose, daily-respiratory-rate, sleep,
-exercise). Registering a data type the app doesn't handle just means its notifications are ignored.
+heart-rate-variability, daily-heart-rate-variability, weight, body-fat, blood-glucose,
+daily-respiratory-rate, sleep, exercise). Registering a data type the app doesn't handle just means its notifications are ignored.
 </Note>
 
 ## Next Steps


### PR DESCRIPTION
## Description

Adds the Daily type `daily-heart-rate-variability` to the `google` metrics registry, mapped to
`heart_rate_variability_rmssd` as a daily total from
`dailyHeartRateVariability.averageHeartRateVariabilityMilliseconds`, alongside the intraday `heart-rate-variability`
samples (distinguished by `is_daily_total`). Deep-sleep RMSSD, non-REM heart rate and entropy are ignored for now (no
unified series). Same pattern as `daily-resting-heart-rate`; field names verified against
`users.dataTypes.dataPoints#dailyheartratevariability`. The coverage matrix does not change (the series was already
provided by google); webhook registration picks the type up automatically.

## Checklist

- [x] Code style (`ruff`, `ty`) · [x] self-review · [x] tests (`tests/providers/google/test_health_api_daily_hrv.py`)
- [x] New and existing tests pass locally
- [x] `uv run pre-commit run --all-files` passes (backend hooks; this PR does not touch `frontend/`)

## Testing Instructions

1. `cd backend && SECRET_KEY=test ENV=test uv run pytest tests/providers/google tests/providers/test_provider_coverage.py -q`
2. With a Google Health connection, after a historical sync: `SELECT count(*) FROM data_point_series WHERE is_daily_total AND series_type_definition_id = (SELECT id FROM series_type_definition WHERE code = 'heart_rate_variability_rmssd')`.

**Expected behavior:** one daily-total RMSSD sample per day with data, next to the intraday samples.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google Health API’s daily heart rate variability data.
  * Daily HRV values are available as RMSSD-based daily summaries.

* **Documentation**
  * Updated Google Health API integration guidance to include the daily heart rate variability webhook data type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->