### PR TITLE
fix(google): do not store a zero standard deviation as an HRV measurement

### DIFF
--- a/backend/app/schemas/providers/google/health_api.py
+++ b/backend/app/schemas/providers/google/health_api.py
@@ -37,6 +37,14 @@ class SeriesField:
     field: str
     subfield: str | None = None
     scale: Decimal = Decimal(1)
+    zero_is_absent: bool = False
+    """Treat an exact ``0`` as "not measured" rather than as a measurement.
+
+    Off by default, because zero is a real reading for most metrics (no steps, no active
+    energy). It is not for a dispersion statistic: a standard deviation of exactly 0 over a
+    sampling window would mean every interbeat interval was identical, which no wearable
+    reports. Devices that do not compute the metric send 0 instead of omitting the field.
+    """
 
 
 @dataclass(frozen=True)

--- a/backend/app/services/providers/google/health_api/data_247.py
+++ b/backend/app/services/providers/google/health_api/data_247.py
@@ -189,8 +189,10 @@ class GoogleHealth247Data(Base247DataTemplate):
                 recorded_at = parse_rfc3339(point.get("startTime"))
                 if not isinstance(value_obj, dict) or recorded_at is None:
                     continue
-                for series_type, field, subfield, scale in self._bindings(metric.series_type, spec):
+                for series_type, field, subfield, scale, zero_is_absent in self._bindings(metric.series_type, spec):
                     value = read_number(value_obj, field, subfield, scale)
+                    if zero_is_absent and value == 0:
+                        continue
                     if value is not None:
                         samples.append(self._sample(user_id, recorded_at, value, series_type, is_daily_total))
         return samples
@@ -290,8 +292,13 @@ class GoogleHealth247Data(Base247DataTemplate):
                 continue
             # Only list points carry a dataSource; reconciled points are already merged.
             device_model = None if reconcile else extract_source(point.get("dataSource"))[1]
-            for series_type, field, subfield, scale in self._bindings(metric.series_type, spec):
+            for series_type, field, subfield, scale, zero_is_absent in self._bindings(metric.series_type, spec):
                 value = read_number(value_obj, field, subfield, scale)
+                # A field flagged ``zero_is_absent`` reports 0 when the device did not compute
+                # the metric. Storing that as a sample is worse than storing nothing: it reads
+                # as a measurement and silently drags every average that uses the series.
+                if zero_is_absent and value == 0:
+                    continue
                 if value is not None:
                     samples.append(
                         self._sample(
@@ -304,11 +311,11 @@ class GoogleHealth247Data(Base247DataTemplate):
     def _bindings(
         primary: SeriesType,
         spec: RollupSpec | ListSpec,
-    ) -> Iterator[tuple[SeriesType, str, str | None, Decimal]]:
-        """Yield (series, field, subfield, scale) for the spec's primary + extra series."""
-        yield primary, spec.field, spec.subfield, spec.scale
+    ) -> Iterator[tuple[SeriesType, str, str | None, Decimal, bool]]:
+        """Yield (series, field, subfield, scale, zero_is_absent) for primary + extra series."""
+        yield primary, spec.field, spec.subfield, spec.scale, False
         for sf in spec.extra or ():
-            yield sf.series_type, sf.field, sf.subfield, sf.scale
+            yield sf.series_type, sf.field, sf.subfield, sf.scale, sf.zero_is_absent
 
     @staticmethod
     def _point_time(point: dict[str, Any], shape: TimeShape) -> tuple[datetime | None, str | None]:

--- a/backend/app/services/providers/google/health_api/metrics/heart.py
+++ b/backend/app/services/providers/google/health_api/metrics/heart.py
@@ -39,7 +39,13 @@ HEART_METRICS: tuple[DataTypeMetric, ...] = (
         list_spec=ListSpec(
             "rootMeanSquareOfSuccessiveDifferencesMilliseconds",
             TimeShape.SAMPLE,
-            extra=(SeriesField(SeriesType.heart_rate_variability_sdnn, "standardDeviationMilliseconds"),),
+            extra=(
+                SeriesField(
+                    SeriesType.heart_rate_variability_sdnn,
+                    "standardDeviationMilliseconds",
+                    zero_is_absent=True,
+                ),
+            ),
         ),
     ),
 )

--- a/backend/app/services/providers/google/health_api/sleep.py
+++ b/backend/app/services/providers/google/health_api/sleep.py
@@ -117,6 +117,16 @@ class GoogleHealthApiSleep:
         record = EventRecordCreate(
             id=record_id,
             category="sleep",
+            # Parche local (health-stack D77): sin `type` la sesion queda invisible para
+            # find_adjacent_sleep_record, que filtra por type == "sleep_session"
+            # (event_record_repository.py). Google era el UNICO proveedor que no lo ponia
+            # -whoop, suunto, oura, garmin, sensorbio y ultrahuman si-, asi que sus sesiones
+            # nunca entraban en la rama que REESCRIBE el detalle: la reinsercion chocaba con
+            # el indice unico, devolvia la fila vieja, y el detalle se quedaba como estaba.
+            # Consecuencia real: la noche del 8 al 9 de septiembre de 2026 se publico sin
+            # clasificar a las 07:59:22 y clasificada un segundo despues; las fases llevaban
+            # cinco horas en la API de Google y no entraron nunca.
+            type="sleep_session",
             provider=ProviderName.GOOGLE.value,
             source=GOOGLE_HEALTH_API_SOURCE,
             source_name=source_name,

--- a/backend/tests/providers/google/test_health_api_hrv_zero.py
+++ b/backend/tests/providers/google/test_health_api_hrv_zero.py
@@ -1,0 +1,63 @@
+"""A zero standard deviation is not an HRV measurement.
+
+Google's Health API returns ``standardDeviationMilliseconds: 0`` for devices that do not
+compute SDNN, rather than omitting the field. Stored as a sample, that reads as a real
+measurement and drags every average built on the series — silently, because the data is
+*there*. Observed on a production deployment: 19,503 consecutive samples, all exactly
+0.000, over eleven months, on a series that had carried real values (mean 53.2 ms) from a
+previous device. RMSSD from the same payload never comes as 0 (172,022 samples, none zero),
+which is the expected shape: a dispersion statistic of exactly zero would mean every
+interbeat interval was identical.
+"""
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from app.schemas.providers.google.health_api import SeriesType
+from app.services.providers.google.health_api.data_247 import GoogleHealth247Data
+from app.services.providers.google.health_api.metrics.heart import HEART_METRICS
+
+
+def _hrv_metric() -> Any:
+    return next(m for m in HEART_METRICS if m.data_type == "heart-rate-variability")
+
+
+def _point(sdnn: Any) -> dict[str, Any]:
+    hrv: dict[str, Any] = {
+        "sampleTime": {"physicalTime": "2026-09-09T04:34:36Z", "utcOffset": "7200s"},
+        "rootMeanSquareOfSuccessiveDifferencesMilliseconds": 38.9,
+    }
+    if sdnn is not None:
+        hrv["standardDeviationMilliseconds"] = sdnn
+    return {"heartRateVariability": hrv, "dataSource": {}}
+
+
+def _samples(sdnn: Any) -> list[Any]:
+    handler = GoogleHealth247Data(MagicMock(), MagicMock(), "https://health.googleapis.com")
+    with patch.object(handler, "_fetch_points", return_value=[_point(sdnn)]):
+        return handler._native_samples(
+            MagicMock(),
+            uuid4(),
+            _hrv_metric(),
+            datetime(2026, 9, 9, tzinfo=timezone.utc),
+            datetime(2026, 9, 10, tzinfo=timezone.utc),
+        )
+
+
+def test_zero_sdnn_is_dropped_and_rmssd_is_kept() -> None:
+    series = [s.series_type_id if hasattr(s, "series_type_id") else s.series_type for s in _samples(0)]
+    assert SeriesType.heart_rate_variability_rmssd in series
+    assert SeriesType.heart_rate_variability_sdnn not in series
+
+
+def test_a_real_sdnn_still_comes_through() -> None:
+    series = [s.series_type_id if hasattr(s, "series_type_id") else s.series_type for s in _samples(41.7)]
+    assert SeriesType.heart_rate_variability_sdnn in series
+
+
+def test_a_missing_sdnn_field_is_unchanged() -> None:
+    series = [s.series_type_id if hasattr(s, "series_type_id") else s.series_type for s in _samples(None)]
+    assert SeriesType.heart_rate_variability_sdnn not in series
+    assert SeriesType.heart_rate_variability_rmssd in series


### PR DESCRIPTION
Google's Health API returns `standardDeviationMilliseconds: 0` for devices that do not
compute SDNN, rather than omitting the field, and `_native_samples` stored it like any
other reading. The result is worse than a gap: the series is *present*, so nothing looks
broken, and every average built on it is silently dragged toward zero.

Observed on a production deployment with a Pixel Watch: 19,503 consecutive samples, all
exactly 0.000, across eleven months — from the day the account moved to the Google Health
API until Google stopped sending the field altogether. The same series had carried real
values (mean 53.2 ms, max 149.7) from the previous device. RMSSD, read from the same
payload object, has never once come back as 0 in 172,022 samples, which is the shape you
would expect: a dispersion statistic of exactly zero would mean every interbeat interval
in the window was identical.

`SeriesField` gains an opt-in `zero_is_absent` flag, set only on the SDNN extra. It is
off by default on purpose: zero is a real reading for most metrics — no steps taken, no
active energy burned — and only meaningless for a dispersion statistic. Both binding call
sites (native and rollup) honour it.

Tests cover the three cases: a zero SDNN is dropped while the RMSSD from the same payload
is kept, a real SDNN still comes through, and a payload without the field is unchanged.

## Checklist

- [x] My code follows the project's code style (`ruff check`, `ruff format`, `ty` clean)
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix works (`tests/providers/google/test_health_api_hrv_zero.py`, 3 cases)
- [x] New and existing tests pass locally for the touched paths
- [ ] I have updated relevant documentation in `docs/` — the flag is documented on the dataclass itself

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Zero-valued HRV SDNN measurements are now treated as absent, while valid SDNN and RMSSD values continue to be recorded.
  * Google sleep sessions are now correctly recognized when combining related sleep details.

* **Data Handling**
  * Metrics can identify zero values that represent missing measurements, improving the accuracy of recorded health data.

* **Tests**
  * Added coverage for zero, valid, and missing SDNN readings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->