### PR TITLE
fix(auth): restrict developer update by ID to the caller's own account

### DIFF
--- a/backend/app/api/routes/v1/developers.py
+++ b/backend/app/api/routes/v1/developers.py
@@ -21,7 +21,16 @@ def get_developer(developer_id: UUID, db: DbSession, _auth: DeveloperDep):
     return developer_service.get(db, developer_id, raise_404=True)
 
 
-@router.patch("/{developer_id}", response_model=DeveloperRead)
+@router.patch(
+    "/{developer_id}",
+    response_model=DeveloperRead,
+    responses={
+        403: {
+            "description": "The ID is not the authenticated developer's own",
+            "content": {"application/json": {"example": {"detail": "You can only update your own developer account"}}},
+        },
+    },
+)
 def update_developer(
     developer_id: UUID,
     payload: DeveloperUpdate,

--- a/backend/app/api/routes/v1/developers.py
+++ b/backend/app/api/routes/v1/developers.py
@@ -31,7 +31,7 @@ def update_developer(
     """Update the authenticated developer's own profile.
 
     Developers have no roles, so there is no one entitled to edit another developer's
-    email or password. Allowing it would let any team member take over another account.
+    email or password.
     """
     if developer_id != developer.id:
         raise HTTPException(

--- a/backend/app/api/routes/v1/developers.py
+++ b/backend/app/api/routes/v1/developers.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, status
 
 from app.database import DbSession
 from app.schemas.model_crud.user_management import DeveloperRead, DeveloperUpdate
@@ -26,9 +26,18 @@ def update_developer(
     developer_id: UUID,
     payload: DeveloperUpdate,
     db: DbSession,
-    _auth: DeveloperDep,
+    developer: DeveloperDep,
 ):
-    """Update developer by ID."""
+    """Update the authenticated developer's own profile.
+
+    Developers have no roles, so there is no one entitled to edit another developer's
+    email or password. Allowing it would let any team member take over another account.
+    """
+    if developer_id != developer.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can only update your own developer account",
+        )
     return developer_service.update_developer_info(db, developer_id, payload, raise_404=True)
 
 

--- a/backend/tests/api/v1/test_auth.py
+++ b/backend/tests/api/v1/test_auth.py
@@ -427,32 +427,77 @@ class TestGetDeveloperById:
 class TestUpdateDeveloperById:
     """Tests for PATCH /api/v1/developers/{developer_id}."""
 
-    def test_update_developer_by_id_success(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
-        """Test updating developer by ID."""
+    def test_update_own_developer_success(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
+        """A developer can update their own account through the by-ID endpoint."""
         # Arrange
-        auth_developer = DeveloperFactory(email="auth@example.com", password="test123")
-        target_developer = DeveloperFactory(email="target@example.com", password="test123")
-        headers = developer_auth_headers(auth_developer.id)
+        developer = DeveloperFactory(email="me@example.com", password="test123")
+        headers = developer_auth_headers(developer.id)
         payload = {"email": "updated@example.com"}
 
         # Act
         response = client.patch(
-            f"{api_v1_prefix}/developers/{target_developer.id}",
+            f"{api_v1_prefix}/developers/{developer.id}",
             json=payload,
             headers=headers,
         )
 
         # Assert
         assert response.status_code == 200
-        data = response.json()
-        assert data["email"] == "updated@example.com"
+        assert response.json()["email"] == "updated@example.com"
+        db.refresh(developer)
+        assert developer.email == "updated@example.com"
 
-        # Verify in database
-        db.refresh(target_developer)
-        assert target_developer.email == "updated@example.com"
+    def test_update_other_developer_forbidden(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
+        """Developers have no roles, so nobody may edit another developer's account."""
+        # Arrange
+        attacker = DeveloperFactory(email="attacker@example.com", password="test123")
+        victim = DeveloperFactory(email="victim@example.com", password="test123")
+        headers = developer_auth_headers(attacker.id)
+        payload = {"email": "hijacked@example.com"}
+
+        # Act
+        response = client.patch(
+            f"{api_v1_prefix}/developers/{victim.id}",
+            json=payload,
+            headers=headers,
+        )
+
+        # Assert
+        assert response.status_code == 403
+        db.refresh(victim)
+        assert victim.email == "victim@example.com"
+
+    def test_update_other_developer_password_does_not_take_over_account(
+        self, client: TestClient, db: Session, api_v1_prefix: str
+    ) -> None:
+        """Regression: cross-account PATCH must not change the victim's password."""
+        # Arrange
+        attacker = DeveloperFactory(email="attacker@example.com", password="test123")
+        victim = DeveloperFactory(email="victim@example.com", password="victim-original")
+        headers = developer_auth_headers(attacker.id)
+
+        # Act
+        response = client.patch(
+            f"{api_v1_prefix}/developers/{victim.id}",
+            json={"password": "AttackerControlled1!"},
+            headers=headers,
+        )
+
+        # Assert
+        assert response.status_code == 403
+        victim_login = client.post(
+            f"{api_v1_prefix}/auth/login",
+            data={"username": "victim@example.com", "password": "victim-original"},
+        )
+        assert victim_login.status_code == 200
+        attacker_login = client.post(
+            f"{api_v1_prefix}/auth/login",
+            data={"username": "victim@example.com", "password": "AttackerControlled1!"},
+        )
+        assert attacker_login.status_code == 401
 
     def test_update_developer_by_id_not_found(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
-        """Test updating non-existent developer raises ResourceNotFoundError."""
+        """An unknown ID is not the caller's own ID, so it is rejected without revealing existence."""
 
         # Arrange
         developer = DeveloperFactory(email="test@example.com", password="test123")
@@ -464,7 +509,7 @@ class TestUpdateDeveloperById:
         response = client.patch(f"{api_v1_prefix}/developers/{fake_id}", json=payload, headers=headers)
 
         # Assert
-        assert response.status_code == 404
+        assert response.status_code == 403
 
     def test_update_developer_by_id_unauthorized(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test updating developer by ID fails without authentication."""
@@ -481,14 +526,13 @@ class TestUpdateDeveloperById:
     def test_update_developer_by_id_invalid_data(self, client: TestClient, db: Session, api_v1_prefix: str) -> None:
         """Test updating developer with invalid data."""
         # Arrange
-        auth_developer = DeveloperFactory(email="auth@example.com", password="test123")
-        target_developer = DeveloperFactory(email="target@example.com", password="test123")
-        headers = developer_auth_headers(auth_developer.id)
+        developer = DeveloperFactory(email="me@example.com", password="test123")
+        headers = developer_auth_headers(developer.id)
         payload = {"email": "not-an-email", "password": "short"}
 
         # Act
         response = client.patch(
-            f"{api_v1_prefix}/developers/{target_developer.id}",
+            f"{api_v1_prefix}/developers/{developer.id}",
             json=payload,
             headers=headers,
         )


### PR DESCRIPTION
## What does this change?

`PATCH /api/v1/developers/{developer_id}` returns 403 unless the ID is the caller's own. `PATCH /auth/me` and `POST /auth/change-password` are unaffected.

## Why?

The endpoint only checked that the caller was an authenticated developer and never compared the path ID with the caller. Developers have no roles, so any team member could set another developer's password or email and take over the account. The portal never used this path, so nothing changes in the UI.

`DELETE /developers/{id}` is left as is, since removing team members is a feature of the Team tab. An unknown ID now returns 403 instead of 404 so the endpoint no longer reveals whether an account exists.

## How did you test this?

Automatic tests. The existing test asserted that cross-account update succeeds, so it was rewritten, and two regression tests cover the reported takeover flow. They fail without the route change.

## AI usage

Claude Code (Fable 5.1) for verifying the report and writing the fix and tests. Reviewed and edited by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Developer account updates are now restricted to the authenticated developer’s own account.
  - Attempts to update another developer’s email or password are rejected with a 403 error.
  - Password update requests can no longer be used to take over another account.
  - Requests for unauthorized or unknown developer IDs now return a consistent 403 response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->