### PR TITLE
fix(auth): store API keys hashed and show the raw key only once

### DIFF
--- a/backend/app/api/routes/v1/api_keys.py
+++ b/backend/app/api/routes/v1/api_keys.py
@@ -1,39 +1,58 @@
 from typing import Annotated
+from uuid import UUID
 
 from fastapi import APIRouter, Body, status
 
 from app.database import DbSession
-from app.schemas.model_crud.credentials import ApiKeyRead, ApiKeyUpdate
+from app.models import ApiKey
+from app.schemas.model_crud.credentials import ApiKeyRead, ApiKeyReadWithSecret, ApiKeyUpdate
 from app.services import DeveloperDep, api_key_service
 
 router = APIRouter()
 
 
+def _with_secret(api_key: ApiKey, raw_key: str) -> ApiKeyReadWithSecret:
+    return ApiKeyReadWithSecret(
+        id=api_key.id,
+        name=api_key.name,
+        key_prefix=api_key.key_prefix,
+        created_by=api_key.created_by,
+        created_at=api_key.created_at,
+        key=raw_key,
+    )
+
+
 @router.get("/api-keys", response_model=list[ApiKeyRead])
 def list_api_keys(db: DbSession, _developer: DeveloperDep):
-    """List all API keys."""
+    """List all API keys.
+
+    Only a short prefix of each key is returned - the full value is never stored.
+    """
     return api_key_service.list_api_keys(db)
 
 
-@router.post("/api-keys", status_code=status.HTTP_201_CREATED, response_model=ApiKeyRead)
+@router.post("/api-keys", status_code=status.HTTP_201_CREATED)
 def create_api_key(
     db: DbSession,
     _developer: DeveloperDep,
     name: Annotated[str, Body(embed=True, description="Name for the API key")] = "Default",
-):
-    """Generate new API key."""
-    return api_key_service.create_api_key(db, _developer.id, name)
+) -> ApiKeyReadWithSecret:
+    """Generate new API key.
+
+    Returns the full key only once - store it securely as it cannot be retrieved again.
+    """
+    return _with_secret(*api_key_service.create_api_key(db, _developer.id, name))
 
 
 @router.delete("/api-keys/{key_id}", response_model=ApiKeyRead)
-def delete_api_key(key_id: str, db: DbSession, _developer: DeveloperDep):
-    """Delete API key by key value."""
+def delete_api_key(key_id: UUID, db: DbSession, _developer: DeveloperDep):
+    """Delete API key by id."""
     return api_key_service.delete(db, key_id, raise_404=True)
 
 
 @router.patch("/api-keys/{key_id}", response_model=ApiKeyRead)
 def update_api_key(
-    key_id: str,
+    key_id: UUID,
     payload: ApiKeyUpdate,
     db: DbSession,
     _developer: DeveloperDep,
@@ -42,7 +61,10 @@ def update_api_key(
     return api_key_service.update(db, key_id, payload, raise_404=True)
 
 
-@router.post("/api-keys/{key_id}/rotate", status_code=status.HTTP_201_CREATED, response_model=ApiKeyRead)
-def rotate_api_key(key_id: str, db: DbSession, _developer: DeveloperDep):
-    """Rotate API key - delete old and generate new."""
-    return api_key_service.rotate_api_key(db, key_id, _developer.id)
+@router.post("/api-keys/{key_id}/rotate", status_code=status.HTTP_201_CREATED)
+def rotate_api_key(key_id: UUID, db: DbSession, _developer: DeveloperDep) -> ApiKeyReadWithSecret:
+    """Rotate API key - delete old and generate new one with the same name.
+
+    Returns the full key only once - store it securely as it cannot be retrieved again.
+    """
+    return _with_secret(*api_key_service.rotate_api_key(db, key_id, _developer.id))

--- a/backend/app/models/api_key.py
+++ b/backend/app/models/api_key.py
@@ -1,14 +1,22 @@
+from uuid import UUID
+
 from sqlalchemy.orm import Mapped
 
 from app.database import BaseDbModel
-from app.mappings import FKDeveloper, PrimaryKey, str_64
+from app.mappings import FKDeveloper, PrimaryKey, Unique, str_10, str_64
 
 
 class ApiKey(BaseDbModel):
-    """Global API key for external service access."""
+    """Global API key for external service access.
+
+    The raw key value is never stored: only its SHA-256 hash (for lookup) and a short
+    prefix (for display). The full value is returned once, on create or rotate.
+    """
 
     __tablename__ = "api_key"
 
-    id: Mapped[PrimaryKey[str_64]]  # The actual key value (sk-...)
+    id: Mapped[PrimaryKey[UUID]]
+    key_hash: Mapped[Unique[str_64]]  # sha256 hex digest of the raw key
+    key_prefix: Mapped[str_10]  # first characters of the raw key, shown in the UI
     name: Mapped[str]
     created_by: Mapped[FKDeveloper | None]

--- a/backend/app/repositories/api_key_repository.py
+++ b/backend/app/repositories/api_key_repository.py
@@ -11,3 +11,7 @@ class ApiKeyRepository(CrudRepository[ApiKey, ApiKeyCreate, ApiKeyUpdate]):
     def get_all_ordered(self, db_session: DbSession) -> list[ApiKey]:
         """Get all API keys ordered by creation date descending."""
         return db_session.query(self.model).order_by(self.model.created_at.desc()).all()
+
+    def get_by_hash(self, db_session: DbSession, key_hash: str) -> ApiKey | None:
+        """Look up an API key by the hash of its raw value."""
+        return db_session.query(self.model).filter(self.model.key_hash == key_hash).one_or_none()

--- a/backend/app/schemas/model_crud/credentials/__init__.py
+++ b/backend/app/schemas/model_crud/credentials/__init__.py
@@ -1,6 +1,7 @@
 from .api_key import (
     ApiKeyCreate,
     ApiKeyRead,
+    ApiKeyReadWithSecret,
     ApiKeyUpdate,
 )
 from .application import (
@@ -27,6 +28,7 @@ from .user_invitation_code import (
 __all__ = [
     # ApiKey
     "ApiKeyRead",
+    "ApiKeyReadWithSecret",
     "ApiKeyCreate",
     "ApiKeyUpdate",
     # Application

--- a/backend/app/schemas/model_crud/credentials/api_key.py
+++ b/backend/app/schemas/model_crud/credentials/api_key.py
@@ -1,20 +1,33 @@
 from datetime import datetime, timezone
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
 
 
 class ApiKeyRead(BaseModel):
+    """Schema for reading an API key (never includes the raw key value)."""
+
     model_config = ConfigDict(from_attributes=True)
 
-    id: str
+    id: UUID
     name: str
+    key_prefix: str
     created_by: UUID | None
     created_at: datetime
 
 
+class ApiKeyReadWithSecret(ApiKeyRead):
+    """Schema returned only on create / rotate - contains the raw key value."""
+
+    key: str  # Only shown once, cannot be retrieved again
+
+
 class ApiKeyCreate(BaseModel):
-    id: str
+    """Internal creator: the raw key is hashed by the service before it gets here."""
+
+    id: UUID = Field(default_factory=uuid4)
+    key_hash: str
+    key_prefix: str
     name: str
     created_by: UUID | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/backend/app/services/api_key_service.py
+++ b/backend/app/services/api_key_service.py
@@ -12,7 +12,7 @@ from app.repositories.api_key_repository import ApiKeyRepository
 from app.schemas.model_crud.credentials import ApiKeyCreate, ApiKeyUpdate
 from app.services.services import AppService
 from app.utils.auth import get_current_developer_optional, oauth2_scheme
-from app.utils.exceptions import ResourceNotFoundError
+from app.utils.exceptions import ResourceNotFoundError, handle_exceptions
 from app.utils.security import hash_api_key
 
 # Number of leading characters of the raw key kept in clear for display ("sk-" + 7 hex chars).
@@ -32,6 +32,7 @@ class ApiKeyService(AppService[ApiKeyRepository, ApiKey, ApiKeyCreate, ApiKeyUpd
         """Generate random API key with sk- prefix and 32 hex characters."""
         return f"sk-{secrets.token_hex(16)}"
 
+    @handle_exceptions
     def create_api_key(self, db: DbSession, created_by: UUID | None, name: str = "Default") -> tuple[ApiKey, str]:
         """Create an API key.
 
@@ -56,8 +57,12 @@ class ApiKeyService(AppService[ApiKeyRepository, ApiKey, ApiKeyCreate, ApiKeyUpd
         self.logger.debug(f"Listed {len(keys)} API keys")
         return keys
 
+    @handle_exceptions
     def rotate_api_key(self, db: DbSession, key_id: UUID, created_by: UUID | None) -> tuple[ApiKey, str]:
         """Rotate API key - delete the old one and create a new one with the same name.
+
+        The delete is only flushed, so the commit issued when the replacement is created
+        covers both steps. If creating the replacement fails, the old key stays valid.
 
         Returns:
             Tuple of (new ApiKey, raw_key). The raw key is shown to the caller exactly once.
@@ -65,11 +70,16 @@ class ApiKeyService(AppService[ApiKeyRepository, ApiKey, ApiKeyCreate, ApiKeyUpd
         if not (old_key := self.get(db, key_id, raise_404=True)):
             raise ResourceNotFoundError(self.name, key_id)
         name = old_key.name
-        self.crud.delete(db, old_key)
-        new_key, raw_key = self.create_api_key(db, created_by, name)
+        self.crud.delete_flush(db, old_key)
+        try:
+            new_key, raw_key = self.create_api_key(db, created_by, name)
+        except Exception:
+            db.rollback()
+            raise
         self.logger.debug(f"Rotated API key {key_id} to {new_key.id}")
         return new_key, raw_key
 
+    @handle_exceptions
     def validate_api_key(self, db: DbSession, key: str) -> ApiKey:
         """Validate the raw API key against stored hashes. Raises 401 if invalid."""
         if not key or not (api_key := self.crud.get_by_hash(db, hash_api_key(key))):

--- a/backend/app/services/api_key_service.py
+++ b/backend/app/services/api_key_service.py
@@ -12,6 +12,11 @@ from app.repositories.api_key_repository import ApiKeyRepository
 from app.schemas.model_crud.credentials import ApiKeyCreate, ApiKeyUpdate
 from app.services.services import AppService
 from app.utils.auth import get_current_developer_optional, oauth2_scheme
+from app.utils.exceptions import ResourceNotFoundError
+from app.utils.security import hash_api_key
+
+# Number of leading characters of the raw key kept in clear for display ("sk-" + 7 hex chars).
+KEY_PREFIX_LENGTH = 10
 
 
 class ApiKeyService(AppService[ApiKeyRepository, ApiKey, ApiKeyCreate, ApiKeyUpdate]):
@@ -27,12 +32,23 @@ class ApiKeyService(AppService[ApiKeyRepository, ApiKey, ApiKeyCreate, ApiKeyUpd
         """Generate random API key with sk- prefix and 32 hex characters."""
         return f"sk-{secrets.token_hex(16)}"
 
-    def create_api_key(self, db: DbSession, created_by: UUID | None, name: str = "Default") -> ApiKey:
-        key_value = self._generate_key_value()
-        creator = ApiKeyCreate(id=key_value, name=name, created_by=created_by)
+    def create_api_key(self, db: DbSession, created_by: UUID | None, name: str = "Default") -> tuple[ApiKey, str]:
+        """Create an API key.
+
+        Returns:
+            Tuple of (ApiKey, raw_key). Only the hash and a short prefix are persisted,
+            so the raw key can be shown to the caller exactly once.
+        """
+        raw_key = self._generate_key_value()
+        creator = ApiKeyCreate(
+            key_hash=hash_api_key(raw_key),
+            key_prefix=raw_key[:KEY_PREFIX_LENGTH],
+            name=name,
+            created_by=created_by,
+        )
         api_key = self.create(db, creator)
-        self.logger.debug(f"Created API key {api_key.id} by developer {created_by} with name {name}")
-        return api_key
+        self.logger.debug(f"Created API key {api_key.id} ({api_key.key_prefix}...) by developer {created_by}")
+        return api_key, raw_key
 
     def list_api_keys(self, db: DbSession) -> list[ApiKey]:
         """List all API keys ordered by creation date."""
@@ -40,16 +56,23 @@ class ApiKeyService(AppService[ApiKeyRepository, ApiKey, ApiKeyCreate, ApiKeyUpd
         self.logger.debug(f"Listed {len(keys)} API keys")
         return keys
 
-    def rotate_api_key(self, db: DbSession, old_key: str, created_by: UUID | None) -> ApiKey:
-        """Rotate API key - delete old and create new."""
-        self.delete(db, old_key, raise_404=True)
-        new_key = self.create_api_key(db, created_by)
-        self.logger.debug(f"Rotated API key from {old_key} to {new_key.id}")
-        return new_key
+    def rotate_api_key(self, db: DbSession, key_id: UUID, created_by: UUID | None) -> tuple[ApiKey, str]:
+        """Rotate API key - delete the old one and create a new one with the same name.
+
+        Returns:
+            Tuple of (new ApiKey, raw_key). The raw key is shown to the caller exactly once.
+        """
+        if not (old_key := self.get(db, key_id, raise_404=True)):
+            raise ResourceNotFoundError(self.name, key_id)
+        name = old_key.name
+        self.crud.delete(db, old_key)
+        new_key, raw_key = self.create_api_key(db, created_by, name)
+        self.logger.debug(f"Rotated API key {key_id} to {new_key.id}")
+        return new_key, raw_key
 
     def validate_api_key(self, db: DbSession, key: str) -> ApiKey:
-        """Validate API key exists in database. Raises 401 if invalid."""
-        if not (api_key := self.get(db, key)):
+        """Validate the raw API key against stored hashes. Raises 401 if invalid."""
+        if not key or not (api_key := self.crud.get_by_hash(db, hash_api_key(key))):
             raise HTTPException(status_code=401, detail="Invalid or missing API key")
         return api_key
 
@@ -61,7 +84,7 @@ async def _authenticate(db: Session, developer: Developer | None, api_key: str |
     if developer:
         return str(developer.id)
     if api_key:
-        return api_key_service.validate_api_key(db, api_key).id
+        return str(api_key_service.validate_api_key(db, api_key).id)
     raise HTTPException(status_code=401, detail="Authentication required: provide JWT token or API key")
 
 

--- a/backend/app/utils/auth.py
+++ b/backend/app/utils/auth.py
@@ -131,7 +131,7 @@ async def get_sdk_auth(
     # Fall back to API key (backwards compatibility)
     if x_open_wearables_api_key:
         api_key = api_key_service.validate_api_key(db, x_open_wearables_api_key)
-        return SDKAuthContext(auth_type="api_key", api_key_id=api_key.id)
+        return SDKAuthContext(auth_type="api_key", api_key_id=str(api_key.id))
 
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/app/utils/security.py
+++ b/backend/app/utils/security.py
@@ -1,3 +1,4 @@
+import hashlib
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -33,3 +34,13 @@ def get_password_hash(password: str) -> str:
     salt = bcrypt.gensalt()
     hashed = bcrypt.hashpw(password_bytes, salt)
     return hashed.decode("utf-8")
+
+
+def hash_api_key(api_key: str) -> str:
+    """Return the SHA-256 hex digest of a raw API key.
+
+    A plain (unsalted) hash is enough here: keys are generated with 128 bits of entropy,
+    so they cannot be brute-forced the way user-chosen passwords can, and a deterministic
+    digest lets us look the key up with a single indexed query.
+    """
+    return hashlib.sha256(api_key.encode("utf-8")).hexdigest()

--- a/backend/migrations/versions/2026_09_10_1200-a7c3e9f1b2d4_hash_api_keys.py
+++ b/backend/migrations/versions/2026_09_10_1200-a7c3e9f1b2d4_hash_api_keys.py
@@ -1,0 +1,60 @@
+"""hash_api_keys
+
+Store API keys as SHA-256 hashes with a display prefix instead of the raw value,
+and switch the primary key from the raw key string to a UUID.
+
+Revision ID: a7c3e9f1b2d4
+Revises: cf76dead11f5
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a7c3e9f1b2d4"
+down_revision: Union[str, None] = "cf76dead11f5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("api_key", sa.Column("uuid_id", sa.UUID(), nullable=True))
+    op.add_column("api_key", sa.Column("key_hash", sa.String(length=64), nullable=True))
+    op.add_column("api_key", sa.Column("key_prefix", sa.String(length=10), nullable=True))
+
+    # Existing rows hold the raw key in "id": hash it in place so no key stops working.
+    op.execute(
+        """
+        UPDATE api_key
+        SET uuid_id = gen_random_uuid(),
+            key_hash = encode(sha256(convert_to(id, 'UTF8')), 'hex'),
+            key_prefix = left(id, 10)
+        """
+    )
+
+    op.alter_column("api_key", "uuid_id", nullable=False)
+    op.alter_column("api_key", "key_hash", nullable=False)
+    op.alter_column("api_key", "key_prefix", nullable=False)
+
+    op.drop_constraint("api_key_pkey", "api_key", type_="primary")
+    op.drop_column("api_key", "id")
+    op.alter_column("api_key", "uuid_id", new_column_name="id")
+    op.create_primary_key("api_key_pkey", "api_key", ["id"])
+    op.create_unique_constraint("api_key_key_hash_key", "api_key", ["key_hash"])
+
+
+def downgrade() -> None:
+    # The raw key values are gone for good, so the old string primary key cannot be restored.
+    # Rows are dropped: after downgrading, developers must generate new keys.
+    op.execute("DELETE FROM api_key")
+
+    op.drop_constraint("api_key_key_hash_key", "api_key", type_="unique")
+    op.drop_constraint("api_key_pkey", "api_key", type_="primary")
+    op.drop_column("api_key", "id")
+    op.drop_column("api_key", "key_prefix")
+    op.drop_column("api_key", "key_hash")
+    op.add_column("api_key", sa.Column("id", sa.String(length=64), nullable=False))
+    op.create_primary_key("api_key_pkey", "api_key", ["id"])

--- a/backend/tests/api/v1/conftest.py
+++ b/backend/tests/api/v1/conftest.py
@@ -37,4 +37,4 @@ def auth_headers(developer: Developer) -> dict[str, str]:
 @pytest.fixture
 def api_key_header(api_key: ApiKey) -> dict[str, str]:
     """Get API key headers."""
-    return api_key_headers(api_key.id)
+    return api_key_headers(api_key.plain_key)

--- a/backend/tests/api/v1/test_api_keys.py
+++ b/backend/tests/api/v1/test_api_keys.py
@@ -2,18 +2,23 @@
 Tests for API key management endpoints.
 
 Tests cover:
-- GET /api/v1/developer/api-keys - list API keys
-- POST /api/v1/developer/api-keys - create new API key
+- GET /api/v1/developer/api-keys - list API keys (prefix only, never the raw key)
+- POST /api/v1/developer/api-keys - create new API key (raw key returned once)
 - DELETE /api/v1/developer/api-keys/{key_id} - delete API key
 - PATCH /api/v1/developer/api-keys/{key_id} - update API key
-- POST /api/v1/developer/api-keys/{key_id}/rotate - rotate API key
+- POST /api/v1/developer/api-keys/{key_id}/rotate - rotate API key (raw key returned once)
 """
+
+from uuid import UUID, uuid4
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app.services import api_key_service
 from tests.factories import ApiKeyFactory, DeveloperFactory
-from tests.utils import developer_auth_headers
+from tests.utils import api_key_headers, developer_auth_headers
+
+READ_FIELDS = {"id", "name", "key_prefix", "created_by", "created_at"}
 
 
 class TestListApiKeys:
@@ -34,22 +39,32 @@ class TestListApiKeys:
         assert response.status_code == 200
         data = response.json()
         assert isinstance(data, list)
-        assert len(data) >= 2
 
-        # Find our test keys
-        key_ids = [api_key1.id, api_key2.id]
-        found_keys = [k for k in data if k["id"] in key_ids]
+        found_keys = [k for k in data if k["id"] in {str(api_key1.id), str(api_key2.id)}]
         assert len(found_keys) == 2
-
-        # Verify structure
         for key in found_keys:
-            assert "id" in key
-            assert "name" in key
-            assert "created_by" in key
-            assert "created_at" in key
+            assert set(key) == READ_FIELDS
+
+    def test_list_api_keys_never_exposes_raw_key(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
+        """The response must contain only a prefix - not the raw key, nor its hash."""
+        # Arrange
+        developer = DeveloperFactory(email="test@example.com", password="test123")
+        api_key = ApiKeyFactory(developer=developer, name="Secret Key")
+        headers = developer_auth_headers(developer.id)
+
+        # Act
+        response = client.get(f"{api_v1_prefix}/developer/api-keys", headers=headers)
+
+        # Assert
+        assert response.status_code == 200
+        body = response.text
+        assert api_key.plain_key not in body
+        assert api_key.key_hash not in body
+        item = next(k for k in response.json() if k["id"] == str(api_key.id))
+        assert item["key_prefix"] == api_key.plain_key[:10]
 
     def test_list_api_keys_empty(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
-        """Test listing API keys when developer has none."""
+        """Test listing API keys when there are none."""
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         headers = developer_auth_headers(developer.id)
@@ -59,8 +74,7 @@ class TestListApiKeys:
 
         # Assert
         assert response.status_code == 200
-        data = response.json()
-        assert isinstance(data, list)
+        assert response.json() == []
 
     def test_list_api_keys_unauthorized(self, client: TestClient, api_v1_prefix: str) -> None:
         """Test listing API keys fails without authentication."""
@@ -82,7 +96,7 @@ class TestListApiKeys:
         assert response.status_code == 401
 
     def test_list_api_keys_shows_all_keys(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
-        """Test that authenticated developer can see all API keys."""
+        """Keys are global to the deployment: every developer sees all of them (prefix only)."""
         # Arrange
         developer1 = DeveloperFactory(email="dev1@example.com", password="test123")
         developer2 = DeveloperFactory(email="dev2@example.com", password="test123")
@@ -95,17 +109,17 @@ class TestListApiKeys:
 
         # Assert
         assert response.status_code == 200
-        data = response.json()
-        key_ids = [k["id"] for k in data]
-        assert key1.id in key_ids
-        assert key2.id in key_ids
+        key_ids = [k["id"] for k in response.json()]
+        assert str(key1.id) in key_ids
+        assert str(key2.id) in key_ids
+        assert key2.plain_key not in response.text
 
 
 class TestCreateApiKey:
     """Tests for POST /api/v1/developer/api-keys."""
 
     def test_create_api_key_with_name(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
-        """Test creating API key with custom name."""
+        """Test creating API key returns the raw key exactly once."""
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         headers = developer_auth_headers(developer.id)
@@ -117,34 +131,49 @@ class TestCreateApiKey:
         # Assert
         assert response.status_code == 201
         data = response.json()
+        assert set(data) == READ_FIELDS | {"key"}
         assert data["name"] == "Production API Key"
-        assert "id" in data
-        assert data["id"].startswith("sk-")
+        assert data["key"].startswith("sk-")
+        assert data["key_prefix"] == data["key"][:10]
         assert data["created_by"] == str(developer.id)
-        assert "created_at" in data
 
-        # Verify in database
-        from app.services import api_key_service
-
-        api_key = api_key_service.get(db, data["id"])
+        # Verify in database: only the hash is stored
+        api_key = api_key_service.get(db, UUID(data["id"]))
         assert api_key is not None
         assert api_key.name == "Production API Key"
+        assert api_key.key_hash != data["key"]
+
+    def test_created_key_authenticates_and_is_not_listed_again(
+        self, client: TestClient, db: Session, api_v1_prefix: str
+    ) -> None:
+        """The raw key works for API auth, but never shows up in the list afterwards."""
+        # Arrange
+        developer = DeveloperFactory(email="test@example.com", password="test123")
+        headers = developer_auth_headers(developer.id)
+        raw_key = client.post(f"{api_v1_prefix}/developer/api-keys", headers=headers).json()["key"]
+
+        # Act
+        auth_response = client.get(f"{api_v1_prefix}/users", headers=api_key_headers(raw_key))
+        list_response = client.get(f"{api_v1_prefix}/developer/api-keys", headers=headers)
+
+        # Assert
+        assert auth_response.status_code == 200
+        assert raw_key not in list_response.text
 
     def test_create_api_key_default_name(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test creating API key with default name."""
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         headers = developer_auth_headers(developer.id)
-        payload = {}
 
         # Act
-        response = client.post(f"{api_v1_prefix}/developer/api-keys", json=payload, headers=headers)
+        response = client.post(f"{api_v1_prefix}/developer/api-keys", json={}, headers=headers)
 
         # Assert
         assert response.status_code == 201
         data = response.json()
         assert data["name"] == "Default"
-        assert "id" in data
+        assert "key" in data
 
     def test_create_api_key_no_body(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test creating API key without request body."""
@@ -157,59 +186,45 @@ class TestCreateApiKey:
 
         # Assert
         assert response.status_code == 201
-        data = response.json()
-        assert data["name"] == "Default"
+        assert response.json()["name"] == "Default"
 
     def test_create_api_key_empty_name(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test creating API key with empty name."""
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         headers = developer_auth_headers(developer.id)
-        payload = {"name": ""}
 
         # Act
-        response = client.post(f"{api_v1_prefix}/developer/api-keys", json=payload, headers=headers)
+        response = client.post(f"{api_v1_prefix}/developer/api-keys", json={"name": ""}, headers=headers)
 
         # Assert
         assert response.status_code == 201
-        data = response.json()
-        assert data["name"] == ""
+        assert response.json()["name"] == ""
 
     def test_create_api_key_unauthorized(self, client: TestClient, api_v1_prefix: str) -> None:
         """Test creating API key fails without authentication."""
         # Act
-        response = client.post(
-            f"{api_v1_prefix}/developer/api-keys",
-            json={"name": "Test Key"},
-        )
+        response = client.post(f"{api_v1_prefix}/developer/api-keys", json={"name": "Test Key"})
 
         # Assert
         assert response.status_code == 401
 
     def test_create_multiple_api_keys(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
-        """Test creating multiple API keys for the same developer."""
+        """Test creating multiple API keys yields distinct keys."""
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         headers = developer_auth_headers(developer.id)
 
-        # Act - Create multiple keys
-        response1 = client.post(
-            f"{api_v1_prefix}/developer/api-keys",
-            json={"name": "Key 1"},
-            headers=headers,
-        )
-        response2 = client.post(
-            f"{api_v1_prefix}/developer/api-keys",
-            json={"name": "Key 2"},
-            headers=headers,
-        )
+        # Act
+        response1 = client.post(f"{api_v1_prefix}/developer/api-keys", json={"name": "Key 1"}, headers=headers)
+        response2 = client.post(f"{api_v1_prefix}/developer/api-keys", json={"name": "Key 2"}, headers=headers)
 
         # Assert
         assert response1.status_code == 201
         assert response2.status_code == 201
-        data1 = response1.json()
-        data2 = response2.json()
+        data1, data2 = response1.json(), response2.json()
         assert data1["id"] != data2["id"]
+        assert data1["key"] != data2["key"]
         assert data1["name"] == "Key 1"
         assert data2["name"] == "Key 2"
 
@@ -218,12 +233,13 @@ class TestDeleteApiKey:
     """Tests for DELETE /api/v1/developer/api-keys/{key_id}."""
 
     def test_delete_api_key_success(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
-        """Test deleting API key successfully."""
+        """Test deleting API key successfully revokes it."""
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer, name="To Delete")
         headers = developer_auth_headers(developer.id)
         key_id = api_key.id
+        raw_key = api_key.plain_key
 
         # Act
         response = client.delete(f"{api_v1_prefix}/developer/api-keys/{key_id}", headers=headers)
@@ -231,28 +247,38 @@ class TestDeleteApiKey:
         # Assert
         assert response.status_code == 200
         data = response.json()
-        assert data["id"] == key_id
+        assert data["id"] == str(key_id)
         assert data["name"] == "To Delete"
+        assert "key" not in data
 
-        # Verify key is deleted from database
-        from app.services import api_key_service
-
-        deleted_key = api_key_service.get(db, key_id, raise_404=False)
-        assert deleted_key is None
+        assert api_key_service.get(db, key_id, raise_404=False) is None
+        assert client.get(f"{api_v1_prefix}/users", headers=api_key_headers(raw_key)).status_code == 401
 
     def test_delete_api_key_not_found(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
-        """Test deleting non-existent API key raises ResourceNotFoundError."""
-
+        """Test deleting non-existent API key returns 404."""
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         headers = developer_auth_headers(developer.id)
-        fake_key_id = "sk-nonexistent1234567890"
 
         # Act
-        response = client.delete(f"{api_v1_prefix}/developer/api-keys/{fake_key_id}", headers=headers)
+        response = client.delete(f"{api_v1_prefix}/developer/api-keys/{uuid4()}", headers=headers)
 
         # Assert
         assert response.status_code == 404
+
+    def test_delete_api_key_by_raw_value_is_rejected(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
+        """Keys are addressed by UUID now, so the raw value is not a valid path parameter."""
+        # Arrange
+        developer = DeveloperFactory(email="test@example.com", password="test123")
+        api_key = ApiKeyFactory(developer=developer)
+        headers = developer_auth_headers(developer.id)
+
+        # Act
+        response = client.delete(f"{api_v1_prefix}/developer/api-keys/{api_key.plain_key}", headers=headers)
+
+        # Assert
+        assert response.status_code == 400  # validation errors are mapped to 400 by the app
+        assert api_key_service.get(db, api_key.id) is not None
 
     def test_delete_api_key_unauthorized(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test deleting API key fails without authentication."""
@@ -291,12 +317,11 @@ class TestUpdateApiKey:
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer, name="Old Name")
         headers = developer_auth_headers(developer.id)
-        payload = {"name": "New Name"}
 
         # Act
         response = client.patch(
             f"{api_v1_prefix}/developer/api-keys/{api_key.id}",
-            json=payload,
+            json={"name": "New Name"},
             headers=headers,
         )
 
@@ -304,45 +329,36 @@ class TestUpdateApiKey:
         assert response.status_code == 200
         data = response.json()
         assert data["name"] == "New Name"
-        assert data["id"] == api_key.id
+        assert data["id"] == str(api_key.id)
+        assert "key" not in data
 
-        # Verify in database
         db.refresh(api_key)
         assert api_key.name == "New Name"
 
     def test_update_api_key_empty_payload(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
-        """Test updating API key with empty payload."""
+        """Test updating API key with empty payload keeps the name."""
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer, name="Original Name")
         headers = developer_auth_headers(developer.id)
-        payload = {}
 
         # Act
-        response = client.patch(
-            f"{api_v1_prefix}/developer/api-keys/{api_key.id}",
-            json=payload,
-            headers=headers,
-        )
+        response = client.patch(f"{api_v1_prefix}/developer/api-keys/{api_key.id}", json={}, headers=headers)
 
         # Assert
         assert response.status_code == 200
-        data = response.json()
-        assert data["name"] == "Original Name"
+        assert response.json()["name"] == "Original Name"
 
     def test_update_api_key_not_found(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
-        """Test updating non-existent API key raises ResourceNotFoundError."""
-
+        """Test updating non-existent API key returns 404."""
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         headers = developer_auth_headers(developer.id)
-        fake_key_id = "sk-nonexistent1234567890"
-        payload = {"name": "New Name"}
 
         # Act
         response = client.patch(
-            f"{api_v1_prefix}/developer/api-keys/{fake_key_id}",
-            json=payload,
+            f"{api_v1_prefix}/developer/api-keys/{uuid4()}",
+            json={"name": "New Name"},
             headers=headers,
         )
 
@@ -354,13 +370,9 @@ class TestUpdateApiKey:
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer)
-        payload = {"name": "New Name"}
 
         # Act
-        response = client.patch(
-            f"{api_v1_prefix}/developer/api-keys/{api_key.id}",
-            json=payload,
-        )
+        response = client.patch(f"{api_v1_prefix}/developer/api-keys/{api_key.id}", json={"name": "New Name"})
 
         # Assert
         assert response.status_code == 401
@@ -370,51 +382,43 @@ class TestRotateApiKey:
     """Tests for POST /api/v1/developer/api-keys/{key_id}/rotate."""
 
     def test_rotate_api_key_success(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
-        """Test rotating API key successfully."""
+        """Test rotating API key returns a fresh raw key once and revokes the old one."""
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
-        old_api_key = ApiKeyFactory(developer=developer, name="To Rotate")
+        old_api_key = ApiKeyFactory(developer=developer, name="Production Key")
         headers = developer_auth_headers(developer.id)
         old_key_id = old_api_key.id
+        old_raw_key = old_api_key.plain_key
 
         # Act
-        response = client.post(
-            f"{api_v1_prefix}/developer/api-keys/{old_key_id}/rotate",
-            headers=headers,
-        )
+        response = client.post(f"{api_v1_prefix}/developer/api-keys/{old_key_id}/rotate", headers=headers)
 
         # Assert
         assert response.status_code == 201
         data = response.json()
-        assert data["name"] == "Default"  # New key gets default name
-        assert data["id"] != old_key_id  # New key ID should be different
-        assert data["id"].startswith("sk-")
+        assert set(data) == READ_FIELDS | {"key"}
+        assert data["name"] == "Production Key"
+        assert data["id"] != str(old_key_id)
+        assert data["key"].startswith("sk-")
+        assert data["key"] != old_raw_key
         assert data["created_by"] == str(developer.id)
 
-        # Verify old key is deleted from database
-        from app.services import api_key_service
-
-        old_key = api_key_service.get(db, old_key_id, raise_404=False)
-        assert old_key is None
-
-        # Verify new key exists
-        new_key = api_key_service.get(db, data["id"])
+        assert api_key_service.get(db, old_key_id, raise_404=False) is None
+        new_key = api_key_service.get(db, UUID(data["id"]))
         assert new_key is not None
-        assert new_key.name == "Default"
+        assert new_key.name == "Production Key"
+
+        assert client.get(f"{api_v1_prefix}/users", headers=api_key_headers(old_raw_key)).status_code == 401
+        assert client.get(f"{api_v1_prefix}/users", headers=api_key_headers(data["key"])).status_code == 200
 
     def test_rotate_api_key_not_found(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
-        """Test rotating non-existent API key raises ResourceNotFoundError."""
-
+        """Test rotating non-existent API key returns 404."""
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         headers = developer_auth_headers(developer.id)
-        fake_key_id = "sk-nonexistent1234567890"
 
         # Act
-        response = client.post(
-            f"{api_v1_prefix}/developer/api-keys/{fake_key_id}/rotate",
-            headers=headers,
-        )
+        response = client.post(f"{api_v1_prefix}/developer/api-keys/{uuid4()}/rotate", headers=headers)
 
         # Assert
         assert response.status_code == 404
@@ -446,54 +450,25 @@ class TestRotateApiKey:
         # Assert
         assert response.status_code == 401
 
-    def test_rotate_preserves_key_name(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
-        """Test that rotation creates new key with default name (not preserving original)."""
-        # Arrange
-        developer = DeveloperFactory(email="test@example.com", password="test123")
-        old_api_key = ApiKeyFactory(developer=developer, name="Production Key")
-        headers = developer_auth_headers(developer.id)
-
-        # Act
-        response = client.post(
-            f"{api_v1_prefix}/developer/api-keys/{old_api_key.id}/rotate",
-            headers=headers,
-        )
-
-        # Assert
-        assert response.status_code == 201
-        data = response.json()
-        # The new key gets default name (implementation doesn't preserve original name)
-        assert data["name"] == "Default"
-
     def test_rotate_multiple_times(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
-        """Test rotating the same API key multiple times."""
+        """Test rotating the same API key multiple times leaves only the final key."""
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer, name="Multi Rotate")
         headers = developer_auth_headers(developer.id)
 
-        # Act - First rotation
-        response1 = client.post(
-            f"{api_v1_prefix}/developer/api-keys/{api_key.id}/rotate",
-            headers=headers,
-        )
+        # Act
+        response1 = client.post(f"{api_v1_prefix}/developer/api-keys/{api_key.id}/rotate", headers=headers)
         assert response1.status_code == 201
-        new_key_id_1 = response1.json()["id"]
+        new_key_id_1 = UUID(response1.json()["id"])
 
-        # Act - Second rotation
-        response2 = client.post(
-            f"{api_v1_prefix}/developer/api-keys/{new_key_id_1}/rotate",
-            headers=headers,
-        )
+        response2 = client.post(f"{api_v1_prefix}/developer/api-keys/{new_key_id_1}/rotate", headers=headers)
 
         # Assert
         assert response2.status_code == 201
-        new_key_id_2 = response2.json()["id"]
+        new_key_id_2 = UUID(response2.json()["id"])
         assert new_key_id_2 != new_key_id_1
         assert new_key_id_2 != api_key.id
-
-        # Verify only the final key exists
-        from app.services import api_key_service
 
         assert api_key_service.get(db, api_key.id, raise_404=False) is None
         assert api_key_service.get(db, new_key_id_1, raise_404=False) is None

--- a/backend/tests/api/v1/test_connections.py
+++ b/backend/tests/api/v1/test_connections.py
@@ -48,7 +48,7 @@ class TestConnectionsEndpoints:
             status=ConnectionStatus.ACTIVE,
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.get(f"/api/v1/users/{user.id}/connections", headers=headers)
@@ -65,7 +65,7 @@ class TestConnectionsEndpoints:
         # Arrange
         user = UserFactory()
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.get(f"/api/v1/users/{user.id}/connections", headers=headers)
@@ -82,7 +82,7 @@ class TestConnectionsEndpoints:
         providers = ["garmin", "polar", "suunto", "apple"]
         [UserConnectionFactory(user=user, provider=provider) for provider in providers]
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.get(f"/api/v1/users/{user.id}/connections", headers=headers)
@@ -114,7 +114,7 @@ class TestConnectionsEndpoints:
             status=ConnectionStatus.EXPIRED,
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.get(f"/api/v1/users/{user.id}/connections", headers=headers)
@@ -136,7 +136,7 @@ class TestConnectionsEndpoints:
         connection1 = UserConnectionFactory(user=user1, provider="garmin")
         UserConnectionFactory(user=user2, provider="polar")
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act - get user1's connections
         response = client.get(f"/api/v1/users/{user1.id}/connections", headers=headers)
@@ -160,7 +160,7 @@ class TestConnectionsEndpoints:
             status=ConnectionStatus.ACTIVE,
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.get(f"/api/v1/users/{user.id}/connections", headers=headers)
@@ -216,7 +216,7 @@ class TestConnectionsEndpoints:
         """Test handling of invalid user ID format returns 400."""
         # Arrange
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act - FastAPI/Starlette validates UUID path params and returns 400 Bad Request
         response = client.get("/api/v1/users/not-a-uuid/connections", headers=headers)
@@ -230,7 +230,7 @@ class TestConnectionsEndpoints:
         from uuid import uuid4
 
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
         nonexistent_user_id = uuid4()
 
         # Act
@@ -255,7 +255,7 @@ class TestConnectionsEndpoints:
             last_synced_at=last_synced,
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.get(f"/api/v1/users/{user.id}/connections", headers=headers)
@@ -280,7 +280,7 @@ class TestConnectionsEndpoints:
             refresh_token="secret_refresh_token",
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.get(f"/api/v1/users/{user.id}/connections", headers=headers)
@@ -309,7 +309,7 @@ class TestDisconnectEndpoint:
             status=ConnectionStatus.ACTIVE,
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"/api/v1/users/{user.id}/connections/garmin", headers=headers)
@@ -332,7 +332,7 @@ class TestDisconnectEndpoint:
             token_expires_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         client.delete(f"/api/v1/users/{user.id}/connections/garmin", headers=headers)
@@ -353,7 +353,7 @@ class TestDisconnectEndpoint:
             status=ConnectionStatus.REVOKED,
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"/api/v1/users/{user.id}/connections/garmin", headers=headers)
@@ -366,7 +366,7 @@ class TestDisconnectEndpoint:
         # Arrange
         user = UserFactory()
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"/api/v1/users/{user.id}/connections/garmin", headers=headers)
@@ -384,7 +384,7 @@ class TestDisconnectEndpoint:
             status=ConnectionStatus.EXPIRED,
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"/api/v1/users/{user.id}/connections/polar", headers=headers)
@@ -399,7 +399,7 @@ class TestDisconnectEndpoint:
         # Arrange
         user = UserFactory()
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"/api/v1/users/{user.id}/connections/not_a_provider", headers=headers)
@@ -443,7 +443,7 @@ class TestDisconnectEndpoint:
             token_expires_at=None,
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"/api/v1/users/{user.id}/connections/apple", headers=headers)
@@ -461,7 +461,7 @@ class TestDisconnectEndpoint:
         UserConnectionFactory(user=user1, provider="garmin", status=ConnectionStatus.ACTIVE)
         UserConnectionFactory(user=user2, provider="garmin", status=ConnectionStatus.ACTIVE)
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act - disconnect user1's garmin
         response = client.delete(f"/api/v1/users/{user1.id}/connections/garmin", headers=headers)
@@ -494,7 +494,7 @@ class TestDeleteProviderDataEndpoint:
         ds = self._seed_provider_data(user, "apple")
         ds_id = ds.id
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"/api/v1/users/{user.id}/connections/apple/data", headers=headers)
@@ -520,7 +520,7 @@ class TestDeleteProviderDataEndpoint:
         suunto_ds = self._seed_provider_data(user, "suunto")
         suunto_ds_id = suunto_ds.id
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"/api/v1/users/{user.id}/connections/apple/data", headers=headers)
@@ -544,7 +544,7 @@ class TestDeleteProviderDataEndpoint:
         self._seed_provider_data(user1, "apple")
         self._seed_provider_data(user2, "apple")
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"/api/v1/users/{user1.id}/connections/apple/data", headers=headers)
@@ -562,7 +562,7 @@ class TestDeleteProviderDataEndpoint:
         UserConnectionFactory(user=user, provider="apple", status=ConnectionStatus.REVOKED)
         self._seed_provider_data(user, "apple")
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"/api/v1/users/{user.id}/connections/apple/data", headers=headers)
@@ -577,7 +577,7 @@ class TestDeleteProviderDataEndpoint:
         # Arrange
         user = UserFactory()
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"/api/v1/users/{user.id}/connections/garmin/data", headers=headers)
@@ -618,7 +618,7 @@ class TestDisconnectDeregistration:
             access_token="garmin_access_token",
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"/api/v1/users/{user.id}/connections/garmin", headers=headers)
@@ -650,7 +650,7 @@ class TestDisconnectDeregistration:
             access_token="garmin_access_token",
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"/api/v1/users/{user.id}/connections/garmin", headers=headers)
@@ -674,7 +674,7 @@ class TestDisconnectDeregistration:
             access_token=None,
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"/api/v1/users/{user.id}/connections/garmin", headers=headers)

--- a/backend/tests/api/v1/test_events_delete.py
+++ b/backend/tests/api/v1/test_events_delete.py
@@ -38,7 +38,7 @@ class TestDeleteWorkout:
 
         response = client.delete(
             f"/api/v1/users/{user.id}/events/workouts/{workout.id}",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 204
@@ -54,7 +54,7 @@ class TestDeleteWorkout:
 
         response = client.delete(
             f"/api/v1/users/{user.id}/events/workouts/{workout.id}",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 204
@@ -68,7 +68,7 @@ class TestDeleteWorkout:
 
         response = client.delete(
             f"/api/v1/users/{user.id}/events/workouts/{uuid4()}",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 404
@@ -82,7 +82,7 @@ class TestDeleteWorkout:
 
         response = client.delete(
             f"/api/v1/users/{other_user.id}/events/workouts/{workout.id}",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 404
@@ -98,7 +98,7 @@ class TestDeleteWorkout:
 
         response = client.delete(
             f"/api/v1/users/{user.id}/events/workouts/{sleep.id}",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 404
@@ -117,7 +117,7 @@ class TestDeleteSleepSession:
 
         response = client.delete(
             f"/api/v1/users/{user.id}/events/sleep/{sleep.id}",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 204
@@ -133,7 +133,7 @@ class TestDeleteSleepSession:
 
         response = client.delete(
             f"/api/v1/users/{user.id}/events/sleep/{sleep.id}",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 204
@@ -145,7 +145,7 @@ class TestDeleteSleepSession:
 
         response = client.delete(
             f"/api/v1/users/{user.id}/events/sleep/{uuid4()}",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 404
@@ -159,7 +159,7 @@ class TestDeleteSleepSession:
 
         response = client.delete(
             f"/api/v1/users/{other_user.id}/events/sleep/{sleep.id}",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 404
@@ -174,7 +174,7 @@ class TestDeleteSleepSession:
 
         response = client.delete(
             f"/api/v1/users/{user.id}/events/sleep/{workout.id}",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 404

--- a/backend/tests/api/v1/test_health_scores.py
+++ b/backend/tests/api/v1/test_health_scores.py
@@ -28,7 +28,7 @@ class TestHealthScoresEndpoint:
 
         response = client.get(
             f"/api/v1/users/{user.id}/health-scores",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 200
@@ -43,7 +43,7 @@ class TestHealthScoresEndpoint:
 
         response = client.get(
             f"/api/v1/users/{user.id}/health-scores",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 200
@@ -59,7 +59,7 @@ class TestHealthScoresEndpoint:
 
         response = client.get(
             f"/api/v1/users/{user.id}/health-scores",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"category": "sleep"},
         )
 
@@ -77,7 +77,7 @@ class TestHealthScoresEndpoint:
 
         response = client.get(
             f"/api/v1/users/{user.id}/health-scores",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"provider": "garmin"},
         )
 
@@ -96,7 +96,7 @@ class TestHealthScoresEndpoint:
 
         response = client.get(
             f"/api/v1/users/{user.id}/health-scores",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={
                 "start_date": (now - timedelta(days=3)).isoformat(),
                 "end_date": now.isoformat(),
@@ -122,7 +122,7 @@ class TestHealthScoresEndpoint:
 
         response = client.get(
             f"/api/v1/users/{user_a.id}/health-scores",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 200

--- a/backend/tests/api/v1/test_import_data.py
+++ b/backend/tests/api/v1/test_import_data.py
@@ -26,7 +26,7 @@ class TestXMLImportEndpoint:
         # Arrange
         user = UserFactory()
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
         payload = {
             "filename": "export.xml",
         }
@@ -77,7 +77,7 @@ class TestXMLImportEndpoint:
         # Arrange
         user = UserFactory()
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
         payload = {
             "expiration_seconds": 30,  # Less than minimum (60)
         }

--- a/backend/tests/api/v1/test_multipart_upload.py
+++ b/backend/tests/api/v1/test_multipart_upload.py
@@ -16,7 +16,7 @@ BASE = "/api/v1/users/{user_id}/import/apple/xml/s3/multipart"
 class TestCreateMultipart:
     def test_create_success(self, client: TestClient, db: Session, mock_external_apis: dict[str, MagicMock]) -> None:
         user = UserFactory()
-        headers = api_key_headers(ApiKeyFactory().id)
+        headers = api_key_headers(ApiKeyFactory().plain_key)
 
         response = client.post(
             BASE.format(user_id=user.id) + "/create",
@@ -43,7 +43,7 @@ class TestCreateMultipart:
         self, client: TestClient, db: Session, mock_external_apis: dict[str, MagicMock]
     ) -> None:
         user = UserFactory()
-        headers = api_key_headers(ApiKeyFactory().id)
+        headers = api_key_headers(ApiKeyFactory().plain_key)
         response = client.post(
             BASE.format(user_id=user.id) + "/create",
             headers=headers,
@@ -55,7 +55,7 @@ class TestCreateMultipart:
 class TestSignMultipart:
     def test_sign_returns_urls(self, client: TestClient, db: Session, mock_external_apis: dict[str, MagicMock]) -> None:
         user = UserFactory()
-        headers = api_key_headers(ApiKeyFactory().id)
+        headers = api_key_headers(ApiKeyFactory().plain_key)
         response = client.post(
             BASE.format(user_id=user.id) + "/sign",
             headers=headers,
@@ -75,7 +75,7 @@ class TestSignMultipart:
         self, client: TestClient, db: Session, mock_external_apis: dict[str, MagicMock]
     ) -> None:
         user = UserFactory()
-        headers = api_key_headers(ApiKeyFactory().id)
+        headers = api_key_headers(ApiKeyFactory().plain_key)
         response = client.post(
             BASE.format(user_id=user.id) + "/sign",
             headers=headers,
@@ -98,7 +98,7 @@ class TestCompleteMultipart:
     ) -> None:
         monkeypatch.setattr(settings, "apple_xml_upload_completion_mode", "client")
         user = UserFactory()
-        headers = api_key_headers(ApiKeyFactory().id)
+        headers = api_key_headers(ApiKeyFactory().plain_key)
         key = f"{user.id}/raw/export.xml"
 
         with patch("app.api.routes.v1.import_xml.complete_and_process_aws_upload") as mock_task:
@@ -132,7 +132,7 @@ class TestCompleteMultipart:
     ) -> None:
         monkeypatch.setattr(settings, "apple_xml_upload_completion_mode", "client")
         user = UserFactory()
-        headers = api_key_headers(ApiKeyFactory().id)
+        headers = api_key_headers(ApiKeyFactory().plain_key)
         key = f"{user.id}/raw/export.xml"
 
         with patch("app.api.routes.v1.import_xml.complete_and_process_aws_upload") as mock_task:
@@ -156,7 +156,7 @@ class TestCompleteMultipart:
     ) -> None:
         monkeypatch.setattr(settings, "apple_xml_upload_completion_mode", "sns")
         user = UserFactory()
-        headers = api_key_headers(ApiKeyFactory().id)
+        headers = api_key_headers(ApiKeyFactory().plain_key)
         key = f"{user.id}/raw/export.xml"
 
         with patch("app.api.routes.v1.import_xml.complete_and_process_aws_upload") as mock_task:
@@ -174,7 +174,7 @@ class TestCompleteMultipart:
         self, client: TestClient, db: Session, mock_external_apis: dict[str, MagicMock]
     ) -> None:
         user = UserFactory()
-        headers = api_key_headers(ApiKeyFactory().id)
+        headers = api_key_headers(ApiKeyFactory().plain_key)
         response = client.post(
             BASE.format(user_id=user.id) + "/complete",
             headers=headers,
@@ -186,7 +186,7 @@ class TestCompleteMultipart:
 class TestAbortMultipart:
     def test_abort_success(self, client: TestClient, db: Session, mock_external_apis: dict[str, MagicMock]) -> None:
         user = UserFactory()
-        headers = api_key_headers(ApiKeyFactory().id)
+        headers = api_key_headers(ApiKeyFactory().plain_key)
         key = f"{user.id}/raw/export.xml"
         response = client.post(
             BASE.format(user_id=user.id) + "/abort",

--- a/backend/tests/api/v1/test_sdk_logs.py
+++ b/backend/tests/api/v1/test_sdk_logs.py
@@ -69,7 +69,7 @@ class TestSDKLogsHappyPath:
         api_key = ApiKeyFactory()
         response = client.post(
             _url(),
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             json=_payload(SYNC_START_EVENT, SYNC_END_EVENT, DEVICE_STATE_EVENT),
         )
         assert response.status_code == 202
@@ -81,7 +81,7 @@ class TestSDKLogsHappyPath:
         api_key = ApiKeyFactory()
         response = client.post(
             _url(),
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             json=_payload(SYNC_START_EVENT),
         )
         assert response.status_code == 202
@@ -91,7 +91,7 @@ class TestSDKLogsHappyPath:
         api_key = ApiKeyFactory()
         response = client.post(
             _url(),
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             json=_payload(SYNC_END_EVENT),
         )
         assert response.status_code == 202
@@ -101,7 +101,7 @@ class TestSDKLogsHappyPath:
         api_key = ApiKeyFactory()
         response = client.post(
             _url(),
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             json=_payload(DEVICE_STATE_EVENT),
         )
         assert response.status_code == 202
@@ -111,7 +111,7 @@ class TestSDKLogsHappyPath:
         api_key = ApiKeyFactory()
         response = client.post(
             _url(),
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             json={"sdkVersion": "1.0.0", "events": [DEVICE_STATE_EVENT]},
         )
         assert response.status_code == 202
@@ -130,7 +130,7 @@ class TestSDKLogsHappyPath:
         }
         response = client.post(
             _url(),
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             json=_payload(event, DEVICE_STATE_EVENT),
         )
         assert response.status_code == 202
@@ -149,7 +149,7 @@ class TestSDKLogsHappyPath:
         }
         response = client.post(
             _url(),
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             json=_payload(event),
         )
         assert response.status_code == 202
@@ -228,7 +228,7 @@ class TestSDKLogsAuth:
         api_key = ApiKeyFactory()
         response = client.post(
             _url(),
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             json=_payload(DEVICE_STATE_EVENT),
         )
         assert response.status_code == 202
@@ -256,7 +256,7 @@ class TestSDKLogsValidation:
         api_key = ApiKeyFactory()
         response = client.post(
             _url(),
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             json={"sdkVersion": "1.0.0", "provider": "apple", "events": []},
         )
         assert response.status_code in (400, 422)
@@ -265,7 +265,7 @@ class TestSDKLogsValidation:
         api_key = ApiKeyFactory()
         response = client.post(
             _url(),
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             json=_payload({"eventType": "something_unknown", "timestamp": "2026-04-09T10:00:00Z"}),
         )
         assert response.status_code in (400, 422)
@@ -274,7 +274,7 @@ class TestSDKLogsValidation:
         api_key = ApiKeyFactory()
         response = client.post(
             _url(),
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             json={"provider": "apple", "events": [DEVICE_STATE_EVENT]},
         )
         assert response.status_code in (400, 422)

--- a/backend/tests/api/v1/test_sdk_sync_auth.py
+++ b/backend/tests/api/v1/test_sdk_sync_auth.py
@@ -55,7 +55,7 @@ class TestSDKSyncWithSDKToken:
 
         response = client.post(
             f"{api_v1_prefix}/sdk/users/{user_id}/sync/",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             json={
                 "data": {
                     "provider": "apple",

--- a/backend/tests/api/v1/test_sdk_sync_offload.py
+++ b/backend/tests/api/v1/test_sdk_sync_offload.py
@@ -30,7 +30,7 @@ def _sync(client: TestClient, api_v1_prefix: str) -> object:
     api_key = ApiKeyFactory()
     return client.post(
         f"{api_v1_prefix}/sdk/users/{_USER_ID}/sync/",
-        headers={"X-Open-Wearables-API-Key": api_key.id},
+        headers={"X-Open-Wearables-API-Key": api_key.plain_key},
         json=_BODY,
     )
 

--- a/backend/tests/api/v1/test_summaries.py
+++ b/backend/tests/api/v1/test_summaries.py
@@ -44,7 +44,7 @@ class TestSleepSummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/sleep",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
         assert response.status_code == 200
@@ -86,7 +86,7 @@ class TestSleepSummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/sleep",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -149,7 +149,7 @@ class TestSleepSummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/sleep",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -188,7 +188,7 @@ class TestSleepSummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/sleep",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -255,7 +255,7 @@ class TestSleepSummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/sleep",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -317,7 +317,7 @@ class TestSleepSummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/sleep",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -363,7 +363,7 @@ class TestSleepSummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/sleep",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -392,7 +392,7 @@ class TestActivitySummaryEndpoint:
 
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/activity",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -431,7 +431,7 @@ class TestActivitySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/activity",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -478,7 +478,7 @@ class TestActivitySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/activity",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -510,7 +510,7 @@ class TestActivitySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/activity",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -562,7 +562,7 @@ class TestActivitySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/activity",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -617,7 +617,7 @@ class TestActivitySummaryEndpoint:
 
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/activity",
-            headers=api_key_headers(ApiKeyFactory().id),
+            headers=api_key_headers(ApiKeyFactory().plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -641,7 +641,7 @@ class TestActivitySummaryEndpoint:
 
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/activity",
-            headers=api_key_headers(ApiKeyFactory().id),
+            headers=api_key_headers(ApiKeyFactory().plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -674,7 +674,7 @@ class TestActivitySummaryEndpoint:
 
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/activity",
-            headers=api_key_headers(ApiKeyFactory().id),
+            headers=api_key_headers(ApiKeyFactory().plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -709,7 +709,7 @@ class TestActivitySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/activity",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-28T00:00:00Z"},
         )
 
@@ -759,7 +759,7 @@ class TestActivitySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/activity",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -811,7 +811,7 @@ class TestActivitySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/activity",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -875,7 +875,7 @@ class TestActivitySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/activity",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -950,7 +950,7 @@ class TestActivitySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/activity",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -992,7 +992,7 @@ class TestActivitySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/activity",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-27T00:00:00Z"},
         )
 
@@ -1040,7 +1040,7 @@ class TestBodySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/body",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 200
@@ -1071,7 +1071,7 @@ class TestBodySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/body",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 200
@@ -1114,7 +1114,7 @@ class TestBodySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/body",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 200
@@ -1164,7 +1164,7 @@ class TestBodySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/body",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"average_period": 7},
         )
 
@@ -1216,7 +1216,7 @@ class TestBodySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/body",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"average_period": 1},
         )
 
@@ -1262,7 +1262,7 @@ class TestBodySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/body",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"latest_window_hours": 4},
         )
 
@@ -1312,7 +1312,7 @@ class TestBodySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/body",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"latest_window_hours": 4},
         )
 
@@ -1351,7 +1351,7 @@ class TestBodySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/body",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"latest_window_hours": 4},
         )
 
@@ -1389,7 +1389,7 @@ class TestBodySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/body",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"latest_window_hours": 4},
         )
 
@@ -1408,7 +1408,7 @@ class TestBodySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/body",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 200
@@ -1444,7 +1444,7 @@ class TestBodySummaryEndpoint:
         api_key = ApiKeyFactory()
         response = client.get(
             f"/api/v1/users/{user.id}/summaries/body",
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
         )
 
         assert response.status_code == 200
@@ -1480,7 +1480,7 @@ class TestRecoverySummaryEndpoint:
         )
         api_key = ApiKeyFactory()
 
-        response = client.get(self._url(user.id), headers=api_key_headers(api_key.id), params=self.BASE_PARAMS)
+        response = client.get(self._url(user.id), headers=api_key_headers(api_key.plain_key), params=self.BASE_PARAMS)
 
         assert response.status_code == 200
         data = response.json()
@@ -1509,7 +1509,7 @@ class TestRecoverySummaryEndpoint:
         )
         api_key = ApiKeyFactory()
 
-        response = client.get(self._url(user.id), headers=api_key_headers(api_key.id), params=self.BASE_PARAMS)
+        response = client.get(self._url(user.id), headers=api_key_headers(api_key.plain_key), params=self.BASE_PARAMS)
 
         assert response.status_code == 200
         item = response.json()["data"][0]
@@ -1525,7 +1525,7 @@ class TestRecoverySummaryEndpoint:
 
         response = client.get(
             self._url(user.id),
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2025-12-25T00:00:00Z", "end_date": "2025-12-26T00:00:00Z"},
         )
 
@@ -1547,7 +1547,7 @@ class TestRecoverySummaryEndpoint:
                 recorded_at=datetime(2025, 12, day, 0, 0, 0, tzinfo=timezone.utc),
             )
 
-        response = client.get(self._url(user.id), headers=api_key_headers(api_key.id), params=self.BASE_PARAMS)
+        response = client.get(self._url(user.id), headers=api_key_headers(api_key.plain_key), params=self.BASE_PARAMS)
 
         assert response.status_code == 200
         scores = [item["recovery_score"] for item in response.json()["data"]]
@@ -1584,7 +1584,7 @@ class TestRecoverySummaryEndpoint:
             recorded_at=datetime(2025, 12, 28, 0, 0, 0, tzinfo=timezone.utc),
         )
 
-        response = client.get(self._url(user.id), headers=api_key_headers(api_key.id), params=self.BASE_PARAMS)
+        response = client.get(self._url(user.id), headers=api_key_headers(api_key.plain_key), params=self.BASE_PARAMS)
 
         assert response.status_code == 200
         data = response.json()["data"]
@@ -1605,7 +1605,7 @@ class TestRecoverySummaryEndpoint:
         )
         api_key = ApiKeyFactory()
 
-        response = client.get(self._url(user.id), headers=api_key_headers(api_key.id), params=self.BASE_PARAMS)
+        response = client.get(self._url(user.id), headers=api_key_headers(api_key.plain_key), params=self.BASE_PARAMS)
 
         assert response.status_code == 200
         item = response.json()["data"][0]
@@ -1632,7 +1632,7 @@ class TestRecoverySummaryEndpoint:
 
         response = client.get(
             self._url(user.id),
-            headers=api_key_headers(api_key.id),
+            headers=api_key_headers(api_key.plain_key),
             params={"start_date": "2026-01-01T00:00:00Z", "end_date": "2026-01-31T00:00:00Z", "limit": 3},
         )
 
@@ -1668,7 +1668,7 @@ class TestDataTimelineEndpoint:
 
         response = client.get(
             self._url(user.id),
-            headers=api_key_headers(ApiKeyFactory().id),
+            headers=api_key_headers(ApiKeyFactory().plain_key),
             params={"start_date": "2026-06-01", "end_date": "2026-06-08"},
         )
 
@@ -1687,7 +1687,7 @@ class TestDataTimelineEndpoint:
 
         response = client.get(
             self._url(user.id),
-            headers=api_key_headers(ApiKeyFactory().id),
+            headers=api_key_headers(ApiKeyFactory().plain_key),
             params={"bucket": "month"},
         )
 

--- a/backend/tests/api/v1/test_sync_data.py
+++ b/backend/tests/api/v1/test_sync_data.py
@@ -41,7 +41,7 @@ class TestSyncDataEndpoint:
         # Act - use async=false to test synchronous path
         response = client.post(
             f"/api/v1/providers/garmin/users/{user.id}/sync",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             params={"async": "false"},
         )
 
@@ -73,7 +73,7 @@ class TestSyncDataEndpoint:
         # Act - async=true is default
         response = client.post(
             f"/api/v1/providers/garmin/users/{user.id}/sync",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
         )
 
         # Assert
@@ -118,7 +118,7 @@ class TestSyncDataEndpoint:
         # Act - use async=false to test synchronous path
         response = client.post(
             f"/api/v1/providers/garmin/users/{user.id}/sync",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             params={"async": "false"},
         )
 
@@ -135,7 +135,7 @@ class TestSyncDataEndpoint:
         # Act - use async=false to test synchronous path
         response = client.post(
             f"/api/v1/providers/polar/users/{user.id}/sync",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             params={"async": "false"},
         )
 
@@ -155,7 +155,7 @@ class TestSyncDataEndpoint:
         # Act - use async=false to test synchronous path with params
         response = client.post(
             f"/api/v1/providers/suunto/users/{user.id}/sync",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             params={"since": 1609459200, "limit": 25, "offset": 10, "async": "false"},
         )
 
@@ -179,7 +179,7 @@ class TestSyncDataEndpoint:
         # Act
         response = client.post(
             f"/api/v1/providers/invalid_provider/users/{user.id}/sync",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
         )
 
         # Assert
@@ -205,7 +205,7 @@ class TestSyncDataEndpoint:
         # Act - explicitly request only workouts to trigger 501 (use async=false)
         response = client.post(
             f"/api/v1/providers/apple/users/{user.id}/sync",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             params={"data_type": "workouts", "async": "false"},
         )
 
@@ -243,7 +243,7 @@ class TestSyncHistoricalEndpoint:
 
         response = client.post(
             f"/api/v1/providers/oura/users/{user.id}/sync/historical",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
         )
 
         assert response.status_code == 200
@@ -272,7 +272,7 @@ class TestSyncHistoricalEndpoint:
 
         response = client.post(
             f"/api/v1/providers/oura/users/{user.id}/sync/historical",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             params={"days": 30},
         )
 
@@ -292,7 +292,7 @@ class TestSyncHistoricalEndpoint:
 
         response = client.post(
             f"/api/v1/providers/apple/users/{user.id}/sync/historical",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
         )
 
         assert response.status_code == 400

--- a/backend/tests/api/v1/test_users.py
+++ b/backend/tests/api/v1/test_users.py
@@ -42,7 +42,7 @@ class TestListUsers:
         api_key = ApiKeyFactory(developer=developer)
         user1 = UserFactory(email="user1@example.com", first_name="John", last_name="Doe")
         user2 = UserFactory(email="user2@example.com", first_name="Jane", last_name="Smith")
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.get(f"{api_v1_prefix}/users", headers=headers)
@@ -68,7 +68,7 @@ class TestListUsers:
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.get(f"{api_v1_prefix}/users", headers=headers)
@@ -106,7 +106,7 @@ class TestListUsers:
         api_key = ApiKeyFactory(developer=developer)
         UserFactory(email="user1@ci.local", first_name="John", last_name="Doe")
         user2 = UserFactory(email="user2@example.com", first_name="Jane", last_name="Smith")
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.get(f"{api_v1_prefix}/users", headers=headers)
@@ -130,7 +130,7 @@ class TestGetUser:
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer)
         user = UserFactory(email="user@example.com", first_name="John", last_name="Doe")
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.get(f"{api_v1_prefix}/users/{user.id}", headers=headers)
@@ -150,7 +150,7 @@ class TestGetUser:
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
         fake_id = "00000000-0000-0000-0000-000000000000"
 
         # Act
@@ -164,7 +164,7 @@ class TestGetUser:
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.get(f"{api_v1_prefix}/users/not-a-uuid", headers=headers)
@@ -192,7 +192,7 @@ class TestCreateUser:
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
         payload = {
             "email": "newuser@example.com",
             "first_name": "Alice",
@@ -225,7 +225,7 @@ class TestCreateUser:
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
         payload = {}
 
         # Act
@@ -242,7 +242,7 @@ class TestCreateUser:
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
         payload = {"email": "onlyemail@example.com"}
 
         # Act
@@ -260,7 +260,7 @@ class TestCreateUser:
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
         payload = {"email": "not-an-email"}
 
         # Act
@@ -274,7 +274,7 @@ class TestCreateUser:
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
         payload = {
             "first_name": "a" * 101,  # Max is 100
             "last_name": "Smith",
@@ -428,7 +428,7 @@ class TestUpdateUser:
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer)
         user = UserFactory(email="user@example.com")
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
         payload = {"email": "new@example.com"}
 
         # Act
@@ -507,7 +507,7 @@ class TestDeleteUser:
         developer = DeveloperFactory(email="test@example.com", password="test123")
         api_key = ApiKeyFactory(developer=developer)
         user = UserFactory(email="user@example.com")
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.delete(f"{api_v1_prefix}/users/{user.id}", headers=headers)
@@ -522,7 +522,7 @@ class TestListUsersConnections:
     @pytest.fixture
     def headers(self) -> dict[str, str]:
         developer = DeveloperFactory(email="connections@example.com", password="test123")
-        return api_key_headers(ApiKeyFactory(developer=developer).id)
+        return api_key_headers(ApiKeyFactory(developer=developer).plain_key)
 
     def test_connections_absent_by_default(self, client: TestClient, api_v1_prefix: str, headers: dict) -> None:
         """Test that connections are omitted unless the expansion is requested."""
@@ -593,7 +593,7 @@ class TestListUsersFilters:
     @pytest.fixture
     def headers(self) -> dict[str, str]:
         developer = DeveloperFactory(email="filters@example.com", password="test123")
-        return api_key_headers(ApiKeyFactory(developer=developer).id)
+        return api_key_headers(ApiKeyFactory(developer=developer).plain_key)
 
     @pytest.fixture
     def users(self) -> dict[str, User]:
@@ -743,7 +743,7 @@ class TestGetUserDetailProjection:
     @pytest.fixture
     def headers(self) -> dict[str, str]:
         developer = DeveloperFactory(email="detail@example.com", password="test123")
-        return api_key_headers(ApiKeyFactory(developer=developer).id)
+        return api_key_headers(ApiKeyFactory(developer=developer).plain_key)
 
     def test_reports_last_sync_and_active_connection(
         self, client: TestClient, api_v1_prefix: str, headers: dict

--- a/backend/tests/api/v1/test_vendor_workouts.py
+++ b/backend/tests/api/v1/test_vendor_workouts.py
@@ -53,7 +53,7 @@ class TestVendorWorkoutsEndpoints:
         # Act
         response = client.get(
             f"/api/v1/providers/garmin/users/{user.id}/workouts",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
         )
 
         # Assert
@@ -99,7 +99,7 @@ class TestVendorWorkoutsEndpoints:
         # Act
         response = client.get(
             f"/api/v1/providers/garmin/users/{user.id}/workouts",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
         )
 
         # Assert
@@ -120,7 +120,7 @@ class TestVendorWorkoutsEndpoints:
         # Act
         response = client.get(
             f"/api/v1/providers/polar/users/{user.id}/workouts",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
         )
 
         # Assert
@@ -144,7 +144,7 @@ class TestVendorWorkoutsEndpoints:
         # Act
         response = client.get(
             f"/api/v1/providers/polar/users/{user.id}/workouts",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             params={"samples": True, "zones": True, "route": True},
         )
 
@@ -171,7 +171,7 @@ class TestVendorWorkoutsEndpoints:
         # Act
         response = client.get(
             f"/api/v1/providers/suunto/users/{user.id}/workouts",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
         )
 
         # Assert
@@ -195,7 +195,7 @@ class TestVendorWorkoutsEndpoints:
         # Act
         response = client.get(
             f"/api/v1/providers/suunto/users/{user.id}/workouts",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             params={"since": 1609459200, "limit": 25, "offset": 10},
         )
 
@@ -223,7 +223,7 @@ class TestVendorWorkoutsEndpoints:
         # Act
         response = client.get(
             f"/api/v1/providers/garmin/users/{user.id}/workouts/{workout_id}",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
         )
 
         # Assert
@@ -257,7 +257,7 @@ class TestVendorWorkoutsEndpoints:
         # Act
         response = client.get(
             f"/api/v1/providers/garmin/users/{user.id}/workouts/{workout_id}",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
         )
 
         # Assert
@@ -272,7 +272,7 @@ class TestVendorWorkoutsEndpoints:
         # Act
         response = client.get(
             f"/api/v1/providers/invalid_provider/users/{user.id}/workouts",
-            headers={"X-Open-Wearables-API-Key": api_key.id},
+            headers={"X-Open-Wearables-API-Key": api_key.plain_key},
         )
 
         # Assert
@@ -294,7 +294,7 @@ class TestVendorWorkoutsEndpoints:
             # Act
             response = client.get(
                 f"/api/v1/providers/apple/users/{user.id}/workouts",
-                headers={"X-Open-Wearables-API-Key": api_key.id},
+                headers={"X-Open-Wearables-API-Key": api_key.plain_key},
             )
 
             # Assert

--- a/backend/tests/api/v1/test_workouts.py
+++ b/backend/tests/api/v1/test_workouts.py
@@ -37,7 +37,7 @@ class TestWorkoutsEndpoints:
             duration_seconds=1800,
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         # Provide required start_date and end_date
@@ -63,7 +63,7 @@ class TestWorkoutsEndpoints:
         # Arrange
         user = UserFactory()
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         now = datetime.now(timezone.utc)
@@ -89,7 +89,7 @@ class TestWorkoutsEndpoints:
         workout = EventRecordFactory(mapping=mapping, category="workout")
         EventRecordFactory(mapping=mapping, category="sleep", type="sleep")
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         now = datetime.now(timezone.utc)
@@ -117,7 +117,7 @@ class TestWorkoutsEndpoints:
         running = EventRecordFactory(mapping=mapping, category="workout", type_="running")
         EventRecordFactory(mapping=mapping, category="workout", type_="cycling")
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act - note: API uses 'record_type' parameter (not 'type') and does ILIKE substring matching
         now = datetime.now(timezone.utc)
@@ -156,7 +156,7 @@ class TestWorkoutsEndpoints:
             end_datetime=now - timedelta(days=2, hours=-1),
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act - filter for last 5 days (note: API uses 'start_date' parameter, not 'start_datetime')
         start_date = (now - timedelta(days=5)).isoformat()
@@ -180,7 +180,7 @@ class TestWorkoutsEndpoints:
         # Create 5 workouts
         [EventRecordFactory(mapping=mapping, category="workout") for _ in range(5)]
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act - get page 2 with 2 items per page
         now = datetime.now(timezone.utc)
@@ -220,7 +220,7 @@ class TestWorkoutsEndpoints:
             start_datetime=now,
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act - sort by start_datetime ascending
         now = datetime.now(timezone.utc)
@@ -253,7 +253,7 @@ class TestWorkoutsEndpoints:
         workout1 = EventRecordFactory(mapping=mapping1, category="workout")
         EventRecordFactory(mapping=mapping2, category="workout")
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act - get user1's workouts
         now = datetime.now(timezone.utc)
@@ -313,7 +313,7 @@ class TestWorkoutsEndpoints:
         """Test handling of invalid user ID format."""
         # Arrange
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act & Assert - Invalid UUID causes 400 Bad Request (or 422 depending on config, but here 400)
         now = datetime.now(timezone.utc)
@@ -333,7 +333,7 @@ class TestWorkoutsEndpoints:
         from uuid import uuid4
 
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
         nonexistent_user_id = uuid4()
 
         # Act
@@ -366,7 +366,7 @@ class TestWorkoutsEndpoints:
             duration_seconds=3600,
         )
         api_key = ApiKeyFactory()
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         now = datetime.now(timezone.utc)

--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -35,7 +35,7 @@ from app.models import (
 )
 from app.schemas.auth import ConnectionStatus
 from app.schemas.enums import HealthScoreCategory, ProviderName
-from app.utils.security import get_password_hash
+from app.utils.security import get_password_hash, hash_api_key
 
 
 class BaseFactory(factory.alchemy.SQLAlchemyModelFactory):
@@ -279,18 +279,22 @@ class DeveloperFactory(BaseFactory):
 
 
 class ApiKeyFactory(BaseFactory):
-    """Factory for ApiKey model."""
+    """Factory for ApiKey model.
+
+    Only the hash of the key is persisted, so the raw value is exposed on the created
+    instance as ``plain_key`` for tests that need to authenticate with it.
+    """
 
     class Meta:
         model = ApiKey
 
-    id = LazyFunction(lambda: f"sk-{uuid4().hex[:32]}")
+    id = LazyFunction(uuid4)
     name = Sequence(lambda n: f"Test API Key {n}")
     created_at = LazyFunction(lambda: datetime.now(timezone.utc))
 
     @classmethod
     def _create(cls, model_class: type[ApiKey], *args: Any, **kwargs: Any) -> ApiKey:
-        """Override create to handle developer relationship."""
+        """Override create to handle developer relationship and key hashing."""
         developer = kwargs.pop("developer", None)
         # Remove any stale created_by that might have been set
         kwargs.pop("created_by", None)
@@ -298,7 +302,13 @@ class ApiKeyFactory(BaseFactory):
             # Create a developer if not provided
             developer = DeveloperFactory()
         kwargs["created_by"] = developer.id
-        return super()._create(model_class, *args, **kwargs)
+
+        plain_key = kwargs.pop("plain_key", None) or f"sk-{uuid4().hex[:32]}"
+        kwargs.setdefault("key_hash", hash_api_key(plain_key))
+        kwargs.setdefault("key_prefix", plain_key[:10])
+        api_key = super()._create(model_class, *args, **kwargs)
+        api_key.plain_key = plain_key  # type: ignore[attr-defined]
+        return api_key
 
 
 class ApplicationFactory(BaseFactory):

--- a/backend/tests/integrations/test_apple_import.py
+++ b/backend/tests/integrations/test_apple_import.py
@@ -26,7 +26,7 @@ class TestAppleXMLImport:
         user = UserFactory()
         developer = DeveloperFactory()
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.post(
@@ -49,7 +49,7 @@ class TestAppleXMLImport:
         user = UserFactory()
         developer = DeveloperFactory()
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Configure mock S3
         mock_s3 = MagicMock()

--- a/backend/tests/integrations/test_polar_import.py
+++ b/backend/tests/integrations/test_polar_import.py
@@ -55,7 +55,7 @@ class TestPolarOAuthFlow:
         user = UserFactory()
         developer = DeveloperFactory()
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         mock_redis = MagicMock()
         mock_redis.setex.return_value = True
@@ -145,7 +145,7 @@ class TestPolarWorkoutsAPI:
         UserConnectionFactory(user=user, provider="polar")
         developer = DeveloperFactory()
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         mock_request.return_value = [sample_polar_exercise]
 
@@ -172,7 +172,7 @@ class TestPolarWorkoutsAPI:
         UserConnectionFactory(user=user, provider="polar")
         developer = DeveloperFactory()
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         mock_request.return_value = sample_polar_exercise
         workout_id = "ABC123"
@@ -194,7 +194,7 @@ class TestPolarWorkoutsAPI:
         UserConnectionFactory(user=user, provider="polar")
         developer = DeveloperFactory()
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         mock_request.return_value = []
 
@@ -214,7 +214,7 @@ class TestPolarWorkoutsAPI:
         user = UserFactory()
         developer = DeveloperFactory()
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.get(
@@ -247,7 +247,7 @@ class TestPolarDataSync:
         UserConnectionFactory(user=user, provider="polar")
         developer = DeveloperFactory()
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         mock_request.return_value = [sample_polar_exercise]
 
@@ -268,7 +268,7 @@ class TestPolarDataSync:
         UserConnectionFactory(user=user, provider="polar")
         developer = DeveloperFactory()
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         mock_request.return_value = []
 
@@ -291,7 +291,7 @@ class TestPolarDataSync:
         user = UserFactory()
         developer = DeveloperFactory()
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Act
         response = client.post(

--- a/backend/tests/integrations/test_provider_oauth.py
+++ b/backend/tests/integrations/test_provider_oauth.py
@@ -287,7 +287,7 @@ class TestConnectionManagement:
         user = UserFactory()
         developer = DeveloperFactory()
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Create test connections
         UserConnectionFactory(user=user, provider="garmin", status=ConnectionStatus.ACTIVE)
@@ -320,7 +320,7 @@ class TestConnectionManagement:
         user = UserFactory()
         developer = DeveloperFactory()
         api_key = ApiKeyFactory(developer=developer)
-        headers = api_key_headers(api_key.id)
+        headers = api_key_headers(api_key.plain_key)
 
         # Create an expired connection
         UserConnectionFactory(

--- a/backend/tests/repositories/test_api_key_repository.py
+++ b/backend/tests/repositories/test_api_key_repository.py
@@ -4,25 +4,21 @@ Tests for ApiKeyRepository.
 Tests cover:
 - CRUD operations (create, get, get_all, delete)
 - get_all_ordered method (ordered by created_at descending)
-- API key specific behaviors (string ID)
+- get_by_hash lookup used for authentication
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import cast
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 import pytest
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.models import ApiKey
 from app.repositories.api_key_repository import ApiKeyRepository
 from app.schemas.model_crud.credentials import ApiKeyCreate, ApiKeyUpdate
+from app.utils.security import hash_api_key
 from tests.factories import ApiKeyFactory, DeveloperFactory
-
-
-def _str_id_as_uuid(str_id: str) -> UUID:
-    """Cast string ID to UUID for type checker (ApiKey uses string IDs)."""
-    return cast(UUID, str_id)
 
 
 class TestApiKeyRepository:
@@ -37,9 +33,10 @@ class TestApiKeyRepository:
         """Test creating a new API key."""
         # Arrange
         developer = DeveloperFactory()
-        key_id = f"sk-{uuid4().hex[:32]}"
+        raw_key = f"sk-{uuid4().hex[:32]}"
         api_key_data = ApiKeyCreate(
-            id=key_id,
+            key_hash=hash_api_key(raw_key),
+            key_prefix=raw_key[:10],
             name="Test API Key",
             created_by=developer.id,
             created_at=datetime.now(timezone.utc),
@@ -47,25 +44,28 @@ class TestApiKeyRepository:
 
         # Act
         result = api_key_repo.create(db, api_key_data)
+        key_id = result.id
 
         # Assert
-        assert result.id == key_id
+        assert result.key_hash == hash_api_key(raw_key)
+        assert result.key_prefix == raw_key[:10]
         assert result.name == "Test API Key"
         assert result.created_by == developer.id
         assert isinstance(result.created_at, datetime)
 
         # Verify in database
         db.expire_all()
-        db_api_key = api_key_repo.get(db, _str_id_as_uuid(key_id))
+        db_api_key = api_key_repo.get(db, key_id)
         assert db_api_key is not None
         assert db_api_key.name == "Test API Key"
 
     def test_create_without_developer(self, db: Session, api_key_repo: ApiKeyRepository) -> None:
         """Test creating an API key without a developer (orphaned key)."""
         # Arrange
-        key_id = f"sk-{uuid4().hex[:32]}"
+        raw_key = f"sk-{uuid4().hex[:32]}"
         api_key_data = ApiKeyCreate(
-            id=key_id,
+            key_hash=hash_api_key(raw_key),
+            key_prefix=raw_key[:10],
             name="Orphaned Key",
             created_by=None,
         )
@@ -74,7 +74,7 @@ class TestApiKeyRepository:
         result = api_key_repo.create(db, api_key_data)
 
         # Assert
-        assert result.id == key_id
+        assert result.id is not None
         assert result.name == "Orphaned Key"
         assert result.created_by is None
 
@@ -84,7 +84,7 @@ class TestApiKeyRepository:
         api_key = ApiKeyFactory(name="My Test Key")
 
         # Act
-        result = api_key_repo.get(db, _str_id_as_uuid(api_key.id))
+        result = api_key_repo.get(db, api_key.id)
 
         # Assert
         assert result is not None
@@ -94,7 +94,7 @@ class TestApiKeyRepository:
     def test_get_nonexistent(self, db: Session, api_key_repo: ApiKeyRepository) -> None:
         """Test retrieving a nonexistent API key returns None."""
         # Act
-        result = api_key_repo.get(db, _str_id_as_uuid("sk-nonexistent-key-12345"))
+        result = api_key_repo.get(db, uuid4())
 
         # Assert
         assert result is None
@@ -218,7 +218,7 @@ class TestApiKeyRepository:
 
         # Assert
         db.expire_all()
-        deleted_key = api_key_repo.get(db, _str_id_as_uuid(key_id))
+        deleted_key = api_key_repo.get(db, key_id)
         assert deleted_key is None
 
     def test_update_not_implemented(self, db: Session, api_key_repo: ApiKeyRepository) -> None:
@@ -235,7 +235,7 @@ class TestApiKeyRepository:
 
         # Verify in database
         db.expire_all()
-        db_key = api_key_repo.get(db, _str_id_as_uuid(api_key.id))
+        db_key = api_key_repo.get(db, api_key.id)
         assert db_key is not None
         assert db_key.name == "Updated Name"
 
@@ -243,9 +243,10 @@ class TestApiKeyRepository:
         """Test creating an API key with a specific timestamp."""
         # Arrange
         custom_time = datetime(2023, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
-        key_id = f"sk-{uuid4().hex[:32]}"
+        raw_key = f"sk-{uuid4().hex[:32]}"
         api_key_data = ApiKeyCreate(
-            id=key_id,
+            key_hash=hash_api_key(raw_key),
+            key_prefix=raw_key[:10],
             name="Historical Key",
             created_at=custom_time,
         )
@@ -275,22 +276,38 @@ class TestApiKeyRepository:
         assert "Key 2" in key_names
         assert "Key 3" in key_names
 
-    def test_api_key_id_format(self, db: Session, api_key_repo: ApiKeyRepository) -> None:
-        """Test that API key IDs are stored correctly (string format)."""
+    def test_get_by_hash(self, db: Session, api_key_repo: ApiKeyRepository) -> None:
+        """Test looking up an API key by the hash of its raw value."""
         # Arrange
-        key_id = "sk-test-custom-key-id-12345"
-        api_key_data = ApiKeyCreate(
-            id=key_id,
-            name="Custom ID Key",
-        )
+        api_key = ApiKeyFactory(name="Hashed Key")
 
         # Act
-        result = api_key_repo.create(db, api_key_data)
+        result = api_key_repo.get_by_hash(db, hash_api_key(api_key.plain_key))
 
         # Assert
-        assert isinstance(result.id, str)
-        assert result.id == key_id
-        assert result.id.startswith("sk-")
+        assert result is not None
+        assert result.id == api_key.id
+
+    def test_get_by_hash_does_not_match_raw_value(self, db: Session, api_key_repo: ApiKeyRepository) -> None:
+        """The raw key is never stored, so looking it up verbatim finds nothing."""
+        # Arrange
+        api_key = ApiKeyFactory()
+
+        # Act
+        result = api_key_repo.get_by_hash(db, api_key.plain_key)
+
+        # Assert
+        assert result is None
+
+    def test_key_hash_is_unique(self, db: Session, api_key_repo: ApiKeyRepository) -> None:
+        """Two rows cannot share the same key hash."""
+        # Arrange
+        ApiKeyFactory(plain_key="sk-duplicate")
+
+        # Act & Assert
+        with pytest.raises(IntegrityError):
+            ApiKeyFactory(plain_key="sk-duplicate")
+        db.rollback()
 
     def test_get_all_ordered_empty_database(self, db: Session, api_key_repo: ApiKeyRepository) -> None:
         """Test get_all_ordered with no API keys."""

--- a/backend/tests/services/test_api_key_service.py
+++ b/backend/tests/services/test_api_key_service.py
@@ -10,6 +10,7 @@ Tests cover:
 """
 
 from datetime import datetime, timedelta, timezone
+from typing import NoReturn
 from uuid import uuid4
 
 import pytest
@@ -226,6 +227,32 @@ class TestApiKeyServiceRotateApiKey:
         # Assert
         assert new_key.id != old_key_id
         assert new_key.created_by is None
+
+    def test_rotate_api_key_keeps_old_key_when_replacement_fails(
+        self, db: Session, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should leave the old key intact and valid if creating the replacement fails."""
+        # Arrange
+        developer = DeveloperFactory()
+        old_key = ApiKeyFactory(developer=developer, name="Production Key")
+        old_key_id = old_key.id
+        old_raw_key = old_key.plain_key
+        # The factory only flushes; commit so the rollback inside rotate cannot undo the arrange step
+        db.commit()
+
+        def _fail(*_args: object, **_kwargs: object) -> NoReturn:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(api_key_service, "create_api_key", _fail)
+
+        # Act
+        with pytest.raises(RuntimeError):
+            api_key_service.rotate_api_key(db, old_key_id, developer.id)
+
+        # Assert - the delete was rolled back together with the failed create
+        assert api_key_service.get(db, old_key_id) is not None
+        assert api_key_service.validate_api_key(db, old_raw_key).id == old_key_id
+        assert len(api_key_service.list_api_keys(db)) == 1
 
     def test_rotate_nonexistent_key_raises_404(self, db: Session) -> None:
         """Should raise HTTPException(404) when rotating non-existent key."""

--- a/backend/tests/services/test_api_key_service.py
+++ b/backend/tests/services/test_api_key_service.py
@@ -2,53 +2,68 @@
 Tests for ApiKeyService.
 
 Tests cover:
-- Creating API keys with sk- prefix
+- Creating API keys: raw key returned once, only hash + prefix persisted
 - Listing API keys ordered by creation date
-- Rotating API keys (delete old, create new)
-- Validating API keys
+- Rotating API keys (delete old, create new with the same name)
+- Validating raw API keys against stored hashes
 - Key generation format
 """
 
 from datetime import datetime, timedelta, timezone
+from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from app.services.api_key_service import api_key_service
+from app.services.api_key_service import KEY_PREFIX_LENGTH, api_key_service
+from app.utils.security import hash_api_key
 from tests.factories import ApiKeyFactory, DeveloperFactory
 
 
 class TestApiKeyServiceCreateApiKey:
     """Test API key creation with proper format."""
 
-    def test_create_api_key_generates_sk_prefix(self, db: Session) -> None:
-        """Should generate API key with sk- prefix."""
+    def test_create_api_key_returns_raw_key_with_sk_prefix(self, db: Session) -> None:
+        """Should return the raw key with sk- prefix alongside the persisted record."""
         # Arrange
         developer = DeveloperFactory()
 
         # Act
-        api_key = api_key_service.create_api_key(db, developer.id, "Test Key")
+        api_key, raw_key = api_key_service.create_api_key(db, developer.id, "Test Key")
 
         # Assert
-        assert api_key.id.startswith("sk-")
+        assert raw_key.startswith("sk-")
         assert api_key.name == "Test Key"
         assert api_key.created_by == developer.id
 
-    def test_create_api_key_has_correct_length(self, db: Session) -> None:
+    def test_create_api_key_raw_key_has_correct_length(self, db: Session) -> None:
         """Should generate key with correct format: sk- + 32 hex chars."""
         # Arrange
         developer = DeveloperFactory()
 
         # Act
-        api_key = api_key_service.create_api_key(db, developer.id)
+        _, raw_key = api_key_service.create_api_key(db, developer.id)
 
         # Assert
         # Format: "sk-" (3 chars) + 32 hex chars = 35 total
-        assert len(api_key.id) == 35
-        # Verify hex portion is valid hexadecimal
-        hex_portion = api_key.id[3:]
+        assert len(raw_key) == 35
+        hex_portion = raw_key[3:]
         assert all(c in "0123456789abcdef" for c in hex_portion)
+
+    def test_create_api_key_persists_only_hash_and_prefix(self, db: Session) -> None:
+        """The raw key must not be stored anywhere on the record."""
+        # Arrange
+        developer = DeveloperFactory()
+
+        # Act
+        api_key, raw_key = api_key_service.create_api_key(db, developer.id)
+
+        # Assert
+        assert api_key.key_hash == hash_api_key(raw_key)
+        assert api_key.key_prefix == raw_key[:KEY_PREFIX_LENGTH]
+        assert len(api_key.key_prefix) == KEY_PREFIX_LENGTH
+        assert raw_key not in {str(v) for v in vars(api_key).values()}
 
     def test_create_api_key_default_name(self, db: Session) -> None:
         """Should use default name when not provided."""
@@ -56,7 +71,7 @@ class TestApiKeyServiceCreateApiKey:
         developer = DeveloperFactory()
 
         # Act
-        api_key = api_key_service.create_api_key(db, developer.id)
+        api_key, _ = api_key_service.create_api_key(db, developer.id)
 
         # Assert
         assert api_key.name == "Default"
@@ -64,10 +79,10 @@ class TestApiKeyServiceCreateApiKey:
     def test_create_api_key_without_developer(self, db: Session) -> None:
         """Should create API key with None as created_by."""
         # Act
-        api_key = api_key_service.create_api_key(db, None, "Anonymous Key")
+        api_key, raw_key = api_key_service.create_api_key(db, None, "Anonymous Key")
 
         # Assert
-        assert api_key.id.startswith("sk-")
+        assert raw_key.startswith("sk-")
         assert api_key.created_by is None
         assert api_key.name == "Anonymous Key"
 
@@ -77,11 +92,10 @@ class TestApiKeyServiceCreateApiKey:
         developer = DeveloperFactory()
 
         # Act
-        api_key = api_key_service.create_api_key(db, developer.id, "Timestamped Key")
+        api_key, _ = api_key_service.create_api_key(db, developer.id, "Timestamped Key")
 
         # Assert
         assert api_key.created_at is not None
-        # Verify timestamp is recent (within last minute)
         assert (datetime.now(timezone.utc) - api_key.created_at).total_seconds() < 60
 
     def test_create_api_key_generates_unique_keys(self, db: Session) -> None:
@@ -90,11 +104,13 @@ class TestApiKeyServiceCreateApiKey:
         developer = DeveloperFactory()
 
         # Act
-        key1 = api_key_service.create_api_key(db, developer.id, "Key 1")
-        key2 = api_key_service.create_api_key(db, developer.id, "Key 2")
+        key1, raw1 = api_key_service.create_api_key(db, developer.id, "Key 1")
+        key2, raw2 = api_key_service.create_api_key(db, developer.id, "Key 2")
 
         # Assert
         assert key1.id != key2.id
+        assert raw1 != raw2
+        assert key1.key_hash != key2.key_hash
 
 
 class TestApiKeyServiceGenerateKeyValue:
@@ -117,19 +133,18 @@ class TestApiKeyServiceGenerateKeyValue:
         keys = [api_key_service._generate_key_value() for _ in range(100)]
 
         # Assert
-        assert len(keys) == len(set(keys))  # All unique
+        assert len(keys) == len(set(keys))
 
 
 class TestApiKeyServiceListApiKeys:
     """Test listing API keys."""
 
     def test_list_api_keys_ordered_by_created_at(self, db: Session) -> None:
-        """Should list API keys ordered by creation date."""
+        """Should list API keys ordered by creation date, newest first."""
         # Arrange
         developer = DeveloperFactory()
         now = datetime.now(timezone.utc)
 
-        # Create keys at different times
         key1 = ApiKeyFactory(developer=developer, name="First", created_at=now - timedelta(days=2))
         key2 = ApiKeyFactory(developer=developer, name="Second", created_at=now - timedelta(days=1))
         key3 = ApiKeyFactory(developer=developer, name="Third", created_at=now)
@@ -138,11 +153,8 @@ class TestApiKeyServiceListApiKeys:
         keys = api_key_service.list_api_keys(db)
 
         # Assert
-        assert len(keys) >= 3
-        # Find our test keys in the result
         test_keys = [k for k in keys if k.id in [key1.id, key2.id, key3.id]]
         assert len(test_keys) == 3
-        # Verify ordering - newest first based on actual implementation
         assert test_keys[0].id == key3.id
         assert test_keys[1].id == key2.id
         assert test_keys[2].id == key1.id
@@ -156,7 +168,7 @@ class TestApiKeyServiceListApiKeys:
         assert keys == []
 
     def test_list_api_keys_multiple_developers(self, db: Session) -> None:
-        """Should list keys from all developers."""
+        """Keys are global to the deployment: every developer sees all of them."""
         # Arrange
         dev1 = DeveloperFactory(email="dev1@example.com")
         dev2 = DeveloperFactory(email="dev2@example.com")
@@ -177,31 +189,39 @@ class TestApiKeyServiceRotateApiKey:
     """Test API key rotation."""
 
     def test_rotate_api_key_deletes_old_creates_new(self, db: Session) -> None:
-        """Should delete old key and create new one."""
+        """Should delete old key and create a new one that keeps the name."""
         # Arrange
         developer = DeveloperFactory()
-        old_key = ApiKeyFactory(developer=developer, name="Old Key")
+        old_key = ApiKeyFactory(developer=developer, name="Production Key")
         old_key_id = old_key.id
+        old_raw_key = old_key.plain_key
 
         # Act
-        new_key = api_key_service.rotate_api_key(db, old_key_id, developer.id)
+        new_key, raw_key = api_key_service.rotate_api_key(db, old_key_id, developer.id)
 
         # Assert
         assert new_key.id != old_key_id
-        assert new_key.id.startswith("sk-")
+        assert new_key.name == "Production Key"
         assert new_key.created_by == developer.id
+        assert raw_key.startswith("sk-")
+        assert raw_key != old_raw_key
 
-        # Verify old key is deleted
+        # Old key is gone and no longer authenticates
         assert api_key_service.get(db, old_key_id) is None
+        with pytest.raises(HTTPException):
+            api_key_service.validate_api_key(db, old_raw_key)
+
+        # New raw key authenticates
+        assert api_key_service.validate_api_key(db, raw_key).id == new_key.id
 
     def test_rotate_api_key_with_none_creator(self, db: Session) -> None:
         """Should rotate key with None as creator."""
         # Arrange
-        old_key = ApiKeyFactory(developer=None)
+        old_key = ApiKeyFactory()
         old_key_id = old_key.id
 
         # Act
-        new_key = api_key_service.rotate_api_key(db, old_key_id, None)
+        new_key, _ = api_key_service.rotate_api_key(db, old_key_id, None)
 
         # Assert
         assert new_key.id != old_key_id
@@ -210,14 +230,11 @@ class TestApiKeyServiceRotateApiKey:
     def test_rotate_nonexistent_key_raises_404(self, db: Session) -> None:
         """Should raise HTTPException(404) when rotating non-existent key."""
         # Arrange
-        from fastapi import HTTPException
-
-        fake_key = "sk-nonexistent"
         developer = DeveloperFactory()
 
         # Act & Assert
         with pytest.raises(HTTPException) as exc_info:
-            api_key_service.rotate_api_key(db, fake_key, developer.id)
+            api_key_service.rotate_api_key(db, uuid4(), developer.id)
 
         assert exc_info.value.status_code == 404
 
@@ -226,17 +243,39 @@ class TestApiKeyServiceValidateApiKey:
     """Test API key validation."""
 
     def test_validate_api_key_existing_key(self, db: Session) -> None:
-        """Should validate and return existing API key."""
+        """Should validate the raw key and return the matching record."""
         # Arrange
         developer = DeveloperFactory()
         api_key = ApiKeyFactory(developer=developer)
 
         # Act
-        validated = api_key_service.validate_api_key(db, api_key.id)
+        validated = api_key_service.validate_api_key(db, api_key.plain_key)
 
         # Assert
         assert validated.id == api_key.id
         assert validated.created_by == developer.id
+
+    def test_validate_api_key_rejects_hash_as_credential(self, db: Session) -> None:
+        """Presenting the stored hash instead of the raw key must not authenticate."""
+        # Arrange
+        api_key = ApiKeyFactory()
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            api_key_service.validate_api_key(db, api_key.key_hash)
+
+        assert exc_info.value.status_code == 401
+
+    def test_validate_api_key_rejects_prefix_as_credential(self, db: Session) -> None:
+        """The displayed prefix alone must not authenticate."""
+        # Arrange
+        api_key = ApiKeyFactory()
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            api_key_service.validate_api_key(db, api_key.key_prefix)
+
+        assert exc_info.value.status_code == 401
 
     def test_validate_api_key_nonexistent_raises_401(self, db: Session) -> None:
         """Should raise 401 for non-existent key."""
@@ -278,11 +317,8 @@ class TestApiKeyServiceGet:
 
     def test_get_nonexistent_api_key_returns_none(self, db: Session) -> None:
         """Should return None for non-existent key."""
-        # Arrange
-        fake_key = "sk-doesnotexist123456789012345678"
-
         # Act
-        result = api_key_service.get(db, fake_key)
+        result = api_key_service.get(db, uuid4())
 
         # Assert
         assert result is None
@@ -302,13 +338,9 @@ class TestApiKeyServiceDelete:
         api_key_service.delete(db, key_id)
 
         # Assert
-        result = api_key_service.get(db, key_id)
-        assert result is None
+        assert api_key_service.get(db, key_id) is None
 
     def test_delete_nonexistent_api_key(self, db: Session) -> None:
         """Should handle deleting non-existent key gracefully."""
-        # Arrange
-        fake_key = "sk-doesnotexist123456789012345678"
-
         # Act & Assert - should not raise error
-        api_key_service.delete(db, fake_key, raise_404=False)
+        api_key_service.delete(db, uuid4(), raise_404=False)

--- a/backend/tests/utils_tests/test_auth_utils.py
+++ b/backend/tests/utils_tests/test_auth_utils.py
@@ -275,9 +275,9 @@ class TestRequireApiKeyDetached:
 
         with patch("app.services.api_key_service.SessionLocal") as mock_session_local:
             mock_session_local.return_value.__enter__.return_value = db
-            result = await _require_api_key_detached(token=None, x_open_wearables_api_key=api_key.id)
+            result = await _require_api_key_detached(token=None, x_open_wearables_api_key=api_key.plain_key)
 
-        assert result == api_key.id
+        assert result == str(api_key.id)
 
     @pytest.mark.asyncio
     async def test_rejects_a_request_with_neither(self, db: Session) -> None:

--- a/backend/tests/utils_tests/test_sdk_auth.py
+++ b/backend/tests/utils_tests/test_sdk_auth.py
@@ -29,10 +29,10 @@ class TestGetSDKAuth:
         """Valid API key should return SDKAuthContext."""
         api_key = ApiKeyFactory()
 
-        result = await get_sdk_auth(db=db, token=None, x_open_wearables_api_key=api_key.id)
+        result = await get_sdk_auth(db=db, token=None, x_open_wearables_api_key=api_key.plain_key)
 
         assert result.auth_type == "api_key"
-        assert result.api_key_id == api_key.id
+        assert result.api_key_id == str(api_key.id)
 
     @pytest.mark.asyncio
     async def test_no_auth_raises_401(self, db: Session) -> None:
@@ -57,7 +57,7 @@ class TestGetSDKAuth:
         user_id = "123e4567-e89b-12d3-a456-426614174001"
         token = create_sdk_user_token("app_123", user_id)
 
-        result = await get_sdk_auth(db=db, token=token, x_open_wearables_api_key=api_key.id)
+        result = await get_sdk_auth(db=db, token=token, x_open_wearables_api_key=api_key.plain_key)
 
         assert result.auth_type == "sdk_token"
         assert str(result.user_id) == user_id

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -102,7 +102,7 @@ X-Open-Wearables-API-Key: YOUR_API_KEY
 5. Copy and securely store the key - it is shown only once
 
 <Warning>
-  The full key is displayed only at creation time. Open Wearables stores a hash of the key, so it cannot be retrieved later - the portal shows just a short prefix (for example `sk-a1b2c3d`) to help you tell keys apart. If you lose a key, rotate it from the same section to get a new one.
+  The full key is displayed only once, right after you create or rotate it. Open Wearables stores a hash of the key, so it cannot be retrieved later - the portal shows just a short prefix (for example `sk-a1b2c3d`) to help you tell keys apart. If you lose a key, rotate it from the same section to get a new one.
 </Warning>
 
 API keys are shared across the whole deployment. Every developer account can see, rotate, and delete every key, see [Credentials](/developer-portal/settings/credentials#keys-are-shared-across-the-deployment).

--- a/docs/api-reference/introduction.mdx
+++ b/docs/api-reference/introduction.mdx
@@ -99,7 +99,11 @@ X-Open-Wearables-API-Key: YOUR_API_KEY
 2. Log in
 3. Navigate to **Settings → Credentials → API Keys**
 4. Generate a new API key
-5. Copy and securely store the key
+5. Copy and securely store the key - it is shown only once
+
+<Warning>
+  The full key is displayed only at creation time. Open Wearables stores a hash of the key, so it cannot be retrieved later - the portal shows just a short prefix (for example `sk-a1b2c3d`) to help you tell keys apart. If you lose a key, rotate it from the same section to get a new one.
+</Warning>
 
 API keys are shared across the whole deployment. Every developer account can see, rotate, and delete every key, see [Credentials](/developer-portal/settings/credentials#keys-are-shared-across-the-deployment).
 

--- a/docs/architecture/unified-data-model.mdx
+++ b/docs/architecture/unified-data-model.mdx
@@ -186,8 +186,10 @@ erDiagram
     }
     
     ApiKey {
-        string id PK
+        uuid id PK
         uuid created_by FK
+        string key_hash UK
+        string key_prefix
         string name
         timestamp created_at
     }

--- a/docs/developer-portal/settings/credentials.mdx
+++ b/docs/developer-portal/settings/credentials.mdx
@@ -2,7 +2,7 @@
 title: "Credentials"
 sidebarTitle: "Credentials"
 description: "Manage API keys for the REST API and application credentials for the Mobile SDK from Settings → Credentials in the Open Wearables developer portal."
-keywords: ["open wearables api key", "create api key", "sdk application credentials", "app id app secret", "rotate secret"]
+keywords: ["open wearables api key", "create api key", "rotate api key", "sdk application credentials", "app id app secret", "rotate secret"]
 "og:title": "Credentials | Open Wearables"
 "og:description": "Manage API keys for the REST API and application credentials for the Mobile SDK from Settings → Credentials in the Open Wearables developer portal."
 "og:url": "https://docs.openwearables.io/developer-portal/settings/credentials"
@@ -18,14 +18,15 @@ keywords: ["open wearables api key", "create api key", "sdk application credenti
 
 API keys authenticate requests to the REST API through the `X-Open-Wearables-API-Key` header and are used to embed widgets. See [Authentication](/api-reference/introduction#authentication) for how to send them.
 
-- **Create API Key** - give the key a name and it appears in the list. The name is only a label, you can change it later.
-- **Show / copy** - keys are masked in the table. Use the eye icon to reveal a key and the copy icon to copy it.
+- **Create API Key** - give the key a name. The dialog then shows the full key with a copy button. The name is only a label, you can change it later.
+- **The key is shown only once.** Open Wearables stores a hash of the key, so it cannot be retrieved later. The table shows just a short prefix (for example `sk-a1b2c3d…`) to help you tell keys apart. If you lose a key, rotate it.
+- **Rotate** - generates a new key under the same name and shows it once. The previous key stops working immediately, so update every integration that used it.
 - **Rename** - update the display name of a key.
 - **Delete** - the key stops working immediately for every integration that uses it.
 
 ### Keys are shared across the deployment
 
-API keys belong to the deployment, not to the developer who created them. Every developer sees all keys and can create, rename, and delete any of them, including keys created by someone else. The **created by** attribute is audit information only. It does not grant ownership and does not restrict what other developers can do with the key. See [Team](/developer-portal/settings/team#access-model) for the full access model.
+API keys belong to the deployment, not to the developer who created them. Every developer sees all keys and can create, rotate, rename, and delete any of them, including keys created by someone else. The **created by** attribute is audit information only. It does not grant ownership and does not restrict what other developers can do with the key. See [Team](/developer-portal/settings/team#access-model) for the full access model.
 
 ## Applications
 

--- a/docs/developer-portal/settings/credentials.mdx
+++ b/docs/developer-portal/settings/credentials.mdx
@@ -24,6 +24,15 @@ API keys authenticate requests to the REST API through the `X-Open-Wearables-API
 - **Rename** - update the display name of a key.
 - **Delete** - the key stops working immediately for every integration that uses it.
 
+Send the key in the `X-Open-Wearables-API-Key` header of every request:
+
+```bash
+curl http://localhost:8000/api/v1/users \
+  -H "X-Open-Wearables-API-Key: sk-a1b2c3d4e5f60718293a4b5c6d7e8f90"
+```
+
+A missing or invalid key returns `401 Unauthorized`. See [Authentication](/api-reference/introduction#authentication) for response formats and status codes.
+
 ### Keys are shared across the deployment
 
 API keys belong to the deployment, not to the developer who created them. Every developer sees all keys and can create, rotate, rename, and delete any of them, including keys created by someone else. The **created by** attribute is audit information only. It does not grant ownership and does not restrict what other developers can do with the key. See [Team](/developer-portal/settings/team#access-model) for the full access model.

--- a/docs/mcp-server/claude-desktop.mdx
+++ b/docs/mcp-server/claude-desktop.mdx
@@ -86,7 +86,7 @@ If configured correctly, Claude will use the `get_users` tool to fetch available
 
 ### "Invalid API key" error
 
-Ensure your `OPEN_WEARABLES_API_KEY` in `config/.env` is valid. Keys are generated in the API Keys section of the Open Wearables developer portal (Settings tab). The full key is shown only once at creation - if you no longer have it, rotate the key in the portal and update `config/.env` with the new value.
+Ensure your `OPEN_WEARABLES_API_KEY` in `config/.env` is valid. Keys are generated in the API Keys section of the Open Wearables developer portal (Settings tab). The full key is shown only once, right after it is created or rotated - if you no longer have it, rotate the key in the portal and update `config/.env` with the new value.
 
 ### "Connection refused" error
 

--- a/docs/mcp-server/claude-desktop.mdx
+++ b/docs/mcp-server/claude-desktop.mdx
@@ -86,9 +86,7 @@ If configured correctly, Claude will use the `get_users` tool to fetch available
 
 ### "Invalid API key" error
 
-Ensure your `OPEN_WEARABLES_API_KEY` in `config/.env` is valid. You can get an API key from:
-1. The Open Wearables developer portal
-2. Or via the backend admin panel at `/api/v1/developer/api-keys`
+Ensure your `OPEN_WEARABLES_API_KEY` in `config/.env` is valid. Keys are generated in the API Keys section of the Open Wearables developer portal (Settings tab). The full key is shown only once at creation - if you no longer have it, rotate the key in the portal and update `config/.env` with the new value.
 
 ### "Connection refused" error
 

--- a/docs/mcp-server/cursor.mdx
+++ b/docs/mcp-server/cursor.mdx
@@ -72,7 +72,7 @@ Then configure the connection:
 
 ### "Invalid API key" error
 
-Ensure your `OPEN_WEARABLES_API_KEY` in `config/.env` is valid. Keys are generated in the API Keys section of the Open Wearables developer portal (Settings tab). The full key is shown only once at creation - if you no longer have it, rotate the key in the portal and update `config/.env` with the new value.
+Ensure your `OPEN_WEARABLES_API_KEY` in `config/.env` is valid. Keys are generated in the API Keys section of the Open Wearables developer portal (Settings tab). The full key is shown only once, right after it is created or rotated - if you no longer have it, rotate the key in the portal and update `config/.env` with the new value.
 
 ### "Connection refused" error
 

--- a/docs/mcp-server/cursor.mdx
+++ b/docs/mcp-server/cursor.mdx
@@ -72,9 +72,7 @@ Then configure the connection:
 
 ### "Invalid API key" error
 
-Ensure your `OPEN_WEARABLES_API_KEY` in `config/.env` is valid. You can get an API key from:
-1. The Open Wearables developer portal
-2. Or via the backend admin panel at `/api/v1/developer/api-keys`
+Ensure your `OPEN_WEARABLES_API_KEY` in `config/.env` is valid. Keys are generated in the API Keys section of the Open Wearables developer portal (Settings tab). The full key is shown only once at creation - if you no longer have it, rotate the key in the portal and update `config/.env` with the new value.
 
 ### "Connection refused" error
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -148,7 +148,7 @@ Get Open Wearables running locally and start integrating wearable device data.
   2. **Create an API key**:
      An admin account is automatically created on startup using the `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables (defaults: `admin@admin.com` / `your-secure-password`). The seed runs only while the developer table is empty: once any developer account exists it is skipped, so changing `ADMIN_PASSWORD` later does not update an existing account - **change the default password from the developer portal right after your first login**. To add further accounts, invite them from **Settings → Team**. All developer accounts have the same permissions, see [Team](/developer-portal/settings/team#access-model).
 
-     Use the [developer portal](/developer-portal) at http://localhost:3000/ to log in and generate API keys.
+     Use the [developer portal](/developer-portal) at http://localhost:3000/ to log in and generate API keys. Copy the key right away - it is shown only once and cannot be retrieved later.
 
   3. **Seed sample data** (optional):
      If you want test users and sample activity data:

--- a/frontend/src/hooks/api/use-api-keys.ts
+++ b/frontend/src/hooks/api/use-api-keys.ts
@@ -51,6 +51,21 @@ export function useCreateApiKey() {
   });
 }
 
+export function useRotateApiKey() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => apiKeysService.rotateApiKey(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.apiKeys.lists() });
+      toast.success('API key rotated successfully');
+    },
+    onError: (error) => {
+      toast.error(`Failed to rotate API key: ${getErrorMessage(error)}`);
+    },
+  });
+}
+
 export function useRevokeApiKey() {
   const queryClient = useQueryClient();
 

--- a/frontend/src/lib/api/services/api-keys.service.ts
+++ b/frontend/src/lib/api/services/api-keys.service.ts
@@ -1,6 +1,11 @@
 import { apiClient } from '../client';
 import { API_ENDPOINTS } from '../config';
-import type { ApiKey, ApiKeyCreate, ApiKeyUpdate } from '../types';
+import type {
+  ApiKey,
+  ApiKeyCreate,
+  ApiKeyUpdate,
+  ApiKeyWithSecret,
+} from '../types';
 
 export const apiKeysService = {
   async getApiKeys(): Promise<ApiKey[]> {
@@ -11,12 +16,18 @@ export const apiKeysService = {
     return apiClient.get<ApiKey>(API_ENDPOINTS.apiKeyDetail(id));
   },
 
-  async createApiKey(data: ApiKeyCreate): Promise<ApiKey> {
-    return apiClient.post<ApiKey>(API_ENDPOINTS.apiKeys, data);
+  /** The returned `key` is shown only once - it cannot be fetched again. */
+  async createApiKey(data: ApiKeyCreate): Promise<ApiKeyWithSecret> {
+    return apiClient.post<ApiKeyWithSecret>(API_ENDPOINTS.apiKeys, data);
   },
 
   async updateApiKey(id: string, data: ApiKeyUpdate): Promise<ApiKey> {
     return apiClient.patch<ApiKey>(API_ENDPOINTS.apiKeyDetail(id), data);
+  },
+
+  /** Revokes the old key and returns a new one; `key` is shown only once. */
+  async rotateApiKey(id: string): Promise<ApiKeyWithSecret> {
+    return apiClient.post<ApiKeyWithSecret>(API_ENDPOINTS.apiKeyRotate(id));
   },
 
   async revokeApiKey(id: string): Promise<void> {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -517,10 +517,16 @@ export interface ActivitySummary {
 }
 
 export interface ApiKey {
-  id: string; // This is the actual API key value (sk-...)
+  id: string;
   name: string;
-  created_by: string;
+  key_prefix: string; // First characters of the key (sk-xxxxxxx) - the full value is never stored
+  created_by: string | null;
   created_at: string;
+}
+
+/** Returned only on create / rotate - the full key cannot be retrieved again. */
+export interface ApiKeyWithSecret extends ApiKey {
+  key: string;
 }
 
 export interface ApiKeyCreate {

--- a/frontend/src/routes/_authenticated/settings/-api-keys-section.tsx
+++ b/frontend/src/routes/_authenticated/settings/-api-keys-section.tsx
@@ -1,13 +1,22 @@
 import { useState } from 'react';
-import { Plus, Eye, EyeOff, Copy, Trash2, Key, Pencil } from 'lucide-react';
+import {
+  AlertTriangle,
+  Copy,
+  Key,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Trash2,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import {
   useApiKeys,
   useCreateApiKey,
   useDeleteApiKey,
+  useRotateApiKey,
   useUpdateApiKey,
 } from '@/hooks/api/use-api-keys';
-import type { ApiKey } from '@/lib/api/types';
+import type { ApiKey, ApiKeyWithSecret } from '@/lib/api/types';
 import { copyToClipboard } from '@/lib/utils/clipboard';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -33,16 +42,19 @@ import {
 
 export function ApiKeysSection() {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
-  const [visibleKeys, setVisibleKeys] = useState<Set<string>>(new Set());
   const [keyName, setKeyName] = useState('');
   const [editingKey, setEditingKey] = useState<ApiKey | null>(null);
   const [renameKeyName, setRenameKeyName] = useState('');
   const [keyToDelete, setKeyToDelete] = useState<ApiKey | null>(null);
+  const [keyToRotate, setKeyToRotate] = useState<ApiKey | null>(null);
+  const [revealedKey, setRevealedKey] = useState<ApiKeyWithSecret | null>(null);
+  const [revealTitle, setRevealTitle] = useState('API Key Created');
 
   const { data: apiKeys, isLoading, error, refetch } = useApiKeys();
   const createMutation = useCreateApiKey();
   const deleteMutation = useDeleteApiKey();
   const updateMutation = useUpdateApiKey();
+  const rotateMutation = useRotateApiKey();
 
   const handleCreate = async () => {
     if (!keyName.trim()) {
@@ -50,17 +62,25 @@ export function ApiKeysSection() {
       return;
     }
 
-    const newKey = await createMutation.mutateAsync({ name: keyName });
+    const newKey = await createMutation.mutateAsync({ name: keyName.trim() });
     setIsCreateDialogOpen(false);
     setKeyName('');
-
-    setVisibleKeys((prev) => new Set(prev).add(newKey.id));
+    setRevealTitle('API Key Created');
+    setRevealedKey(newKey);
   };
 
   const handleDeleteConfirm = async () => {
     if (!keyToDelete) return;
     await deleteMutation.mutateAsync(keyToDelete.id);
     setKeyToDelete(null);
+  };
+
+  const handleRotateConfirm = async () => {
+    if (!keyToRotate) return;
+    const rotated = await rotateMutation.mutateAsync(keyToRotate.id);
+    setKeyToRotate(null);
+    setRevealTitle('API Key Rotated');
+    setRevealedKey(rotated);
   };
 
   const openRenameDialog = (key: ApiKey) => {
@@ -81,23 +101,6 @@ export function ApiKeysSection() {
     });
     setEditingKey(null);
     setRenameKeyName('');
-  };
-
-  const toggleKeyVisibility = (id: string) => {
-    setVisibleKeys((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
-  };
-
-  const maskKey = (key: string) => {
-    if (key.length < 10) return '****';
-    return key.substring(0, 10) + '****' + key.substring(key.length - 4);
   };
 
   const formatDate = (dateString: string) => {
@@ -135,7 +138,8 @@ export function ApiKeysSection() {
           <div>
             <h3 className="text-sm font-medium text-foreground">API Keys</h3>
             <p className="text-xs text-muted-foreground mt-1">
-              Use these keys to authenticate API requests and embed widgets
+              Use these keys to authenticate API requests and embed widgets. The
+              full key is shown only once, when it is created or rotated.
             </p>
           </div>
           <Button
@@ -177,37 +181,25 @@ export function ApiKeysSection() {
                       {key.name}
                     </td>
                     <td className="px-6 py-4">
-                      <div className="flex items-center gap-2">
-                        <code className="font-mono text-xs bg-muted text-foreground/90 px-2 py-1 rounded">
-                          {visibleKeys.has(key.id) ? key.id : maskKey(key.id)}
-                        </code>
-                        <Button
-                          variant="ghost-faded"
-                          size="icon-sm"
-                          aria-label="Toggle key visibility"
-                          onClick={() => toggleKeyVisibility(key.id)}
-                        >
-                          {visibleKeys.has(key.id) ? (
-                            <EyeOff className="h-4 w-4" />
-                          ) : (
-                            <Eye className="h-4 w-4" />
-                          )}
-                        </Button>
-                        <Button
-                          variant="ghost-faded"
-                          size="icon-sm"
-                          aria-label="Copy key ID"
-                          onClick={() => copyToClipboard(key.id)}
-                        >
-                          <Copy className="h-4 w-4" />
-                        </Button>
-                      </div>
+                      <code className="font-mono text-xs bg-muted text-foreground/90 px-2 py-1 rounded">
+                        {key.key_prefix}
+                        {'…'}
+                      </code>
                     </td>
                     <td className="px-6 py-4 text-xs text-muted-foreground">
                       {formatDate(key.created_at)}
                     </td>
                     <td className="px-6 py-4">
                       <div className="flex justify-end items-center gap-2">
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          aria-label="Rotate API key"
+                          onClick={() => setKeyToRotate(key)}
+                          disabled={rotateMutation.isPending}
+                        >
+                          <RefreshCw className="h-4 w-4" aria-hidden />
+                        </Button>
                         <Button
                           variant="outline"
                           size="icon"
@@ -250,6 +242,66 @@ export function ApiKeysSection() {
           </div>
         )}
       </div>
+
+      {/* One-time key reveal */}
+      <Dialog
+        open={revealedKey !== null}
+        onOpenChange={(open) => {
+          if (!open) setRevealedKey(null);
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{revealTitle}</DialogTitle>
+            <DialogDescription>
+              Store this key in your backend environment. It is shown only once
+              and cannot be retrieved again.
+            </DialogDescription>
+          </DialogHeader>
+
+          {revealedKey && (
+            <div className="space-y-4">
+              <div className="flex items-start gap-2 rounded-lg border border-[hsl(var(--warning-muted)/0.3)] bg-[hsl(var(--warning-muted)/0.1)] p-3 text-sm text-[hsl(var(--warning-muted))]">
+                <AlertTriangle className="h-4 w-4 mt-0.5 shrink-0" />
+                <p>
+                  Copy the key now. If you lose it, you will need to rotate it
+                  and update your integration.
+                </p>
+              </div>
+
+              <div className="space-y-1.5">
+                <Label className="text-foreground/90">
+                  {revealedKey.name || 'API Key'}
+                </Label>
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 font-mono text-xs bg-muted text-foreground/90 px-3 py-2 rounded break-all">
+                    {revealedKey.key}
+                  </code>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    aria-label="Copy API key"
+                    onClick={() =>
+                      copyToClipboard(revealedKey.key, 'API key copied')
+                    }
+                  >
+                    <Copy className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button
+              onClick={() => setRevealedKey(null)}
+              aria-label="Close key reveal"
+            >
+              I&apos;ve saved the key
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog
         open={editingKey !== null}
@@ -311,7 +363,8 @@ export function ApiKeysSection() {
           <DialogHeader>
             <DialogTitle>Create New API Key</DialogTitle>
             <DialogDescription>
-              Generate a new API key for your application
+              Generate a new API key for your application. The key will be shown
+              once after creation.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-1.5">
@@ -352,6 +405,36 @@ export function ApiKeysSection() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <AlertDialog
+        open={keyToRotate !== null}
+        onOpenChange={(open) => {
+          if (!open) setKeyToRotate(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Rotate API Key</AlertDialogTitle>
+            <AlertDialogDescription>
+              {keyToRotate
+                ? `Rotate "${keyToRotate.name}"? The current key will stop working immediately and a new one will be shown once.`
+                : 'Rotate this API key? The current key will stop working immediately and a new one will be shown once.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={rotateMutation.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleRotateConfirm}
+              disabled={rotateMutation.isPending}
+              aria-label="Rotate key"
+            >
+              {rotateMutation.isPending ? 'Rotating...' : 'Rotate Key'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <AlertDialog
         open={keyToDelete !== null}


### PR DESCRIPTION
## What does this change?

API keys are stored as a SHA-256 hash plus a 10-char display prefix; the raw key is returned only from create and rotate. Keys are addressed by UUID instead of the key value, rotate keeps the key name, and the settings panel shows a one-time "copy now" dialog with a rotate action.

## Why?

Any developer could read every raw key from `GET /developer/api-keys`. Keys are deployment-global by design (every developer is an admin), so per-owner filtering would not fit the product - instead the listing is made harmless by never storing the raw value. Also closes the hashing half of #50; the unique `name` constraint is left out on purpose.

The migration hashes existing rows in place, so current integrations keep working. Downgrade is lossy (rows are dropped) because raw values cannot be recovered.

Related issue: #50

## How did you test this?

- `uv run pytest` in `backend/`: 2340 passed. Frontend `tsc` and `vitest` green.
- Migration on a local Docker DB seeded with a plaintext key: hash and prefix match, `downgrade -1` / `upgrade head` cycle works.
- HTTP scenario against the Docker app: legacy key authenticates after migration, list contains no raw key or hash, create -> auth 200, prefix alone -> 401, rotate keeps name and revokes the old key, delete revokes, delete by raw value -> 400.

## AI usage

Claude Code (Fable 5.1): analysis of the report vs #50, implementation, tests, migration and this description. Reviewed and edited by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - API keys now display a masked prefix instead of the full secret.
  - Full API keys are shown only once after creation or rotation.
  - Added key rotation with confirmation and success/error feedback.
  - Rotating a key immediately invalidates the previous key.
- **Bug Fixes**
  - Improved API key authentication and revocation behavior.
- **Documentation**
  - Updated setup and troubleshooting guidance for one-time key visibility, secure storage, and rotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->