### PR TITLE
fix(auth): revoke developer refresh tokens on password change

### DIFF
--- a/backend/app/services/developer_service.py
+++ b/backend/app/services/developer_service.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from app.database import DbSession
 from app.models import Developer
 from app.repositories.developer_repository import DeveloperRepository
+from app.repositories.refresh_token_repository import refresh_token_repository
 from app.schemas.model_crud.user_management import (
     DeveloperCreate,
     DeveloperCreateInternal,
@@ -50,7 +51,14 @@ class DeveloperService(AppService[DeveloperRepository, Developer, DeveloperCreat
         if updater.password:
             internal_updater.hashed_password = get_password_hash(updater.password)
 
-        return self.crud.update(db_session, developer, internal_updater)
+        updated = self.crud.update(db_session, developer, internal_updater)
+
+        if updater.password:
+            # Sessions issued before the password change must not survive it.
+            revoked = refresh_token_repository.revoke_all_for_developer(db_session, developer.id)
+            self.logger.info(f"Password changed for developer {developer.id}, revoked {revoked} refresh token(s)")
+
+        return updated
 
 
 developer_service = DeveloperService(log=getLogger(__name__))

--- a/backend/app/services/developer_service.py
+++ b/backend/app/services/developer_service.py
@@ -50,15 +50,13 @@ class DeveloperService(AppService[DeveloperRepository, Developer, DeveloperCreat
 
         if updater.password:
             internal_updater.hashed_password = get_password_hash(updater.password)
-
-        updated = self.crud.update(db_session, developer, internal_updater)
-
-        if updater.password:
-            # Sessions issued before the password change must not survive it.
+            # Sessions issued before the password change must not survive it. Revoke before
+            # persisting the new hash: if the update fails, the old password still works and
+            # the user simply logs in again, which is safer than the reverse order.
             revoked = refresh_token_repository.revoke_all_for_developer(db_session, developer.id)
-            self.logger.info(f"Password changed for developer {developer.id}, revoked {revoked} refresh token(s)")
+            self.logger.info(f"Password change for developer {developer.id}, revoked {revoked} refresh token(s)")
 
-        return updated
+        return self.crud.update(db_session, developer, internal_updater)
 
 
 developer_service = DeveloperService(log=getLogger(__name__))

--- a/backend/tests/api/v1/test_auth.py
+++ b/backend/tests/api/v1/test_auth.py
@@ -557,3 +557,69 @@ class TestDeleteDeveloperById:
 
         # Assert
         assert response.status_code in [400, 422]
+
+
+class TestPasswordChangeRevokesRefreshTokens:
+    """Changing a developer's password must invalidate refresh tokens issued before the change."""
+
+    @staticmethod
+    def _login(client: TestClient, api_v1_prefix: str, email: str, password: str) -> str:
+        response = client.post(f"{api_v1_prefix}/auth/login", data={"username": email, "password": password})
+        assert response.status_code == 200
+        return response.json()["refresh_token"]
+
+    def test_change_password_revokes_existing_refresh_tokens(
+        self, client: TestClient, db: Session, api_v1_prefix: str
+    ) -> None:
+        developer = DeveloperFactory(email="victim@example.com", password="OldPassword123")
+        old_refresh_token = self._login(client, api_v1_prefix, "victim@example.com", "OldPassword123")
+        headers = developer_auth_headers(developer.id)
+
+        response = client.post(
+            f"{api_v1_prefix}/auth/change-password",
+            json={
+                "current_password": "OldPassword123",
+                "new_password": "NewPassword456",
+                "confirm_password": "NewPassword456",
+            },
+            headers=headers,
+        )
+        assert response.status_code == 200
+
+        response = client.post(f"{api_v1_prefix}/token/refresh", json={"refresh_token": old_refresh_token})
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid or revoked refresh token"
+
+    def test_cross_developer_password_update_revokes_refresh_tokens(
+        self, client: TestClient, db: Session, api_v1_prefix: str
+    ) -> None:
+        victim = DeveloperFactory(email="victim@example.com", password="OldPassword123")
+        attacker = DeveloperFactory(email="other@example.com", password="Whatever123")
+        victim_refresh_token = self._login(client, api_v1_prefix, "victim@example.com", "OldPassword123")
+
+        response = client.patch(
+            f"{api_v1_prefix}/developers/{victim.id}",
+            json={"password": "NewPassword456"},
+            headers=developer_auth_headers(attacker.id),
+        )
+        assert response.status_code == 200
+
+        response = client.post(f"{api_v1_prefix}/token/refresh", json={"refresh_token": victim_refresh_token})
+        assert response.status_code == 401
+
+    def test_update_without_password_keeps_refresh_tokens(
+        self, client: TestClient, db: Session, api_v1_prefix: str
+    ) -> None:
+        developer = DeveloperFactory(email="dev@example.com", password="OldPassword123")
+        refresh_token = self._login(client, api_v1_prefix, "dev@example.com", "OldPassword123")
+
+        response = client.patch(
+            f"{api_v1_prefix}/auth/me",
+            json={"first_name": "Renamed"},
+            headers=developer_auth_headers(developer.id),
+        )
+        assert response.status_code == 200
+
+        response = client.post(f"{api_v1_prefix}/token/refresh", json={"refresh_token": refresh_token})
+        assert response.status_code == 200
+        assert "access_token" in response.json()

--- a/backend/tests/api/v1/test_auth.py
+++ b/backend/tests/api/v1/test_auth.py
@@ -15,6 +15,8 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.config import settings
+from app.schemas.model_crud.user_management import DeveloperUpdate
+from app.services import developer_service
 from tests.factories import DeveloperFactory
 from tests.utils import developer_auth_headers
 
@@ -590,21 +592,32 @@ class TestPasswordChangeRevokesRefreshTokens:
         assert response.status_code == 401
         assert response.json()["detail"] == "Invalid or revoked refresh token"
 
-    def test_cross_developer_password_update_revokes_refresh_tokens(
+    def test_update_me_with_password_revokes_refresh_tokens(
         self, client: TestClient, db: Session, api_v1_prefix: str
     ) -> None:
-        victim = DeveloperFactory(email="victim@example.com", password="OldPassword123")
-        attacker = DeveloperFactory(email="other@example.com", password="Whatever123")
-        victim_refresh_token = self._login(client, api_v1_prefix, "victim@example.com", "OldPassword123")
+        developer = DeveloperFactory(email="dev@example.com", password="OldPassword123")
+        old_refresh_token = self._login(client, api_v1_prefix, "dev@example.com", "OldPassword123")
 
         response = client.patch(
-            f"{api_v1_prefix}/developers/{victim.id}",
+            f"{api_v1_prefix}/auth/me",
             json={"password": "NewPassword456"},
-            headers=developer_auth_headers(attacker.id),
+            headers=developer_auth_headers(developer.id),
         )
         assert response.status_code == 200
 
-        response = client.post(f"{api_v1_prefix}/token/refresh", json={"refresh_token": victim_refresh_token})
+        response = client.post(f"{api_v1_prefix}/token/refresh", json={"refresh_token": old_refresh_token})
+        assert response.status_code == 401
+
+    def test_service_level_password_update_revokes_refresh_tokens(
+        self, client: TestClient, db: Session, api_v1_prefix: str
+    ) -> None:
+        """Any caller of update_developer_info (e.g. an administrative reset) must revoke tokens too."""
+        developer = DeveloperFactory(email="dev@example.com", password="OldPassword123")
+        old_refresh_token = self._login(client, api_v1_prefix, "dev@example.com", "OldPassword123")
+
+        developer_service.update_developer_info(db, developer.id, DeveloperUpdate(password="NewPassword456"))
+
+        response = client.post(f"{api_v1_prefix}/token/refresh", json={"refresh_token": old_refresh_token})
         assert response.status_code == 401
 
     def test_update_without_password_keeps_refresh_tokens(


### PR DESCRIPTION
## What does this change?

Changing a developer's password now revokes every refresh token that developer holds. This applies to all three paths that can set a password: `POST /auth/change-password`, `PATCH /auth/me` and `PATCH /developers/{id}`.

## Why?

A refresh token issued before a password change kept working after it. Anyone holding a leaked refresh token could keep minting new access tokens indefinitely, and the developer had no way to lock them out short of finding and revoking each token by hand. Refresh tokens also have no expiry, so "eventually" never came.

## How did you test this?

Automatic tests.

Manual check of the reported flow against the local backend container: log in, save the refresh token, change the password, call `POST /token/refresh` with the old token.

Before:

```
# POST /auth/change-password
{"message":"Password updated successfully"} (HTTP 200)
# POST /token/refresh with the old refresh token
{"access_token":"<redacted>","token_type":"bearer","refresh_token":"rt-<redacted>","expires_in":3600}
HTTP 200
```

After:

```
# POST /auth/change-password
{"message":"Password updated successfully"} (HTTP 200)
# POST /token/refresh with the old refresh token
{"detail":"Invalid or revoked refresh token"}
HTTP 401
```

## AI usage

Claude Code (Fable 5.1) for tracing the code paths and writing the tests. Reviewed and edited by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Changing a developer password now revokes all existing refresh tokens, requiring sign-in again on other sessions.
  - Non-password profile updates continue to preserve active sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->