### PR TITLE
docs: clarify that the admin seed only runs on an empty developer table

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Get Open Wearables up and running in minutes.
 
 4. **Log in to the developer portal:**
 
-   An admin account is automatically created on startup using the `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables (defaults: `admin@admin.com` / `your-secure-password`).
+   An admin account is automatically created on startup using the `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables (defaults: `admin@admin.com` / `your-secure-password`). The seed runs only while the developer table is empty: once any developer account exists it is skipped, so changing `ADMIN_PASSWORD` later does not update an existing account - **change the default password from the developer portal right after your first login**. To add further accounts, invite them from the developer portal.
 
    Open http://localhost:3000 to access the developer portal and create API keys.
 

--- a/backend/config/.env.example
+++ b/backend/config/.env.example
@@ -52,7 +52,10 @@ SECRET_KEY=secret-key-str
 # MIN_PASSWORD_LENGTH=8
 
 #--- ADMIN SEED ---#
-# Auto-created on first startup if no developer account exists
+# Auto-created on first startup, only while no developer account exists.
+# Once any developer exists the seed is skipped; changing ADMIN_PASSWORD does not
+# update an existing account - change the default password from the developer portal
+# right after the first login. Add further accounts by invitation from the portal.
 ADMIN_EMAIL=admin@admin.com
 ADMIN_PASSWORD=your-secure-password
 

--- a/docs/deployment/railway.mdx
+++ b/docs/deployment/railway.mdx
@@ -29,7 +29,7 @@ Railway provides the fastest way to get a production Open Wearables instance run
 />
 
 <Tip>
-An admin account is created automatically on first startup (`admin@admin.com` / `your-secure-password`). To use custom credentials, set `ADMIN_EMAIL` and `ADMIN_PASSWORD` on the **Backend** service before deploying (as shown on the video)
+An admin account is created automatically on first startup (`admin@admin.com` / `your-secure-password`), but only while no developer account exists yet. To use custom credentials, set `ADMIN_EMAIL` and `ADMIN_PASSWORD` on the **Backend** service before deploying (as shown on the video) - setting them after an account exists has no effect. **If you deployed with the default credentials, change the password from the developer portal right after your first login.** Additional accounts are added by invitation from the developer portal.
 </Tip>
 
 ## What gets deployed

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -146,7 +146,7 @@ Get Open Wearables running locally and start integrating wearable device data.
      Should return: `{"message": "Server is running!"}`
 
   2. **Create an API key**:
-     An admin account is automatically created on startup using the `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables (defaults: `admin@admin.com` / `your-secure-password`).
+     An admin account is automatically created on startup using the `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables (defaults: `admin@admin.com` / `your-secure-password`). The seed runs only while the developer table is empty: once any developer account exists it is skipped, so changing `ADMIN_PASSWORD` later does not update an existing account - **change the default password from the developer portal right after your first login**. To add further accounts, invite them from the developer portal.
 
      Use the admin panel at http://localhost:3000/ to log in and generate API keys.
 


### PR DESCRIPTION
The admin seed is intentionally skipped once any developer account exists, so that an account deleted through the portal cannot be recreated by the next restart, but the docs only said the account is created from `ADMIN_EMAIL`/`ADMIN_PASSWORD` on startup.

Documents the empty-table condition, that changing `ADMIN_PASSWORD` does not update an existing account, and that the default password must be changed from the developer portal after the first login.

Refs #1548


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that the initial administrator account is created only when no developer accounts exist.
  - Documented that changing administrator credentials later does not update an existing account.
  - Added guidance to change the default password after first login.
  - Explained how to add additional accounts through portal invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->