### PR TITLE
fix(google): type sleep sessions as sleep_session so their stages can be updated

### DIFF
--- a/backend/app/services/providers/google/health_api/sleep.py
+++ b/backend/app/services/providers/google/health_api/sleep.py
@@ -117,6 +117,7 @@ class GoogleHealthApiSleep:
         record = EventRecordCreate(
             id=record_id,
             category="sleep",
+            type="sleep_session",
             provider=ProviderName.GOOGLE.value,
             source=GOOGLE_HEALTH_API_SOURCE,
             source_name=source_name,

--- a/backend/tests/providers/google/test_health_api_sleep_type.py
+++ b/backend/tests/providers/google/test_health_api_sleep_type.py
@@ -1,0 +1,53 @@
+"""Google Health API sleep sessions must carry ``type="sleep_session"``.
+
+Regression test: ``EventRecordService`` only reaches the branch that *rewrites* an
+existing sleep detail through ``find_adjacent_sleep_record``, which filters on
+``EventRecord.type == "sleep_session"``. Every other provider sets the field, so a
+Google session that was first published unclassified — Google's API returns a single
+``sleeping`` block and fills in the stages moments later — could never be repaired: the
+re-insert hits the ``(data_source_id, start_datetime, end_datetime)`` unique index,
+returns the existing row, and the detail insert hits the primary key and returns the
+stored detail untouched. The stages stayed lost for the life of the record.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from app.services.providers.google.health_api.sleep import GoogleHealthApiSleep
+
+
+def _handler() -> GoogleHealthApiSleep:
+    return GoogleHealthApiSleep(MagicMock(), MagicMock(), "https://health.googleapis.com")
+
+
+def _point() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    interval = {
+        "startTime": "2026-09-09T01:47:00Z",
+        "endTime": "2026-09-09T07:59:00Z",
+        "startUtcOffset": "7200s",
+    }
+    sleep = {
+        "sleepStages": [
+            {"stage": "DEEP", "interval": interval},
+        ],
+        "metadata": {"externalId": "sleep-1"},
+    }
+    point = {"name": "dataPoints/1", "dataSource": "derived:com.google.sleep.segment", "interval": interval}
+    return point, sleep, interval
+
+
+def test_sleep_record_is_typed_as_sleep_session() -> None:
+    point, sleep, interval = _point()
+    record, _detail = _handler()._normalize(
+        point,
+        sleep,
+        interval,
+        datetime(2026, 9, 9, 1, 47, tzinfo=timezone.utc),
+        datetime(2026, 9, 9, 7, 59, tzinfo=timezone.utc),
+        uuid4(),
+    )
+
+    assert record.category == "sleep"
+    assert record.type == "sleep_session"


### PR DESCRIPTION
`EventRecordService` only rewrites an existing sleep detail through
`find_adjacent_sleep_record`, which filters on `EventRecord.type == "sleep_session"`.
Every other provider that ingests sleep sets the field — WHOOP, Suunto, Oura, Garmin,
SensorBio and Ultrahuman — but the Google Health API handler did not, so a Google
session already in the database could never be repaired.

That matters because Google publishes a sleep session as soon as it ends and fills in
the stage breakdown moments later: the first read returns a single `sleeping` block and
the next one carries DEEP / LIGHT / REM / AWAKE. With `type` unset, the second read took
the create path instead: the insert hit the `(data_source_id, start_datetime,
end_datetime)` unique index and returned the existing row, and the detail insert hit the
primary key and returned the stored detail untouched. The stages were dropped silently,
for the life of the record.

Measured on a production deployment against the raw payload archive — 1,663 API reads
over 275 sleep sessions — the stage breakdown arrives within one second of the session
itself (p50 0 s, p90 0 s, max 1 s), and 269 of 275 sessions were already classified on
the first read. The remaining ones were published unclassified and never recovered: one
session was seen unclassified at 07:59:22 and classified at 07:59:23, and five hours and
nineteen reads later the database still held `deep`, `rem` and `light` as NULL.

Deployments that already have Google sleep rows need a one-off backfill for the fix to
reach them, since the filter matches on the stored value:

    UPDATE event_record SET type = 'sleep_session'
     WHERE category = 'sleep' AND type IS NULL
       AND data_source_id IN (SELECT id FROM data_source WHERE provider = 'google');

Verified in production: after the backfill and the first sync, a night that had held
NULL stages for five hours came back with 69 min deep, 95 REM, 195 light, 12 awake.

## Checklist

- [x] My code follows the project's code style (`ruff check`, `ruff format`, `ty` clean on the touched files)
- [x] I have performed a self-review of my code
- [x] I have added a test that proves the fix works (`tests/providers/google/test_health_api_sleep_type.py`; it fails on `main` and passes with the change)
- [x] New and existing tests pass locally for the touched paths
- [ ] I have updated relevant documentation in `docs/` — not needed, no behaviour is documented per-provider for this field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Google Health sleep records are now consistently classified as sleep sessions during normalization.

- **Tests**
  - Added regression coverage to verify correct sleep category and session type classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->