### PR TITLE
feat(auth): let SDK tokens disconnect their own SDK connections

### DIFF
--- a/backend/app/api/routes/v1/connections.py
+++ b/backend/app/api/routes/v1/connections.py
@@ -1,16 +1,18 @@
 import contextlib
 from uuid import UUID
 
-from fastapi import APIRouter, Response, status
+from fastapi import APIRouter, HTTPException, Response, status
 
 from app.database import DbSession
 from app.models import ProviderSetting
 from app.repositories.provider_settings_repository import ProviderSettingsRepository
-from app.schemas.auth import ConnectionStatus, LiveSyncMode
+from app.schemas.auth import ConnectionStatus, LiveSyncMode, SDKAuthContext
 from app.schemas.enums import ProviderName
 from app.schemas.model_crud.user_management import UserConnectionWithCapabilities
 from app.services import ApiKeyDep, user_connection_service
+from app.services.providers.base_strategy import BaseProviderStrategy
 from app.services.providers.factory import ProviderFactory
+from app.utils.auth import CombinedAuthDep
 
 router = APIRouter()
 factory = ProviderFactory()
@@ -70,16 +72,52 @@ def get_connections_endpoint(
     ]
 
 
+def _assert_sdk_token_may_disconnect(
+    db: DbSession,
+    auth: SDKAuthContext,
+    user_id: UUID,
+    strategy: BaseProviderStrategy,
+) -> None:
+    """Confine an SDK-token caller to its own user's SDK-fed connections.
+
+    The token carries no provider claim, and neither remaining source covers the scope
+    alone: ``client_sdk`` still rejects a Garmin row whose tokens a prior disconnect
+    already cleared, and only the row's tokens separate hybrid Google's OAuth-fed
+    connections - which the app must not force a re-authorization on - from its SDK-fed
+    ones.
+    """
+    if auth.user_id != user_id:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "Token does not match user_id")
+
+    if not strategy.capabilities.client_sdk:
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "SDK tokens cannot disconnect this provider")
+
+    connection = user_connection_service.get_connection(db, user_id, strategy.name)
+    if connection and (connection.access_token or connection.refresh_token):
+        raise HTTPException(status.HTTP_403_FORBIDDEN, "SDK tokens cannot disconnect an OAuth connection")
+
+
 @router.delete("/users/{user_id}/connections/{provider}")
 def disconnect_provider_endpoint(
     user_id: UUID,
     provider: ProviderName,
     db: DbSession,
-    _api_key: ApiKeyDep,
+    auth: CombinedAuthDep,
 ) -> Response:
-    """Disconnect a user from a provider, revoking the connection and clearing tokens."""
+    """Disconnect a user from a provider, revoking the connection and clearing tokens.
+
+    Also takes an SDK user token, so the mobile SDK can report a sign-out its local-only
+    ``signOut()`` would otherwise hide. That path skips provider deregistration: leaving an
+    app is no reason to unregister the user from the provider's API.
+    """
     strategy = ProviderFactory().get_provider(provider.value)
-    user_connection_service.disconnect(db, user_id, provider.value, oauth=strategy.oauth)
+
+    if auth.auth_type == "sdk_token":
+        _assert_sdk_token_may_disconnect(db, auth, user_id, strategy)
+        user_connection_service.disconnect(db, user_id, provider.value, oauth=None, reason="sdk_sign_out")
+    else:
+        user_connection_service.disconnect(db, user_id, provider.value, oauth=strategy.oauth)
+
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 

--- a/backend/app/schemas/auth/sdk_auth.py
+++ b/backend/app/schemas/auth/sdk_auth.py
@@ -15,9 +15,10 @@ class SDKTokenRequest(BaseModel):
 
 
 class SDKAuthContext(BaseModel):
-    """Context returned by SDK authentication dependency."""
+    """Context returned by the SDK-capable authentication dependencies."""
 
-    auth_type: Literal["sdk_token", "api_key"]
+    auth_type: Literal["sdk_token", "api_key", "developer"]
     user_id: UUID | None = None  # From SDK token (sub claim)
     app_id: str | None = None  # From SDK token
     api_key_id: str | None = None  # From API key
+    developer_id: str | None = None  # From developer JWT

--- a/backend/app/services/user_connection_service.py
+++ b/backend/app/services/user_connection_service.py
@@ -49,6 +49,11 @@ class UserConnectionService(
         """Get all connections for a user."""
         return self.crud.get_by_user_id(db_session, user_id)
 
+    @handle_exceptions
+    def get_connection(self, db_session: DbSession, user_id: UUID, provider: str) -> UserConnection | None:
+        """Get a user's connection for one provider, or None if there is none."""
+        return self.crud.get_by_user_and_provider(db_session, user_id, provider)
+
     def get_linked_user_ids(
         self,
         db_session: DbSession,
@@ -95,12 +100,19 @@ class UserConnectionService(
 
     @handle_exceptions
     def disconnect(
-        self, db_session: DbSession, user_id: UUID, provider: str, oauth: BaseOAuthTemplate | None = None
+        self,
+        db_session: DbSession,
+        user_id: UUID,
+        provider: str,
+        oauth: BaseOAuthTemplate | None = None,
+        reason: str = "user_disconnected",
     ) -> None:
         """Disconnect a user from a provider. Raises 404 if connection not found.
 
         If oauth is provided, calls the provider's deregistration API before clearing tokens.
         Deregistration failures are logged but do not block the disconnect.
+
+        ``reason`` reaches the log line and the ``connection.revoked`` webhook.
         """
         if oauth:
             self._deregister_from_provider(db_session, user_id, provider, oauth)
@@ -113,7 +125,7 @@ class UserConnectionService(
                 "info",
                 "Connection revoked",
                 action="connection_revoked",
-                reason="user_disconnected",
+                reason=reason,
                 provider=provider,
                 user_id=str(user_id),
                 connection_id=str(connection.id) if connection else None,
@@ -123,7 +135,7 @@ class UserConnectionService(
                     user_id=user_id,
                     provider=provider,
                     connection_id=connection.id,
-                    reason="user_disconnected",
+                    reason=reason,
                     revoked_at=connection.updated_at.isoformat(),
                 )
             return

--- a/backend/app/utils/auth.py
+++ b/backend/app/utils/auth.py
@@ -140,3 +140,24 @@ async def get_sdk_auth(
 
 
 SDKAuthDep = Annotated[SDKAuthContext, Depends(get_sdk_auth)]
+
+
+async def get_combined_auth(
+    db: DbSession,
+    token: Annotated[str | None, Depends(oauth2_scheme)] = None,
+    x_open_wearables_api_key: str | None = Header(None, alias="X-Open-Wearables-API-Key"),
+) -> SDKAuthContext:
+    """Accept a developer JWT, an API key, or an SDK user token.
+
+    For endpoints both the dashboard and the mobile SDK call.
+    ``get_current_developer_optional`` returns None for SDK-scoped tokens, so they fall
+    through to ``get_sdk_auth``. An ``sdk_token`` caller speaks only for its own user, so
+    endpoints branching on ``auth_type`` have to scope it themselves.
+    """
+    if developer := await get_current_developer_optional(db, token):
+        return SDKAuthContext(auth_type="developer", developer_id=str(developer.id))
+
+    return await get_sdk_auth(db, token, x_open_wearables_api_key)
+
+
+CombinedAuthDep = Annotated[SDKAuthContext, Depends(get_combined_auth)]

--- a/backend/tests/api/v1/test_connections.py
+++ b/backend/tests/api/v1/test_connections.py
@@ -11,23 +11,26 @@ Tests the /api/v1/users/{user_id}/connections endpoint including:
 
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.models import DataPointSeries, DataSource, EventRecord, HealthScore, User, UserConnection, WorkoutDetails
 from app.schemas.auth import ConnectionStatus
+from app.services.sdk_token_service import create_sdk_user_token
 from tests.factories import (
     ApiKeyFactory,
     DataPointSeriesFactory,
     DataSourceFactory,
+    DeveloperFactory,
     EventRecordFactory,
     HealthScoreFactory,
     UserConnectionFactory,
     UserFactory,
     WorkoutDetailsFactory,
 )
-from tests.utils import api_key_headers
+from tests.utils import api_key_headers, developer_auth_headers
 
 
 class TestConnectionsEndpoints:
@@ -472,6 +475,180 @@ class TestDisconnectEndpoint:
         conn2 = db.query(UserConnection).filter_by(user_id=user2.id, provider="garmin").one()
         assert conn1.status == ConnectionStatus.REVOKED
         assert conn2.status == ConnectionStatus.ACTIVE
+
+
+def sdk_token_headers(user_id: UUID, app_id: str = "app_123") -> dict[str, str]:
+    """Bearer headers for an SDK user token scoped to user_id."""
+    return {"Authorization": f"Bearer {create_sdk_user_token(app_id, str(user_id))}"}
+
+
+class TestDisconnectWithSDKToken:
+    """SDK sign-out: DELETE /users/{user_id}/connections/{provider} with an SDK user token."""
+
+    def test_sdk_token_disconnects_own_sdk_connection(self, client: TestClient, db: Session) -> None:
+        """An SDK token revokes its own user's SDK-fed connection."""
+        # Arrange
+        user = UserFactory()
+        UserConnectionFactory(
+            user=user,
+            provider="apple",
+            status=ConnectionStatus.ACTIVE,
+            access_token=None,
+            refresh_token=None,
+        )
+
+        # Act
+        response = client.delete(f"/api/v1/users/{user.id}/connections/apple", headers=sdk_token_headers(user.id))
+
+        # Assert
+        assert response.status_code == 204
+        conn = db.query(UserConnection).filter_by(user_id=user.id, provider="apple").one()
+        assert conn.status == ConnectionStatus.REVOKED
+
+    def test_sdk_token_cannot_disconnect_another_user(self, client: TestClient, db: Session) -> None:
+        """An SDK token scoped to user1 cannot revoke user2's connection."""
+        # Arrange
+        user1 = UserFactory()
+        user2 = UserFactory()
+        UserConnectionFactory(
+            user=user2,
+            provider="apple",
+            status=ConnectionStatus.ACTIVE,
+            access_token=None,
+            refresh_token=None,
+        )
+
+        # Act
+        response = client.delete(f"/api/v1/users/{user2.id}/connections/apple", headers=sdk_token_headers(user1.id))
+
+        # Assert
+        assert response.status_code == 403
+        conn = db.query(UserConnection).filter_by(user_id=user2.id, provider="apple").one()
+        assert conn.status == ConnectionStatus.ACTIVE
+
+    def test_sdk_token_cannot_disconnect_oauth_only_provider(self, client: TestClient, db: Session) -> None:
+        """An SDK token cannot revoke a provider that never arrives over the SDK."""
+        # Arrange - tokens are already cleared, so only the capability check can catch this
+        user = UserFactory()
+        UserConnectionFactory(
+            user=user,
+            provider="garmin",
+            status=ConnectionStatus.ACTIVE,
+            access_token=None,
+            refresh_token=None,
+        )
+
+        # Act
+        response = client.delete(f"/api/v1/users/{user.id}/connections/garmin", headers=sdk_token_headers(user.id))
+
+        # Assert
+        assert response.status_code == 403
+        conn = db.query(UserConnection).filter_by(user_id=user.id, provider="garmin").one()
+        assert conn.status == ConnectionStatus.ACTIVE
+
+    def test_sdk_token_cannot_disconnect_oauth_fed_hybrid_connection(self, client: TestClient, db: Session) -> None:
+        """Google is hybrid: an OAuth-fed row stays out of the SDK's reach."""
+        # Arrange
+        user = UserFactory()
+        UserConnectionFactory(
+            user=user,
+            provider="google",
+            status=ConnectionStatus.ACTIVE,
+            access_token="secret_access",
+            refresh_token="secret_refresh",
+        )
+
+        # Act
+        response = client.delete(f"/api/v1/users/{user.id}/connections/google", headers=sdk_token_headers(user.id))
+
+        # Assert
+        assert response.status_code == 403
+        conn = db.query(UserConnection).filter_by(user_id=user.id, provider="google").one()
+        assert conn.status == ConnectionStatus.ACTIVE
+        assert conn.access_token == "secret_access"
+
+    def test_sdk_token_disconnects_sdk_fed_hybrid_connection(self, client: TestClient, db: Session) -> None:
+        """The same provider without OAuth tokens is SDK-fed and may be revoked."""
+        # Arrange
+        user = UserFactory()
+        UserConnectionFactory(
+            user=user,
+            provider="google",
+            status=ConnectionStatus.ACTIVE,
+            access_token=None,
+            refresh_token=None,
+        )
+
+        # Act
+        response = client.delete(f"/api/v1/users/{user.id}/connections/google", headers=sdk_token_headers(user.id))
+
+        # Assert
+        assert response.status_code == 204
+        conn = db.query(UserConnection).filter_by(user_id=user.id, provider="google").one()
+        assert conn.status == ConnectionStatus.REVOKED
+
+    def test_sdk_token_on_nonexistent_connection_returns_404(self, client: TestClient, db: Session) -> None:
+        """Nothing to revoke is still a 404, not a 403."""
+        # Arrange
+        user = UserFactory()
+
+        # Act
+        response = client.delete(f"/api/v1/users/{user.id}/connections/apple", headers=sdk_token_headers(user.id))
+
+        # Assert
+        assert response.status_code == 404
+
+    @patch("app.api.routes.v1.connections.user_connection_service.disconnect")
+    def test_sdk_path_skips_provider_deregistration(
+        self, mock_disconnect: MagicMock, client: TestClient, db: Session
+    ) -> None:
+        """Signing out of an app must not deregister the user from the provider's API."""
+        # Arrange
+        user = UserFactory()
+        UserConnectionFactory(
+            user=user,
+            provider="google",
+            status=ConnectionStatus.ACTIVE,
+            access_token=None,
+            refresh_token=None,
+        )
+
+        # Act
+        client.delete(f"/api/v1/users/{user.id}/connections/google", headers=sdk_token_headers(user.id))
+
+        # Assert
+        assert mock_disconnect.call_args.kwargs["oauth"] is None
+        assert mock_disconnect.call_args.kwargs["reason"] == "sdk_sign_out"
+
+    def test_developer_jwt_still_disconnects(self, client: TestClient, db: Session) -> None:
+        """The dashboard's developer JWT keeps working after the auth was widened."""
+        # Arrange
+        user = UserFactory()
+        UserConnectionFactory(user=user, provider="polar", status=ConnectionStatus.ACTIVE)
+        developer = DeveloperFactory()
+
+        # Act
+        response = client.delete(
+            f"/api/v1/users/{user.id}/connections/polar",
+            headers=developer_auth_headers(developer.id),
+        )
+
+        # Assert
+        assert response.status_code == 204
+        conn = db.query(UserConnection).filter_by(user_id=user.id, provider="polar").one()
+        assert conn.status == ConnectionStatus.REVOKED
+
+    def test_no_credentials_returns_401(self, client: TestClient, db: Session) -> None:
+        """Widening the auth did not make the endpoint public."""
+        # Arrange
+        user = UserFactory()
+        UserConnectionFactory(user=user, provider="apple", status=ConnectionStatus.ACTIVE)
+
+        # Act
+        response = client.delete(f"/api/v1/users/{user.id}/connections/apple")
+
+        # Assert
+        assert response.status_code == 401
 
 
 class TestDeleteProviderDataEndpoint:

--- a/docs/api-reference/guides/webhooks.mdx
+++ b/docs/api-reference/guides/webhooks.mdx
@@ -259,6 +259,7 @@ Every payload envelope has `type` (the event name as a string) and `data`.
 | Reason | Cause |
 |--------|-------|
 | `user_disconnected` | The connection was disconnected via the API. |
+| `sdk_sign_out` | The user signed out of the mobile app; the SDK reported it with its own token. |
 | `refresh_failed` | The OAuth refresh token was rejected by the provider. |
 | `deregistration` | The user deregistered on the provider side (Garmin). |
 

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -94,6 +94,33 @@ The SDK uses a secure token-based authentication flow that keeps your App creden
   **Never embed your `app_id` / `app_secret` in your mobile app.** Always generate access tokens on your backend and pass only the tokens to the mobile SDK.
 </Warning>
 
+## Disconnecting
+
+`signOut()` only clears the credentials stored on the device. It makes no network call, so on its own the backend never learns the user left: the connection stays `active` behind a plausible `last_synced_at` and is indistinguishable from a healthy one.
+
+To report the disconnect, call [`DELETE /api/v1/users/{user_id}/connections/{provider}`](/api-reference/connections/disconnect-provider-endpoint) with the SDK access token **before** signing out locally:
+
+```bash
+curl -X DELETE "https://api.openwearables.io/api/v1/users/$USER_ID/connections/apple" \
+  -H "Authorization: Bearer $SDK_ACCESS_TOKEN"
+```
+
+A `204` means the connection is revoked. The endpoint is idempotent, so a retry after a failed sign-out is safe, and a `404` means there was no connection to revoke.
+
+An SDK token is deliberately narrower here than a developer JWT or an API key:
+
+| Rule | Response when violated |
+|------|------------------------|
+| The token's user must be the `user_id` in the path | `403` |
+| The provider must be one that can be fed by the SDK (Apple Health, Google Health Connect, Samsung Health) | `403` |
+| The connection must not hold OAuth tokens - Google Health is hybrid, and its OAuth-fed connections are out of the app's reach | `403` |
+
+No provider deregistration runs on this path: signing out of an app is not a reason to unregister the user from the provider's API. The resulting `connection.revoked` webhook carries `reason: "sdk_sign_out"`, which distinguishes it from a disconnect made in the dashboard.
+
+<Note>
+  Revoking permissions in the iOS Settings app and deleting the app cannot be reported - the SDK never runs again to make the call. Treat a connection that stops uploading as a separate signal from one that was explicitly revoked.
+</Note>
+
 ## Next Steps
 
 <CardGroup cols={3}>


### PR DESCRIPTION
Resolves #1426 

Was required for https://github.com/the-momentum/open_wearables_ios_sdk/issues/39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SDK access tokens can now disconnect eligible provider connections.
  * Developer authentication is supported for connection management.
  * Connection revocation events can identify SDK sign-outs.

* **Documentation**
  * Added SDK sign-out guidance, response behavior, permissions, and limitations.
  * Documented the new `sdk_sign_out` webhook reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->