### PR TITLE
fix(backend): release the DB connection before an SSE stream starts

### DIFF
--- a/backend/app/api/routes/v1/sync_status.py
+++ b/backend/app/api/routes/v1/sync_status.py
@@ -30,7 +30,7 @@ from starlette.concurrency import run_in_threadpool
 
 from app.database import DbSession, SessionLocal
 from app.schemas.sync_status import SyncRunDetail, SyncRunRecord, SyncRunSummary, SyncScope, SyncStatusEvent
-from app.services import ApiKeyDep, user_service
+from app.services import ApiKeyDep, StreamingApiKeyDep, user_service
 from app.services.sync_status_service import (
     MAX_RECENT_EVENTS,
     get_all_run_summaries,
@@ -81,7 +81,7 @@ def _ensure_user_exists_detached(user_id: UUID) -> None:
 )
 async def stream_user_sync_status(
     user_id: UUID,
-    _api_key: ApiKeyDep,
+    _api_key: StreamingApiKeyDep,
     replay: Annotated[int, Query(ge=1, le=MAX_RECENT_EVENTS, description="Replay last N events on connect.")] = 20,
 ) -> StreamingResponse:
     """Open a Server-Sent Events stream of sync status for a user.

--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -1,6 +1,6 @@
 from app.utils.auth import DeveloperDep, SDKAuthDep
 
-from .api_key_service import ApiKeyDep, api_key_service
+from .api_key_service import ApiKeyDep, StreamingApiKeyDep, api_key_service
 from .apple.apple_xml.presigned_url_service import presigned_url_service
 from .apple.healthkit.import_service import import_service as hk_import_service
 from .application_service import application_service
@@ -31,6 +31,7 @@ __all__ = [
     "user_invitation_code_service",
     "DeveloperDep",
     "ApiKeyDep",
+    "StreamingApiKeyDep",
     "SDKAuthDep",
     "user_connection_service",
     "user_service",

--- a/backend/app/services/api_key_service.py
+++ b/backend/app/services/api_key_service.py
@@ -4,13 +4,14 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends, Header, HTTPException
+from sqlalchemy.orm import Session
 
-from app.database import DbSession
+from app.database import DbSession, SessionLocal
 from app.models import ApiKey, Developer
 from app.repositories.api_key_repository import ApiKeyRepository
 from app.schemas.model_crud.credentials import ApiKeyCreate, ApiKeyUpdate
 from app.services.services import AppService
-from app.utils.auth import get_current_developer_optional
+from app.utils.auth import get_current_developer_optional, oauth2_scheme
 
 
 class ApiKeyService(AppService[ApiKeyRepository, ApiKey, ApiKeyCreate, ApiKeyUpdate]):
@@ -56,16 +57,35 @@ class ApiKeyService(AppService[ApiKeyRepository, ApiKey, ApiKeyCreate, ApiKeyUpd
 api_key_service = ApiKeyService(log=getLogger(__name__))
 
 
+async def _authenticate(db: Session, developer: Developer | None, api_key: str | None) -> str:
+    if developer:
+        return str(developer.id)
+    if api_key:
+        return api_key_service.validate_api_key(db, api_key).id
+    raise HTTPException(status_code=401, detail="Authentication required: provide JWT token or API key")
+
+
 async def _require_api_key(
     db: DbSession,
     developer: Developer | None = Depends(get_current_developer_optional),
     x_open_wearables_api_key: str | None = Header(None, alias="X-Open-Wearables-API-Key"),
 ) -> str:
-    if developer:
-        return str(developer.id)
-    if x_open_wearables_api_key:
-        return api_key_service.validate_api_key(db, x_open_wearables_api_key).id
-    raise HTTPException(status_code=401, detail="Authentication required: provide JWT token or API key")
+    return await _authenticate(db, developer, x_open_wearables_api_key)
+
+
+async def _require_api_key_detached(
+    token: Annotated[str | None, Depends(oauth2_scheme)] = None,
+    x_open_wearables_api_key: str | None = Header(None, alias="X-Open-Wearables-API-Key"),
+) -> str:
+    """Same rule as ApiKeyDep, but on a session released before the endpoint returns.
+
+    DbSession is a yield dependency, so anything that declares it — including the usual auth
+    dependency — holds a pooled connection until the response completes. For a stream that is
+    until the client disconnects, so a streaming endpoint has to authenticate detached.
+    """
+    with SessionLocal() as db:
+        return await _authenticate(db, await get_current_developer_optional(db, token), x_open_wearables_api_key)
 
 
 ApiKeyDep = Annotated[str, Depends(_require_api_key)]
+StreamingApiKeyDep = Annotated[str, Depends(_require_api_key_detached)]

--- a/backend/tests/api/v1/test_sync_status.py
+++ b/backend/tests/api/v1/test_sync_status.py
@@ -2,19 +2,45 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
 from fastapi import HTTPException
+from fastapi.dependencies.models import Dependant
+from fastapi.dependencies.utils import get_dependant
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 import app.services.sync_status_service as sync_status_service
-from app.api.routes.v1.sync_status import _ensure_user_exists_detached
+from app.api.routes.v1.sync_status import (
+    _ensure_user_exists_detached,
+    list_recent_sync_events,
+    stream_user_sync_status,
+)
+from app.database import _get_db_dependency
 from app.schemas.sync_status import SyncScope, SyncSource, SyncStage, SyncStatus, SyncStatusEvent
+from app.services.api_key_service import _require_api_key, _require_api_key_detached
 from tests.factories import UserFactory
+
+
+def _dependency_calls(endpoint: Callable) -> list:
+    """Every dependency an endpoint resolves, nested ones included.
+
+    Built the way FastAPI builds it for the route, so the answer is the one the framework
+    acts on rather than a re-reading of the signature.
+    """
+    calls: list = []
+
+    def walk(dependant: Dependant) -> None:
+        for sub in dependant.dependencies:
+            calls.append(sub.call)
+            walk(sub)
+
+    walk(get_dependant(path="/", call=endpoint))
+    return calls
 
 
 def _emit(user_id: UUID, *, run_id: str | None = None) -> SyncStatusEvent:
@@ -162,8 +188,22 @@ class TestHistoryEndpointFilters:
         assert [r["run_key"] for r in response.json()] == ["garmin_march"]
 
 
-class TestStreamUserExistence:
-    """The stream checks the user on a session of its own, so the pool is free while it runs."""
+class TestStreamHoldsNoDbSession:
+    """A stream must not park a pooled connection for as long as the client stays connected."""
+
+    def test_no_dependency_of_the_stream_declares_the_request_session(self) -> None:
+        """DbSession is a yield dependency, released only once the response completes.
+
+        For an SSE response that is at client disconnect, so ~50 open admin tabs would take
+        the whole pool. The non-streaming sibling is checked too, so a broken walk over the
+        dependency tree cannot make this pass by accident.
+        """
+        stream_deps = _dependency_calls(stream_user_sync_status)
+        assert _get_db_dependency not in stream_deps
+        assert _require_api_key not in stream_deps
+        assert _require_api_key_detached in stream_deps
+
+        assert _get_db_dependency in _dependency_calls(list_recent_sync_events)
 
     def test_checks_the_user_without_the_request_session(self, db: Session) -> None:
         user = UserFactory()

--- a/backend/tests/utils_tests/test_auth_utils.py
+++ b/backend/tests/utils_tests/test_auth_utils.py
@@ -5,6 +5,7 @@ Tests JWT token extraction, developer authentication, and error handling.
 """
 
 from datetime import timedelta
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -13,9 +14,10 @@ from jose import jwt
 from sqlalchemy.orm import Session
 
 from app.config import settings
+from app.services.api_key_service import _require_api_key_detached
 from app.utils.auth import get_current_developer, get_current_developer_optional
 from app.utils.security import create_access_token
-from tests.factories import DeveloperFactory
+from tests.factories import ApiKeyFactory, DeveloperFactory
 
 
 class TestGetCurrentDeveloper:
@@ -252,6 +254,48 @@ class TestGetCurrentDeveloperOptional:
 
         # Assert
         assert result is None
+
+
+class TestRequireApiKeyDetached:
+    """The streaming variant of the API-key rule: same outcomes, own short-lived session."""
+
+    @pytest.mark.asyncio
+    async def test_accepts_a_developer_token(self, db: Session) -> None:
+        developer = DeveloperFactory(email="detached@example.com")
+
+        with patch("app.services.api_key_service.SessionLocal") as mock_session_local:
+            mock_session_local.return_value.__enter__.return_value = db
+            result = await _require_api_key_detached(token=create_access_token(subject=str(developer.id)))
+
+        assert result == str(developer.id)
+
+    @pytest.mark.asyncio
+    async def test_accepts_an_api_key_header(self, db: Session) -> None:
+        api_key = ApiKeyFactory()
+
+        with patch("app.services.api_key_service.SessionLocal") as mock_session_local:
+            mock_session_local.return_value.__enter__.return_value = db
+            result = await _require_api_key_detached(token=None, x_open_wearables_api_key=api_key.id)
+
+        assert result == api_key.id
+
+    @pytest.mark.asyncio
+    async def test_rejects_a_request_with_neither(self, db: Session) -> None:
+        with patch("app.services.api_key_service.SessionLocal") as mock_session_local:
+            mock_session_local.return_value.__enter__.return_value = db
+            with pytest.raises(HTTPException) as exc_info:
+                await _require_api_key_detached(token=None, x_open_wearables_api_key=None)
+
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_rejects_an_unknown_api_key(self, db: Session) -> None:
+        with patch("app.services.api_key_service.SessionLocal") as mock_session_local:
+            mock_session_local.return_value.__enter__.return_value = db
+            with pytest.raises(HTTPException) as exc_info:
+                await _require_api_key_detached(token=None, x_open_wearables_api_key="nope")
+
+        assert exc_info.value.status_code == 401
 
 
 class TestAuthWorkflow:


### PR DESCRIPTION
Fixes #1566 

`/users/{user_id}/sync/stream` now uses a new `StreamingApiKeyDep`, which applies the same auth rule on a session it opens and closes itself. `ApiKeyDep` is unchanged.

Measured locally, 8 concurrent streams, one-line difference:

| stream auth | connections held |
|---|---|
| `ApiKeyDep` | 8 `idle in transaction` |
| `StreamingApiKeyDep` | 0 |

**Not in scope:** `stream_user_events` is still a sync generator, so each stream holds an anyio worker - the limit is now the 40-thread pool, not the DB pool.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication for sync-status streaming connections, allowing them to remain stable without retaining an open database session.
  - Preserved existing API-key and token authentication behavior for standard endpoints.

- **Tests**
  - Added coverage for streaming authentication, including valid credentials and unauthorized requests.
  - Added checks confirming streaming and non-streaming endpoints use the appropriate session handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->