### PR TITLE
fix(backend): allow removing webhook event filters

### DIFF
--- a/backend/app/schemas/webhooks/endpoints.py
+++ b/backend/app/schemas/webhooks/endpoints.py
@@ -37,7 +37,10 @@ class EndpointCreateRequest(BaseModel):
 class EndpointUpdateRequest(BaseModel):
     url: str | None = None
     description: str | None = None
-    filter_types: list[str] | None = None
+    filter_types: list[str] | None = Field(
+        None,
+        description="Only deliver events of these types. Pass an empty list to remove the filter.",
+    )
     user_id: UUID | None = Field(
         None,
         description="Subscribe only to events for this user. Pass null to remove the filter.",

--- a/backend/app/schemas/webhooks/endpoints.py
+++ b/backend/app/schemas/webhooks/endpoints.py
@@ -21,11 +21,11 @@ class EndpointCreateRequest(BaseModel):
     description: str | None = Field(None, description="Human-readable label for this endpoint.")
     filter_types: list[str] | None = Field(
         None,
-        description="Only deliver events of these types. Empty / None = all types.",
+        description="Only deliver events of these types. Omit, or pass an empty list, to receive all event types.",
     )
     user_id: UUID | None = Field(
         None,
-        description="Subscribe only to events for this user. Empty / None = all users.",
+        description="Subscribe only to events for this user. Omit, or pass null, to receive events for all users.",
     )
 
     @field_validator("url")
@@ -39,11 +39,19 @@ class EndpointUpdateRequest(BaseModel):
     description: str | None = None
     filter_types: list[str] | None = Field(
         None,
-        description="Only deliver events of these types. Pass an empty list to remove the filter.",
+        description=(
+            "Only deliver events of these types. Pass an empty list to remove the filter and "
+            "receive all event types again. Omitting the field — or sending null — leaves the "
+            "current filter unchanged."
+        ),
     )
     user_id: UUID | None = Field(
         None,
-        description="Subscribe only to events for this user. Pass null to remove the filter.",
+        description=(
+            "Subscribe only to events for this user. Pass null to remove the filter and receive "
+            "events for all users again. Omitting the field leaves the current scope unchanged. "
+            "Note the asymmetry with `filter_types`, where null is a no-op and an empty list clears."
+        ),
     )
 
     @field_validator("url")

--- a/backend/app/services/outgoing_webhooks/svix.py
+++ b/backend/app/services/outgoing_webhooks/svix.py
@@ -297,6 +297,10 @@ def patch_endpoint(
     if description is not None:
         patch_data["description"] = description
     if filter_types is not None:
+        # [] is the public "remove the filter" signal (Svix rejects an empty list,
+        # so it goes out as an explicit null).  None stays a no-op: it is what an
+        # omitted field deserialises to and external clients already rely on that,
+        # so it must not be repurposed into a second clearing signal.
         patch_data["filter_types"] = filter_types or None
     if user_id is not None:
         patch_data["channels"] = _user_channels(user_id)

--- a/backend/app/services/outgoing_webhooks/svix.py
+++ b/backend/app/services/outgoing_webhooks/svix.py
@@ -249,7 +249,7 @@ def create_endpoint(
         "url": url,
         "description": description or "",
     }
-    if filter_types is not None:
+    if filter_types:
         endpoint_data["filter_types"] = filter_types
     channels = _user_channels(user_id)
     if channels is not None:
@@ -297,7 +297,7 @@ def patch_endpoint(
     if description is not None:
         patch_data["description"] = description
     if filter_types is not None:
-        patch_data["filter_types"] = filter_types
+        patch_data["filter_types"] = filter_types or None
     if user_id is not None:
         patch_data["channels"] = _user_channels(user_id)
     elif clear_user_id:

--- a/backend/tests/api/v1/test_outgoing_webhooks.py
+++ b/backend/tests/api/v1/test_outgoing_webhooks.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session
 
 from app.integrations.celery.tasks.emit_webhook_event_task import emit_webhook_event
 from app.schemas.webhooks.event_types import EVENT_TYPE_DESCRIPTIONS, WebhookEventType
+from app.services.outgoing_webhooks import svix as svix_service
 from app.services.outgoing_webhooks.events import (
     SVIX_MAX_SAMPLES_PER_EVENT,
     _dispatch,
@@ -489,3 +490,56 @@ class TestOutgoingWebhooksAPI:
             headers={"Authorization": f"Bearer {token}"},
         )
         assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# svix_service.create_endpoint / patch_endpoint — filter_types translation
+# ---------------------------------------------------------------------------
+
+
+class TestSvixFilterTypesHandling:
+    """Svix rejects an empty `filter_types` list outright ("eventTypes can't
+    be empty, it must have at least one item"), so an empty selection must be
+    translated to omitting the key (create) or an explicit null (patch)
+    before it reaches the Svix client — never sent through as [].
+    """
+
+    @pytest.fixture
+    def mock_client(self) -> Generator[MagicMock, None, None]:
+        mock = MagicMock()
+        with patch("app.services.outgoing_webhooks.svix._client", mock):
+            yield mock
+
+    @pytest.mark.parametrize("filter_types", [None, []])
+    def test_create_endpoint_omits_filter_types_when_empty(
+        self, mock_client: MagicMock, filter_types: list[str] | None
+    ) -> None:
+        svix_service.create_endpoint("app_1", "https://example.com/wh", filter_types=filter_types)
+
+        sent = mock_client.endpoint.create.call_args.args[1]
+        assert "filter_types" not in sent.model_fields_set
+
+    def test_create_endpoint_includes_filter_types_when_populated(self, mock_client: MagicMock) -> None:
+        svix_service.create_endpoint("app_1", "https://example.com/wh", filter_types=["workout.created"])
+
+        sent = mock_client.endpoint.create.call_args.args[1]
+        assert sent.filter_types == ["workout.created"]
+
+    def test_patch_endpoint_leaves_filter_types_untouched_when_not_provided(self, mock_client: MagicMock) -> None:
+        svix_service.patch_endpoint("app_1", "ep_1", filter_types=None)
+
+        sent = mock_client.endpoint.patch.call_args.args[2]
+        assert "filter_types" not in sent.model_fields_set
+
+    def test_patch_endpoint_clears_filter_types_with_explicit_null(self, mock_client: MagicMock) -> None:
+        svix_service.patch_endpoint("app_1", "ep_1", filter_types=[])
+
+        sent = mock_client.endpoint.patch.call_args.args[2]
+        assert "filter_types" in sent.model_fields_set
+        assert sent.filter_types is None
+
+    def test_patch_endpoint_sets_filter_types_when_populated(self, mock_client: MagicMock) -> None:
+        svix_service.patch_endpoint("app_1", "ep_1", filter_types=["sleep.created"])
+
+        sent = mock_client.endpoint.patch.call_args.args[2]
+        assert sent.filter_types == ["sleep.created"]

--- a/backend/tests/api/v1/test_outgoing_webhooks.py
+++ b/backend/tests/api/v1/test_outgoing_webhooks.py
@@ -543,3 +543,81 @@ class TestSvixFilterTypesHandling:
 
         sent = mock_client.endpoint.patch.call_args.args[2]
         assert sent.filter_types == ["sleep.created"]
+
+
+# ---------------------------------------------------------------------------
+# PATCH /endpoints/{id} — clearing semantics, pinned against regressions
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateEndpointClearingContract:
+    """The two fields clear differently, and both conventions are public API.
+
+    `filter_types`: an empty list clears; an omitted field or an explicit null
+    leaves the current filter alone.
+    `user_id`: an explicit null clears; an omitted field leaves the scope alone.
+
+    The asymmetry is deliberate — external clients already depend on a null
+    `filter_types` being a no-op, so it must never become a second clearing
+    signal.  These tests fail if anyone "harmonises" the two.
+    """
+
+    @pytest.fixture(autouse=True)
+    def mock_svix(self) -> Any:
+        with patch("app.api.routes.v1.outgoing_webhooks.svix_service") as m:
+            m.is_enabled.return_value = True
+            m.ensure_application.return_value = "app_uid_123"
+            m.user_id_from_endpoint.return_value = None
+            m.patch_endpoint.return_value = MagicMock(
+                id="ep_123",
+                url="https://example.com/wh",
+                description="",
+                filter_types=None,
+            )
+            yield m
+
+    def _patch(self, client: TestClient, body: dict[str, Any]) -> Any:
+        token = create_access_token(DeveloperFactory().id)
+        resp = client.patch(
+            "/api/v1/webhooks/endpoints/ep_123",
+            json=body,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        return resp
+
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            ({"description": "only the label"}, None),
+            ({"filter_types": None}, None),
+            ({"filter_types": []}, []),
+            ({"filter_types": ["workout.created"]}, ["workout.created"]),
+        ],
+        ids=["omitted", "explicit-null", "empty-list", "populated"],
+    )
+    def test_filter_types_reaches_the_service_verbatim(
+        self,
+        client: TestClient,
+        db: Session,
+        mock_svix: MagicMock,
+        body: dict[str, Any],
+        expected: list[str] | None,
+    ) -> None:
+        self._patch(client, body)
+
+        assert mock_svix.patch_endpoint.call_args.kwargs["filter_types"] == expected
+
+    def test_explicit_null_user_id_clears_the_user_scope(
+        self, client: TestClient, db: Session, mock_svix: MagicMock
+    ) -> None:
+        self._patch(client, {"user_id": None})
+
+        assert mock_svix.patch_endpoint.call_args.kwargs["clear_user_id"] is True
+
+    def test_omitted_user_id_leaves_the_user_scope_untouched(
+        self, client: TestClient, db: Session, mock_svix: MagicMock
+    ) -> None:
+        self._patch(client, {"description": "only the label"})
+
+        assert mock_svix.patch_endpoint.call_args.kwargs["clear_user_id"] is False

--- a/docs/api-reference/guides/webhooks.mdx
+++ b/docs/api-reference/guides/webhooks.mdx
@@ -498,6 +498,15 @@ curl -X POST "http://localhost:8000/api/v1/webhooks/endpoints" \
 
 Omit the field entirely to receive all event types.
 
+To later remove the event type filter from an existing endpoint (receive all event types again), send a `PATCH` with `"filter_types": []`:
+
+```bash
+curl -X PATCH "http://localhost:8000/api/v1/webhooks/endpoints/ep_2t8Q4Xv9mNkRpLzYoB3cW7" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "filter_types": [] }'
+```
+
 ### Filter by user
 
 Pass `user_id` to scope an endpoint to events for a single user. All other users' events are silently dropped before delivery.

--- a/docs/api-reference/guides/webhooks.mdx
+++ b/docs/api-reference/guides/webhooks.mdx
@@ -507,6 +507,13 @@ curl -X PATCH "http://localhost:8000/api/v1/webhooks/endpoints/ep_2t8Q4Xv9mNkRpL
   -d '{ "filter_types": [] }'
 ```
 
+<Note>
+  The empty list is what clears the filter. Sending `"filter_types": null` — or leaving the field
+  out — keeps the current filter, so a client that serialises unset fields as `null` will not wipe
+  an endpoint's event types by accident. Note that `user_id` works the other way round: there
+  `null` is what removes the filter.
+</Note>
+
 ### Filter by user
 
 Pass `user_id` to scope an endpoint to events for a single user. All other users' events are silently dropped before delivery.

--- a/frontend/src/components/webhooks/webhook-create-dialog.tsx
+++ b/frontend/src/components/webhooks/webhook-create-dialog.tsx
@@ -40,7 +40,7 @@ export function WebhookCreateDialog({
               {
                 url: data.url,
                 description: data.description ?? null,
-                filter_types: data.filter_types ?? null,
+                filter_types: data.filter_types,
                 user_id: data.user_id ?? null,
               },
               {

--- a/frontend/src/components/webhooks/webhook-form.tsx
+++ b/frontend/src/components/webhooks/webhook-form.tsx
@@ -58,7 +58,7 @@ export function WebhookForm({
     onSubmit({
       url: data.url.trim(),
       description: data.description?.trim() || undefined,
-      filter_types: data.filter_types?.length ? data.filter_types : undefined,
+      filter_types: data.filter_types ?? [],
       user_id: data.user_id?.trim() || undefined,
     });
   });

--- a/frontend/src/routes/_authenticated/webhooks/$endpointId.tsx
+++ b/frontend/src/routes/_authenticated/webhooks/$endpointId.tsx
@@ -173,7 +173,7 @@ function WebhookDetailPage() {
                   data: {
                     url: data.url,
                     description: data.description ?? null,
-                    filter_types: data.filter_types ?? null,
+                    filter_types: data.filter_types,
                     user_id: data.user_id ?? null,
                   },
                 })


### PR DESCRIPTION
## Description

Cannot deselect all event types in webhook settings.
In the recording I showed - I deselect everything, click save changes, the UI shows "Great, great, removing it now" but after refreshing I still have the same 2 categories that were supposed to be removed.

[Screencast From 2026-09-09 13-41-40.webm](https://github.com/user-attachments/assets/1250135b-7322-4e66-a6d5-b9fdbec43afd)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook event type filters can be cleared by submitting an empty list.
  * Webhook forms now consistently save an empty event type selection as unfiltered.
  * User-specific filters can be cleared by submitting `null`.

* **Bug Fixes**
  * Improved webhook update handling so omitted values remain unchanged, while supported empty values correctly clear filters.

* **Documentation**
  * Added API guidance and examples explaining how to clear event type filters and the differences between omitted, empty, and `null` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->