### PR TITLE
feat(mcp): add HTTP transport with bearer/OAuth auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,16 @@ The platform's most powerful feature - define intelligent health insights using 
 - 🔄 Customizable AI models (swap models to match your needs)
 - 🔍 Natural language queries about user health metrics
 
+### MCP Server
+Query wearable health data from AI assistants using the [Model Context Protocol](https://modelcontextprotocol.io/):
+- 💬 **Natural Language Access**: Ask about steps, sleep, workouts, and more from Claude Desktop, Cursor, or claude.ai
+- 🖥️ **Local or Remote**: Runs over stdio for local desktop clients, or as an HTTP server behind a reverse proxy for remote connectors
+- 🔐 **Authenticated HTTP Mode**: Static bearer token or full OAuth 2.1 flow for remote clients
+
+See [mcp/README.md](mcp/README.md) for setup and configuration.
+
 ### Unified API
 Access health data through a consistent REST API regardless of the source device.
-
-### MCP Server
-Query wearable health data from AI assistants (Claude Desktop, Cursor, claude.ai) through natural language via the [Model Context Protocol](https://modelcontextprotocol.io/). Runs locally over stdio or as a remote HTTP server behind a reverse proxy. See [mcp/README.md](mcp/README.md) for setup.
 
 ### Provider Support
 - ☁️ **Cloud-based**: Garmin, Oura, Whoop, Suunto, Polar, Ultrahuman, Strava, Fitbit

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ The platform's most powerful feature - define intelligent health insights using 
 ### Unified API
 Access health data through a consistent REST API regardless of the source device.
 
+### MCP Server
+Query wearable health data from AI assistants (Claude Desktop, Cursor, claude.ai) through natural language via the [Model Context Protocol](https://modelcontextprotocol.io/). Runs locally over stdio or as a remote HTTP server behind a reverse proxy. See [mcp/README.md](mcp/README.md) for setup.
+
 ### Provider Support
 - ☁️ **Cloud-based**: Garmin, Oura, Whoop, Suunto, Polar, Ultrahuman, Strava, Fitbit
 - 📱 **SDK-based**: Apple HealthKit, Samsung Health, Google Health Connect

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -230,6 +230,8 @@ services:
       - path: ./mcp/config/.env
         required: false
     environment:
+      # Fixed for the containerized deployment - override any conflicting
+      # values from mcp/config/.env, which `environment:` always wins over.
       - OPEN_WEARABLES_API_URL=http://app:8000
       - MCP_TRANSPORT=http
       - MCP_HOST=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -219,6 +219,34 @@ services:
           path: ./frontend/vite.config.ts
     restart: on-failure
 
+  mcp:
+    build:
+      context: ./mcp
+      dockerfile: Dockerfile
+    container_name: mcp__open-wearables
+    image: open-wearables-mcp:latest
+    pull_policy: never
+    env_file:
+      - path: ./mcp/config/.env
+        required: false
+    environment:
+      - OPEN_WEARABLES_API_URL=http://app:8000
+      - MCP_TRANSPORT=http
+      - MCP_HOST=0.0.0.0
+      - MCP_PORT=8100
+    ports:
+      - "127.0.0.1:${MCP_PORT:-8100}:8100"
+    depends_on:
+      - app
+    develop:
+      watch:
+        - action: sync+restart
+          path: ./mcp/app
+          target: /root_project/app
+        - action: rebuild
+          path: ./mcp/uv.lock
+    restart: on-failure
+
 volumes:
   postgres_data:
   redis_data:

--- a/mcp/.dockerignore
+++ b/mcp/.dockerignore
@@ -1,0 +1,15 @@
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+
+.pytest_cache/
+.ruff_cache/
+
+config/.env
+.env
+.env.*
+
+*.log
+*.tmp
+*.bak

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -29,6 +29,10 @@ FROM python:3.13-slim
     ENV UV_PROJECT_ENVIRONMENT=/opt/venv
     ENV UV_NO_SYNC=true
 
+    RUN useradd --create-home --shell /usr/sbin/nologin --uid 1000 mcp \
+        && chown -R mcp:mcp /opt/venv /root_project
+    USER mcp
+
     EXPOSE 8100
 
     CMD ["start"]

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.13-slim AS builder
+
+    COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+    WORKDIR /root_project
+
+    # Install dependencies first (cached unless lock/pyproject change)
+    COPY uv.lock pyproject.toml ./
+    ENV VIRTUAL_ENV=/opt/venv
+    ENV UV_PROJECT_ENVIRONMENT=/opt/venv
+    RUN uv venv $VIRTUAL_ENV
+    ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+    RUN uv sync --locked --no-dev --no-install-project
+
+    # Copy source and install the project itself (fast, deps already cached)
+    COPY . .
+    RUN uv sync --locked --no-dev --no-editable
+
+FROM python:3.13-slim
+
+    WORKDIR /root_project
+
+    COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+    COPY --from=builder /opt/venv /opt/venv
+    COPY --from=builder /root_project /root_project
+    ENV VIRTUAL_ENV=/opt/venv
+    ENV PATH="/opt/venv/bin:$PATH"
+    ENV UV_PROJECT_ENVIRONMENT=/opt/venv
+    ENV UV_NO_SYNC=true
+
+    EXPOSE 8100
+
+    CMD ["start"]

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,6 @@
 # Open Wearables MCP Server
 
-MCP (Model Context Protocol) server for Open Wearables, enabling AI assistants like Claude Desktop and Cursor to query wearable health data through natural language.
+MCP (Model Context Protocol) server for Open Wearables, enabling AI assistants like Claude Desktop, Cursor, and claude.ai to query wearable health data through natural language. Runs locally over stdio, or as a remote HTTP server - see [HTTP Mode](#http-mode-remote-clients).
 
 ## Features
 
@@ -88,6 +88,38 @@ Add to Cursor MCP settings:
   }
 }
 ```
+
+## HTTP Mode (remote clients)
+
+By default the server runs over stdio, launched as a local subprocess by Claude Desktop/Cursor. For remote clients (e.g. claude.ai custom connectors), run it as a standalone HTTP server instead:
+
+```bash
+MCP_TRANSPORT=http
+MCP_HOST=127.0.0.1
+MCP_PORT=8100
+```
+
+Bind to `127.0.0.1` and put a reverse proxy (TLS) in front - don't expose the port directly. `docker compose up -d mcp` builds and runs it as part of the main stack.
+
+### Authentication
+
+HTTP mode requires one of the following (the server refuses to start without either):
+
+- **`MCP_BEARER_TOKEN`** - a static shared secret sent as `Authorization: Bearer <token>`. Simplest option, works with clients that let you paste in a token (MCPJam, most HTTP MCP clients). Generate with `openssl rand -hex 32`.
+- **`MCP_OAUTH_PASSWORD`** - a self-contained OAuth 2.1 flow (dynamic client registration + a password-gated login page). Required for clients that only support remote OAuth connectors, such as claude.ai custom connectors. Also set `MCP_PUBLIC_URL` to the server's public HTTPS URL, used for the OAuth issuer/redirect URLs. Generate the password with `openssl rand -hex 24`.
+
+If both are set, `MCP_OAUTH_PASSWORD` takes priority.
+
+### Connecting from claude.ai
+
+claude.ai's custom connectors only support the OAuth flow, not a bearer token, so run the server with `MCP_OAUTH_PASSWORD` and `MCP_PUBLIC_URL` set.
+
+1. In claude.ai, go to **Settings → Connectors → Add custom connector**.
+2. Enter the server URL: `https://your-domain.example.com/mcp`.
+3. claude.ai registers itself as a client and redirects you to the server's login page - enter the `MCP_OAUTH_PASSWORD` you configured. That's the only credential involved: there's no separate token to generate or copy, the OAuth exchange issues the access/refresh tokens behind the scenes.
+4. Once authorized, the connector is available in your conversations.
+
+For clients that take a manual bearer token instead (e.g. MCPJam), skip the login page entirely and paste the `MCP_BEARER_TOKEN` value as the Authorization header.
 
 ## Example Interactions
 
@@ -183,7 +215,9 @@ Get sleep summaries for a user within a date range.
 mcp/
 ├── app/
 │   ├── main.py           # FastMCP entry point
-│   ├── config.py         # Settings (API URL, API key)
+│   ├── config.py         # Settings (API URL, API key, transport, auth)
+│   ├── auth.py           # Bearer token verifier (HTTP mode)
+│   ├── oauth.py          # OAuth 2.1 provider (HTTP mode)
 │   ├── tools/
 │   │   ├── users.py      # get_users tool
 │   │   ├── activity.py   # get_activity_summary tool

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -99,7 +99,7 @@ MCP_HOST=127.0.0.1
 MCP_PORT=8100
 ```
 
-Bind to `127.0.0.1` and put a reverse proxy (TLS) in front - don't expose the port directly. `docker compose up -d mcp` builds and runs it as part of the main stack.
+Bind to `127.0.0.1` and put a reverse proxy (TLS) in front - don't expose the port directly. `docker compose up -d mcp` builds and runs it as part of the main stack - transport/host/port are fixed to `http`/`0.0.0.0`/`8100` in that case (see `docker-compose.yml`), so `MCP_TRANSPORT`/`MCP_HOST`/`MCP_PORT` in `.env` only apply when running the server directly (`uv run start`).
 
 ### Authentication
 

--- a/mcp/app/auth.py
+++ b/mcp/app/auth.py
@@ -1,0 +1,20 @@
+"""Bearer-token auth for the HTTP transport."""
+
+import hmac
+
+from fastmcp.server.auth import AccessToken, TokenVerifier
+
+from app.config import settings
+
+
+class SharedSecretVerifier(TokenVerifier):
+    """Validates the MCP bearer token against a single shared secret."""
+
+    def __init__(self) -> None:
+        super().__init__(required_scopes=None)
+        self._token = settings.mcp_bearer_token.get_secret_value()
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        if not self._token or not hmac.compare_digest(token, self._token):
+            return None
+        return AccessToken(token=token, client_id="open-wearables-mcp-client", scopes=[])

--- a/mcp/app/auth.py
+++ b/mcp/app/auth.py
@@ -11,10 +11,12 @@ class SharedSecretVerifier(TokenVerifier):
     """Validates the MCP bearer token against a single shared secret."""
 
     def __init__(self) -> None:
+        """Load the shared bearer token from settings."""
         super().__init__(required_scopes=None)
         self._token = settings.mcp_bearer_token.get_secret_value()
 
     async def verify_token(self, token: str) -> AccessToken | None:
+        """Validate a bearer token against the configured shared secret."""
         if not self._token or not hmac.compare_digest(token, self._token):
             return None
         return AccessToken(token=token, client_id="open-wearables-mcp-client", scopes=[])

--- a/mcp/app/config.py
+++ b/mcp/app/config.py
@@ -30,6 +30,26 @@ class Settings(BaseSettings):
     log_level: str = Field(default="INFO", description="Logging level")
     request_timeout: int = Field(default=30, description="HTTP request timeout in seconds")
 
+    # Transport settings
+    mcp_transport: str = Field(default="stdio", description="MCP transport: 'stdio' or 'http'")
+    mcp_host: str = Field(default="127.0.0.1", description="Bind host when mcp_transport='http'")
+    mcp_port: int = Field(default=8100, description="Bind port when mcp_transport='http'")
+    mcp_bearer_token: SecretStr = Field(
+        default=SecretStr(""),
+        description="Shared bearer token required from HTTP clients. Used when mcp_transport='http' "
+        "and mcp_oauth_password is not set.",
+    )
+
+    # OAuth settings
+    mcp_oauth_password: SecretStr = Field(
+        default=SecretStr(""),
+        description="Password gating the OAuth login page. Enables OAuth mode when mcp_transport='http'.",
+    )
+    mcp_public_url: str = Field(
+        default="http://localhost:8100",
+        description="Public HTTPS URL this server is reachable at, used for OAuth issuer/redirect URLs.",
+    )
+
     def is_configured(self) -> bool:
         """Check if the API key is configured."""
         return bool(self.open_wearables_api_key.get_secret_value())

--- a/mcp/app/config.py
+++ b/mcp/app/config.py
@@ -2,6 +2,7 @@
 
 import sys
 from pathlib import Path
+from typing import Literal
 
 from pydantic import Field, SecretStr, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -31,7 +32,7 @@ class Settings(BaseSettings):
     request_timeout: int = Field(default=30, description="HTTP request timeout in seconds")
 
     # Transport settings
-    mcp_transport: str = Field(default="stdio", description="MCP transport: 'stdio' or 'http'")
+    mcp_transport: Literal["stdio", "http"] = Field(default="stdio", description="MCP transport")
     mcp_host: str = Field(default="127.0.0.1", description="Bind host when mcp_transport='http'")
     mcp_port: int = Field(default=8100, description="Bind port when mcp_transport='http'")
     mcp_bearer_token: SecretStr = Field(
@@ -64,4 +65,7 @@ try:
         )
 except ValidationError as e:
     print(f"Configuration error: {e}", file=sys.stderr)
-    settings = Settings(open_wearables_api_key=SecretStr(""))
+    # Fall back to field defaults directly, bypassing env/dotenv parsing - the
+    # invalid value that triggered this is still in the environment, so
+    # re-running Settings() here would just raise the same error again.
+    settings = Settings.model_construct(open_wearables_api_key=SecretStr(""))

--- a/mcp/app/main.py
+++ b/mcp/app/main.py
@@ -160,13 +160,18 @@ mcp.mount(menstrual_cycles_router)
 # Mount prompts
 mcp.mount(prompts_router)
 
+# Set before main() so the auth provider is attached to `mcp` as soon as this
+# module is imported - e.g. by a FastMCP CLI runner that imports `mcp` and
+# never calls main() - rather than only when the server is started directly.
+if settings.mcp_transport == "http":
+    mcp.auth = _build_auth_provider()
+
 logger.info(f"Open Wearables MCP server initialized. API URL: {settings.open_wearables_api_url}")
 
 
 def main() -> None:
     """Entry point for the MCP server."""
     if settings.mcp_transport == "http":
-        mcp.auth = _build_auth_provider()
         mcp.run(transport="http", host=settings.mcp_host, port=settings.mcp_port)
     else:
         mcp.run()

--- a/mcp/app/main.py
+++ b/mcp/app/main.py
@@ -5,6 +5,7 @@ import sys
 from datetime import date
 
 from fastmcp import FastMCP
+from fastmcp.server.auth import AuthProvider
 
 from app.config import settings
 from app.prompts import prompts_router
@@ -23,34 +24,42 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-auth_provider = None
-if settings.mcp_transport == "http":
+
+def _build_auth_provider() -> AuthProvider:
+    """Build the HTTP-mode auth provider, or exit if neither secret is configured."""
     if settings.mcp_oauth_password.get_secret_value():
         from fastmcp.server.auth.auth import ClientRegistrationOptions, RevocationOptions
 
         from app.oauth import SinglePasswordOAuthProvider
 
-        auth_provider = SinglePasswordOAuthProvider(
+        if settings.mcp_public_url.startswith(("http://localhost", "http://127.0.0.1")):
+            print(
+                f"Warning: MCP_PUBLIC_URL is still {settings.mcp_public_url!r} - set it to the "
+                "server's public HTTPS URL, or remote clients won't be able to complete OAuth.",
+                file=sys.stderr,
+            )
+
+        return SinglePasswordOAuthProvider(
             base_url=settings.mcp_public_url,
             client_registration_options=ClientRegistrationOptions(enabled=True),
             revocation_options=RevocationOptions(enabled=True),
         )
-    elif settings.mcp_bearer_token.get_secret_value():
+    if settings.mcp_bearer_token.get_secret_value():
         from app.auth import SharedSecretVerifier
 
-        auth_provider = SharedSecretVerifier()
-    else:
-        print(
-            "Fatal: MCP_TRANSPORT=http requires MCP_OAUTH_PASSWORD or MCP_BEARER_TOKEN to be set "
-            "(the server would otherwise be reachable without authentication).",
-            file=sys.stderr,
-        )
-        sys.exit(1)
+        return SharedSecretVerifier()
+
+    print(
+        "Fatal: MCP_TRANSPORT=http requires MCP_OAUTH_PASSWORD or MCP_BEARER_TOKEN to be set "
+        "(the server would otherwise be reachable without authentication).",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
 
 # Create FastMCP server instance
 mcp = FastMCP(
     "open-wearables",
-    auth=auth_provider,
     instructions=f"""
     Today's date is {date.today().isoformat()}.
 
@@ -157,6 +166,7 @@ logger.info(f"Open Wearables MCP server initialized. API URL: {settings.open_wea
 def main() -> None:
     """Entry point for the MCP server."""
     if settings.mcp_transport == "http":
+        mcp.auth = _build_auth_provider()
         mcp.run(transport="http", host=settings.mcp_host, port=settings.mcp_port)
     else:
         mcp.run()

--- a/mcp/app/main.py
+++ b/mcp/app/main.py
@@ -1,6 +1,7 @@
 """Open Wearables MCP Server - Main entry point."""
 
 import logging
+import sys
 from datetime import date
 
 from fastmcp import FastMCP
@@ -22,9 +23,34 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+auth_provider = None
+if settings.mcp_transport == "http":
+    if settings.mcp_oauth_password.get_secret_value():
+        from fastmcp.server.auth.auth import ClientRegistrationOptions, RevocationOptions
+
+        from app.oauth import SinglePasswordOAuthProvider
+
+        auth_provider = SinglePasswordOAuthProvider(
+            base_url=settings.mcp_public_url,
+            client_registration_options=ClientRegistrationOptions(enabled=True),
+            revocation_options=RevocationOptions(enabled=True),
+        )
+    elif settings.mcp_bearer_token.get_secret_value():
+        from app.auth import SharedSecretVerifier
+
+        auth_provider = SharedSecretVerifier()
+    else:
+        print(
+            "Fatal: MCP_TRANSPORT=http requires MCP_OAUTH_PASSWORD or MCP_BEARER_TOKEN to be set "
+            "(the server would otherwise be reachable without authentication).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
 # Create FastMCP server instance
 mcp = FastMCP(
     "open-wearables",
+    auth=auth_provider,
     instructions=f"""
     Today's date is {date.today().isoformat()}.
 
@@ -130,7 +156,10 @@ logger.info(f"Open Wearables MCP server initialized. API URL: {settings.open_wea
 
 def main() -> None:
     """Entry point for the MCP server."""
-    mcp.run()
+    if settings.mcp_transport == "http":
+        mcp.run(transport="http", host=settings.mcp_host, port=settings.mcp_port)
+    else:
+        mcp.run()
 
 
 if __name__ == "__main__":

--- a/mcp/app/oauth.py
+++ b/mcp/app/oauth.py
@@ -10,17 +10,18 @@ import secrets
 import time
 from dataclasses import dataclass
 
-from fastmcp.server.auth.auth import OAuthProvider
+from fastmcp.server.auth.auth import AccessToken, ClientRegistrationOptions, OAuthProvider, RevocationOptions
 from fastmcp.utilities.ui import INFO_BOX_STYLES, create_page, create_secure_html_response
 from mcp.server.auth.provider import (
-    AccessToken,
     AuthorizationCode,
     AuthorizationParams,
     RefreshToken,
+    RegistrationError,
     TokenError,
     construct_redirect_uri,
 )
 from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from pydantic import AnyHttpUrl
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, RedirectResponse, Response
 from starlette.routing import Route
@@ -31,12 +32,27 @@ AUTH_CODE_EXPIRY_SECONDS = 5 * 60
 PENDING_AUTH_EXPIRY_SECONDS = 10 * 60
 ACCESS_TOKEN_EXPIRY_SECONDS = 30 * 24 * 60 * 60
 
+# A wrong password can't be retried more than this many times against a given
+# authorization attempt before the client has to restart the OAuth flow ...
+LOGIN_MAX_ATTEMPTS_PER_TXN = 5
+# ... nor more than this many times from a given address within the window,
+# which also bounds guessing across freshly-started authorization attempts.
+LOGIN_RATE_LIMIT_WINDOW_SECONDS = 5 * 60
+LOGIN_RATE_LIMIT_MAX_ATTEMPTS = 10
+
+# Dynamic client registration (RFC 7591) is unauthenticated by design, so cap
+# how many clients it can create to bound memory growth from abuse.
+MAX_REGISTERED_CLIENTS = 100
+
 
 @dataclass
 class _PendingAuthorization:
+    """An in-flight `/authorize` request, waiting on the login form."""
+
     client: OAuthClientInformationFull
     params: AuthorizationParams
     expires_at: float
+    attempts: int = 0
 
 
 class SinglePasswordOAuthProvider(OAuthProvider):
@@ -47,28 +63,51 @@ class SinglePasswordOAuthProvider(OAuthProvider):
     (see _issue_tokens below) that this server needs to enforce.
     """
 
-    def __init__(self, **kwargs: object) -> None:
-        super().__init__(**kwargs)
+    def __init__(
+        self,
+        *,
+        base_url: AnyHttpUrl | str,
+        client_registration_options: ClientRegistrationOptions | None = None,
+        revocation_options: RevocationOptions | None = None,
+    ) -> None:
+        """Initialize in-memory client/token/authorization-code storage."""
+        super().__init__(
+            base_url=base_url,
+            client_registration_options=client_registration_options,
+            revocation_options=revocation_options,
+        )
         self.clients: dict[str, OAuthClientInformationFull] = {}
         self.auth_codes: dict[str, AuthorizationCode] = {}
         self.access_tokens: dict[str, AccessToken] = {}
         self.refresh_tokens: dict[str, RefreshToken] = {}
         self._access_to_refresh: dict[str, str] = {}
         self._refresh_to_access: dict[str, str] = {}
+        # RefreshToken (unlike AccessToken/AuthorizationCode) has no `resource`
+        # field, so the RFC 8707 resource indicator is tracked here instead.
+        self._refresh_resource: dict[str, str | None] = {}
         self._pending: dict[str, _PendingAuthorization] = {}
+        self._failed_logins_by_ip: dict[str, list[float]] = {}
 
     # --- Dynamic client registration (RFC 7591) ---
     async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        """Look up a previously registered client by ID."""
         return self.clients.get(client_id)
 
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        """Register a new OAuth client, bounded by MAX_REGISTERED_CLIENTS."""
         if client_info.client_id is None:
-            raise ValueError("client_id is required for client registration")
+            raise RegistrationError(error="invalid_client_metadata", error_description="client_id is required")
         self._gc()
+        if len(self.clients) >= MAX_REGISTERED_CLIENTS:
+            raise RegistrationError(
+                error="invalid_client_metadata",
+                error_description="Server has reached its maximum number of registered OAuth clients.",
+            )
         self.clients[client_info.client_id] = client_info
 
     # --- Authorization: hand off to our own login page ---
     async def authorize(self, client: OAuthClientInformationFull, params: AuthorizationParams) -> str:
+        """Start an authorization attempt and return the login page URL."""
         self._gc()
         txn = secrets.token_urlsafe(24)
         self._pending[txn] = _PendingAuthorization(
@@ -93,6 +132,28 @@ class SinglePasswordOAuthProvider(OAuthProvider):
         for token, access in list(self.access_tokens.items()):
             if access.expires_at is not None and access.expires_at < now:
                 self._revoke(access=token)
+        cutoff = now - LOGIN_RATE_LIMIT_WINDOW_SECONDS
+        for ip in list(self._failed_logins_by_ip):
+            attempts = [t for t in self._failed_logins_by_ip[ip] if t > cutoff]
+            if attempts:
+                self._failed_logins_by_ip[ip] = attempts
+            else:
+                del self._failed_logins_by_ip[ip]
+
+    def _record_failed_login(self, client_ip: str) -> None:
+        """Record a failed login attempt from an address for rate limiting."""
+        now = time.time()
+        cutoff = now - LOGIN_RATE_LIMIT_WINDOW_SECONDS
+        attempts = [t for t in self._failed_logins_by_ip.get(client_ip, []) if t > cutoff]
+        attempts.append(now)
+        self._failed_logins_by_ip[client_ip] = attempts
+
+    def _is_login_rate_limited(self, client_ip: str) -> bool:
+        """Check whether an address has too many recent failed login attempts."""
+        now = time.time()
+        cutoff = now - LOGIN_RATE_LIMIT_WINDOW_SECONDS
+        attempts = [t for t in self._failed_logins_by_ip.get(client_ip, []) if t > cutoff]
+        return len(attempts) >= LOGIN_RATE_LIMIT_MAX_ATTEMPTS
 
     def _render_login(
         self,
@@ -101,6 +162,7 @@ class SinglePasswordOAuthProvider(OAuthProvider):
         redirect_uri: str,
         error: str | None = None,
     ) -> str:
+        """Render the password login page for a pending authorization."""
         error_box = f'<div class="info-box error"><p>{html.escape(error)}</p></div>' if error else ""
         client_name = html.escape(client.client_name or client.client_id or "An application")
         content = f"""
@@ -125,6 +187,7 @@ class SinglePasswordOAuthProvider(OAuthProvider):
         return create_page(content=content, title="Sign in", additional_styles=INFO_BOX_STYLES)
 
     async def _handle_login_get(self, request: Request) -> HTMLResponse:
+        """Serve the login page for a pending authorization transaction."""
         txn = request.query_params.get("txn", "")
         pending = self._pending.get(txn)
         if pending is None:
@@ -141,6 +204,7 @@ class SinglePasswordOAuthProvider(OAuthProvider):
         return create_secure_html_response(login_page)
 
     async def _handle_login_post(self, request: Request) -> Response:
+        """Validate the submitted password and issue an authorization code."""
         form = await request.form()
         txn = str(form.get("txn", ""))
         password = str(form.get("password", ""))
@@ -155,9 +219,22 @@ class SinglePasswordOAuthProvider(OAuthProvider):
                 status_code=400,
             )
 
+        client_ip = request.client.host if request.client else "unknown"
+        base = str(self.base_url).rstrip("/")
+        if self._is_login_rate_limited(client_ip) or pending.attempts >= LOGIN_MAX_ATTEMPTS_PER_TXN:
+            return create_secure_html_response(
+                create_page(
+                    content='<div class="container"><h1>Too many attempts</h1>'
+                    "<p>Please wait and reconnect from your MCP client.</p></div>",
+                    title="Too many attempts",
+                ),
+                status_code=429,
+            )
+
         expected = settings.mcp_oauth_password.get_secret_value()
         if not expected or not hmac.compare_digest(password, expected):
-            base = str(self.base_url).rstrip("/")
+            pending.attempts += 1
+            self._record_failed_login(client_ip)
             return RedirectResponse(f"{base}/login?txn={txn}&error=Incorrect+password", status_code=303)
 
         del self._pending[txn]
@@ -180,6 +257,7 @@ class SinglePasswordOAuthProvider(OAuthProvider):
         return RedirectResponse(redirect_uri, status_code=303)
 
     def get_routes(self, mcp_path: str | None = None) -> list[Route]:
+        """Add the login page routes to the standard OAuth server routes."""
         routes = super().get_routes(mcp_path)
         routes.append(Route("/login", endpoint=self._handle_login_get, methods=["GET"]))
         routes.append(Route("/login", endpoint=self._handle_login_post, methods=["POST"]))
@@ -191,6 +269,7 @@ class SinglePasswordOAuthProvider(OAuthProvider):
         client: OAuthClientInformationFull,
         authorization_code: str,
     ) -> AuthorizationCode | None:
+        """Look up a still-valid authorization code issued to this client."""
         code = self.auth_codes.get(authorization_code)
         if code is None:
             return None
@@ -204,6 +283,7 @@ class SinglePasswordOAuthProvider(OAuthProvider):
         client: OAuthClientInformationFull,
         authorization_code: AuthorizationCode,
     ) -> OAuthToken:
+        """Redeem a one-time authorization code for an access/refresh token pair."""
         if authorization_code.code not in self.auth_codes:
             raise TokenError("invalid_grant", "Authorization code not found or already used.")
         del self.auth_codes[authorization_code.code]
@@ -216,6 +296,7 @@ class SinglePasswordOAuthProvider(OAuthProvider):
         client: OAuthClientInformationFull,
         refresh_token: str,
     ) -> RefreshToken | None:
+        """Look up a refresh token previously issued to this client."""
         token = self.refresh_tokens.get(refresh_token)
         if token is None or token.client_id != client.client_id:
             return None
@@ -227,14 +308,17 @@ class SinglePasswordOAuthProvider(OAuthProvider):
         refresh_token: RefreshToken,
         scopes: list[str],
     ) -> OAuthToken:
+        """Rotate a refresh token for a new access/refresh token pair."""
         if not set(scopes).issubset(set(refresh_token.scopes)):
             raise TokenError("invalid_scope", "Requested scopes exceed those authorized by the refresh token.")
         if client.client_id is None:
             raise TokenError("invalid_client", "Client ID is required")
+        resource = self._refresh_resource.get(refresh_token.token)
         self._revoke(access=self._refresh_to_access.get(refresh_token.token), refresh=refresh_token.token)
-        return self._issue_tokens(client.client_id, scopes, refresh_token.resource)
+        return self._issue_tokens(client.client_id, scopes, resource)
 
     async def load_access_token(self, token: str) -> AccessToken | None:
+        """Look up a still-valid access token, revoking it if it has expired."""
         access = self.access_tokens.get(token)
         if access is None:
             return None
@@ -244,15 +328,18 @@ class SinglePasswordOAuthProvider(OAuthProvider):
         return access
 
     async def verify_token(self, token: str) -> AccessToken | None:
+        """Validate a bearer token for the TokenVerifier protocol."""
         return await self.load_access_token(token)
 
     async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
+        """Revoke an access or refresh token, and its linked counterpart."""
         if isinstance(token, AccessToken):
             self._revoke(access=token.token)
         else:
             self._revoke(refresh=token.token)
 
     def _issue_tokens(self, client_id: str, scopes: list[str], resource: str | None) -> OAuthToken:
+        """Mint and store a fresh access/refresh token pair."""
         access_value = secrets.token_hex(32)
         refresh_value = secrets.token_hex(32)
         expires_at = int(time.time() + ACCESS_TOKEN_EXPIRY_SECONDS)
@@ -263,13 +350,15 @@ class SinglePasswordOAuthProvider(OAuthProvider):
             expires_at=expires_at,
             resource=resource,
         )
+        # RefreshToken has no `resource` field - tracked separately so it can
+        # be carried over to the next access token on rotation.
         self.refresh_tokens[refresh_value] = RefreshToken(
             token=refresh_value,
             client_id=client_id,
             scopes=scopes,
             expires_at=None,
-            resource=resource,
         )
+        self._refresh_resource[refresh_value] = resource
         self._access_to_refresh[access_value] = refresh_value
         self._refresh_to_access[refresh_value] = access_value
         return OAuthToken(
@@ -281,14 +370,17 @@ class SinglePasswordOAuthProvider(OAuthProvider):
         )
 
     def _revoke(self, access: str | None = None, refresh: str | None = None) -> None:
+        """Revoke an access and/or refresh token, and its linked counterpart."""
         if access and access in self.access_tokens:
             del self.access_tokens[access]
             linked_refresh = self._access_to_refresh.pop(access, None)
             if linked_refresh:
                 self.refresh_tokens.pop(linked_refresh, None)
+                self._refresh_resource.pop(linked_refresh, None)
                 self._refresh_to_access.pop(linked_refresh, None)
         if refresh and refresh in self.refresh_tokens:
             del self.refresh_tokens[refresh]
+            self._refresh_resource.pop(refresh, None)
             linked_access = self._refresh_to_access.pop(refresh, None)
             if linked_access:
                 self.access_tokens.pop(linked_access, None)

--- a/mcp/app/oauth.py
+++ b/mcp/app/oauth.py
@@ -40,7 +40,12 @@ class _PendingAuthorization:
 
 
 class SinglePasswordOAuthProvider(OAuthProvider):
-    """OAuth authorization server backed by one shared password."""
+    """OAuth authorization server backed by one shared password.
+
+    Doesn't reuse fastmcp's InMemoryOAuthProvider: that one is documented as a
+    testing double, and it doesn't track the resource/audience restriction
+    (see _issue_tokens below) that this server needs to enforce.
+    """
 
     def __init__(self, **kwargs: object) -> None:
         super().__init__(**kwargs)
@@ -59,11 +64,12 @@ class SinglePasswordOAuthProvider(OAuthProvider):
     async def register_client(self, client_info: OAuthClientInformationFull) -> None:
         if client_info.client_id is None:
             raise ValueError("client_id is required for client registration")
+        self._gc()
         self.clients[client_info.client_id] = client_info
 
     # --- Authorization: hand off to our own login page ---
     async def authorize(self, client: OAuthClientInformationFull, params: AuthorizationParams) -> str:
-        self._gc_pending()
+        self._gc()
         txn = secrets.token_urlsafe(24)
         self._pending[txn] = _PendingAuthorization(
             client=client,
@@ -73,17 +79,35 @@ class SinglePasswordOAuthProvider(OAuthProvider):
         base = str(self.base_url).rstrip("/")
         return f"{base}/login?txn={txn}"
 
-    def _gc_pending(self) -> None:
+    def _gc(self) -> None:
+        """Sweep expired pending authorizations and access tokens.
+
+        Bounds memory growth for a long-running, unattended server - clients
+        and refresh tokens have no expiry by design (a personal deployment is
+        expected to stay connected), so those are only removed via explicit
+        revocation or rotation.
+        """
         now = time.time()
         for txn in [k for k, v in self._pending.items() if v.expires_at < now]:
             del self._pending[txn]
+        for token, access in list(self.access_tokens.items()):
+            if access.expires_at is not None and access.expires_at < now:
+                self._revoke(access=token)
 
-    def _render_login(self, txn: str, error: str | None = None) -> str:
+    def _render_login(
+        self,
+        txn: str,
+        client: OAuthClientInformationFull,
+        redirect_uri: str,
+        error: str | None = None,
+    ) -> str:
         error_box = f'<div class="info-box error"><p>{html.escape(error)}</p></div>' if error else ""
+        client_name = html.escape(client.client_name or client.client_id or "An application")
         content = f"""
             <div class="container">
                 <h1>Sign in to Open Wearables</h1>
-                <p>Authorize this application to access wearable health data.</p>
+                <p><strong>{client_name}</strong> wants to access your wearable health data.
+                   It will be redirected to <code>{html.escape(redirect_uri)}</code> once you sign in.</p>
                 {error_box}
                 <form method="post" action="/login">
                     <input type="hidden" name="txn" value="{html.escape(txn)}">
@@ -102,7 +126,8 @@ class SinglePasswordOAuthProvider(OAuthProvider):
 
     async def _handle_login_get(self, request: Request) -> HTMLResponse:
         txn = request.query_params.get("txn", "")
-        if txn not in self._pending:
+        pending = self._pending.get(txn)
+        if pending is None:
             return create_secure_html_response(
                 create_page(
                     content='<div class="container"><h1>Authorization request expired</h1>'
@@ -112,7 +137,8 @@ class SinglePasswordOAuthProvider(OAuthProvider):
                 status_code=400,
             )
         error = request.query_params.get("error")
-        return create_secure_html_response(self._render_login(txn, error))
+        login_page = self._render_login(txn, pending.client, str(pending.params.redirect_uri), error)
+        return create_secure_html_response(login_page)
 
     async def _handle_login_post(self, request: Request) -> Response:
         form = await request.form()
@@ -206,7 +232,7 @@ class SinglePasswordOAuthProvider(OAuthProvider):
         if client.client_id is None:
             raise TokenError("invalid_client", "Client ID is required")
         self._revoke(access=self._refresh_to_access.get(refresh_token.token), refresh=refresh_token.token)
-        return self._issue_tokens(client.client_id, scopes, None)
+        return self._issue_tokens(client.client_id, scopes, refresh_token.resource)
 
     async def load_access_token(self, token: str) -> AccessToken | None:
         access = self.access_tokens.get(token)
@@ -242,6 +268,7 @@ class SinglePasswordOAuthProvider(OAuthProvider):
             client_id=client_id,
             scopes=scopes,
             expires_at=None,
+            resource=resource,
         )
         self._access_to_refresh[access_value] = refresh_value
         self._refresh_to_access[refresh_value] = access_value

--- a/mcp/app/oauth.py
+++ b/mcp/app/oauth.py
@@ -1,0 +1,268 @@
+"""Self-contained OAuth 2.1 authorization server, gated by a single password.
+
+State (clients, codes, tokens) is kept in memory; a restart just means
+connected clients need to reauthorize.
+"""
+
+import hmac
+import html
+import secrets
+import time
+from dataclasses import dataclass
+
+from fastmcp.server.auth.auth import OAuthProvider
+from fastmcp.utilities.ui import INFO_BOX_STYLES, create_page, create_secure_html_response
+from mcp.server.auth.provider import (
+    AccessToken,
+    AuthorizationCode,
+    AuthorizationParams,
+    RefreshToken,
+    TokenError,
+    construct_redirect_uri,
+)
+from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, RedirectResponse, Response
+from starlette.routing import Route
+
+from app.config import settings
+
+AUTH_CODE_EXPIRY_SECONDS = 5 * 60
+PENDING_AUTH_EXPIRY_SECONDS = 10 * 60
+ACCESS_TOKEN_EXPIRY_SECONDS = 30 * 24 * 60 * 60
+
+
+@dataclass
+class _PendingAuthorization:
+    client: OAuthClientInformationFull
+    params: AuthorizationParams
+    expires_at: float
+
+
+class SinglePasswordOAuthProvider(OAuthProvider):
+    """OAuth authorization server backed by one shared password."""
+
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self.clients: dict[str, OAuthClientInformationFull] = {}
+        self.auth_codes: dict[str, AuthorizationCode] = {}
+        self.access_tokens: dict[str, AccessToken] = {}
+        self.refresh_tokens: dict[str, RefreshToken] = {}
+        self._access_to_refresh: dict[str, str] = {}
+        self._refresh_to_access: dict[str, str] = {}
+        self._pending: dict[str, _PendingAuthorization] = {}
+
+    # --- Dynamic client registration (RFC 7591) ---
+    async def get_client(self, client_id: str) -> OAuthClientInformationFull | None:
+        return self.clients.get(client_id)
+
+    async def register_client(self, client_info: OAuthClientInformationFull) -> None:
+        if client_info.client_id is None:
+            raise ValueError("client_id is required for client registration")
+        self.clients[client_info.client_id] = client_info
+
+    # --- Authorization: hand off to our own login page ---
+    async def authorize(self, client: OAuthClientInformationFull, params: AuthorizationParams) -> str:
+        self._gc_pending()
+        txn = secrets.token_urlsafe(24)
+        self._pending[txn] = _PendingAuthorization(
+            client=client,
+            params=params,
+            expires_at=time.time() + PENDING_AUTH_EXPIRY_SECONDS,
+        )
+        base = str(self.base_url).rstrip("/")
+        return f"{base}/login?txn={txn}"
+
+    def _gc_pending(self) -> None:
+        now = time.time()
+        for txn in [k for k, v in self._pending.items() if v.expires_at < now]:
+            del self._pending[txn]
+
+    def _render_login(self, txn: str, error: str | None = None) -> str:
+        error_box = f'<div class="info-box error"><p>{html.escape(error)}</p></div>' if error else ""
+        content = f"""
+            <div class="container">
+                <h1>Sign in to Open Wearables</h1>
+                <p>Authorize this application to access wearable health data.</p>
+                {error_box}
+                <form method="post" action="/login">
+                    <input type="hidden" name="txn" value="{html.escape(txn)}">
+                    <input type="password" name="password" placeholder="Password" autofocus required
+                           style="width:100%;padding:.6rem;margin:1rem 0;border:1px solid #e5e7eb;
+                                  border-radius:.5rem;box-sizing:border-box;">
+                    <button type="submit"
+                            style="width:100%;padding:.6rem;border:0;border-radius:.5rem;
+                                   background:#0a0a0a;color:#fff;font-weight:600;cursor:pointer;">
+                        Authorize
+                    </button>
+                </form>
+            </div>
+        """
+        return create_page(content=content, title="Sign in", additional_styles=INFO_BOX_STYLES)
+
+    async def _handle_login_get(self, request: Request) -> HTMLResponse:
+        txn = request.query_params.get("txn", "")
+        if txn not in self._pending:
+            return create_secure_html_response(
+                create_page(
+                    content='<div class="container"><h1>Authorization request expired</h1>'
+                    "<p>Please reconnect from your MCP client.</p></div>",
+                    title="Expired",
+                ),
+                status_code=400,
+            )
+        error = request.query_params.get("error")
+        return create_secure_html_response(self._render_login(txn, error))
+
+    async def _handle_login_post(self, request: Request) -> Response:
+        form = await request.form()
+        txn = str(form.get("txn", ""))
+        password = str(form.get("password", ""))
+        pending = self._pending.get(txn)
+        if pending is None or pending.expires_at < time.time():
+            return create_secure_html_response(
+                create_page(
+                    content='<div class="container"><h1>Authorization request expired</h1>'
+                    "<p>Please reconnect from your MCP client.</p></div>",
+                    title="Expired",
+                ),
+                status_code=400,
+            )
+
+        expected = settings.mcp_oauth_password.get_secret_value()
+        if not expected or not hmac.compare_digest(password, expected):
+            base = str(self.base_url).rstrip("/")
+            return RedirectResponse(f"{base}/login?txn={txn}&error=Incorrect+password", status_code=303)
+
+        del self._pending[txn]
+        client, params = pending.client, pending.params
+        if client.client_id is None:
+            raise TokenError("invalid_client", "Client ID is required")
+
+        code_value = secrets.token_hex(32)
+        self.auth_codes[code_value] = AuthorizationCode(
+            code=code_value,
+            client_id=client.client_id,
+            redirect_uri=params.redirect_uri,
+            redirect_uri_provided_explicitly=params.redirect_uri_provided_explicitly,
+            scopes=params.scopes or [],
+            expires_at=time.time() + AUTH_CODE_EXPIRY_SECONDS,
+            code_challenge=params.code_challenge,
+            resource=params.resource,
+        )
+        redirect_uri = construct_redirect_uri(str(params.redirect_uri), code=code_value, state=params.state)
+        return RedirectResponse(redirect_uri, status_code=303)
+
+    def get_routes(self, mcp_path: str | None = None) -> list[Route]:
+        routes = super().get_routes(mcp_path)
+        routes.append(Route("/login", endpoint=self._handle_login_get, methods=["GET"]))
+        routes.append(Route("/login", endpoint=self._handle_login_post, methods=["POST"]))
+        return routes
+
+    # --- Codes / tokens ---
+    async def load_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: str,
+    ) -> AuthorizationCode | None:
+        code = self.auth_codes.get(authorization_code)
+        if code is None:
+            return None
+        if code.client_id != client.client_id or code.expires_at < time.time():
+            self.auth_codes.pop(authorization_code, None)
+            return None
+        return code
+
+    async def exchange_authorization_code(
+        self,
+        client: OAuthClientInformationFull,
+        authorization_code: AuthorizationCode,
+    ) -> OAuthToken:
+        if authorization_code.code not in self.auth_codes:
+            raise TokenError("invalid_grant", "Authorization code not found or already used.")
+        del self.auth_codes[authorization_code.code]
+        if client.client_id is None:
+            raise TokenError("invalid_client", "Client ID is required")
+        return self._issue_tokens(client.client_id, authorization_code.scopes, authorization_code.resource)
+
+    async def load_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: str,
+    ) -> RefreshToken | None:
+        token = self.refresh_tokens.get(refresh_token)
+        if token is None or token.client_id != client.client_id:
+            return None
+        return token
+
+    async def exchange_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        if not set(scopes).issubset(set(refresh_token.scopes)):
+            raise TokenError("invalid_scope", "Requested scopes exceed those authorized by the refresh token.")
+        if client.client_id is None:
+            raise TokenError("invalid_client", "Client ID is required")
+        self._revoke(access=self._refresh_to_access.get(refresh_token.token), refresh=refresh_token.token)
+        return self._issue_tokens(client.client_id, scopes, None)
+
+    async def load_access_token(self, token: str) -> AccessToken | None:
+        access = self.access_tokens.get(token)
+        if access is None:
+            return None
+        if access.expires_at is not None and access.expires_at < time.time():
+            self._revoke(access=token)
+            return None
+        return access
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        return await self.load_access_token(token)
+
+    async def revoke_token(self, token: AccessToken | RefreshToken) -> None:
+        if isinstance(token, AccessToken):
+            self._revoke(access=token.token)
+        else:
+            self._revoke(refresh=token.token)
+
+    def _issue_tokens(self, client_id: str, scopes: list[str], resource: str | None) -> OAuthToken:
+        access_value = secrets.token_hex(32)
+        refresh_value = secrets.token_hex(32)
+        expires_at = int(time.time() + ACCESS_TOKEN_EXPIRY_SECONDS)
+        self.access_tokens[access_value] = AccessToken(
+            token=access_value,
+            client_id=client_id,
+            scopes=scopes,
+            expires_at=expires_at,
+            resource=resource,
+        )
+        self.refresh_tokens[refresh_value] = RefreshToken(
+            token=refresh_value,
+            client_id=client_id,
+            scopes=scopes,
+            expires_at=None,
+        )
+        self._access_to_refresh[access_value] = refresh_value
+        self._refresh_to_access[refresh_value] = access_value
+        return OAuthToken(
+            access_token=access_value,
+            token_type="Bearer",
+            expires_in=ACCESS_TOKEN_EXPIRY_SECONDS,
+            refresh_token=refresh_value,
+            scope=" ".join(scopes),
+        )
+
+    def _revoke(self, access: str | None = None, refresh: str | None = None) -> None:
+        if access and access in self.access_tokens:
+            del self.access_tokens[access]
+            linked_refresh = self._access_to_refresh.pop(access, None)
+            if linked_refresh:
+                self.refresh_tokens.pop(linked_refresh, None)
+                self._refresh_to_access.pop(linked_refresh, None)
+        if refresh and refresh in self.refresh_tokens:
+            del self.refresh_tokens[refresh]
+            linked_access = self._refresh_to_access.pop(refresh, None)
+            if linked_access:
+                self.access_tokens.pop(linked_access, None)
+                self._access_to_refresh.pop(linked_access, None)

--- a/mcp/config/.env.example
+++ b/mcp/config/.env.example
@@ -18,9 +18,12 @@ REQUEST_TIMEOUT=30
 
 # Optional: MCP transport. "stdio" (default) runs as a local subprocess
 # (Claude Desktop/Cursor). Set to "http" to run as a standalone HTTP server.
+# Ignored when running via `docker compose` - the mcp service there always
+# forces http/0.0.0.0:8100 regardless of this file (see docker-compose.yml).
 MCP_TRANSPORT=stdio
 
-# Only used when MCP_TRANSPORT=http. Bind to 127.0.0.1 and put a reverse
+# Only used when MCP_TRANSPORT=http, and only outside of `docker compose`
+# (where these are fixed - see above). Bind to 127.0.0.1 and put a reverse
 # proxy with TLS in front - do not expose this port directly.
 MCP_HOST=127.0.0.1
 MCP_PORT=8100

--- a/mcp/config/.env.example
+++ b/mcp/config/.env.example
@@ -15,3 +15,27 @@ LOG_LEVEL=INFO
 
 # Optional: HTTP request timeout in seconds
 REQUEST_TIMEOUT=30
+
+# Optional: MCP transport. "stdio" (default) runs as a local subprocess
+# (Claude Desktop/Cursor). Set to "http" to run as a standalone HTTP server.
+MCP_TRANSPORT=stdio
+
+# Only used when MCP_TRANSPORT=http. Bind to 127.0.0.1 and put a reverse
+# proxy with TLS in front - do not expose this port directly.
+MCP_HOST=127.0.0.1
+MCP_PORT=8100
+
+# Public HTTPS URL this server is reachable at, for OAuth issuer/redirect
+# URLs. Only needed when MCP_OAUTH_PASSWORD is set.
+MCP_PUBLIC_URL=https://your-domain.example.com
+
+# Set ONE of the following when MCP_TRANSPORT=http:
+#
+# MCP_OAUTH_PASSWORD - full OAuth 2.1 flow with a login page gated by this
+# password. Required for clients that only support remote OAuth connectors
+# (e.g. claude.ai custom connectors). Generate with: openssl rand -hex 24
+MCP_OAUTH_PASSWORD=
+#
+# MCP_BEARER_TOKEN - static shared secret sent as "Authorization: Bearer
+# <token>". Ignored if MCP_OAUTH_PASSWORD is set. Generate with: openssl rand -hex 32
+MCP_BEARER_TOKEN=


### PR DESCRIPTION
## What does this change?

Adds an HTTP transport to the MCP server (`MCP_TRANSPORT=http`) alongside the existing stdio mode, so it can run as a standalone server for remote clients, with either a static bearer token or a self-contained OAuth 2.1 flow for auth.

## Why?

stdio only works for clients that spawn the server as a local subprocess (Claude Desktop, Cursor). claude.ai's custom connectors need an HTTP-reachable server with OAuth - a bearer token alone doesn't fit that flow, since there's no authorization server for the client to register against. Bearer stays as the simpler option for clients that accept a manual token (MCPJam and similar).

Considered subclassing fastmcp's `InMemoryOAuthProvider` instead of writing our own - dropped that because it's documented as a testing double and doesn't track the `resource`/audience restriction we need for token scoping.

Related issue: none.

## How did you test this?

- Deployed the `mcp` service behind a reverse proxy on a real HTTPS domain, with `MCP_OAUTH_PASSWORD` set.
- Added it as a custom connector in claude.ai (Settings → Connectors), went through the full OAuth flow end to end (dynamic client registration → password login → token exchange), and queried real wearable data through it.
- Bearer-token mode and the edge cases from a review pass (confused-deputy phishing on the login page, dropped resource restriction on token refresh, config validation, secrets ending up in the Docker image) were verified with targeted checks in an isolated environment, not against a live client.

## AI usage

Built with Claude Code (Sonnet 5): implementation, a code-review pass that surfaced and fixed several issues in the auth flow, and this PR description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an MCP server for querying wearable health data through AI assistants.
  - Supports local stdio connections and remote HTTP access.
  - Added bearer-token and OAuth 2.1 authentication for remote clients.
  - Added Docker Compose support for running the MCP server locally.
  - Added protections for OAuth client registration, password attempts, and token handling.

- **Documentation**
  - Documented setup, supported assistants, transport modes, authentication, remote connections, and security guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->