### PR TITLE
fix(integrations): a manual Strava activity has no streams, not a failure

### DIFF
--- a/backend/app/services/providers/strava/workouts.py
+++ b/backend/app/services/providers/strava/workouts.py
@@ -3,6 +3,8 @@ from decimal import Decimal
 from typing import Any
 from uuid import UUID, uuid4
 
+from fastapi import HTTPException, status
+
 from app.config import settings
 from app.constants.workout_types import get_unified_strava_workout_type
 from app.database import DbSession
@@ -319,6 +321,28 @@ class StravaWorkouts(BaseWorkoutsTemplate):
                 record.zone_offset,
                 activity.device_name or "",
             )
+        except HTTPException as exc:
+            if exc.status_code == status.HTTP_404_NOT_FOUND:
+                # Manual activities carry no streams; Strava answers /streams with 404.
+                # Not a failure, so don't report it — otherwise every sync pass that
+                # re-covers the activity raises it again, for as long as it exists.
+                log_structured(
+                    self.logger,
+                    "info",
+                    "Strava activity has no streams (manual entry); skipping samples",
+                    provider="strava",
+                    action="strava_streams_absent",
+                    activity_id=str(activity.id),
+                    user_id=str(user_id),
+                )
+                return 0
+            log_and_capture_error(
+                exc,
+                self.logger,
+                "Failed to fetch Strava workout streams, skipping samples",
+                extra={"activity_id": activity.id},
+            )
+            return 0
         except Exception as exc:
             log_and_capture_error(
                 exc,

--- a/backend/tests/providers/strava/test_strava_workout_samples.py
+++ b/backend/tests/providers/strava/test_strava_workout_samples.py
@@ -350,3 +350,32 @@ class TestIngestionWiring:
 
         mock_ts.bulk_create_samples.assert_not_called()
         assert count == 0
+
+
+class TestManualActivityWithoutStreams:
+    """Strava answers /streams with 404 for manual entries — they have no streams."""
+
+    def _ingest(self, sw: StravaWorkouts, exc: Exception) -> tuple[int, MagicMock]:
+        record, _ = sw._normalize_workout(_SAMPLE_ACTIVITY, uuid4())
+        with (
+            patch.object(sw, "_build_workout_samples", side_effect=exc),
+            patch("app.services.providers.strava.workouts.settings") as mock_settings,
+            patch("app.services.providers.strava.workouts.log_and_capture_error") as mock_report,
+        ):
+            mock_settings.ingest_workout_samples = True
+            result = sw._ingest_workout_streams(MagicMock(), _SAMPLE_ACTIVITY, uuid4(), record)
+        return result, mock_report
+
+    def test_404_is_not_reported_as_an_error(self, strava_workouts: StravaWorkouts) -> None:
+        from fastapi import HTTPException
+
+        result, mock_report = self._ingest(strava_workouts, HTTPException(status_code=404, detail="Record Not Found"))
+        assert result == 0
+        mock_report.assert_not_called()
+
+    def test_other_http_errors_are_still_reported(self, strava_workouts: StravaWorkouts) -> None:
+        from fastapi import HTTPException
+
+        result, mock_report = self._ingest(strava_workouts, HTTPException(status_code=500, detail="boom"))
+        assert result == 0
+        mock_report.assert_called_once()


### PR DESCRIPTION
Hi!

Strava answers `GET /activities/{id}/streams` with 404 for manual activities — they have no streams by definition. `_ingest_workout_streams` reports that through `log_and_capture_error`, so one hand-logged gym session produces a traceback and a Sentry event on every sync pass that re-covers it.

In our deployment that was twice an hour, indefinitely: the trailing lookback keeps re-covering the activity, and it never gains samples, so nothing ever settles. The workout itself is stored correctly; only the reporting is wrong.

This treats 404 from the streams endpoint as "this activity has no streams" and skips quietly, with an info line carrying the activity id. Every other status keeps its current reporting, including the 500 path.

Real example that prompted it: a manual "Workout" entry with `manual: true`, no device, zero distance.

Verification: `uv run pytest tests/providers/strava/` — 16 passed, including two new cases (404 not reported, other errors still reported); `ruff check` clean.

Unrelated to #1298 and #1447, so this can land independently of either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EY3bZLVL41Q5SHG4uW39Xo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Manual Strava activities without workout stream data are now handled gracefully without being reported as errors.
  - Other errors returned by Strava’s stream endpoint continue to be recorded for investigation.

- **Tests**
  - Added coverage for manual activities without streams and for handling other stream-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->