### PR TITLE
ci(backend): guard the migration chain against re-pointed migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,29 @@ jobs:
         working-directory: backend
         run: uv run pytest -v --cov=app --cov-report=xml --cov-report=term-missing
 
+  backend-migrations:
+    needs: changes
+    if: ${{ needs.changes.outputs.backend == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Add uv to PATH
+        run: echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Install dependencies
+        working-directory: backend
+        run: uv sync
+      - name: Check migration chain
+        working-directory: backend
+        run: uv run python scripts/check_migrations.py --base origin/${{ github.base_ref || 'main' }}
+
   mcp-build:
     needs: changes
     if: ${{ needs.changes.outputs.mcp == 'true' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,6 @@ make stop
 | `make test` | Run backend tests |
 | `make migrate` | Apply database migrations |
 | `make create_migration m="..."` | Create new migration |
-| `make check_migrations` | Verify the migration chain before opening a PR |
 | `make seed` | Seed sample data |
 
 ### Code Quality
@@ -89,7 +88,7 @@ When you rebase and `main` gained a migration in the meantime, `alembic heads` s
 
 1. Set `down_revision` of your migration to the head from `main`.
 2. Rename your file so its date is later than the last migration on `main` (keep the `rev` id; a dev database that already ran it is unaffected).
-3. Run `make check_migrations`. CI runs the same check and fails on a second head or on any change to a migration already on `main`.
+3. CI checks the chain and fails on a second head or on any change to a migration already on `main`.
 
 ## Guidelines for AI Agents
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ make stop
 | `make test` | Run backend tests |
 | `make migrate` | Apply database migrations |
 | `make create_migration m="..."` | Create new migration |
+| `make check_migrations` | Verify the migration chain before opening a PR |
 | `make seed` | Seed sample data |
 
 ### Code Quality

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,8 +87,8 @@ cd frontend && pnpm run lint:fix && pnpm run format
 When you rebase and `main` gained a migration in the meantime, `alembic heads` shows two heads. Resolve it by moving **your** migration to the end of the chain. Never touch a migration that is already on `main`: databases that applied it treat everything inserted before it as already done and skip it silently.
 
 1. Set `down_revision` of your migration to the head from `main`.
-2. Rename your file so its date is later than the last migration on `main` (keep the `rev` id; a dev database that already ran it is unaffected).
-3. CI checks the chain and fails on a second head or on any change to a migration already on `main`.
+2. Rename your file so its date is later than the last migration on `main`. Keep the `rev` id. If your dev database already ran this migration, run `make downgrade` before re-pointing and `make migrate` after; otherwise the database keeps your revision as current and never applies the migration from `main`.
+3. CI checks the chain and fails on a second head, on a changed `down_revision` in a migration already on `main`, and on a deleted or renamed migration.
 
 ## Guidelines for AI Agents
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,14 @@ cd backend && uv run pre-commit run --all-files
 cd frontend && pnpm run lint:fix && pnpm run format
 ```
 
+### Database Migrations
+
+When you rebase and `main` gained a migration in the meantime, `alembic heads` shows two heads. Resolve it by moving **your** migration to the end of the chain. Never touch a migration that is already on `main`: databases that applied it treat everything inserted before it as already done and skip it silently.
+
+1. Set `down_revision` of your migration to the head from `main`.
+2. Rename your file so its date is later than the last migration on `main` (keep the `rev` id; a dev database that already ran it is unaffected).
+3. Run `make check_migrations`. CI runs the same check and fails on a second head or on any change to a migration already on `main`.
+
 ## Guidelines for AI Agents
 
 1. **Read specialized docs** - See `backend/AGENTS.md` and `frontend/AGENTS.md` for patterns

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ create_migration:  ## Create a new migration. Use 'make create_migration m="Desc
 	fi
 	$(DOCKER_EXEC) $(ALEMBIC_CMD) revision --autogenerate -m "$(m)"
 
+check_migrations:  ## Verify the migration chain (single head, no re-pointed migrations)
+	cd backend && uv run python scripts/check_migrations.py
+
 downgrade:  ## Revert the last migration
 	$(DOCKER_EXEC) $(ALEMBIC_CMD) downgrade -1
 

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,6 @@ create_migration:  ## Create a new migration. Use 'make create_migration m="Desc
 	fi
 	$(DOCKER_EXEC) $(ALEMBIC_CMD) revision --autogenerate -m "$(m)"
 
-check_migrations:  ## Verify the migration chain (single head, no re-pointed migrations)
-	# Runs on the host like `make test`: it diffs against origin/main, and the app container has no .git
-	cd backend && uv run python scripts/check_migrations.py
-
 downgrade:  ## Revert the last migration
 	$(DOCKER_EXEC) $(ALEMBIC_CMD) downgrade -1
 

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ create_migration:  ## Create a new migration. Use 'make create_migration m="Desc
 	$(DOCKER_EXEC) $(ALEMBIC_CMD) revision --autogenerate -m "$(m)"
 
 check_migrations:  ## Verify the migration chain (single head, no re-pointed migrations)
+	# Runs on the host like `make test`: it diffs against origin/main, and the app container has no .git
 	cd backend && uv run python scripts/check_migrations.py
 
 downgrade:  ## Revert the last migration

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -248,8 +248,8 @@ make downgrade                             # Rollback
 When you rebase and `main` gained a migration in the meantime, `alembic heads` shows two heads. Resolve it by moving **your** migration to the end of the chain. Never touch a migration that is already on `main`: databases that applied it treat everything inserted before it as already done and skip it silently.
 
 1. Set `down_revision` of your migration to the head from `main`.
-2. Rename your file so its date is later than the last migration on `main` (keep the `rev` id; a dev database that already ran it is unaffected).
-3. CI checks the chain and fails on a second head or on any change to a migration already on `main`.
+2. Rename your file so its date is later than the last migration on `main`. Keep the `rev` id. If your dev database already ran this migration, run `make downgrade` before re-pointing and `make migrate` after; otherwise the database keeps your revision as current and never applies the migration from `main`.
+3. CI checks the chain and fails on a second head, on a changed `down_revision` in a migration already on `main`, and on a deleted or renamed migration.
 
 ### Data migrations
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -241,7 +241,16 @@ Schema changes use Alembic:
 make create_migration m="Add user table"  # Create
 make migrate                               # Apply
 make downgrade                             # Rollback
+make check_migrations                      # Verify the chain before opening a PR
 ```
+
+### Resolving migration conflicts
+
+When you rebase and `main` gained a migration in the meantime, `alembic heads` shows two heads. Resolve it by moving **your** migration to the end of the chain. Never touch a migration that is already on `main`: databases that applied it treat everything inserted before it as already done and skip it silently.
+
+1. Set `down_revision` of your migration to the head from `main`.
+2. Rename your file so its date is later than the last migration on `main` (keep the `rev` id; a dev database that already ran it is unaffected).
+3. Run `make check_migrations`. CI runs the same check and fails on a second head or on any change to a migration already on `main`.
 
 ### Data migrations
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -241,7 +241,6 @@ Schema changes use Alembic:
 make create_migration m="Add user table"  # Create
 make migrate                               # Apply
 make downgrade                             # Rollback
-make check_migrations                      # Verify the chain before opening a PR
 ```
 
 ### Resolving migration conflicts
@@ -250,7 +249,7 @@ When you rebase and `main` gained a migration in the meantime, `alembic heads` s
 
 1. Set `down_revision` of your migration to the head from `main`.
 2. Rename your file so its date is later than the last migration on `main` (keep the `rev` id; a dev database that already ran it is unaffected).
-3. Run `make check_migrations`. CI runs the same check and fails on a second head or on any change to a migration already on `main`.
+3. CI checks the chain and fails on a second head or on any change to a migration already on `main`.
 
 ### Data migrations
 

--- a/backend/migrations/README
+++ b/backend/migrations/README
@@ -22,7 +22,10 @@ migration to the end of the chain:
 
 1. Set `down_revision` of your migration to the head from `main`.
 2. Rename your file so its date is later than the last migration on `main`.
-   Keep the `rev` id; a dev database that already ran it is unaffected.
+   Keep the `rev` id. If your dev database already ran this migration, run
+   `make downgrade` before re-pointing and `make migrate` after. Otherwise the
+   database keeps your revision as current and never applies the migration
+   from `main`.
 3. Let CI verify the chain.
 
 Never change `down_revision` of a migration that is already on `main`. It makes

--- a/backend/migrations/README
+++ b/backend/migrations/README
@@ -5,7 +5,6 @@ Create, apply and roll back with the Makefile targets:
     make create_migration m="Description"
     make migrate
     make downgrade
-    make check_migrations
 
 Alembic builds the migration graph only from `revision` and `down_revision` inside
 the files. The date in the file name is a label for humans and does not affect
@@ -24,7 +23,7 @@ migration to the end of the chain:
 1. Set `down_revision` of your migration to the head from `main`.
 2. Rename your file so its date is later than the last migration on `main`.
    Keep the `rev` id; a dev database that already ran it is unaffected.
-3. Run `make check_migrations`.
+3. Let CI verify the chain.
 
 Never change `down_revision` of a migration that is already on `main`. It makes
 the chain look linear, but every database that already applied it will skip the

--- a/backend/migrations/README
+++ b/backend/migrations/README
@@ -1,1 +1,32 @@
-Generic single-database configuration.
+Alembic migrations for the backend database.
+
+Create, apply and roll back with the Makefile targets:
+
+    make create_migration m="Description"
+    make migrate
+    make downgrade
+    make check_migrations
+
+Alembic builds the migration graph only from `revision` and `down_revision` inside
+the files. The date in the file name is a label for humans and does not affect
+ordering.
+
+Resolving a two-head conflict after a rebase
+--------------------------------------------
+
+A database records only its current revision. On `upgrade head`, Alembic runs the
+revisions that are ancestors of the head but not ancestors of the recorded one.
+Anything behind the recorded revision is assumed to be applied and is never run.
+
+So when `main` gained a migration while yours was in review, move **your**
+migration to the end of the chain:
+
+1. Set `down_revision` of your migration to the head from `main`.
+2. Rename your file so its date is later than the last migration on `main`.
+   Keep the `rev` id; a dev database that already ran it is unaffected.
+3. Run `make check_migrations`.
+
+Never change `down_revision` of a migration that is already on `main`. It makes
+the chain look linear, but every database that already applied it will skip the
+migration inserted before it. `scripts/check_migrations.py` fails CI on that
+change, on a deleted or renamed migration, and on a second head.

--- a/backend/scripts/check_migrations.py
+++ b/backend/scripts/check_migrations.py
@@ -10,7 +10,9 @@ Two checks:
    the merged revision treats the new migration as an ancestor and never runs it.
 
 The correct way to resolve a two-head conflict is to re-point the migration that is *not* on the
-base branch yet, so it becomes the new head.
+base branch yet, so it becomes the new head: set its ``down_revision`` to the head from the base
+branch and rename the file so its date is later than the last migration there. Keep the ``rev`` id,
+so databases that already ran it are unaffected.
 
 Usage (from ``backend/``)::
 

--- a/backend/scripts/check_migrations.py
+++ b/backend/scripts/check_migrations.py
@@ -1,0 +1,117 @@
+"""Guard the Alembic migration chain against changes that make deployed databases skip migrations.
+
+Two checks:
+
+1. ``migrations/versions`` has exactly one head. Two heads mean two branches added a migration
+   on the same parent and nobody resolved the conflict yet.
+2. No migration that already exists on the base branch has its ``down_revision`` changed, and no
+   existing migration is deleted or renamed. Re-pointing an already-merged migration so that a new
+   one sits "behind" it looks fine to ``alembic heads``, but every database that already recorded
+   the merged revision treats the new migration as an ancestor and never runs it.
+
+The correct way to resolve a two-head conflict is to re-point the migration that is *not* on the
+base branch yet, so it becomes the new head.
+
+Usage (from ``backend/``)::
+
+    uv run python scripts/check_migrations.py [--base origin/main]
+
+Needs only git and the migration files: no database, no application settings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+BACKEND_DIR = Path(__file__).resolve().parents[1]
+VERSIONS_DIR = "migrations/versions"
+DOWN_REVISION_RE = re.compile(r"^down_revision\b.*$", re.MULTILINE)
+
+
+def _git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=BACKEND_DIR,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def _down_revision_line(source: str) -> str | None:
+    match = DOWN_REVISION_RE.search(source)
+    return match.group(0).strip() if match else None
+
+
+def check_single_head() -> list[str]:
+    config = Config(str(BACKEND_DIR / "alembic.ini"))
+    config.set_main_option("script_location", str(BACKEND_DIR / "migrations"))
+    heads = ScriptDirectory.from_config(config).get_heads()
+    if len(heads) == 1:
+        return []
+    if not heads:
+        return ["no migration head found in migrations/versions"]
+    return [
+        f"{len(heads)} migration heads found: {', '.join(sorted(heads))}. "
+        "Re-point the migration from this branch so its down_revision is the other head.",
+    ]
+
+
+def check_existing_migrations_unchanged(base_ref: str) -> list[str]:
+    merge_base = _git("merge-base", base_ref, "HEAD").strip()
+    # Compare the merge base with the working tree so the check also works before committing.
+    diff = _git("diff", "--name-status", "-M", "--relative", merge_base, "--", VERSIONS_DIR)
+
+    errors: list[str] = []
+    for line in diff.splitlines():
+        parts = line.split("\t")
+        status, paths = parts[0], parts[1:]
+        if status.startswith("A"):
+            continue
+        if status.startswith("D"):
+            errors.append(f"{paths[0]}: migration already on {base_ref} was deleted")
+            continue
+        if status.startswith("R"):
+            errors.append(f"{paths[0]}: migration already on {base_ref} was renamed to {paths[1]}")
+            continue
+        if not status.startswith("M"):
+            continue
+
+        path = paths[0]
+        before = _down_revision_line(_git("show", f"{merge_base}:./{path}"))
+        after = _down_revision_line((BACKEND_DIR / path).read_text())
+        if before != after:
+            errors.append(
+                f"{path}: down_revision changed from `{before}` to `{after}`. "
+                f"This migration is already on {base_ref}; databases that applied it will skip "
+                "anything inserted before it. Re-point the new migration instead.",
+            )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--base", default="origin/main", help="git ref of the branch the change will merge into")
+    args = parser.parse_args()
+
+    errors = check_single_head() + check_existing_migrations_unchanged(args.base)
+    if errors:
+        print("Migration chain check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print("Migration chain OK: single head, existing migrations untouched.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/check_migrations.py
+++ b/backend/scripts/check_migrations.py
@@ -11,8 +11,9 @@ Two checks:
 
 The correct way to resolve a two-head conflict is to re-point the migration that is *not* on the
 base branch yet, so it becomes the new head: set its ``down_revision`` to the head from the base
-branch and rename the file so its date is later than the last migration there. Keep the ``rev`` id,
-so databases that already ran it are unaffected.
+branch and rename the file so its date is later than the last migration there. Keep the ``rev`` id.
+A dev database that already ran it must be downgraded first and upgraded again afterwards, or it
+never applies the migration from the base branch.
 
 Usage (from ``backend/``)::
 


### PR DESCRIPTION
## What does this change?

Adds `backend/scripts/check_migrations.py` and a `backend-migrations` CI job. The check fails when `migrations/versions` has more than one head, or when a migration that already exists on the base branch has its `down_revision` changed, is deleted, or is renamed.

## Why?

`alembic heads` only sees the graph in the repo, not what deployed databases have recorded. When a two-head conflict is resolved by re-pointing the already-merged migration so the new one sits behind it, the chain looks linear, but every database that already applied the merged revision treats the new migration as an ancestor and never runs it.

This is exactly how `9b079dab9585` (`workout_details.entry_source`, `intensity`, `label`) was skipped on databases that upgraded between the merge of `cf76dead11f5` (2026-09-07) and the merge of #1510 (2026-09-08). The right fix in that situation is to re-point the migration from the branch, so it becomes the new head.

The script needs only git and the migration files: no database, no settings.

## How did you test this?

Ran the script in four scenarios on a worktree from `main`: clean tree (passes), the #1510 shape with a migration inserted behind `cf76dead11f5` (fails on the `down_revision` change), two heads (fails), deleted migration (fails), new migration on the end of the chain (passes). `ruff`, `ruff format` and `ty` pass on the script.

## AI usage

Claude Code (Fable 5.1) for the investigation, the script and the CI job. Scope decided by me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated CI validation to ensure database migrations maintain a single valid migration path.
  - CI now detects deleted, renamed, or altered existing migrations before changes are merged.

- **Documentation**
  - Added guidance for creating, applying, and rolling back migrations.
  - Documented how to resolve migration conflicts after rebasing.
  - Clarified migration ordering and safeguards for migrations already merged.
  - Added instructions for resetting or updating development databases when migration history changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->